### PR TITLE
refactor(core): move IM bot providers to services

### DIFF
--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -87,7 +87,7 @@
 当前大型 PR 批次：
 
 - Platform Provider Closure 先收口 remote-connect 与 announcement 中已具备服务层 owner 的 concrete provider：LAN IP/URL 探测、ngrok 进程/tunnel lifecycle、mobile-web relay 上传、announcement remote fetch/cache。core 保留兼容 facade、配置读取和产品编排。
-- IM bot 平台 HTTP adapter、browser automation、terminal tool execution 和 Computer Use OS action 仍属于高影响路径；必须在具备等价测试与清晰 host port 后再迁移，不与本批次混合。
+- IM bot 中的 Telegram / Feishu provider client 已迁入 services-integrations；剩余 Weixin 平台 adapter、browser automation、terminal tool execution 和 Computer Use OS action 仍属于高影响路径；必须在具备等价测试与清晰 host port 后再迁移。
 
 保护：
 

--- a/src/crates/assembly/core/src/service/remote_connect/bot/feishu.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/bot/feishu.rs
@@ -1,285 +1,44 @@
 //! Feishu (Lark) bot integration for Remote Connect.
 //!
 //! Users create their own Feishu bot on the Feishu Open Platform and provide
-//! App ID + App Secret.  The desktop receives messages via Feishu's WebSocket
+//! App ID + App Secret. The desktop receives messages via Feishu's WebSocket
 //! long connection and routes them through the shared command router.
 
 use anyhow::{anyhow, Result};
-use futures::{SinkExt, StreamExt};
-use log::{debug, error, info, warn};
-use serde::{Deserialize, Serialize};
+use bitfun_services_integrations::remote_connect::bot::feishu::{
+    self as feishu_provider, FeishuBotApi,
+};
+pub use bitfun_services_integrations::remote_connect::bot::feishu::{
+    FeishuConfig, MAX_FEISHU_FILE_BYTES,
+};
+use log::{error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 use super::command_router::{
     complete_im_bot_pairing, current_bot_language, execute_forwarded_turn, handle_command,
-    parse_command, welcome_message, BotAction, BotActionStyle, BotChatState, BotInteractionHandler,
+    parse_command, welcome_message, BotAction, BotChatState, BotInteractionHandler,
     BotInteractiveRequest, BotLanguage, BotMessageSender, HandleResult,
 };
 use super::{load_bot_persistence, save_bot_persistence, BotConfig, SavedBotConnection};
-use crate::util::truncate_at_char_boundary;
-
-type FeishuWsStream =
-    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
-type FeishuWsWrite = futures::stream::SplitSink<FeishuWsStream, WsMessage>;
-type SharedFeishuWsWrite = Arc<RwLock<FeishuWsWrite>>;
-
-/// Feishu IM file-upload hard limit (30 MB).
-const MAX_FEISHU_FILE_BYTES: u64 = 30 * 1024 * 1024;
-
-// ── Minimal protobuf codec for Feishu WebSocket binary protocol ─────────
-
-mod pb {
-    //! Protobuf codec matching Feishu SDK's pbbp2.proto.
-    //! Field numbers from pbbp2.pb.go (proto2 with required fields):
-    //!   1: SeqID (uint64)
-    //!   2: LogID (uint64)
-    //!   3: Service (int32)
-    //!   4: Method (int32)       — 0 = control, 1 = data
-    //!   5: Headers (repeated Header)
-    //!   6: PayloadEncoding (string)
-    //!   7: PayloadType (string)
-    //!   8: Payload (bytes)
-    //!   9: LogIDNew (string)
-
-    #[derive(Debug, Default, Clone)]
-    pub struct Frame {
-        pub seq_id: u64,
-        pub log_id: u64,
-        pub service: i32,
-        pub method: i32,
-        pub headers: Vec<(String, String)>,
-        pub payload_encoding: String,
-        pub payload_type: String,
-        pub payload: Vec<u8>,
-        pub log_id_new: String,
-    }
-
-    pub const FRAME_TYPE_CONTROL: i32 = 0;
-    pub const FRAME_TYPE_DATA: i32 = 1;
-
-    fn decode_varint(data: &[u8], pos: &mut usize) -> Option<u64> {
-        let mut result: u64 = 0;
-        let mut shift = 0u32;
-        loop {
-            if *pos >= data.len() {
-                return None;
-            }
-            let byte = data[*pos];
-            *pos += 1;
-            result |= ((byte & 0x7F) as u64) << shift;
-            if byte & 0x80 == 0 {
-                return Some(result);
-            }
-            shift += 7;
-            if shift >= 64 {
-                return None;
-            }
-        }
-    }
-
-    fn encode_varint(mut val: u64) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(10);
-        loop {
-            let mut byte = (val & 0x7F) as u8;
-            val >>= 7;
-            if val != 0 {
-                byte |= 0x80;
-            }
-            buf.push(byte);
-            if val == 0 {
-                break;
-            }
-        }
-        buf
-    }
-
-    fn read_len<'a>(data: &'a [u8], pos: &mut usize) -> Option<&'a [u8]> {
-        let len = decode_varint(data, pos)? as usize;
-        if *pos + len > data.len() {
-            return None;
-        }
-        let slice = &data[*pos..*pos + len];
-        *pos += len;
-        Some(slice)
-    }
-
-    fn decode_header(data: &[u8]) -> Option<(String, String)> {
-        let mut pos = 0;
-        let (mut key, mut val) = (String::new(), String::new());
-        while pos < data.len() {
-            let tag = decode_varint(data, &mut pos)? as u32;
-            match (tag >> 3, tag & 7) {
-                (1, 2) => key = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
-                (2, 2) => val = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
-                (_, 0) => {
-                    decode_varint(data, &mut pos)?;
-                }
-                (_, 2) => {
-                    read_len(data, &mut pos)?;
-                }
-                _ => return None,
-            }
-        }
-        Some((key, val))
-    }
-
-    pub fn decode_frame(data: &[u8]) -> Option<Frame> {
-        let mut pos = 0;
-        let mut f = Frame::default();
-        while pos < data.len() {
-            let tag = decode_varint(data, &mut pos)? as u32;
-            match (tag >> 3, tag & 7) {
-                (1, 0) => f.seq_id = decode_varint(data, &mut pos)?,
-                (2, 0) => f.log_id = decode_varint(data, &mut pos)?,
-                (3, 0) => f.service = decode_varint(data, &mut pos)? as i32,
-                (4, 0) => f.method = decode_varint(data, &mut pos)? as i32,
-                (5, 2) => {
-                    if let Some(h) = decode_header(read_len(data, &mut pos)?) {
-                        f.headers.push(h);
-                    }
-                }
-                (6, 2) => {
-                    f.payload_encoding = String::from_utf8_lossy(read_len(data, &mut pos)?).into()
-                }
-                (7, 2) => {
-                    f.payload_type = String::from_utf8_lossy(read_len(data, &mut pos)?).into()
-                }
-                (8, 2) => f.payload = read_len(data, &mut pos)?.to_vec(),
-                (9, 2) => f.log_id_new = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
-                (_, 0) => {
-                    decode_varint(data, &mut pos)?;
-                }
-                (_, 2) => {
-                    read_len(data, &mut pos)?;
-                }
-                (_, 5) => {
-                    pos += 4;
-                } // fixed32
-                (_, 1) => {
-                    pos += 8;
-                } // fixed64
-                _ => return None,
-            }
-        }
-        Some(f)
-    }
-
-    fn write_varint(buf: &mut Vec<u8>, field: u32, val: u64) {
-        buf.extend(encode_varint((field << 3) as u64));
-        buf.extend(encode_varint(val));
-    }
-
-    fn write_bytes(buf: &mut Vec<u8>, field: u32, data: &[u8]) {
-        buf.extend(encode_varint(((field << 3) | 2) as u64));
-        buf.extend(encode_varint(data.len() as u64));
-        buf.extend(data);
-    }
-
-    fn encode_header(key: &str, value: &str) -> Vec<u8> {
-        let mut buf = Vec::new();
-        write_bytes(&mut buf, 1, key.as_bytes());
-        write_bytes(&mut buf, 2, value.as_bytes());
-        buf
-    }
-
-    pub fn encode_frame(frame: &Frame) -> Vec<u8> {
-        let mut buf = Vec::new();
-        write_varint(&mut buf, 1, frame.seq_id);
-        write_varint(&mut buf, 2, frame.log_id);
-        write_varint(&mut buf, 3, frame.service as u64);
-        write_varint(&mut buf, 4, frame.method as u64);
-        for (k, v) in &frame.headers {
-            let hdr = encode_header(k, v);
-            write_bytes(&mut buf, 5, &hdr);
-        }
-        if !frame.payload_encoding.is_empty() {
-            write_bytes(&mut buf, 6, frame.payload_encoding.as_bytes());
-        }
-        if !frame.payload_type.is_empty() {
-            write_bytes(&mut buf, 7, frame.payload_type.as_bytes());
-        }
-        if !frame.payload.is_empty() {
-            write_bytes(&mut buf, 8, &frame.payload);
-        }
-        if !frame.log_id_new.is_empty() {
-            write_bytes(&mut buf, 9, frame.log_id_new.as_bytes());
-        }
-        buf
-    }
-
-    impl Frame {
-        pub fn get_header(&self, key: &str) -> Option<&str> {
-            self.headers
-                .iter()
-                .find(|(k, _)| k == key)
-                .map(|(_, v)| v.as_str())
-        }
-
-        pub fn new_ping(service_id: i32) -> Self {
-            Frame {
-                method: FRAME_TYPE_CONTROL,
-                service: service_id,
-                headers: vec![("type".into(), "ping".into())],
-                ..Default::default()
-            }
-        }
-
-        pub fn new_response(original: &Frame, status_code: u16) -> Self {
-            let mut headers = original.headers.clone();
-            headers.push(("biz_rt".into(), "0".into()));
-            Frame {
-                seq_id: original.seq_id,
-                log_id: original.log_id,
-                service: original.service,
-                method: original.method,
-                headers,
-                payload: serde_json::to_vec(&serde_json::json!({"code": status_code}))
-                    .unwrap_or_default(),
-                log_id_new: original.log_id_new.clone(),
-                ..Default::default()
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FeishuConfig {
-    pub app_id: String,
-    pub app_secret: String,
-}
-
-#[derive(Debug, Clone)]
-struct FeishuToken {
-    access_token: String,
-    expires_at: i64,
-}
-
-pub struct FeishuBot {
-    config: FeishuConfig,
-    token: Arc<RwLock<Option<FeishuToken>>>,
-    pending_pairings: Arc<RwLock<HashMap<String, PendingPairing>>>,
-    chat_states: Arc<RwLock<HashMap<String, BotChatState>>>,
-}
+use crate::service::remote_connect::remote_server::ImageAttachment;
 
 #[derive(Debug, Clone)]
 struct PendingPairing {
     created_at: i64,
 }
 
-struct ParsedMessage {
-    chat_id: String,
-    message_id: String,
-    text: String,
-    image_keys: Vec<String>,
+pub struct FeishuBot {
+    api: FeishuBotApi,
+    pending_pairings: Arc<RwLock<HashMap<String, PendingPairing>>>,
+    chat_states: Arc<RwLock<HashMap<String, BotChatState>>>,
 }
 
 impl FeishuBot {
     fn invalid_pairing_code_message(language: BotLanguage) -> &'static str {
         if language.is_chinese() {
-            "配对码无效或已过期，请重试。"
+            "\u{914d}\u{5bf9}\u{7801}\u{65e0}\u{6548}\u{6216}\u{5df2}\u{8fc7}\u{671f}\u{ff0c}\u{8bf7}\u{91cd}\u{8bd5}\u{3002}"
         } else {
             "Invalid or expired pairing code. Please try again."
         }
@@ -287,7 +46,7 @@ impl FeishuBot {
 
     fn enter_pairing_code_message(language: BotLanguage) -> &'static str {
         if language.is_chinese() {
-            "请输入 BitFun Desktop 中显示的 6 位配对码。"
+            "\u{8bf7}\u{8f93}\u{5165} BitFun Desktop \u{4e2d}\u{663e}\u{793a}\u{7684} 6 \u{4f4d}\u{914d}\u{5bf9}\u{7801}\u{3002}"
         } else {
             "Please enter the 6-digit pairing code from BitFun Desktop."
         }
@@ -295,16 +54,39 @@ impl FeishuBot {
 
     fn unsupported_message_type_message(language: BotLanguage) -> &'static str {
         if language.is_chinese() {
-            "暂不支持这种消息类型，请发送文本或图片。"
+            "\u{6682}\u{4e0d}\u{652f}\u{6301}\u{8fd9}\u{79cd}\u{6d88}\u{606f}\u{7c7b}\u{578b}\u{ff0c}\u{8bf7}\u{53d1}\u{9001}\u{6587}\u{672c}\u{6216}\u{56fe}\u{7247}\u{3002}"
         } else {
             "This message type is not supported. Please send text or images."
         }
     }
 
+    fn image_truncated_message(
+        language: BotLanguage,
+        max_images: usize,
+        discarded: usize,
+    ) -> String {
+        if language.is_chinese() {
+            format!(
+                "\u{4ec5}\u{4f1a}\u{5904}\u{7406}\u{524d} {max_images} \u{5f20}\u{56fe}\u{7247}\u{ff0c}\u{5176}\u{4f59} {discarded} \u{5f20}\u{5df2}\u{4e22}\u{5f03}\u{3002}"
+            )
+        } else {
+            format!(
+                "Only the first {max_images} images will be processed; the remaining {discarded} were discarded."
+            )
+        }
+    }
+
+    fn image_placeholder_message(language: BotLanguage) -> String {
+        if language.is_chinese() {
+            "[\u{7528}\u{6237}\u{53d1}\u{9001}\u{4e86}\u{4e00}\u{5f20}\u{56fe}\u{7247}]".to_string()
+        } else {
+            "[User sent an image]".to_string()
+        }
+    }
+
     pub fn new(config: FeishuConfig) -> Self {
         Self {
-            config,
-            token: Arc::new(RwLock::new(None)),
+            api: FeishuBotApi::new(config),
             pending_pairings: Arc::new(RwLock::new(HashMap::new())),
             chat_states: Arc::new(RwLock::new(HashMap::new())),
         }
@@ -317,147 +99,19 @@ impl FeishuBot {
             .insert(chat_id.to_string(), state);
     }
 
-    async fn get_access_token(&self) -> Result<String> {
-        {
-            let guard = self.token.read().await;
-            if let Some(t) = guard.as_ref() {
-                if t.expires_at > chrono::Utc::now().timestamp() + 60 {
-                    return Ok(t.access_token.clone());
-                }
-            }
-        }
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal")
-            .json(&serde_json::json!({
-                "app_id": self.config.app_id,
-                "app_secret": self.config.app_secret,
-            }))
-            .send()
-            .await
-            .map_err(|e| anyhow!("feishu token request: {e}"))?;
-
-        let token_resp_text = resp.text().await.unwrap_or_default();
-        let body: serde_json::Value = serde_json::from_str(&token_resp_text).map_err(|e| {
-            anyhow!(
-                "feishu token response parse error: {e}, body: {}",
-                truncate_at_char_boundary(&token_resp_text, 200)
-            )
-        })?;
-        let access_token = body["tenant_access_token"]
-            .as_str()
-            .ok_or_else(|| anyhow!("missing tenant_access_token in response"))?
-            .to_string();
-        let expire = body["expire"].as_i64().unwrap_or(7200);
-
-        *self.token.write().await = Some(FeishuToken {
-            access_token: access_token.clone(),
-            expires_at: chrono::Utc::now().timestamp() + expire,
-        });
-
-        info!("Feishu access token refreshed");
-        Ok(access_token)
-    }
-
     pub async fn send_message(&self, chat_id: &str, content: &str) -> Result<()> {
-        let token = self.get_access_token().await?;
-        let card = Self::build_markdown_card(content);
-        let client = reqwest::Client::new();
-        let resp = client
-            .post("https://open.feishu.cn/open-apis/im/v1/messages")
-            .query(&[("receive_id_type", "chat_id")])
-            .bearer_auth(&token)
-            .json(&serde_json::json!({
-                "receive_id": chat_id,
-                "msg_type": "interactive",
-                "content": serde_json::to_string(&card)?,
-            }))
-            .send()
-            .await?;
-
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        if !status.is_success() {
-            return Err(anyhow!("feishu send_message HTTP {status}: {body}"));
-        }
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) {
-            if let Some(code) = parsed.get("code").and_then(|c| c.as_i64()) {
-                if code != 0 {
-                    let msg = parsed
-                        .get("msg")
-                        .and_then(|m| m.as_str())
-                        .unwrap_or("unknown");
-                    warn!("Feishu send_message API error: code={code}, msg={msg}");
-                    return Err(anyhow!(
-                        "feishu send_message API error: code={code}, msg={msg}"
-                    ));
-                }
-            }
-        }
-        debug!("Feishu message sent to {chat_id}");
-        Ok(())
+        self.api.send_message(chat_id, content).await
     }
 
-    fn build_markdown_card(content: &str) -> serde_json::Value {
-        serde_json::json!({
-            "schema": "2.0",
-            "config": {
-                "wide_screen_mode": true,
-            },
-            "body": {
-                "elements": [
-                    {
-                        "tag": "markdown",
-                        "content": content,
-                        "text_align": "left",
-                        "text_size": "normal",
-                        "margin": "0px 0px 0px 0px",
-                        "element_id": "bitfun_remote_reply_markdown",
-                    }
-                ],
-            },
-        })
-    }
-
-    /// Download a user-sent image from a Feishu message using the message resources API.
-    /// The returned data-URL is compressed to at most 1 MB.
     async fn download_image_as_data_url(&self, message_id: &str, file_key: &str) -> Result<String> {
         use base64::{engine::general_purpose::STANDARD as B64, Engine};
 
-        let token = match self.get_access_token().await {
-            Ok(t) => t,
-            Err(e) => {
-                return Err(e);
-            }
-        };
-        let client = reqwest::Client::new();
-        let url = format!(
-            "https://open.feishu.cn/open-apis/im/v1/messages/{}/resources/{}?type=image",
-            message_id, file_key
-        );
-        let resp = client
-            .get(&url)
-            .bearer_auth(&token)
-            .send()
-            .await
-            .map_err(|e| anyhow!("feishu download image: {e}"))?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!(
-                "feishu image download failed: HTTP {status} — {body}"
-            ));
-        }
-
-        let content_type = resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("image/png")
-            .to_string();
-        let raw_bytes = resp.bytes().await?;
+        let downloaded = self
+            .api
+            .download_image_resource(message_id, file_key)
+            .await?;
+        let content_type = downloaded.content_type;
+        let raw_bytes = downloaded.bytes;
 
         const MAX_BYTES: usize = 1024 * 1024;
         if raw_bytes.len() <= MAX_BYTES {
@@ -471,7 +125,7 @@ impl FeishuBot {
             raw_bytes.len() / 1024
         );
         match crate::agentic::image_analysis::optimize_image_with_size_limit(
-            raw_bytes.to_vec(),
+            raw_bytes.clone(),
             "openai",
             Some(&content_type),
             Some(MAX_BYTES),
@@ -488,17 +142,16 @@ impl FeishuBot {
         }
     }
 
-    /// Download multiple images and convert to ImageAttachment list.
     async fn download_images(
         &self,
         message_id: &str,
         image_keys: &[String],
-    ) -> Vec<super::super::remote_server::ImageAttachment> {
+    ) -> Vec<ImageAttachment> {
         let mut attachments = Vec::new();
         for (i, key) in image_keys.iter().enumerate() {
             match self.download_image_as_data_url(message_id, key).await {
                 Ok(data_url) => {
-                    attachments.push(super::super::remote_server::ImageAttachment {
+                    attachments.push(ImageAttachment {
                         name: format!("image_{}.png", i + 1),
                         data_url,
                     });
@@ -518,27 +171,9 @@ impl FeishuBot {
         content: &str,
         actions: &[BotAction],
     ) -> Result<()> {
-        let token = self.get_access_token().await?;
-        let client = reqwest::Client::new();
-        let card = Self::build_action_card(chat_id, language, content, actions);
-        let resp = client
-            .post("https://open.feishu.cn/open-apis/im/v1/messages")
-            .query(&[("receive_id_type", "chat_id")])
-            .bearer_auth(&token)
-            .json(&serde_json::json!({
-                "receive_id": chat_id,
-                "msg_type": "interactive",
-                "content": serde_json::to_string(&card)?,
-            }))
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("feishu send_action_card failed: {body}"));
-        }
-        debug!("Feishu action card sent to {chat_id}");
-        Ok(())
+        self.api
+            .send_action_card(chat_id, language, content, actions)
+            .await
     }
 
     async fn send_handle_result(&self, chat_id: &str, result: &HandleResult) -> Result<()> {
@@ -548,9 +183,6 @@ impl FeishuBot {
         } else {
             result.menu.render_text_block()
         };
-        // Empty replies (e.g. the silent "forward only" result returned by
-        // `handle_chat`) must not be sent — they would surface as a blank
-        // message in the user's Feishu chat.
         if text.trim().is_empty() {
             return Ok(());
         }
@@ -562,87 +194,10 @@ impl FeishuBot {
         }
     }
 
-    /// Upload a local file to Feishu and return its `file_key`.
-    /// Caller is expected to pre-check size against `MAX_FEISHU_FILE_BYTES`.
-    async fn upload_file_to_feishu(&self, file_path: &str) -> Result<String> {
-        let token = self.get_access_token().await?;
-
-        let content = super::read_workspace_file(file_path, MAX_FEISHU_FILE_BYTES, None).await?;
-
-        // Feishu uses its own file_type enum rather than MIME types.
-        let ext = std::path::Path::new(&content.name)
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-        let file_type = match ext.as_str() {
-            "pdf" => "pdf",
-            "doc" | "docx" => "doc",
-            "xls" | "xlsx" => "xls",
-            "ppt" | "pptx" => "ppt",
-            "mp4" => "mp4",
-            _ => "stream",
-        };
-
-        let part = reqwest::multipart::Part::bytes(content.bytes)
-            .file_name(content.name.clone())
-            .mime_str("application/octet-stream")?;
-
-        let form = reqwest::multipart::Form::new()
-            .text("file_type", file_type.to_string())
-            .text("file_name", content.name)
-            .part("file", part);
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post("https://open.feishu.cn/open-apis/im/v1/files")
-            .bearer_auth(&token)
-            .multipart(form)
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("Feishu file upload failed: {body}"));
-        }
-
-        let body: serde_json::Value = resp.json().await?;
-        body.pointer("/data/file_key")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| anyhow!("Feishu upload response missing file_key"))
-    }
-
-    /// Upload a local file and send it to a Feishu chat as a file message.
     async fn send_file_to_feishu_chat(&self, chat_id: &str, file_path: &str) -> Result<()> {
-        let file_key = self.upload_file_to_feishu(file_path).await?;
-        let token = self.get_access_token().await?;
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post("https://open.feishu.cn/open-apis/im/v1/messages")
-            .query(&[("receive_id_type", "chat_id")])
-            .bearer_auth(&token)
-            .json(&serde_json::json!({
-                "receive_id": chat_id,
-                "msg_type": "file",
-                "content": serde_json::to_string(&serde_json::json!({"file_key": file_key}))?,
-            }))
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("Feishu file message failed: {body}"));
-        }
-        debug!("Feishu file sent to {chat_id}: {file_path}");
-        Ok(())
+        self.api.send_file_to_chat(chat_id, file_path).await
     }
 
-    /// Scan `text` for downloadable file references and push every matching
-    /// file directly to the Feishu chat as a `file` message.  Files exceeding
-    /// `MAX_FEISHU_FILE_BYTES` are skipped with a brief notice; per-file
-    /// failures are reported as plain-text replies.
     async fn notify_files_ready(&self, chat_id: &str, text: &str) {
         let language = current_bot_language().await;
         let workspace_root = {
@@ -657,9 +212,6 @@ impl FeishuBot {
             return;
         }
 
-        // Skip the "正在为你发送 N 个文件……" intro: the file card itself is
-        // visible in the chat; only error / size-skip notices below need to
-        // surface to the user.
         for file in files {
             if file.size > MAX_FEISHU_FILE_BYTES {
                 let notice = super::auto_push_skip_too_large_message(
@@ -689,185 +241,6 @@ impl FeishuBot {
         }
     }
 
-    fn build_action_card(
-        chat_id: &str,
-        language: BotLanguage,
-        content: &str,
-        actions: &[BotAction],
-    ) -> serde_json::Value {
-        let body = Self::card_body_text(language, content);
-        let mut elements = vec![serde_json::json!({
-            "tag": "markdown",
-            "content": body,
-        })];
-
-        for chunk in actions.chunks(2) {
-            let buttons: Vec<_> = chunk
-                .iter()
-                .map(|action| {
-                    let button_type = match action.style {
-                        BotActionStyle::Primary => "primary",
-                        BotActionStyle::Default => "default",
-                    };
-                    serde_json::json!({
-                        "tag": "button",
-                        "text": {
-                            "tag": "plain_text",
-                            "content": action.label,
-                        },
-                        "type": button_type,
-                        "value": {
-                            "chat_id": chat_id,
-                            "command": action.command,
-                        }
-                    })
-                })
-                .collect();
-            elements.push(serde_json::json!({
-                "tag": "action",
-                "actions": buttons,
-            }));
-        }
-
-        serde_json::json!({
-            "config": {
-                "wide_screen_mode": true,
-            },
-            "header": {
-                "title": {
-                    "tag": "plain_text",
-                    "content": "BitFun Remote Connect",
-                }
-            },
-            "elements": elements,
-        })
-    }
-
-    fn card_body_text(language: BotLanguage, content: &str) -> String {
-        let mut removed_command_lines = false;
-        let mut lines = Vec::new();
-
-        for line in content.lines() {
-            let trimmed = line.trim_start();
-            if trimmed.starts_with('/') && trimmed.contains(" - ") {
-                removed_command_lines = true;
-                continue;
-            }
-            if trimmed.contains("/cancel_task ") {
-                lines.push(if language.is_chinese() {
-                    "如需停止本次请求，请使用下方的“取消任务”按钮。".to_string()
-                } else {
-                    "If needed, use the Cancel Task button below to stop this request.".to_string()
-                });
-                continue;
-            }
-            lines.push(Self::replace_command_tokens(language, line));
-        }
-
-        let mut body = lines.join("\n").trim().to_string();
-        if removed_command_lines {
-            if !body.is_empty() {
-                body.push_str("\n\n");
-            }
-            body.push_str(if language.is_chinese() {
-                "请选择下方操作。"
-            } else {
-                "Choose an action below."
-            });
-        }
-
-        if body.is_empty() {
-            if language.is_chinese() {
-                "请选择下方操作。".to_string()
-            } else {
-                "Choose an action below.".to_string()
-            }
-        } else {
-            body
-        }
-    }
-
-    fn replace_command_tokens(language: BotLanguage, line: &str) -> String {
-        let replacements = [
-            (
-                "/switch_workspace",
-                if language.is_chinese() {
-                    "切换工作区"
-                } else {
-                    "Switch Workspace"
-                },
-            ),
-            (
-                "/pro",
-                if language.is_chinese() {
-                    "专业模式"
-                } else {
-                    "Expert Mode"
-                },
-            ),
-            (
-                "/assistant",
-                if language.is_chinese() {
-                    "助理模式"
-                } else {
-                    "Assistant Mode"
-                },
-            ),
-            (
-                "/resume_session",
-                if language.is_chinese() {
-                    "恢复会话"
-                } else {
-                    "Resume Session"
-                },
-            ),
-            (
-                "/new_code_session",
-                if language.is_chinese() {
-                    "新建编码会话"
-                } else {
-                    "New Code Session"
-                },
-            ),
-            (
-                "/new_cowork_session",
-                if language.is_chinese() {
-                    "新建协作会话"
-                } else {
-                    "New Cowork Session"
-                },
-            ),
-            (
-                "/new_claw_session",
-                if language.is_chinese() {
-                    "新建助理会话"
-                } else {
-                    "New Claw Session"
-                },
-            ),
-            (
-                "/cancel_task",
-                if language.is_chinese() {
-                    "取消任务"
-                } else {
-                    "Cancel Task"
-                },
-            ),
-            (
-                "/help",
-                if language.is_chinese() {
-                    "帮助"
-                } else {
-                    "Help"
-                },
-            ),
-        ];
-
-        replacements
-            .iter()
-            .fold(line.to_string(), |acc, (from, to)| acc.replace(from, to))
-    }
-
     pub async fn register_pairing(&self, pairing_code: &str) -> Result<()> {
         self.pending_pairings.write().await.insert(
             pairing_code.to_string(),
@@ -887,243 +260,10 @@ impl FeishuBot {
         false
     }
 
-    /// Obtain a WebSocket URL from Feishu for long-connection event delivery.
-    /// Uses direct AppID/AppSecret auth per Feishu SDK protocol (no bearer token).
-    async fn get_ws_endpoint(&self) -> Result<(String, serde_json::Value)> {
-        let client = reqwest::Client::new();
-        let resp = client
-            .post("https://open.feishu.cn/callback/ws/endpoint")
-            .json(&serde_json::json!({
-                "AppID": self.config.app_id,
-                "AppSecret": self.config.app_secret,
-            }))
-            .send()
-            .await
-            .map_err(|e| anyhow!("feishu ws endpoint request: {e}"))?;
+    async fn handle_pairing_event_payload(&self, payload: &[u8]) -> Option<String> {
+        let event: serde_json::Value = serde_json::from_slice(payload).ok()?;
 
-        let ws_resp_text = resp.text().await.unwrap_or_default();
-        let body: serde_json::Value = serde_json::from_str(&ws_resp_text).map_err(|e| {
-            anyhow!(
-                "feishu ws endpoint parse error: {e}, body: {}",
-                truncate_at_char_boundary(&ws_resp_text, 300)
-            )
-        })?;
-        let code = body["code"].as_i64().unwrap_or(-1);
-        if code != 0 {
-            let msg = body["msg"].as_str().unwrap_or("unknown error");
-            return Err(anyhow!("feishu ws endpoint error {code}: {msg}"));
-        }
-
-        let url = body
-            .pointer("/data/URL")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow!("missing WebSocket URL in feishu response"))?
-            .to_string();
-        let client_config = body
-            .pointer("/data/ClientConfig")
-            .cloned()
-            .unwrap_or_default();
-
-        Ok((url, client_config))
-    }
-
-    /// Parse a Feishu message event into text + image keys.
-    /// Supports `text`, `post` (rich text with images), and `image` message types.
-    fn parse_message_event_full(event: &serde_json::Value) -> Option<ParsedMessage> {
-        let event_type = event
-            .pointer("/header/event_type")
-            .and_then(|v| v.as_str())?;
-        if event_type != "im.message.receive_v1" {
-            return None;
-        }
-
-        let chat_id = event
-            .pointer("/event/message/chat_id")
-            .and_then(|v| v.as_str())?
-            .to_string();
-        let message_id = event
-            .pointer("/event/message/message_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let msg_type = event
-            .pointer("/event/message/message_type")
-            .and_then(|v| v.as_str())?;
-        let content_str = event
-            .pointer("/event/message/content")
-            .and_then(|v| v.as_str())?;
-        let content: serde_json::Value = serde_json::from_str(content_str).ok()?;
-
-        match msg_type {
-            "text" => {
-                let text = content["text"].as_str()?.trim().to_string();
-                if text.is_empty() {
-                    return None;
-                }
-                Some(ParsedMessage {
-                    chat_id,
-                    message_id,
-                    text,
-                    image_keys: vec![],
-                })
-            }
-            "post" => {
-                let (text, image_keys) = Self::extract_from_post(&content);
-                if text.is_empty() && image_keys.is_empty() {
-                    return None;
-                }
-                Some(ParsedMessage {
-                    chat_id,
-                    message_id,
-                    text,
-                    image_keys,
-                })
-            }
-            "image" => {
-                let image_key = content["image_key"].as_str()?.to_string();
-                Some(ParsedMessage {
-                    chat_id,
-                    message_id,
-                    text: String::new(),
-                    image_keys: vec![image_key],
-                })
-            }
-            _ => None,
-        }
-    }
-
-    /// Backward-compatible wrapper: returns (chat_id, text) only for text/post with text content.
-    #[cfg(test)]
-    fn parse_message_event(event: &serde_json::Value) -> Option<(String, String)> {
-        let parsed = Self::parse_message_event_full(event)?;
-        if parsed.text.is_empty() {
-            return None;
-        }
-        Some((parsed.chat_id, parsed.text))
-    }
-
-    /// Extract text and image keys from a Feishu `post` (rich-text) message.
-    fn extract_from_post(content: &serde_json::Value) -> (String, Vec<String>) {
-        let root = if content["content"].is_array() {
-            content
-        } else {
-            content
-                .get("zh_cn")
-                .or_else(|| content.get("en_us"))
-                .or_else(|| content.as_object().and_then(|obj| obj.values().next()))
-                .unwrap_or(content)
-        };
-
-        let paragraphs = match root["content"].as_array() {
-            Some(p) => p,
-            None => return (String::new(), vec![]),
-        };
-
-        let mut text_parts: Vec<String> = Vec::new();
-        let mut image_keys: Vec<String> = Vec::new();
-
-        for para in paragraphs {
-            if let Some(elements) = para.as_array() {
-                for elem in elements {
-                    match elem["tag"].as_str().unwrap_or("") {
-                        "text" | "a" => {
-                            if let Some(t) = elem["text"].as_str() {
-                                let trimmed = t.trim();
-                                if !trimmed.is_empty() {
-                                    text_parts.push(trimmed.to_string());
-                                }
-                            }
-                        }
-                        "img" => {
-                            if let Some(key) = elem["image_key"].as_str() {
-                                if !key.is_empty() {
-                                    image_keys.push(key.to_string());
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-
-        let title = root["title"].as_str().unwrap_or("").trim();
-        if !title.is_empty() {
-            text_parts.insert(0, title.to_string());
-        }
-
-        (text_parts.join(" "), image_keys)
-    }
-
-    /// Extract (chat_id, command) from a Feishu card action callback.
-    fn parse_card_action_event(event: &serde_json::Value) -> Option<(String, String)> {
-        let event_type = event
-            .pointer("/header/event_type")
-            .and_then(|v| v.as_str())?;
-        if event_type != "card.action.trigger" {
-            return None;
-        }
-
-        let chat_id = event
-            .pointer("/event/action/value/chat_id")
-            .and_then(|v| v.as_str())
-            .or_else(|| {
-                event
-                    .pointer("/event/context/open_chat_id")
-                    .and_then(|v| v.as_str())
-            })?
-            .to_string();
-        let command = event
-            .pointer("/event/action/value/command")
-            .and_then(|v| v.as_str())?
-            .trim()
-            .to_string();
-
-        Some((chat_id, command))
-    }
-
-    #[cfg(test)]
-    fn parse_ws_event(event: &serde_json::Value) -> Option<(String, String)> {
-        Self::parse_message_event(event).or_else(|| Self::parse_card_action_event(event))
-    }
-
-    /// Extract chat_id from any im.message.receive_v1 event (regardless of msg_type).
-    fn extract_message_chat_id(event: &serde_json::Value) -> Option<String> {
-        let event_type = event
-            .pointer("/header/event_type")
-            .and_then(|v| v.as_str())?;
-        if event_type != "im.message.receive_v1" {
-            return None;
-        }
-        event
-            .pointer("/event/message/chat_id")
-            .and_then(|v| v.as_str())
-            .map(String::from)
-    }
-
-    /// Handle a single incoming protobuf data frame.
-    /// Returns Some(chat_id) if pairing succeeded, None to continue waiting.
-    async fn handle_data_frame_for_pairing(
-        &self,
-        frame: &pb::Frame,
-        write: &SharedFeishuWsWrite,
-    ) -> Option<String> {
-        let msg_type = frame.get_header("type").unwrap_or("");
-        if msg_type != "event" {
-            return None;
-        }
-
-        let event: serde_json::Value = serde_json::from_slice(&frame.payload).ok()?;
-
-        // Send ack response for this frame
-        let resp_frame = pb::Frame::new_response(frame, 200);
-        let _ = write
-            .write()
-            .await
-            .send(WsMessage::Binary(pb::encode_frame(&resp_frame).into()))
-            .await;
-
-        if let Some(parsed) = Self::parse_message_event_full(&event) {
+        if let Some(parsed) = feishu_provider::parse_message_event_full(&event) {
             let language = current_bot_language().await;
             let chat_id = parsed.chat_id;
             let msg_text = parsed.text;
@@ -1156,7 +296,7 @@ impl FeishuBot {
                     .await
                     .ok();
             }
-        } else if let Some(chat_id) = Self::extract_message_chat_id(&event) {
+        } else if let Some(chat_id) = feishu_provider::extract_message_chat_id(&event) {
             let language = current_bot_language().await;
             self.send_message(&chat_id, Self::enter_pairing_code_message(language))
                 .await
@@ -1164,8 +304,6 @@ impl FeishuBot {
         }
         None
     }
-
-    /// Start polling for pairing codes.  Returns the chat_id on success.
     pub async fn wait_for_pairing(
         &self,
         stop_rx: &mut tokio::sync::watch::Receiver<bool>,
@@ -1176,19 +314,13 @@ impl FeishuBot {
             return Err(anyhow!("bot stop requested"));
         }
 
-        let (ws_url, config) = self.get_ws_endpoint().await?;
-
-        let (ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
-            .await
-            .map_err(|e| anyhow!("feishu ws connect: {e}"))?;
-
-        let (write, mut read) = ws_stream.split();
-        let write = Arc::new(RwLock::new(write));
+        let endpoint = self.api.get_ws_endpoint().await?;
+        let mut connection = self.api.connect_ws(&endpoint.url).await?;
         info!("Feishu WebSocket connected (binary proto), waiting for pairing...");
 
-        let service_id = Self::extract_service_id_from_url(&ws_url);
-
-        let ping_interval = config
+        let service_id = feishu_provider::extract_service_id_from_url(&endpoint.url);
+        let ping_interval = endpoint
+            .client_config
             .get("PingInterval")
             .and_then(|v| v.as_u64())
             .unwrap_or(120);
@@ -1201,68 +333,30 @@ impl FeishuBot {
                     info!("Feishu wait_for_pairing stopped by signal");
                     return Err(anyhow!("bot stop requested"));
                 }
-                msg = read.next() => {
+                msg = connection.next_event() => {
                     match msg {
-                        Some(Ok(WsMessage::Binary(data))) => {
-                            let frame = match pb::decode_frame(&data) {
-                                Some(f) => f,
-                                None => continue,
-                            };
-                            match frame.method {
-                                pb::FRAME_TYPE_DATA => {
-                                    if let Some(chat_id) = self.handle_data_frame_for_pairing(&frame, &write).await {
-                                        return Ok(chat_id);
-                                    }
-                                }
-                                pb::FRAME_TYPE_CONTROL => {
-                                    debug!("Feishu WS control frame: type={}", frame.get_header("type").unwrap_or("?"));
-                                }
-                                _ => {}
+                        Ok(Some(event)) => {
+                            let _ = connection.ack_event(&event).await;
+                            if let Some(chat_id) = self.handle_pairing_event_payload(event.payload()).await {
+                                return Ok(chat_id);
                             }
                         }
-                        Some(Ok(WsMessage::Ping(data))) => {
-                            let _ = write.write().await.send(WsMessage::Pong(data)).await;
-                        }
-                        Some(Err(e)) => {
-                            error!("Feishu WebSocket error during pairing: {e}");
-                            return Err(anyhow!("feishu ws error: {e}"));
-                        }
-                        None => {
+                        Ok(None) => {
                             return Err(anyhow!("feishu ws connection closed during pairing"));
                         }
-                        _ => {}
+                        Err(e) => {
+                            error!("Feishu WebSocket error during pairing: {e}");
+                            return Err(e);
+                        }
                     }
                 }
                 _ = ping_timer.tick() => {
-                    let ping = pb::Frame::new_ping(service_id);
-                    let _ = write
-                        .write()
-                        .await
-                        .send(WsMessage::Binary(pb::encode_frame(&ping).into()))
-                        .await;
+                    let _ = connection.send_ping(service_id).await;
                 }
             }
         }
     }
 
-    fn extract_service_id_from_url(url: &str) -> i32 {
-        url.split('?')
-            .nth(1)
-            .and_then(|qs| {
-                qs.split('&').find_map(|pair| {
-                    let mut kv = pair.splitn(2, '=');
-                    match (kv.next(), kv.next()) {
-                        (Some("service_id"), Some(v)) => v.parse::<i32>().ok(),
-                        _ => None,
-                    }
-                })
-            })
-            .unwrap_or(0)
-    }
-
-    /// Main message loop that runs after pairing is complete.
-    /// Connects to Feishu WebSocket (binary protobuf protocol) and routes
-    /// incoming messages through the command router.
     pub async fn run_message_loop(self: Arc<Self>, stop_rx: tokio::sync::watch::Receiver<bool>) {
         info!("Feishu bot message loop started");
         let mut stop = stop_rx;
@@ -1273,8 +367,7 @@ impl FeishuBot {
                 break;
             }
 
-            let ws_result = self.get_ws_endpoint().await;
-            let (ws_url, config) = match ws_result {
+            let endpoint = match self.api.get_ws_endpoint().await {
                 Ok(v) => v,
                 Err(e) => {
                     error!("Failed to get Feishu WS endpoint: {e}");
@@ -1283,15 +376,14 @@ impl FeishuBot {
                 }
             };
 
-            let ping_interval = config
+            let ping_interval = endpoint
+                .client_config
                 .get("PingInterval")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(120);
+            let service_id = feishu_provider::extract_service_id_from_url(&endpoint.url);
 
-            let service_id = Self::extract_service_id_from_url(&ws_url);
-
-            let ws_conn = tokio_tungstenite::connect_async(&ws_url).await;
-            let (ws_stream, _) = match ws_conn {
+            let mut connection = match self.api.connect_ws(&endpoint.url).await {
                 Ok(v) => v,
                 Err(e) => {
                     error!("Feishu WS connect failed: {e}");
@@ -1300,9 +392,6 @@ impl FeishuBot {
                 }
             };
             info!("Feishu WebSocket connected for message loop (binary proto)");
-
-            let (write, mut read) = ws_stream.split();
-            let write = Arc::new(RwLock::new(write));
 
             let mut ping_timer =
                 tokio::time::interval(std::time::Duration::from_secs(ping_interval));
@@ -1313,137 +402,30 @@ impl FeishuBot {
                         info!("Feishu bot message loop stopped by signal");
                         return;
                     }
-                    msg = read.next() => {
+                    msg = connection.next_event() => {
                         match msg {
-                            Some(Ok(WsMessage::Binary(data))) => {
-                                let frame = match pb::decode_frame(&data) {
-                                    Some(f) => f,
-                                    None => continue,
-                                };
-
-                                match frame.method {
-                                    pb::FRAME_TYPE_DATA => {
-                                        let msg_type = frame.get_header("type").unwrap_or("");
-                                        if msg_type == "event" {
-                                            if let Ok(event) = serde_json::from_slice::<serde_json::Value>(&frame.payload) {
-                                                // Send ack
-                                                let resp = pb::Frame::new_response(&frame, 200);
-                                                let _ = write
-                                                    .write()
-                                                    .await
-                                                    .send(WsMessage::Binary(pb::encode_frame(&resp).into()))
-                                                    .await;
-
-                                                if let Some(parsed) = Self::parse_message_event_full(&event) {
-                                                    let bot = self.clone();
-                                                    tokio::spawn(async move {
-                                                        const MAX_IMAGES: usize = 5;
-                                                        let language = current_bot_language().await;
-                                                        let truncated = parsed.image_keys.len() > MAX_IMAGES;
-                                                        let keys_to_use = if truncated {
-                                                            &parsed.image_keys[..MAX_IMAGES]
-                                                        } else {
-                                                            &parsed.image_keys
-                                                        };
-                                                        let images = if keys_to_use.is_empty() {
-                                                            vec![]
-                                                        } else {
-                                                            bot.download_images(&parsed.message_id, keys_to_use).await
-                                                        };
-                                                        if truncated {
-                                                            let msg = format!(
-                                                                "{} {} {}",
-                                                                if language.is_chinese() {
-                                                                    "仅会处理前"
-                                                                } else {
-                                                                    "Only the first"
-                                                                },
-                                                                MAX_IMAGES,
-                                                                if language.is_chinese() {
-                                                                    format!(
-                                                                        "张图片，其余 {} 张已丢弃。",
-                                                                        parsed.image_keys.len() - MAX_IMAGES
-                                                                    )
-                                                                } else {
-                                                                    format!(
-                                                                        "images will be processed; the remaining {} were discarded.",
-                                                                        parsed.image_keys.len() - MAX_IMAGES
-                                                                    )
-                                                                },
-                                                            );
-                                                            bot.send_message(&parsed.chat_id, &msg).await.ok();
-                                                        }
-                                                        let text = if parsed.text.is_empty() && !images.is_empty() {
-                                                            if language.is_chinese() {
-                                                                "[用户发送了一张图片]".to_string()
-                                                            } else {
-                                                                "[User sent an image]".to_string()
-                                                            }
-                                                        } else {
-                                                            parsed.text
-                                                        };
-                                                        bot.handle_incoming_message(
-                                                            &parsed.chat_id,
-                                                            &text,
-                                                            images,
-                                                        )
-                                                        .await;
-                                                    });
-                                                } else if let Some((chat_id, cmd)) = Self::parse_card_action_event(&event) {
-                                                    let bot = self.clone();
-                                                    tokio::spawn(async move {
-                                                        bot.handle_incoming_message(
-                                                            &chat_id,
-                                                            &cmd,
-                                                            vec![],
-                                                        )
-                                                        .await;
-                                                    });
-                                                } else if let Some(chat_id) = Self::extract_message_chat_id(&event) {
-                                                    let bot = self.clone();
-                                                    tokio::spawn(async move {
-                                                        let language = current_bot_language().await;
-                                                        bot.send_message(
-                                                            &chat_id,
-                                                            Self::unsupported_message_type_message(language),
-                                                        ).await.ok();
-                                                    });
-                                                }
-                                            }
-                                        }
-                                    }
-                                    pb::FRAME_TYPE_CONTROL => {
-                                        debug!("Feishu WS control: type={}", frame.get_header("type").unwrap_or("?"));
-                                    }
-                                    _ => {}
-                                }
+                            Ok(Some(event)) => {
+                                let _ = connection.ack_event(&event).await;
+                                self.handle_event_payload(event.payload()).await;
                             }
-                            Some(Ok(WsMessage::Ping(data))) => {
-                                let _ = write.write().await.send(WsMessage::Pong(data)).await;
-                            }
-                            Some(Err(e)) => {
-                                error!("Feishu WS error: {e}");
-                                break;
-                            }
-                            None => {
+                            Ok(None) => {
                                 warn!("Feishu WS closed, reconnecting...");
                                 break;
                             }
-                            _ => {}
+                            Err(e) => {
+                                error!("Feishu WS error: {e}");
+                                break;
+                            }
                         }
                     }
                     _ = ping_timer.tick() => {
-                        let ping = pb::Frame::new_ping(service_id);
-                        let _ = write
-                            .write()
-                            .await
-                            .send(WsMessage::Binary(pb::encode_frame(&ping).into()))
-                            .await;
+                        let _ = connection.send_ping(service_id).await;
                     }
                 }
             }
 
-            let reconnect_interval = config
+            let reconnect_interval = endpoint
+                .client_config
                 .get("ReconnectInterval")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(3);
@@ -1451,11 +433,60 @@ impl FeishuBot {
         }
     }
 
+    async fn handle_event_payload(self: &Arc<Self>, payload: &[u8]) {
+        let Ok(event) = serde_json::from_slice::<serde_json::Value>(payload) else {
+            return;
+        };
+
+        if let Some(parsed) = feishu_provider::parse_message_event_full(&event) {
+            let bot = self.clone();
+            tokio::spawn(async move {
+                const MAX_IMAGES: usize = 5;
+                let language = current_bot_language().await;
+                let truncated = parsed.image_keys.len() > MAX_IMAGES;
+                let keys_to_use = if truncated {
+                    &parsed.image_keys[..MAX_IMAGES]
+                } else {
+                    &parsed.image_keys
+                };
+                let images = if keys_to_use.is_empty() {
+                    vec![]
+                } else {
+                    bot.download_images(&parsed.message_id, keys_to_use).await
+                };
+                if truncated {
+                    let discarded = parsed.image_keys.len() - MAX_IMAGES;
+                    let msg = Self::image_truncated_message(language, MAX_IMAGES, discarded);
+                    bot.send_message(&parsed.chat_id, &msg).await.ok();
+                }
+                let text = if parsed.text.is_empty() && !images.is_empty() {
+                    Self::image_placeholder_message(language)
+                } else {
+                    parsed.text
+                };
+                bot.handle_incoming_message(&parsed.chat_id, &text, images)
+                    .await;
+            });
+        } else if let Some((chat_id, cmd)) = feishu_provider::parse_card_action_event(&event) {
+            let bot = self.clone();
+            tokio::spawn(async move {
+                bot.handle_incoming_message(&chat_id, &cmd, vec![]).await;
+            });
+        } else if let Some(chat_id) = feishu_provider::extract_message_chat_id(&event) {
+            let bot = self.clone();
+            tokio::spawn(async move {
+                let language = current_bot_language().await;
+                bot.send_message(&chat_id, Self::unsupported_message_type_message(language))
+                    .await
+                    .ok();
+            });
+        }
+    }
     async fn handle_incoming_message(
         self: &Arc<Self>,
         chat_id: &str,
         text: &str,
-        images: Vec<super::super::remote_server::ImageAttachment>,
+        images: Vec<ImageAttachment>,
     ) {
         let mut states = self.chat_states.write().await;
         let state = states.entry(chat_id.to_string()).or_insert_with(|| {
@@ -1567,8 +598,8 @@ impl FeishuBot {
             bot_type: "feishu".to_string(),
             chat_id: chat_id.to_string(),
             config: BotConfig::Feishu {
-                app_id: self.config.app_id.clone(),
-                app_secret: self.config.app_secret.clone(),
+                app_id: self.api.config().app_id.clone(),
+                app_secret: self.api.config().app_secret.clone(),
             },
             chat_state: state.clone(),
             connected_at: chrono::Utc::now().timestamp(),
@@ -1579,8 +610,7 @@ impl FeishuBot {
 
 #[cfg(test)]
 mod tests {
-    use super::FeishuBot;
-    use crate::service::remote_connect::bot::command_router::BotLanguage;
+    use super::feishu_provider;
 
     #[test]
     fn parse_text_message_event() {
@@ -1595,7 +625,7 @@ mod tests {
             }
         });
 
-        let parsed = FeishuBot::parse_ws_event(&event);
+        let parsed = feishu_provider::parse_message_event_full(&event).map(|p| (p.chat_id, p.text));
         assert_eq!(
             parsed,
             Some(("oc_test_chat".to_string(), "/help".to_string()))
@@ -1619,20 +649,10 @@ mod tests {
             }
         });
 
-        let parsed = FeishuBot::parse_ws_event(&event);
+        let parsed = feishu_provider::parse_card_action_event(&event);
         assert_eq!(
             parsed,
             Some(("oc_actual".to_string(), "/switch_workspace".to_string()))
         );
-    }
-
-    #[test]
-    fn card_body_removes_slash_command_list() {
-        let body = FeishuBot::card_body_text(
-            BotLanguage::EnUS,
-            "Available commands:\n/switch_workspace - List and switch workspaces\n/help - Show this help message",
-        );
-
-        assert_eq!(body, "Available commands:\n\nChoose an action below.");
     }
 }

--- a/src/crates/assembly/core/src/service/remote_connect/bot/telegram.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/bot/telegram.rs
@@ -5,8 +5,11 @@
 //! API (long polling) and routes messages through the shared command router.
 
 use anyhow::{anyhow, Result};
-use log::{debug, error, info, warn};
-use serde::{Deserialize, Serialize};
+use bitfun_services_integrations::remote_connect::bot::telegram::TelegramBotApi;
+pub use bitfun_services_integrations::remote_connect::bot::telegram::{
+    TelegramConfig, MAX_TELEGRAM_FILE_BYTES,
+};
+use log::{error, info, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -19,13 +22,8 @@ use super::command_router::{
 use super::{load_bot_persistence, save_bot_persistence, BotConfig, SavedBotConnection};
 use crate::service::remote_connect::remote_server::ImageAttachment;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TelegramConfig {
-    pub bot_token: String,
-}
-
 pub struct TelegramBot {
-    config: TelegramConfig,
+    api: TelegramBotApi,
     pending_pairings: Arc<RwLock<HashMap<String, PendingPairing>>>,
     last_update_id: Arc<RwLock<i64>>,
     chat_states: Arc<RwLock<HashMap<i64, BotChatState>>>,
@@ -34,39 +32,6 @@ pub struct TelegramBot {
 #[derive(Debug, Clone)]
 struct PendingPairing {
     created_at: i64,
-}
-
-/// Telegram Bot API hard limit for `sendDocument` uploads (50 MB), aligned
-/// across all IM platforms by capping at 30 MB to match Feishu / WeChat.
-const MAX_TELEGRAM_FILE_BYTES: u64 = 30 * 1024 * 1024;
-
-/// Telegram caps `sendMessage.text` at 4096 UTF-16 code units. We chunk on
-/// char boundaries and stay slightly under the limit to leave headroom for
-/// any client-side counting differences.
-const MAX_TELEGRAM_TEXT_CHUNK: usize = 4000;
-
-fn chunk_text_for_telegram(text: &str) -> Vec<String> {
-    if text.len() <= MAX_TELEGRAM_TEXT_CHUNK {
-        return vec![text.to_string()];
-    }
-    let mut out = Vec::new();
-    let mut rest = text;
-    while !rest.is_empty() {
-        if rest.len() <= MAX_TELEGRAM_TEXT_CHUNK {
-            out.push(rest.to_string());
-            break;
-        }
-        let mut cut = MAX_TELEGRAM_TEXT_CHUNK;
-        while cut > 0 && !rest.is_char_boundary(cut) {
-            cut -= 1;
-        }
-        if cut == 0 {
-            cut = rest.chars().next().map(|c| c.len_utf8()).unwrap_or(1);
-        }
-        out.push(rest[..cut].to_string());
-        rest = &rest[cut..];
-    }
-    out
 }
 
 impl TelegramBot {
@@ -88,7 +53,7 @@ impl TelegramBot {
 
     pub fn new(config: TelegramConfig) -> Self {
         Self {
-            config,
+            api: TelegramBotApi::new(config),
             pending_pairings: Arc::new(RwLock::new(HashMap::new())),
             last_update_id: Arc::new(RwLock::new(0)),
             chat_states: Arc::new(RwLock::new(HashMap::new())),
@@ -100,36 +65,8 @@ impl TelegramBot {
         self.chat_states.write().await.insert(chat_id, state);
     }
 
-    fn api_url(&self, method: &str) -> String {
-        format!(
-            "https://api.telegram.org/bot{}/{}",
-            self.config.bot_token, method
-        )
-    }
-
     pub async fn send_message(&self, chat_id: i64, text: &str) -> Result<()> {
-        let client = reqwest::Client::new();
-        // Telegram caps a single sendMessage at 4096 UTF-16 code units. We
-        // conservatively chunk on byte/char boundaries so long agent
-        // replies are delivered as multiple messages instead of being
-        // rejected or silently dropped.
-        for chunk in chunk_text_for_telegram(text) {
-            let resp = client
-                .post(self.api_url("sendMessage"))
-                .json(&serde_json::json!({
-                    "chat_id": chat_id,
-                    "text": chunk,
-                }))
-                .send()
-                .await?;
-
-            if !resp.status().is_success() {
-                let body = resp.text().await.unwrap_or_default();
-                return Err(anyhow!("telegram sendMessage failed: {body}"));
-            }
-        }
-        debug!("Telegram message sent to chat {chat_id}");
-        Ok(())
+        self.api.send_message(chat_id, text).await
     }
 
     /// Send a message with Telegram inline keyboard buttons.
@@ -146,64 +83,15 @@ impl TelegramBot {
         text: &str,
         actions: &[BotAction],
     ) -> Result<()> {
-        // Build inline keyboard: one button per row for clarity.
-        let keyboard: Vec<Vec<serde_json::Value>> = actions
-            .iter()
-            .map(|action| {
-                vec![serde_json::json!({
-                    "text": action.label,
-                    "callback_data": action.command,
-                })]
-            })
-            .collect();
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(self.api_url("sendMessage"))
-            .json(&serde_json::json!({
-                "chat_id": chat_id,
-                "text": text,
-                "reply_markup": {
-                    "inline_keyboard": keyboard,
-                },
-            }))
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("telegram sendMessage (keyboard) failed: {body}"));
-        }
-        debug!("Telegram keyboard message sent to chat {chat_id}");
-        Ok(())
+        self.api
+            .send_message_with_keyboard(chat_id, text, actions)
+            .await
     }
 
     /// Send a local file to a Telegram chat as a document attachment.
     /// Caller is expected to pre-check the size against `MAX_TELEGRAM_FILE_BYTES`.
     async fn send_file_as_document(&self, chat_id: i64, file_path: &str) -> Result<()> {
-        let content = super::read_workspace_file(file_path, MAX_TELEGRAM_FILE_BYTES, None).await?;
-
-        let part = reqwest::multipart::Part::bytes(content.bytes)
-            .file_name(content.name.clone())
-            .mime_str("application/octet-stream")?;
-
-        let form = reqwest::multipart::Form::new()
-            .text("chat_id", chat_id.to_string())
-            .part("document", part);
-
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(self.api_url("sendDocument"))
-            .multipart(form)
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("telegram sendDocument failed: {body}"));
-        }
-        debug!("Telegram document sent to chat {chat_id}: {}", content.name);
-        Ok(())
+        self.api.send_file_as_document(chat_id, file_path).await
     }
 
     /// Scan `text` for downloadable file references and push every matching
@@ -256,16 +144,6 @@ impl TelegramBot {
         }
     }
 
-    /// Acknowledge a callback query so Telegram removes the button loading state.
-    async fn answer_callback_query(&self, callback_query_id: &str) {
-        let client = reqwest::Client::new();
-        let _ = client
-            .post(self.api_url("answerCallbackQuery"))
-            .json(&serde_json::json!({ "callback_query_id": callback_query_id }))
-            .send()
-            .await;
-    }
-
     /// Send a `HandleResult`, using an inline keyboard when actions are present.
     ///
     /// For the "Processing your message…" reply the cancel command line in the
@@ -300,31 +178,7 @@ impl TelegramBot {
 
     /// Register the bot command menu visible in Telegram's "/" menu.
     pub async fn set_bot_commands(&self) -> Result<()> {
-        let client = reqwest::Client::new();
-        let commands = serde_json::json!({
-            "commands": [
-                { "command": "menu", "description": "Show the main menu" },
-                { "command": "new", "description": "Create a new session" },
-                { "command": "resume", "description": "Resume an existing session" },
-                { "command": "switch", "description": "Switch assistant or workspace" },
-                { "command": "model", "description": "Switch the session model" },
-                { "command": "cancel", "description": "Cancel the current task" },
-                { "command": "expert", "description": "Switch to Expert mode" },
-                { "command": "assistant", "description": "Switch to Assistant mode" },
-                { "command": "settings", "description": "Open settings" },
-                { "command": "help", "description": "Show help" },
-            ]
-        });
-        let resp = client
-            .post(self.api_url("setMyCommands"))
-            .json(&commands)
-            .send()
-            .await?;
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            warn!("Failed to set Telegram bot commands: {body}");
-        }
-        Ok(())
+        self.api.set_bot_commands().await
     }
 
     pub async fn register_pairing(&self, pairing_code: &str) -> Result<()> {
@@ -346,149 +200,17 @@ impl TelegramBot {
         false
     }
 
-    /// Download a Telegram photo by file_id and return it as an `ImageAttachment`.
-    ///
-    /// Telegram photo updates contain multiple `PhotoSize` entries; callers should
-    /// pass the `file_id` of the last (largest) entry.
-    async fn download_photo(&self, file_id: &str) -> Result<ImageAttachment> {
-        let client = reqwest::Client::new();
-
-        // Step 1: resolve file_path via getFile
-        let get_file_url = self.api_url("getFile");
-        let resp = client
-            .post(&get_file_url)
-            .json(&serde_json::json!({ "file_id": file_id }))
-            .send()
-            .await?;
-        let body: serde_json::Value = resp.json().await?;
-        let file_path = body
-            .pointer("/result/file_path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow!("Telegram getFile: missing file_path for file_id={file_id}"))?
-            .to_string();
-
-        // Step 2: download the actual bytes
-        let download_url = format!(
-            "https://api.telegram.org/file/bot{}/{}",
-            self.config.bot_token, file_path
-        );
-        let bytes = client.get(&download_url).send().await?.bytes().await?;
-
-        // Step 3: encode as base64 data-URL
-        use base64::Engine as _;
-        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-        let mime_type = if file_path.ends_with(".jpg") || file_path.ends_with(".jpeg") {
-            "image/jpeg"
-        } else if file_path.ends_with(".png") {
-            "image/png"
-        } else if file_path.ends_with(".gif") {
-            "image/gif"
-        } else if file_path.ends_with(".webp") {
-            "image/webp"
-        } else {
-            "image/jpeg"
-        };
-        let data_url = format!("data:{mime_type};base64,{b64}");
-        let name = file_path
-            .rsplit('/')
-            .next()
-            .unwrap_or("photo.jpg")
-            .to_string();
-
-        debug!(
-            "Telegram photo downloaded: file_id={file_id}, size={}B",
-            bytes.len()
-        );
-        Ok(ImageAttachment { name, data_url })
-    }
-
     /// Returns `(chat_id, text, images)` tuples for each incoming message.
-    ///
-    /// Handles both plain-text messages and photo messages with an optional
-    /// caption.  For photo messages the highest-resolution variant is downloaded
-    /// and returned as an `ImageAttachment`.
     pub async fn poll_updates(&self) -> Result<Vec<(i64, String, Vec<ImageAttachment>)>> {
-        let offset = *self.last_update_id.read().await;
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(35))
-            .build()?;
-
-        let resp = client
-            .get(self.api_url("getUpdates"))
-            .query(&[
-                ("offset", (offset + 1).to_string()),
-                ("timeout", "30".to_string()),
-            ])
-            .send()
-            .await?;
-
-        let body: serde_json::Value = resp.json().await?;
-        let results = body["result"].as_array().cloned().unwrap_or_default();
-
-        let mut messages = Vec::new();
-        for update in results {
-            if let Some(update_id) = update["update_id"].as_i64() {
-                let mut last = self.last_update_id.write().await;
-                if update_id > *last {
-                    *last = update_id;
-                }
-            }
-
-            // Inline keyboard button press – treat callback_data as a message.
-            if let Some(cq) = update.get("callback_query") {
-                let cq_id = cq["id"].as_str().unwrap_or("").to_string();
-                let chat_id = cq.pointer("/message/chat/id").and_then(|v| v.as_i64());
-                let data = cq["data"].as_str().map(|s| s.trim().to_string());
-                if let (Some(chat_id), Some(data)) = (chat_id, data) {
-                    // Answer the callback query to dismiss the button spinner.
-                    self.answer_callback_query(&cq_id).await;
-                    messages.push((chat_id, data, vec![]));
-                }
-                continue;
-            }
-
-            let Some(chat_id) = update.pointer("/message/chat/id").and_then(|v| v.as_i64()) else {
-                continue;
-            };
-
-            // Plain-text message
-            if let Some(text) = update.pointer("/message/text").and_then(|v| v.as_str()) {
-                messages.push((chat_id, text.trim().to_string(), vec![]));
-                continue;
-            }
-
-            // Photo message (caption is optional)
-            if let Some(photo_array) = update.pointer("/message/photo").and_then(|v| v.as_array()) {
-                // The last PhotoSize entry has the highest resolution
-                let file_id = photo_array
-                    .last()
-                    .and_then(|p| p["file_id"].as_str())
-                    .map(|s| s.to_string());
-
-                let caption = update
-                    .pointer("/message/caption")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .trim()
-                    .to_string();
-
-                let images = if let Some(fid) = file_id {
-                    match self.download_photo(&fid).await {
-                        Ok(attachment) => vec![attachment],
-                        Err(e) => {
-                            warn!("Failed to download Telegram photo file_id={fid}: {e}");
-                            vec![]
-                        }
-                    }
-                } else {
-                    vec![]
-                };
-
-                messages.push((chat_id, caption, images));
-            }
+        let last_update_id = *self.last_update_id.read().await;
+        let (new_last_update_id, messages) = self.api.poll_updates(last_update_id).await?;
+        if new_last_update_id > last_update_id {
+            *self.last_update_id.write().await = new_last_update_id;
         }
-
-        Ok(messages)
+        Ok(messages
+            .into_iter()
+            .map(|message| (message.chat_id, message.text, message.images))
+            .collect())
     }
 
     /// Start a polling loop that checks for pairing codes.
@@ -704,7 +426,7 @@ impl TelegramBot {
             bot_type: "telegram".to_string(),
             chat_id: chat_id.to_string(),
             config: BotConfig::Telegram {
-                bot_token: self.config.bot_token.clone(),
+                bot_token: self.api.config().bot_token.clone(),
             },
             chat_state: state.clone(),
             connected_at: chrono::Utc::now().timestamp(),

--- a/src/crates/services/services-integrations/AGENTS.md
+++ b/src/crates/services/services-integrations/AGENTS.md
@@ -22,9 +22,9 @@ slices that are outside pure product logic but still platform-neutral.
   owner move proves behavior equivalence.
 - Remote-connect platform-neutral primitives belong here: device identity,
   pairing/encryption, QR payload generation, relay client protocol, dialog/cancel
-  orchestration ports, LAN/ngrok provider helpers, mobile-web relay upload,
-  image-context adapter contracts, remote workspace helpers, and command/response
-  assembly.
+  orchestration ports, LAN/ngrok provider helpers, IM bot provider clients,
+  mobile-web relay upload, image-context adapter contracts, remote workspace
+  helpers, and command/response assembly.
 - Remote workspace facts, session metadata, file projection DTOs, and
   workspace/projection host traits belong in `bitfun-runtime-ports`.
 - Workspace-root source selection, persistence/workspace service reads,

--- a/src/crates/services/services-integrations/src/remote_connect/bot/feishu.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/feishu.rs
@@ -1,0 +1,1080 @@
+//! Feishu provider client and WebSocket protocol helpers for Remote Connect.
+
+use anyhow::{anyhow, Result};
+use futures::{SinkExt, StreamExt};
+use log::{debug, info, warn};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+use super::{BotAction, BotActionStyle, BotLanguage};
+
+type FeishuWsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+type FeishuWsWrite = futures::stream::SplitSink<FeishuWsStream, WsMessage>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeishuConfig {
+    pub app_id: String,
+    pub app_secret: String,
+}
+
+#[derive(Debug, Clone)]
+struct FeishuToken {
+    access_token: String,
+    expires_at: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeishuWsEndpoint {
+    pub url: String,
+    pub client_config: serde_json::Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeishuParsedMessage {
+    pub chat_id: String,
+    pub message_id: String,
+    pub text: String,
+    pub image_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeishuDownloadedImage {
+    pub content_type: String,
+    pub bytes: Vec<u8>,
+}
+
+pub struct FeishuBotApi {
+    config: FeishuConfig,
+    token: Arc<RwLock<Option<FeishuToken>>>,
+}
+
+/// Feishu IM file-upload hard limit (30 MB).
+pub const MAX_FEISHU_FILE_BYTES: u64 = 30 * 1024 * 1024;
+
+impl FeishuBotApi {
+    pub fn new(config: FeishuConfig) -> Self {
+        Self {
+            config,
+            token: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub fn config(&self) -> &FeishuConfig {
+        &self.config
+    }
+
+    async fn get_access_token(&self) -> Result<String> {
+        {
+            let guard = self.token.read().await;
+            if let Some(t) = guard.as_ref() {
+                if t.expires_at > chrono::Utc::now().timestamp() + 60 {
+                    return Ok(t.access_token.clone());
+                }
+            }
+        }
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal")
+            .json(&serde_json::json!({
+                "app_id": self.config.app_id,
+                "app_secret": self.config.app_secret,
+            }))
+            .send()
+            .await
+            .map_err(|e| anyhow!("feishu token request: {e}"))?;
+
+        let token_resp_text = resp.text().await.unwrap_or_default();
+        let body: serde_json::Value = serde_json::from_str(&token_resp_text).map_err(|e| {
+            anyhow!(
+                "feishu token response parse error: {e}, body: {}",
+                truncate_for_error(&token_resp_text, 200)
+            )
+        })?;
+        let access_token = body["tenant_access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("missing tenant_access_token in response"))?
+            .to_string();
+        let expire = body["expire"].as_i64().unwrap_or(7200);
+
+        *self.token.write().await = Some(FeishuToken {
+            access_token: access_token.clone(),
+            expires_at: chrono::Utc::now().timestamp() + expire,
+        });
+
+        info!("Feishu access token refreshed");
+        Ok(access_token)
+    }
+
+    pub async fn send_message(&self, chat_id: &str, content: &str) -> Result<()> {
+        let token = self.get_access_token().await?;
+        let card = build_markdown_card(content);
+        let client = reqwest::Client::new();
+        let resp = client
+            .post("https://open.feishu.cn/open-apis/im/v1/messages")
+            .query(&[("receive_id_type", "chat_id")])
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "receive_id": chat_id,
+                "msg_type": "interactive",
+                "content": serde_json::to_string(&card)?,
+            }))
+            .send()
+            .await?;
+
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("feishu send_message HTTP {status}: {body}"));
+        }
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) {
+            if let Some(code) = parsed.get("code").and_then(|c| c.as_i64()) {
+                if code != 0 {
+                    let msg = parsed
+                        .get("msg")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown");
+                    warn!("Feishu send_message API error: code={code}, msg={msg}");
+                    return Err(anyhow!(
+                        "feishu send_message API error: code={code}, msg={msg}"
+                    ));
+                }
+            }
+        }
+        debug!("Feishu message sent to {chat_id}");
+        Ok(())
+    }
+
+    pub async fn send_action_card(
+        &self,
+        chat_id: &str,
+        language: BotLanguage,
+        content: &str,
+        actions: &[BotAction],
+    ) -> Result<()> {
+        let token = self.get_access_token().await?;
+        let client = reqwest::Client::new();
+        let card = build_action_card(chat_id, language, content, actions);
+        let resp = client
+            .post("https://open.feishu.cn/open-apis/im/v1/messages")
+            .query(&[("receive_id_type", "chat_id")])
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "receive_id": chat_id,
+                "msg_type": "interactive",
+                "content": serde_json::to_string(&card)?,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("feishu send_action_card failed: {body}"));
+        }
+        debug!("Feishu action card sent to {chat_id}");
+        Ok(())
+    }
+
+    /// Download a user-sent image from a Feishu message using the message resources API.
+    pub async fn download_image_resource(
+        &self,
+        message_id: &str,
+        file_key: &str,
+    ) -> Result<FeishuDownloadedImage> {
+        let token = self.get_access_token().await?;
+        let client = reqwest::Client::new();
+        let url = format!(
+            "https://open.feishu.cn/open-apis/im/v1/messages/{}/resources/{}?type=image",
+            message_id, file_key
+        );
+        let resp = client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| anyhow!("feishu download image: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "feishu image download failed: HTTP {status} \u{2014} {body}"
+            ));
+        }
+
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("image/png")
+            .to_string();
+        let bytes = resp.bytes().await?.to_vec();
+
+        Ok(FeishuDownloadedImage {
+            content_type,
+            bytes,
+        })
+    }
+
+    /// Upload a local file and send it to a Feishu chat as a file message.
+    pub async fn send_file_to_chat(&self, chat_id: &str, file_path: &str) -> Result<()> {
+        let file_key = self.upload_file(file_path).await?;
+        let token = self.get_access_token().await?;
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post("https://open.feishu.cn/open-apis/im/v1/messages")
+            .query(&[("receive_id_type", "chat_id")])
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "receive_id": chat_id,
+                "msg_type": "file",
+                "content": serde_json::to_string(&serde_json::json!({"file_key": file_key}))?,
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("Feishu file message failed: {body}"));
+        }
+        debug!("Feishu file sent to {chat_id}: {file_path}");
+        Ok(())
+    }
+
+    async fn upload_file(&self, file_path: &str) -> Result<String> {
+        let token = self.get_access_token().await?;
+        let content = super::read_workspace_file(file_path, MAX_FEISHU_FILE_BYTES, None).await?;
+
+        let ext = std::path::Path::new(&content.name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        let file_type = match ext.as_str() {
+            "pdf" => "pdf",
+            "doc" | "docx" => "doc",
+            "xls" | "xlsx" => "xls",
+            "ppt" | "pptx" => "ppt",
+            "mp4" => "mp4",
+            _ => "stream",
+        };
+
+        let part = reqwest::multipart::Part::bytes(content.bytes)
+            .file_name(content.name.clone())
+            .mime_str("application/octet-stream")?;
+
+        let form = reqwest::multipart::Form::new()
+            .text("file_type", file_type.to_string())
+            .text("file_name", content.name)
+            .part("file", part);
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post("https://open.feishu.cn/open-apis/im/v1/files")
+            .bearer_auth(&token)
+            .multipart(form)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("Feishu file upload failed: {body}"));
+        }
+
+        let body: serde_json::Value = resp.json().await?;
+        body.pointer("/data/file_key")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow!("Feishu upload response missing file_key"))
+    }
+
+    /// Obtain a WebSocket URL from Feishu for long-connection event delivery.
+    pub async fn get_ws_endpoint(&self) -> Result<FeishuWsEndpoint> {
+        let client = reqwest::Client::new();
+        let resp = client
+            .post("https://open.feishu.cn/callback/ws/endpoint")
+            .json(&serde_json::json!({
+                "AppID": self.config.app_id,
+                "AppSecret": self.config.app_secret,
+            }))
+            .send()
+            .await
+            .map_err(|e| anyhow!("feishu ws endpoint request: {e}"))?;
+
+        let ws_resp_text = resp.text().await.unwrap_or_default();
+        let body: serde_json::Value = serde_json::from_str(&ws_resp_text).map_err(|e| {
+            anyhow!(
+                "feishu ws endpoint parse error: {e}, body: {}",
+                truncate_for_error(&ws_resp_text, 300)
+            )
+        })?;
+        let code = body["code"].as_i64().unwrap_or(-1);
+        if code != 0 {
+            let msg = body["msg"].as_str().unwrap_or("unknown error");
+            return Err(anyhow!("feishu ws endpoint error {code}: {msg}"));
+        }
+
+        let url = body
+            .pointer("/data/URL")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing WebSocket URL in feishu response"))?
+            .to_string();
+        let client_config = body
+            .pointer("/data/ClientConfig")
+            .cloned()
+            .unwrap_or_default();
+
+        Ok(FeishuWsEndpoint { url, client_config })
+    }
+
+    pub async fn connect_ws(&self, url: &str) -> Result<FeishuWsConnection> {
+        let (ws_stream, _) = tokio_tungstenite::connect_async(url)
+            .await
+            .map_err(|e| anyhow!("feishu ws connect: {e}"))?;
+        let (write, read) = ws_stream.split();
+        Ok(FeishuWsConnection {
+            write: Arc::new(RwLock::new(write)),
+            read,
+        })
+    }
+}
+
+pub struct FeishuWsEvent {
+    payload: Vec<u8>,
+    response: FeishuFrame,
+}
+
+impl FeishuWsEvent {
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+pub struct FeishuWsConnection {
+    write: Arc<RwLock<FeishuWsWrite>>,
+    read: futures::stream::SplitStream<FeishuWsStream>,
+}
+
+impl FeishuWsConnection {
+    async fn next_frame(&mut self) -> Result<Option<FeishuFrame>> {
+        loop {
+            match self.read.next().await {
+                Some(Ok(WsMessage::Binary(data))) => {
+                    if let Some(frame) = decode_frame(&data) {
+                        return Ok(Some(frame));
+                    }
+                    debug!("Ignoring undecodable Feishu WS binary frame");
+                }
+                Some(Ok(WsMessage::Ping(data))) => {
+                    let _ = self.write.write().await.send(WsMessage::Pong(data)).await;
+                }
+                Some(Ok(_)) => {}
+                Some(Err(e)) => return Err(anyhow!("feishu ws error: {e}")),
+                None => return Ok(None),
+            }
+        }
+    }
+
+    async fn send_frame(&self, frame: &FeishuFrame) -> Result<()> {
+        self.write
+            .write()
+            .await
+            .send(WsMessage::Binary(encode_frame(frame).into()))
+            .await
+            .map_err(|e| anyhow!("feishu ws send: {e}"))
+    }
+
+    pub async fn next_event(&mut self) -> Result<Option<FeishuWsEvent>> {
+        loop {
+            let Some(frame) = self.next_frame().await? else {
+                return Ok(None);
+            };
+            match frame.method {
+                FRAME_TYPE_DATA => {
+                    if frame.get_header("type").unwrap_or("") == "event" {
+                        let response = FeishuFrame::new_response(&frame, 200);
+                        return Ok(Some(FeishuWsEvent {
+                            payload: frame.payload,
+                            response,
+                        }));
+                    }
+                }
+                FRAME_TYPE_CONTROL => {
+                    debug!(
+                        "Feishu WS control frame: type={}",
+                        frame.get_header("type").unwrap_or("?")
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub async fn ack_event(&self, event: &FeishuWsEvent) -> Result<()> {
+        self.send_frame(&event.response).await
+    }
+
+    pub async fn send_ping(&self, service_id: i32) -> Result<()> {
+        let ping = FeishuFrame::new_ping(service_id);
+        self.send_frame(&ping).await
+    }
+}
+fn build_markdown_card(content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schema": "2.0",
+        "config": {
+            "wide_screen_mode": true,
+        },
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": content,
+                    "text_align": "left",
+                    "text_size": "normal",
+                    "margin": "0px 0px 0px 0px",
+                    "element_id": "bitfun_remote_reply_markdown",
+                }
+            ],
+        },
+    })
+}
+
+fn build_action_card(
+    chat_id: &str,
+    language: BotLanguage,
+    content: &str,
+    actions: &[BotAction],
+) -> serde_json::Value {
+    let body = card_body_text(language, content);
+    let mut elements = vec![serde_json::json!({
+        "tag": "markdown",
+        "content": body,
+    })];
+
+    for chunk in actions.chunks(2) {
+        let buttons: Vec<_> = chunk
+            .iter()
+            .map(|action| {
+                let button_type = match action.style {
+                    BotActionStyle::Primary => "primary",
+                    BotActionStyle::Default => "default",
+                };
+                serde_json::json!({
+                    "tag": "button",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": action.label,
+                    },
+                    "type": button_type,
+                    "value": {
+                        "chat_id": chat_id,
+                        "command": action.command,
+                    }
+                })
+            })
+            .collect();
+        elements.push(serde_json::json!({
+            "tag": "action",
+            "actions": buttons,
+        }));
+    }
+
+    serde_json::json!({
+        "config": {
+            "wide_screen_mode": true,
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "BitFun Remote Connect",
+            }
+        },
+        "elements": elements,
+    })
+}
+
+fn card_body_text(language: BotLanguage, content: &str) -> String {
+    let mut removed_command_lines = false;
+    let mut lines = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('/') && trimmed.contains(" - ") {
+            removed_command_lines = true;
+            continue;
+        }
+        if trimmed.contains("/cancel_task ") {
+            lines.push(if language.is_chinese() {
+                "如需停止本次请求，请使用下方的“取消任务”按钮。".to_string()
+            } else {
+                "If needed, use the Cancel Task button below to stop this request.".to_string()
+            });
+            continue;
+        }
+        lines.push(replace_command_tokens(language, line));
+    }
+
+    let mut body = lines.join("\n").trim().to_string();
+    if removed_command_lines {
+        if !body.is_empty() {
+            body.push_str("\n\n");
+        }
+        body.push_str(if language.is_chinese() {
+            "请选择下方操作。"
+        } else {
+            "Choose an action below."
+        });
+    }
+
+    if body.is_empty() {
+        if language.is_chinese() {
+            "请选择下方操作。".to_string()
+        } else {
+            "Choose an action below.".to_string()
+        }
+    } else {
+        body
+    }
+}
+
+fn replace_command_tokens(language: BotLanguage, line: &str) -> String {
+    let replacements = [
+        (
+            "/switch_workspace",
+            if language.is_chinese() {
+                "切换工作区"
+            } else {
+                "Switch Workspace"
+            },
+        ),
+        (
+            "/pro",
+            if language.is_chinese() {
+                "专业模式"
+            } else {
+                "Expert Mode"
+            },
+        ),
+        (
+            "/assistant",
+            if language.is_chinese() {
+                "助理模式"
+            } else {
+                "Assistant Mode"
+            },
+        ),
+        (
+            "/resume_session",
+            if language.is_chinese() {
+                "恢复会话"
+            } else {
+                "Resume Session"
+            },
+        ),
+        (
+            "/new_code_session",
+            if language.is_chinese() {
+                "新建编码会话"
+            } else {
+                "New Code Session"
+            },
+        ),
+        (
+            "/new_cowork_session",
+            if language.is_chinese() {
+                "新建协作会话"
+            } else {
+                "New Cowork Session"
+            },
+        ),
+        (
+            "/new_claw_session",
+            if language.is_chinese() {
+                "新建助理会话"
+            } else {
+                "New Claw Session"
+            },
+        ),
+        (
+            "/cancel_task",
+            if language.is_chinese() {
+                "取消任务"
+            } else {
+                "Cancel Task"
+            },
+        ),
+        (
+            "/help",
+            if language.is_chinese() {
+                "帮助"
+            } else {
+                "Help"
+            },
+        ),
+    ];
+
+    replacements
+        .iter()
+        .fold(line.to_string(), |acc, (from, to)| acc.replace(from, to))
+}
+
+pub fn parse_message_event_full(event: &serde_json::Value) -> Option<FeishuParsedMessage> {
+    let event_type = event
+        .pointer("/header/event_type")
+        .and_then(|v| v.as_str())?;
+    if event_type != "im.message.receive_v1" {
+        return None;
+    }
+
+    let chat_id = event
+        .pointer("/event/message/chat_id")
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let message_id = event
+        .pointer("/event/message/message_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let msg_type = event
+        .pointer("/event/message/message_type")
+        .and_then(|v| v.as_str())?;
+    let content_str = event
+        .pointer("/event/message/content")
+        .and_then(|v| v.as_str())?;
+    let content: serde_json::Value = serde_json::from_str(content_str).ok()?;
+
+    match msg_type {
+        "text" => {
+            let text = content["text"].as_str()?.trim().to_string();
+            if text.is_empty() {
+                return None;
+            }
+            Some(FeishuParsedMessage {
+                chat_id,
+                message_id,
+                text,
+                image_keys: vec![],
+            })
+        }
+        "post" => {
+            let (text, image_keys) = extract_from_post(&content);
+            if text.is_empty() && image_keys.is_empty() {
+                return None;
+            }
+            Some(FeishuParsedMessage {
+                chat_id,
+                message_id,
+                text,
+                image_keys,
+            })
+        }
+        "image" => {
+            let image_key = content["image_key"].as_str()?.to_string();
+            Some(FeishuParsedMessage {
+                chat_id,
+                message_id,
+                text: String::new(),
+                image_keys: vec![image_key],
+            })
+        }
+        _ => None,
+    }
+}
+
+fn extract_from_post(content: &serde_json::Value) -> (String, Vec<String>) {
+    let root = if content["content"].is_array() {
+        content
+    } else {
+        content
+            .get("zh_cn")
+            .or_else(|| content.get("en_us"))
+            .or_else(|| content.as_object().and_then(|obj| obj.values().next()))
+            .unwrap_or(content)
+    };
+
+    let paragraphs = match root["content"].as_array() {
+        Some(p) => p,
+        None => return (String::new(), vec![]),
+    };
+
+    let mut text_parts: Vec<String> = Vec::new();
+    let mut image_keys: Vec<String> = Vec::new();
+
+    for para in paragraphs {
+        if let Some(elements) = para.as_array() {
+            for elem in elements {
+                match elem["tag"].as_str().unwrap_or("") {
+                    "text" | "a" => {
+                        if let Some(t) = elem["text"].as_str() {
+                            let trimmed = t.trim();
+                            if !trimmed.is_empty() {
+                                text_parts.push(trimmed.to_string());
+                            }
+                        }
+                    }
+                    "img" => {
+                        if let Some(key) = elem["image_key"].as_str() {
+                            if !key.is_empty() {
+                                image_keys.push(key.to_string());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let title = root["title"].as_str().unwrap_or("").trim();
+    if !title.is_empty() {
+        text_parts.insert(0, title.to_string());
+    }
+
+    (text_parts.join(" "), image_keys)
+}
+
+pub fn parse_card_action_event(event: &serde_json::Value) -> Option<(String, String)> {
+    let event_type = event
+        .pointer("/header/event_type")
+        .and_then(|v| v.as_str())?;
+    if event_type != "card.action.trigger" {
+        return None;
+    }
+
+    let chat_id = event
+        .pointer("/event/action/value/chat_id")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            event
+                .pointer("/event/context/open_chat_id")
+                .and_then(|v| v.as_str())
+        })?
+        .to_string();
+    let command = event
+        .pointer("/event/action/value/command")
+        .and_then(|v| v.as_str())?
+        .trim()
+        .to_string();
+
+    Some((chat_id, command))
+}
+
+pub fn extract_message_chat_id(event: &serde_json::Value) -> Option<String> {
+    let event_type = event
+        .pointer("/header/event_type")
+        .and_then(|v| v.as_str())?;
+    if event_type != "im.message.receive_v1" {
+        return None;
+    }
+    event
+        .pointer("/event/message/chat_id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+#[cfg(test)]
+fn parse_message_event(event: &serde_json::Value) -> Option<(String, String)> {
+    let parsed = parse_message_event_full(event)?;
+    if parsed.text.is_empty() {
+        return None;
+    }
+    Some((parsed.chat_id, parsed.text))
+}
+
+#[cfg(test)]
+fn parse_ws_event(event: &serde_json::Value) -> Option<(String, String)> {
+    parse_message_event(event).or_else(|| parse_card_action_event(event))
+}
+
+pub fn extract_service_id_from_url(url: &str) -> i32 {
+    url.split('?')
+        .nth(1)
+        .and_then(|qs| {
+            qs.split('&').find_map(|pair| {
+                let mut kv = pair.splitn(2, '=');
+                match (kv.next(), kv.next()) {
+                    (Some("service_id"), Some(v)) => v.parse::<i32>().ok(),
+                    _ => None,
+                }
+            })
+        })
+        .unwrap_or(0)
+}
+
+fn truncate_for_error(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
+}
+
+#[derive(Debug, Default, Clone)]
+struct FeishuFrame {
+    pub seq_id: u64,
+    pub log_id: u64,
+    pub service: i32,
+    pub method: i32,
+    pub headers: Vec<(String, String)>,
+    pub payload_encoding: String,
+    pub payload_type: String,
+    pub payload: Vec<u8>,
+    pub log_id_new: String,
+}
+
+const FRAME_TYPE_CONTROL: i32 = 0;
+const FRAME_TYPE_DATA: i32 = 1;
+
+impl FeishuFrame {
+    fn get_header(&self, key: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn new_ping(service_id: i32) -> Self {
+        FeishuFrame {
+            method: FRAME_TYPE_CONTROL,
+            service: service_id,
+            headers: vec![("type".into(), "ping".into())],
+            ..Default::default()
+        }
+    }
+
+    fn new_response(original: &FeishuFrame, status_code: u16) -> Self {
+        let mut headers = original.headers.clone();
+        headers.push(("biz_rt".into(), "0".into()));
+        FeishuFrame {
+            seq_id: original.seq_id,
+            log_id: original.log_id,
+            service: original.service,
+            method: original.method,
+            headers,
+            payload: serde_json::to_vec(&serde_json::json!({"code": status_code}))
+                .unwrap_or_default(),
+            log_id_new: original.log_id_new.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+fn decode_varint(data: &[u8], pos: &mut usize) -> Option<u64> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        if *pos >= data.len() {
+            return None;
+        }
+        let byte = data[*pos];
+        *pos += 1;
+        result |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Some(result);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None;
+        }
+    }
+}
+
+fn encode_varint(mut val: u64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(10);
+    loop {
+        let mut byte = (val & 0x7F) as u8;
+        val >>= 7;
+        if val != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if val == 0 {
+            break;
+        }
+    }
+    buf
+}
+
+fn read_len<'a>(data: &'a [u8], pos: &mut usize) -> Option<&'a [u8]> {
+    let len = decode_varint(data, pos)? as usize;
+    if *pos + len > data.len() {
+        return None;
+    }
+    let slice = &data[*pos..*pos + len];
+    *pos += len;
+    Some(slice)
+}
+
+fn decode_header(data: &[u8]) -> Option<(String, String)> {
+    let mut pos = 0;
+    let (mut key, mut val) = (String::new(), String::new());
+    while pos < data.len() {
+        let tag = decode_varint(data, &mut pos)? as u32;
+        match (tag >> 3, tag & 7) {
+            (1, 2) => key = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
+            (2, 2) => val = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
+            (_, 0) => {
+                decode_varint(data, &mut pos)?;
+            }
+            (_, 2) => {
+                read_len(data, &mut pos)?;
+            }
+            _ => return None,
+        }
+    }
+    Some((key, val))
+}
+
+fn decode_frame(data: &[u8]) -> Option<FeishuFrame> {
+    let mut pos = 0;
+    let mut f = FeishuFrame::default();
+    while pos < data.len() {
+        let tag = decode_varint(data, &mut pos)? as u32;
+        match (tag >> 3, tag & 7) {
+            (1, 0) => f.seq_id = decode_varint(data, &mut pos)?,
+            (2, 0) => f.log_id = decode_varint(data, &mut pos)?,
+            (3, 0) => f.service = decode_varint(data, &mut pos)? as i32,
+            (4, 0) => f.method = decode_varint(data, &mut pos)? as i32,
+            (5, 2) => {
+                if let Some(h) = decode_header(read_len(data, &mut pos)?) {
+                    f.headers.push(h);
+                }
+            }
+            (6, 2) => {
+                f.payload_encoding = String::from_utf8_lossy(read_len(data, &mut pos)?).into()
+            }
+            (7, 2) => f.payload_type = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
+            (8, 2) => f.payload = read_len(data, &mut pos)?.to_vec(),
+            (9, 2) => f.log_id_new = String::from_utf8_lossy(read_len(data, &mut pos)?).into(),
+            (_, 0) => {
+                decode_varint(data, &mut pos)?;
+            }
+            (_, 2) => {
+                read_len(data, &mut pos)?;
+            }
+            (_, 5) => {
+                pos += 4;
+            }
+            (_, 1) => {
+                pos += 8;
+            }
+            _ => return None,
+        }
+    }
+    Some(f)
+}
+
+fn write_varint(buf: &mut Vec<u8>, field: u32, val: u64) {
+    buf.extend(encode_varint((field << 3) as u64));
+    buf.extend(encode_varint(val));
+}
+
+fn write_bytes(buf: &mut Vec<u8>, field: u32, data: &[u8]) {
+    buf.extend(encode_varint(((field << 3) | 2) as u64));
+    buf.extend(encode_varint(data.len() as u64));
+    buf.extend(data);
+}
+
+fn encode_header(key: &str, value: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_bytes(&mut buf, 1, key.as_bytes());
+    write_bytes(&mut buf, 2, value.as_bytes());
+    buf
+}
+
+fn encode_frame(frame: &FeishuFrame) -> Vec<u8> {
+    let mut buf = Vec::new();
+    write_varint(&mut buf, 1, frame.seq_id);
+    write_varint(&mut buf, 2, frame.log_id);
+    write_varint(&mut buf, 3, frame.service as u64);
+    write_varint(&mut buf, 4, frame.method as u64);
+    for (k, v) in &frame.headers {
+        let hdr = encode_header(k, v);
+        write_bytes(&mut buf, 5, &hdr);
+    }
+    if !frame.payload_encoding.is_empty() {
+        write_bytes(&mut buf, 6, frame.payload_encoding.as_bytes());
+    }
+    if !frame.payload_type.is_empty() {
+        write_bytes(&mut buf, 7, frame.payload_type.as_bytes());
+    }
+    if !frame.payload.is_empty() {
+        write_bytes(&mut buf, 8, &frame.payload);
+    }
+    if !frame.log_id_new.is_empty() {
+        write_bytes(&mut buf, 9, frame.log_id_new.as_bytes());
+    }
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_text_message_event() {
+        let event = serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1" },
+            "event": {
+                "message": {
+                    "message_type": "text",
+                    "chat_id": "oc_test_chat",
+                    "content": "{\"text\":\"/help\"}"
+                }
+            }
+        });
+
+        let parsed = parse_ws_event(&event);
+        assert_eq!(
+            parsed,
+            Some(("oc_test_chat".to_string(), "/help".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_card_action_event_uses_embedded_chat_id() {
+        let event = serde_json::json!({
+            "header": { "event_type": "card.action.trigger" },
+            "event": {
+                "context": {
+                    "open_chat_id": "oc_fallback"
+                },
+                "action": {
+                    "value": {
+                        "chat_id": "oc_actual",
+                        "command": "/switch_workspace"
+                    }
+                }
+            }
+        });
+
+        let parsed = parse_ws_event(&event);
+        assert_eq!(
+            parsed,
+            Some(("oc_actual".to_string(), "/switch_workspace".to_string()))
+        );
+    }
+
+    #[test]
+    fn card_body_removes_slash_command_list() {
+        let body = card_body_text(
+            BotLanguage::EnUS,
+            "Available commands:\n/switch_workspace - List and switch workspaces\n/help - Show this help message",
+        );
+
+        assert_eq!(body, "Available commands:\n\nChoose an action below.");
+    }
+
+    #[test]
+    fn decode_frame_rejects_malformed_binary_payload() {
+        assert!(decode_frame(b"not a feishu protobuf frame").is_none());
+    }
+}

--- a/src/crates/services/services-integrations/src/remote_connect/bot/mod.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/mod.rs
@@ -4,19 +4,23 @@
 //! concrete session/runtime dependencies are reduced to service ports.
 
 mod command;
+pub mod feishu;
 mod locale;
 mod menu;
 mod state;
+pub mod telegram;
 
 use serde::{Deserialize, Serialize};
 
 pub use command::{parse_command, BotCommand};
+pub use feishu::{FeishuBotApi, FeishuConfig};
 pub use locale::{fmt_count, strings_for, BotLanguage, BotStrings};
 pub use menu::{MenuItem, MenuItemStyle, MenuView};
 pub use state::{
     BotAction, BotActionStyle, BotChatState, BotDisplayMode, BotInteractionHandler,
     BotInteractiveRequest, BotMessageSender, BotQuestion, BotQuestionOption, PendingAction,
 };
+pub use telegram::{TelegramBotApi, TelegramConfig};
 
 /// Configuration for a bot-based connection.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/crates/services/services-integrations/src/remote_connect/bot/telegram.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/telegram.rs
@@ -1,0 +1,356 @@
+//! Telegram Bot API provider client for Remote Connect.
+
+use anyhow::{anyhow, Result};
+use log::debug;
+use serde::{Deserialize, Serialize};
+
+use super::BotAction;
+use crate::remote_connect::ImageAttachment;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelegramConfig {
+    pub bot_token: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TelegramIncomingMessage {
+    pub chat_id: i64,
+    pub text: String,
+    pub images: Vec<ImageAttachment>,
+}
+
+pub struct TelegramBotApi {
+    config: TelegramConfig,
+}
+
+/// Telegram Bot API hard limit for `sendDocument` uploads (50 MB), aligned
+/// across all IM platforms by capping at 30 MB to match Feishu / WeChat.
+pub const MAX_TELEGRAM_FILE_BYTES: u64 = 30 * 1024 * 1024;
+
+/// Telegram caps `sendMessage.text` at 4096 UTF-16 code units. We chunk on
+/// char boundaries and stay slightly under the limit to leave headroom for
+/// any client-side counting differences.
+const MAX_TELEGRAM_TEXT_CHUNK: usize = 4000;
+
+fn chunk_text_for_telegram(text: &str) -> Vec<String> {
+    if text.len() <= MAX_TELEGRAM_TEXT_CHUNK {
+        return vec![text.to_string()];
+    }
+    let mut out = Vec::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        if rest.len() <= MAX_TELEGRAM_TEXT_CHUNK {
+            out.push(rest.to_string());
+            break;
+        }
+        let mut cut = MAX_TELEGRAM_TEXT_CHUNK;
+        while cut > 0 && !rest.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        if cut == 0 {
+            cut = rest.chars().next().map(|c| c.len_utf8()).unwrap_or(1);
+        }
+        out.push(rest[..cut].to_string());
+        rest = &rest[cut..];
+    }
+    out
+}
+
+impl TelegramBotApi {
+    pub fn new(config: TelegramConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn config(&self) -> &TelegramConfig {
+        &self.config
+    }
+
+    fn api_url(&self, method: &str) -> String {
+        format!(
+            "https://api.telegram.org/bot{}/{}",
+            self.config.bot_token, method
+        )
+    }
+
+    pub async fn send_message(&self, chat_id: i64, text: &str) -> Result<()> {
+        let client = reqwest::Client::new();
+        for chunk in chunk_text_for_telegram(text) {
+            let resp = client
+                .post(self.api_url("sendMessage"))
+                .json(&serde_json::json!({
+                    "chat_id": chat_id,
+                    "text": chunk,
+                }))
+                .send()
+                .await?;
+
+            if !resp.status().is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                return Err(anyhow!("telegram sendMessage failed: {body}"));
+            }
+        }
+        debug!("Telegram message sent to chat {chat_id}");
+        Ok(())
+    }
+
+    /// Send a message with Telegram inline keyboard buttons.
+    pub async fn send_message_with_keyboard(
+        &self,
+        chat_id: i64,
+        text: &str,
+        actions: &[BotAction],
+    ) -> Result<()> {
+        let keyboard: Vec<Vec<serde_json::Value>> = actions
+            .iter()
+            .map(|action| {
+                vec![serde_json::json!({
+                    "text": action.label,
+                    "callback_data": action.command,
+                })]
+            })
+            .collect();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(self.api_url("sendMessage"))
+            .json(&serde_json::json!({
+                "chat_id": chat_id,
+                "text": text,
+                "reply_markup": {
+                    "inline_keyboard": keyboard,
+                },
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("telegram sendMessage (keyboard) failed: {body}"));
+        }
+        debug!("Telegram keyboard message sent to chat {chat_id}");
+        Ok(())
+    }
+
+    /// Send a local file to a Telegram chat as a document attachment.
+    pub async fn send_file_as_document(&self, chat_id: i64, file_path: &str) -> Result<()> {
+        let content = super::read_workspace_file(file_path, MAX_TELEGRAM_FILE_BYTES, None).await?;
+
+        let part = reqwest::multipart::Part::bytes(content.bytes)
+            .file_name(content.name.clone())
+            .mime_str("application/octet-stream")?;
+
+        let form = reqwest::multipart::Form::new()
+            .text("chat_id", chat_id.to_string())
+            .part("document", part);
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(self.api_url("sendDocument"))
+            .multipart(form)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("telegram sendDocument failed: {body}"));
+        }
+        debug!("Telegram document sent to chat {chat_id}: {}", content.name);
+        Ok(())
+    }
+
+    /// Acknowledge a callback query so Telegram removes the button loading state.
+    pub async fn answer_callback_query(&self, callback_query_id: &str) {
+        let client = reqwest::Client::new();
+        let _ = client
+            .post(self.api_url("answerCallbackQuery"))
+            .json(&serde_json::json!({ "callback_query_id": callback_query_id }))
+            .send()
+            .await;
+    }
+
+    /// Register the bot command menu visible in Telegram's "/" menu.
+    pub async fn set_bot_commands(&self) -> Result<()> {
+        let client = reqwest::Client::new();
+        let commands = serde_json::json!({
+            "commands": [
+                { "command": "menu", "description": "Show the main menu" },
+                { "command": "new", "description": "Create a new session" },
+                { "command": "resume", "description": "Resume an existing session" },
+                { "command": "switch", "description": "Switch assistant or workspace" },
+                { "command": "model", "description": "Switch the session model" },
+                { "command": "cancel", "description": "Cancel the current task" },
+                { "command": "expert", "description": "Switch to Expert mode" },
+                { "command": "assistant", "description": "Switch to Assistant mode" },
+                { "command": "settings", "description": "Open settings" },
+                { "command": "help", "description": "Show help" },
+            ]
+        });
+        let resp = client
+            .post(self.api_url("setMyCommands"))
+            .json(&commands)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            log::warn!("Failed to set Telegram bot commands: {body}");
+        }
+        Ok(())
+    }
+
+    /// Download a Telegram photo by file_id and return it as an ImageAttachment.
+    async fn download_photo(&self, file_id: &str) -> Result<ImageAttachment> {
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(self.api_url("getFile"))
+            .json(&serde_json::json!({ "file_id": file_id }))
+            .send()
+            .await?;
+        let body: serde_json::Value = resp.json().await?;
+        let file_path = body
+            .pointer("/result/file_path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Telegram getFile: missing file_path for file_id={file_id}"))?
+            .to_string();
+
+        let download_url = format!(
+            "https://api.telegram.org/file/bot{}/{}",
+            self.config.bot_token, file_path
+        );
+        let bytes = client.get(&download_url).send().await?.bytes().await?;
+
+        use base64::Engine as _;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let mime_type = if file_path.ends_with(".jpg") || file_path.ends_with(".jpeg") {
+            "image/jpeg"
+        } else if file_path.ends_with(".png") {
+            "image/png"
+        } else if file_path.ends_with(".gif") {
+            "image/gif"
+        } else if file_path.ends_with(".webp") {
+            "image/webp"
+        } else {
+            "image/jpeg"
+        };
+        let data_url = format!("data:{mime_type};base64,{b64}");
+        let name = file_path
+            .rsplit('/')
+            .next()
+            .unwrap_or("photo.jpg")
+            .to_string();
+
+        debug!(
+            "Telegram photo downloaded: file_id={file_id}, size={}B",
+            bytes.len()
+        );
+        Ok(ImageAttachment { name, data_url })
+    }
+
+    /// Returns incoming messages from Telegram Bot API long polling.
+    pub async fn poll_updates(
+        &self,
+        last_update_id: i64,
+    ) -> Result<(i64, Vec<TelegramIncomingMessage>)> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(35))
+            .build()?;
+
+        let resp = client
+            .get(self.api_url("getUpdates"))
+            .query(&[
+                ("offset", (last_update_id + 1).to_string()),
+                ("timeout", "30".to_string()),
+            ])
+            .send()
+            .await?;
+
+        let body: serde_json::Value = resp.json().await?;
+        let results = body["result"].as_array().cloned().unwrap_or_default();
+
+        let mut new_last_update_id = last_update_id;
+        let mut messages = Vec::new();
+        for update in results {
+            if let Some(update_id) = update["update_id"].as_i64() {
+                if update_id > new_last_update_id {
+                    new_last_update_id = update_id;
+                }
+            }
+
+            if let Some(cq) = update.get("callback_query") {
+                let cq_id = cq["id"].as_str().unwrap_or("").to_string();
+                let chat_id = cq.pointer("/message/chat/id").and_then(|v| v.as_i64());
+                let data = cq["data"].as_str().map(|s| s.trim().to_string());
+                if let (Some(chat_id), Some(data)) = (chat_id, data) {
+                    self.answer_callback_query(&cq_id).await;
+                    messages.push(TelegramIncomingMessage {
+                        chat_id,
+                        text: data,
+                        images: vec![],
+                    });
+                }
+                continue;
+            }
+
+            let Some(chat_id) = update.pointer("/message/chat/id").and_then(|v| v.as_i64()) else {
+                continue;
+            };
+
+            if let Some(text) = update.pointer("/message/text").and_then(|v| v.as_str()) {
+                messages.push(TelegramIncomingMessage {
+                    chat_id,
+                    text: text.trim().to_string(),
+                    images: vec![],
+                });
+                continue;
+            }
+
+            if let Some(photo_array) = update.pointer("/message/photo").and_then(|v| v.as_array()) {
+                let file_id = photo_array
+                    .last()
+                    .and_then(|p| p["file_id"].as_str())
+                    .map(|s| s.to_string());
+
+                let caption = update
+                    .pointer("/message/caption")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+
+                let images = if let Some(fid) = file_id {
+                    match self.download_photo(&fid).await {
+                        Ok(attachment) => vec![attachment],
+                        Err(e) => {
+                            log::warn!("Failed to download Telegram photo file_id={fid}: {e}");
+                            vec![]
+                        }
+                    }
+                } else {
+                    vec![]
+                };
+
+                messages.push(TelegramIncomingMessage {
+                    chat_id,
+                    text: caption,
+                    images,
+                });
+            }
+        }
+
+        Ok((new_last_update_id, messages))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::chunk_text_for_telegram;
+
+    #[test]
+    fn chunks_text_on_char_boundary() {
+        let text = "a".repeat(4001);
+        let chunks = chunk_text_for_telegram(&text);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 4000);
+        assert_eq!(chunks[1], "a");
+    }
+}


### PR DESCRIPTION
## Summary
- Move Telegram and Feishu Remote Connect provider clients from `bitfun-core` into `bitfun-services-integrations`.
- Keep `bitfun-core` as the compatibility facade for pairing state, command routing, persistence, and product orchestration.
- Preserve provider behavior around Telegram long-poll offsets and Feishu WebSocket frame handling while narrowing Feishu exposure to event-level connection APIs.
- Update ownership docs/plan for remaining high-risk provider work.

## Risk
- No intended behavior change; old config import paths are preserved through core re-exports.
- Live Telegram/Feishu E2E was not run because provider credentials are required; this is covered locally by compile checks, provider parser/card/chunk tests, and boundary checks.

## Verification
- `pnpm run fmt:rs`
- `cargo check -p bitfun-services-integrations --features remote-connect`
- `cargo check -p bitfun-core --features product-full`
- `cargo check -p bitfun-core --no-default-features`
- `cargo test -p bitfun-services-integrations --features remote-connect --lib remote_connect::bot::feishu`
- `cargo test -p bitfun-services-integrations --features remote-connect --lib remote_connect::bot::telegram`
- `cargo test -p bitfun-core --features product-full remote_connect::bot::feishu`
- `node scripts/check-core-boundaries.mjs`
- `node --test scripts/check-core-boundaries.test.mjs`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`