### PR TITLE
feat(glob tool): enrich glob results with scope and truncation metadata

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/glob_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/glob_tool.rs
@@ -7,10 +7,10 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use async_trait::async_trait;
 use log::{info, warn};
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tool_runtime::search::glob_search::{
-    build_remote_find_command, build_remote_rg_command, collect_remote_glob_matches,
-    execute_local_glob, normalize_path, LocalGlobRequest,
+    build_remote_find_command, build_remote_rg_command, collect_remote_glob_result,
+    derive_walk_root, execute_local_glob, normalize_path, LocalGlobRequest,
 };
 
 pub struct GlobTool;
@@ -27,6 +27,69 @@ impl GlobTool {
     }
 }
 
+const GLOB_RESULT_LIMIT: usize = 100;
+
+fn render_glob_result_text(
+    pattern: &str,
+    matches: &[String],
+    total_matches: Option<usize>,
+    truncated: bool,
+    matches_relative_to: Option<&str>,
+) -> String {
+    let relative_note = matches_relative_to
+        .map(|base| format!(" relative to {base}"))
+        .unwrap_or_default();
+
+    if matches.is_empty() {
+        return format!("No files found matching pattern '{pattern}'{relative_note}");
+    }
+
+    let result_text = matches.join("\n");
+    if !truncated {
+        return format!(
+            "Found {} matches{relative_note}\n<matches>\n{result_text}\n</matches>",
+            matches.len()
+        );
+    }
+
+    let count_text = match total_matches {
+        Some(total) => format!(
+            "Showing {} of {} matches{relative_note}",
+            matches.len(),
+            total
+        ),
+        None => format!("Showing {} matches{relative_note}", matches.len()),
+    };
+
+    format!(
+        "{count_text} (This list is truncated and not complete. Narrow the pattern or search a more specific path to see the rest.)\n<matches>\n{result_text}\n</matches>"
+    )
+}
+
+fn display_path(path: &Path) -> String {
+    normalize_path(path)
+}
+
+fn resolve_effective_glob_scope(search_path: &Path, pattern: &str) -> (PathBuf, String) {
+    derive_walk_root(search_path, pattern)
+}
+
+fn relative_base_note(original_search_path: &Path, walk_root: &Path) -> Option<String> {
+    (walk_root != original_search_path).then(|| display_path(walk_root))
+}
+
+fn relative_json_field(base_note: Option<&str>) -> Value {
+    base_note.map_or(Value::Null, |base| json!(base))
+}
+
+fn result_relative_base_note(
+    matches_relative_to: &str,
+    original_search_path: &Path,
+) -> Option<String> {
+    let original = display_path(original_search_path);
+    (matches_relative_to != original).then(|| matches_relative_to.to_string())
+}
+
 #[async_trait]
 impl Tool for GlobTool {
     fn name(&self) -> &str {
@@ -40,11 +103,8 @@ impl Tool for GlobTool {
 - Use this tool when you need to find files by name patterns
 - The path parameter may be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://runtime/...` URI returned by another tool
 - Omit path to search the current workspace. Do not use host roots or placeholder paths such as `/workspace`.
+- Returns up to 100 matching paths. Narrow the pattern or search a more specific path if the result is truncated.
 - You can call multiple tools in a single response. It is always better to speculatively perform multiple searches in parallel if they are potentially useful.
-<example>
-- List files in current workspace: pattern = "*"
-- Search all markdown files in src recursively: path = "src", pattern = "**/*.md"
-</example>
 "#.to_string())
     }
 
@@ -63,10 +123,6 @@ impl Tool for GlobTool {
                 "path": {
                     "type": "string",
                     "description": "The directory to search in. Omit this field to search the current workspace. If provided, use a workspace-relative path, an absolute path inside the current workspace, or an exact bitfun://runtime URI. Do not enter \"undefined\", \"null\", host roots, or placeholder paths such as /workspace."
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "The maximum number of entries to return. Defaults to 100."
                 }
             },
             "required": ["pattern"]
@@ -121,11 +177,7 @@ impl Tool for GlobTool {
                 }
             }
         };
-        let limit = input
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize)
-            .unwrap_or(100);
+        let limit = GLOB_RESULT_LIMIT;
 
         if resolved.uses_remote_workspace_backend() {
             if workspace_search_feature_enabled().await {
@@ -140,6 +192,8 @@ impl Tool for GlobTool {
                             )
                         })?;
                     let resolved_path = PathBuf::from(&resolved.resolved_path);
+                    let (_walk_root, effective_pattern) =
+                        resolve_effective_glob_scope(&resolved_path, pattern);
                     let repo_root = workspace_root.to_string_lossy().to_string();
                     let preferred_connection_id = context
                         .workspace
@@ -163,18 +217,30 @@ impl Tool for GlobTool {
                         .map_err(BitFunError::tool)?;
 
                     let match_count = glob_result.paths.len();
-                    let result_text = if glob_result.paths.is_empty() {
-                        format!("No files found matching pattern '{}'", pattern)
-                    } else {
-                        glob_result.paths.join("\n")
-                    };
+                    let total_matches = glob_result.total_matches;
+                    let truncated = glob_result.truncated;
+                    let result_relative_base = result_relative_base_note(
+                        &glob_result.matches_relative_to,
+                        &PathBuf::from(&resolved.resolved_path),
+                    );
+                    let result_text = render_glob_result_text(
+                        pattern,
+                        &glob_result.paths,
+                        total_matches,
+                        truncated,
+                        result_relative_base.as_deref(),
+                    );
 
                     Ok::<Vec<ToolResult>, BitFunError>(vec![ToolResult::Result {
                         data: json!({
                             "pattern": pattern,
                             "path": resolved.logical_path,
+                            "effective_pattern": effective_pattern,
+                            "matches_relative_to": relative_json_field(result_relative_base.as_deref()),
                             "matches": glob_result.paths,
                             "match_count": match_count,
+                            "total_matches": total_matches,
+                            "truncated": truncated,
                             "repo_phase": glob_result.repo_status.phase,
                             "rebuild_recommended": glob_result.repo_status.rebuild_recommended
                         }),
@@ -201,23 +267,30 @@ impl Tool for GlobTool {
                 .ok_or_else(|| BitFunError::tool("Workspace shell not available".to_string()))?;
 
             let search_dir = resolved.resolved_path.clone();
+            let search_dir_path = PathBuf::from(&search_dir);
+            let (remote_walk_root, _remote_pattern) =
+                resolve_effective_glob_scope(&search_dir_path, pattern);
+            let relative_base = relative_base_note(&search_dir_path, &remote_walk_root);
             let (_stdout, _stderr, exit_code) = ws_shell
                 .exec("command -v rg >/dev/null 2>&1", Some(5_000))
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to detect rg on remote: {}", e)))?;
 
-            let remote_cmd = if exit_code == 0 {
+            let (remote_cmd, exact_total) = if exit_code == 0 {
                 info!(
                     "Glob backend selected: backend=remote_rg, search_path={}, pattern={}",
                     search_dir, pattern
                 );
-                build_remote_rg_command(&search_dir, pattern)
+                (build_remote_rg_command(&search_dir, pattern), true)
             } else {
                 info!(
                     "Glob backend selected: backend=remote_find, reason=rg_not_found, search_path={}, pattern={}",
                     search_dir, pattern
                 );
-                build_remote_find_command(&search_dir, pattern, limit)
+                (
+                    build_remote_find_command(&search_dir, pattern, limit),
+                    false,
+                )
             };
 
             let (stdout, _stderr, _exit_code) = ws_shell
@@ -227,26 +300,34 @@ impl Tool for GlobTool {
                     BitFunError::tool(format!("Failed to glob on remote with rg: {}", e))
                 })?;
 
-            let limited = collect_remote_glob_matches(&search_dir, &stdout, limit)
+            let remote_walk_root_str = remote_walk_root.to_string_lossy().to_string();
+            let glob_result =
+                collect_remote_glob_result(&remote_walk_root_str, &stdout, limit, exact_total);
+            let total_matches = glob_result.total_matches;
+            let truncated = glob_result.truncated;
+            let matches = glob_result
+                .matches
                 .into_iter()
-                .map(|path| {
-                    resolved
-                        .logical_child_path(&path)
-                        .unwrap_or_else(|| normalize_path(&path))
-                })
+                .map(|path| normalize_path(&path))
                 .collect::<Vec<_>>();
-            let result_text = if limited.is_empty() {
-                format!("No files found matching pattern '{}'", pattern)
-            } else {
-                limited.join("\n")
-            };
+            let match_count = matches.len();
+            let result_text = render_glob_result_text(
+                pattern,
+                &matches,
+                total_matches,
+                truncated,
+                relative_base.as_deref(),
+            );
 
             return Ok(vec![ToolResult::Result {
                 data: json!({
                     "pattern": pattern,
                     "path": resolved.logical_path,
-                    "matches": limited,
-                    "match_count": limited.len()
+                    "matches_relative_to": relative_json_field(relative_base.as_deref()),
+                    "matches": matches,
+                    "match_count": match_count,
+                    "total_matches": total_matches,
+                    "truncated": truncated
                 }),
                 result_for_assistant: Some(result_text),
                 image_attachments: None,
@@ -267,6 +348,8 @@ impl Tool for GlobTool {
                         )
                     })?;
                 let resolved_path = PathBuf::from(&resolved_str);
+                let (_walk_root, effective_pattern) =
+                    resolve_effective_glob_scope(&resolved_path, pattern);
                 let glob_result = search_service
                     .glob(GlobSearchRequest {
                         repo_root: workspace_root.clone(),
@@ -276,18 +359,31 @@ impl Tool for GlobTool {
                     })
                     .await?;
 
-                let result_text = if glob_result.paths.is_empty() {
-                    format!("No files found matching pattern '{}'", pattern)
-                } else {
-                    glob_result.paths.join("\n")
-                };
+                let match_count = glob_result.paths.len();
+                let total_matches = glob_result.total_matches;
+                let truncated = glob_result.truncated;
+                let result_relative_base = result_relative_base_note(
+                    &glob_result.matches_relative_to,
+                    &PathBuf::from(&resolved_str),
+                );
+                let result_text = render_glob_result_text(
+                    pattern,
+                    &glob_result.paths,
+                    total_matches,
+                    truncated,
+                    result_relative_base.as_deref(),
+                );
 
                 return Ok(vec![ToolResult::Result {
                     data: json!({
                         "pattern": pattern,
                         "path": resolved_str,
+                        "effective_pattern": effective_pattern,
+                        "matches_relative_to": relative_json_field(result_relative_base.as_deref()),
                         "matches": glob_result.paths,
-                        "match_count": glob_result.paths.len(),
+                        "match_count": match_count,
+                        "total_matches": total_matches,
+                        "truncated": truncated,
                         "repo_phase": glob_result.repo_status.phase,
                         "rebuild_recommended": glob_result.repo_status.rebuild_recommended
                     }),
@@ -312,25 +408,31 @@ impl Tool for GlobTool {
         let matches = glob_result
             .matches
             .into_iter()
-            .map(|path| {
-                resolved
-                    .logical_child_path(&path)
-                    .unwrap_or_else(|| normalize_path(&path))
-            })
+            .map(|path| normalize_path(&path))
             .collect::<Vec<_>>();
 
-        let result_text = if matches.is_empty() {
-            format!("No files found matching pattern '{}'", pattern)
-        } else {
-            matches.join("\n")
-        };
+        let total_matches = glob_result.total_matches;
+        let truncated = glob_result.truncated;
+        let match_count = matches.len();
+        let original_search_path = PathBuf::from(&resolved_str);
+        let relative_base = relative_base_note(&original_search_path, &glob_result.walk_root);
+        let result_text = render_glob_result_text(
+            pattern,
+            &matches,
+            total_matches,
+            truncated,
+            relative_base.as_deref(),
+        );
 
         let result = ToolResult::Result {
             data: json!({
                 "pattern": pattern,
                 "path": resolved.logical_path,
+                "matches_relative_to": relative_json_field(relative_base.as_deref()),
                 "matches": matches,
-                "match_count": matches.len()
+                "match_count": match_count,
+                "total_matches": total_matches,
+                "truncated": truncated
             }),
             result_for_assistant: Some(result_text),
             image_attachments: None,
@@ -342,6 +444,8 @@ impl Tool for GlobTool {
 
 #[cfg(test)]
 mod tests {
+    use super::{render_glob_result_text, GlobTool};
+    use crate::agentic::tools::framework::Tool;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -358,6 +462,39 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("bitfun-glob-tool-{name}-{unique}"));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn input_schema_does_not_expose_model_controlled_limit() {
+        let schema = GlobTool::new().input_schema();
+        assert!(schema["properties"].get("pattern").is_some());
+        assert!(schema["properties"].get("path").is_some());
+        assert!(schema["properties"].get("limit").is_none());
+    }
+
+    #[test]
+    fn renders_truncation_note_from_backend_metadata_only() {
+        let matches = (0..100)
+            .map(|idx| format!("file{idx}.txt"))
+            .collect::<Vec<_>>();
+
+        let exact_limit_complete =
+            render_glob_result_text("*.txt", &matches, Some(100), false, None);
+        assert!(!exact_limit_complete.contains("[truncated:"));
+        assert!(exact_limit_complete.starts_with("Found 100 matches\n<matches>\n"));
+
+        let exact_truncated = render_glob_result_text("*.txt", &matches, Some(101), true, None);
+        assert!(exact_truncated.starts_with("Showing 100 of 101 matches (This list is truncated"));
+        assert!(exact_truncated.contains("not complete"));
+        assert!(exact_truncated.contains("\n<matches>\nfile0.txt"));
+        assert!(exact_truncated.ends_with("</matches>"));
+
+        let unknown_total = render_glob_result_text("*.txt", &matches, None, true, None);
+        assert!(unknown_total.starts_with("Showing 100 matches (This list is truncated"));
+
+        let relative_to =
+            render_glob_result_text("*.txt", &matches[..1], Some(1), false, Some("/repo/src"));
+        assert!(relative_to.starts_with("Found 1 matches relative to /repo/src\n<matches>\n"));
     }
 
     #[test]
@@ -407,11 +544,40 @@ mod tests {
         .collect::<Vec<_>>();
 
         assert_eq!(matches.len(), 2);
-        assert!(matches.iter().any(|path| path.ends_with("/src/lib.rs")));
-        assert!(matches.iter().any(|path| path.ends_with("/tests/mod.rs")));
-        assert!(!matches
-            .iter()
-            .any(|path| path.ends_with("/src/deep/mod.rs")));
+        assert!(matches.iter().any(|path| path == "src/lib.rs"));
+        assert!(matches.iter().any(|path| path == "tests/mod.rs"));
+        assert!(!matches.iter().any(|path| path == "src/deep/mod.rs"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn static_glob_prefix_results_are_relative_to_walk_root() {
+        let root = make_temp_dir("relative-walk-root");
+        fs::create_dir_all(root.join("src/deep")).unwrap();
+        fs::write(root.join("src/lib.rs"), "").unwrap();
+        fs::write(root.join("src/deep/mod.rs"), "").unwrap();
+
+        let result = execute_local_glob(LocalGlobRequest {
+            search_path: root.clone(),
+            pattern: "src/*.rs".to_string(),
+            limit: 10,
+        })
+        .unwrap();
+        let matches = result
+            .matches
+            .into_iter()
+            .map(|path| normalize_path(&path))
+            .collect::<Vec<_>>();
+        let expected_walk_root = fs::canonicalize(&root).unwrap().join("src");
+
+        assert_eq!(
+            normalize_path(&result.walk_root),
+            normalize_path(&expected_walk_root)
+        );
+        assert!(matches.iter().any(|path| path == "lib.rs"));
+        assert!(matches.iter().any(|path| path == "deep/mod.rs"));
+        assert!(matches.iter().all(|path| !path.starts_with("src/")));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/crates/execution/tool-execution/src/search/glob_search.rs
+++ b/src/crates/execution/tool-execution/src/search/glob_search.rs
@@ -23,6 +23,9 @@ pub struct LocalGlobRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalGlobResult {
     pub matches: Vec<PathBuf>,
+    pub walk_root: PathBuf,
+    pub total_matches: Option<usize>,
+    pub truncated: bool,
 }
 
 pub fn extract_glob_base_directory(pattern: &str) -> (String, String) {
@@ -136,8 +139,6 @@ fn build_rg_args(
         "--files".to_string(),
         "--glob".to_string(),
         relative_pattern.to_string(),
-        "--sort".to_string(),
-        "path".to_string(),
     ];
 
     if !apply_gitignore {
@@ -188,13 +189,34 @@ fn match_relative_path(matcher: &GlobMatcher, relative_pattern: &str, relative_p
     matcher.is_match(relative_path)
 }
 
+fn strip_current_dir_prefix(path: &str) -> &str {
+    path.strip_prefix("./")
+        .or_else(|| path.strip_prefix(".\\"))
+        .unwrap_or(path)
+}
+
+fn relativize_remote_stdout_path(search_dir: &str, path: &str) -> String {
+    let normalized_path = strip_current_dir_prefix(path).replace('\\', "/");
+    let normalized_search_dir = search_dir.replace('\\', "/");
+    let search_dir_with_slash = format!("{}/", normalized_search_dir.trim_end_matches('/'));
+
+    if let Some(relative_path) = normalized_path.strip_prefix(&search_dir_with_slash) {
+        return relative_path.to_string();
+    }
+    if normalized_path == normalized_search_dir {
+        return String::new();
+    }
+
+    normalized_path
+}
+
 fn collect_with_walk_fallback(
     walk_root: &Path,
     relative_pattern: &str,
     apply_gitignore: bool,
     ignore_hidden_files: bool,
     limit: usize,
-) -> Result<Vec<PathBuf>, String> {
+) -> Result<LocalGlobResult, String> {
     let matcher = build_fallback_matcher(relative_pattern)?;
     let walker = WalkBuilder::new(walk_root)
         .ignore(apply_gitignore)
@@ -205,6 +227,7 @@ fn collect_with_walk_fallback(
         .build();
 
     let mut best_matches = BinaryHeap::with_capacity(limit.saturating_add(1));
+    let mut total_matches = 0usize;
     for entry in walker {
         let entry = match entry {
             Ok(entry) => entry,
@@ -230,10 +253,10 @@ fn collect_with_walk_fallback(
         let relative_path = normalize_path(relative_path);
 
         if match_relative_path(&matcher, relative_pattern, &relative_path) {
-            let normalized_path = normalize_path(&path);
+            total_matches += 1;
             let candidate = GlobCandidate {
-                depth: normalized_path.split('/').count(),
-                path: normalized_path,
+                depth: relative_path.split('/').count(),
+                path: relative_path,
             };
 
             if best_matches.len() < limit {
@@ -247,11 +270,16 @@ fn collect_with_walk_fallback(
         }
     }
 
-    Ok(best_matches
-        .into_sorted_vec()
-        .into_iter()
-        .map(|candidate| PathBuf::from(candidate.path))
-        .collect())
+    Ok(LocalGlobResult {
+        matches: best_matches
+            .into_sorted_vec()
+            .into_iter()
+            .map(|candidate| PathBuf::from(candidate.path))
+            .collect(),
+        walk_root: walk_root.to_path_buf(),
+        total_matches: Some(total_matches),
+        truncated: total_matches > limit,
+    })
 }
 
 pub fn limit_paths(paths: &[PathBuf], limit: usize) -> Vec<PathBuf> {
@@ -278,13 +306,43 @@ pub fn collect_remote_glob_matches(search_dir: &str, stdout: &str, limit: usize)
     let matches = stdout
         .lines()
         .filter(|line| !line.is_empty())
-        .map(|line| {
-            let relative_path = line.strip_prefix("./").unwrap_or(line);
-            Path::new(search_dir).join(relative_path)
+        .filter_map(|line| {
+            let relative_path = relativize_remote_stdout_path(search_dir, line);
+            (!relative_path.is_empty()).then(|| PathBuf::from(relative_path))
         })
         .collect::<Vec<_>>();
 
     limit_paths(&matches, limit)
+}
+
+pub fn collect_remote_glob_result(
+    search_dir: &str,
+    stdout: &str,
+    limit: usize,
+    exact_total: bool,
+) -> LocalGlobResult {
+    let matches = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let relative_path = relativize_remote_stdout_path(search_dir, line);
+            (!relative_path.is_empty()).then(|| PathBuf::from(relative_path))
+        })
+        .collect::<Vec<_>>();
+    let observed_matches = matches.len();
+    let truncated = observed_matches > limit;
+    let total_matches = if exact_total || !truncated {
+        Some(observed_matches)
+    } else {
+        None
+    };
+
+    LocalGlobResult {
+        matches: limit_paths(&matches, limit),
+        walk_root: PathBuf::from(search_dir),
+        total_matches,
+        truncated,
+    }
 }
 
 pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, String> {
@@ -309,6 +367,9 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
     if !walk_root.exists() || !walk_root.is_dir() || request.limit == 0 {
         return Ok(LocalGlobResult {
             matches: Vec::new(),
+            walk_root,
+            total_matches: Some(0),
+            truncated: false,
         });
     }
 
@@ -347,13 +408,21 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
                 apply_gitignore,
                 ignore_hidden_files,
                 request.limit,
-            )
-            .map(|matches| LocalGlobResult { matches });
+            );
         }
         Err(error) => return Err(error),
     };
 
     if !output.status.success() {
+        if output.status.code() == Some(1) {
+            return Ok(LocalGlobResult {
+                matches: Vec::new(),
+                walk_root,
+                total_matches: Some(0),
+                truncated: false,
+            });
+        }
+
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let message = if stderr.is_empty() {
             format!("rg --files failed with status {}", output.status)
@@ -372,8 +441,7 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
                 apply_gitignore,
                 ignore_hidden_files,
                 request.limit,
-            )
-            .map(|matches| LocalGlobResult { matches });
+            );
         }
         return Err(message);
     }
@@ -382,13 +450,17 @@ pub fn execute_local_glob(request: LocalGlobRequest) -> Result<LocalGlobResult, 
         .lines()
         .filter(|line| !line.is_empty())
         .map(|line| {
-            let relative_path = line.strip_prefix("./").unwrap_or(line);
-            walk_root.join(relative_path)
+            let relative_path = strip_current_dir_prefix(line);
+            PathBuf::from(relative_path)
         })
         .collect::<Vec<_>>();
 
+    let total_matches = all_paths.len();
     Ok(LocalGlobResult {
         matches: limit_paths(&all_paths, request.limit),
+        walk_root,
+        total_matches: Some(total_matches),
+        truncated: total_matches > request.limit,
     })
 }
 
@@ -401,16 +473,15 @@ pub fn build_remote_rg_command(search_dir: &str, pattern: &str) -> String {
     let (remote_walk_root, remote_pattern) = derive_walk_root(search_dir_path, pattern);
     let (apply_gitignore, ignore_hidden_files) = resolve_glob_config(pattern);
 
+    let remote_walk_root = normalize_path(&remote_walk_root);
     let mut parts = vec![
         "cd".to_string(),
-        shell_single_quote(remote_walk_root.to_string_lossy().as_ref()),
+        shell_single_quote(&remote_walk_root),
         "&&".to_string(),
         "rg".to_string(),
         "--files".to_string(),
         "--glob".to_string(),
         shell_single_quote(&remote_pattern),
-        "--sort".to_string(),
-        "path".to_string(),
     ];
 
     if !apply_gitignore {
@@ -438,12 +509,14 @@ pub fn build_remote_find_command(search_dir: &str, pattern: &str, limit: usize) 
         remote_pattern
     };
 
-    let escaped_dir = shell_single_quote(remote_walk_root.to_string_lossy().as_ref());
+    let escaped_dir = shell_single_quote(&normalize_path(&remote_walk_root));
     let escaped_pattern = shell_single_quote(&name_pattern);
 
     format!(
-        "find {} -maxdepth 10 -name {} -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -n {}",
-        escaped_dir, escaped_pattern, limit
+        "find {} -maxdepth 10 -type f -name {} -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -n {}",
+        escaped_dir,
+        escaped_pattern,
+        limit.saturating_add(1)
     )
 }
 
@@ -494,6 +567,7 @@ mod tests {
 
         let wildcard_matches = collect_with_walk_fallback(root, "*", false, false, 10)
             .expect("fallback glob should succeed")
+            .matches
             .into_iter()
             .map(|path| normalized(&path))
             .collect::<Vec<_>>();
@@ -503,18 +577,21 @@ mod tests {
             .all(|path| !path.ends_with("/src") && !path.ends_with("/src/nested")));
         assert!(wildcard_matches
             .iter()
-            .any(|path| path.ends_with("/src/nested/lib.rs")));
+            .any(|path| path == "src/nested/lib.rs"));
 
         let rust_matches = collect_with_walk_fallback(root, "*.rs", false, false, 10)
             .expect("fallback rust glob should succeed")
+            .matches
             .into_iter()
             .map(|path| normalized(&path))
             .collect::<Vec<_>>();
         assert_eq!(rust_matches.len(), 1);
-        assert!(rust_matches[0].ends_with("/src/nested/lib.rs"));
+        assert_eq!(rust_matches[0], "src/nested/lib.rs");
 
         let directory_name_matches = collect_with_walk_fallback(root, "src", false, false, 10)
             .expect("fallback directory-name glob should succeed");
-        assert!(directory_name_matches.is_empty());
+        assert!(directory_name_matches.matches.is_empty());
+        assert_eq!(directory_name_matches.total_matches, Some(0));
+        assert!(!directory_name_matches.truncated);
     }
 }

--- a/src/crates/execution/tool-execution/src/search/mod.rs
+++ b/src/crates/execution/tool-execution/src/search/mod.rs
@@ -3,8 +3,8 @@ pub mod grep_search;
 
 pub use glob_search::{
     build_remote_find_command, build_remote_rg_command, collect_remote_glob_matches,
-    derive_walk_root, execute_local_glob, extract_glob_base_directory, limit_paths, normalize_path,
-    LocalGlobRequest, LocalGlobResult,
+    collect_remote_glob_result, derive_walk_root, execute_local_glob, extract_glob_base_directory,
+    limit_paths, normalize_path, LocalGlobRequest, LocalGlobResult,
 };
 pub use grep_search::{
     apply_offset_and_limit, build_remote_grep_command, count_remote_grep_matches, grep_search,

--- a/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
+++ b/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
@@ -10,7 +10,8 @@ use tool_runtime::fs::{
     WriteLocalFileRequest, WriteLocalFileStatus,
 };
 use tool_runtime::search::glob_search::{
-    collect_remote_glob_matches, execute_local_glob, LocalGlobRequest,
+    build_remote_find_command, build_remote_rg_command, collect_remote_glob_matches,
+    collect_remote_glob_result, execute_local_glob, LocalGlobRequest,
 };
 use tool_runtime::search::grep_search::{
     apply_offset_and_limit, build_remote_grep_command, count_remote_grep_matches,
@@ -215,11 +216,60 @@ fn execute_local_glob_keeps_shallowest_matches() {
         .map(|path| normalized(path))
         .collect::<Vec<_>>();
     assert_eq!(matches.len(), 2);
-    assert!(matches.iter().any(|path| path.ends_with("/src/lib.rs")));
-    assert!(matches.iter().any(|path| path.ends_with("/tests/mod.rs")));
-    assert!(!matches
+    assert_eq!(normalized(&result.walk_root), normalized(&root));
+    assert_eq!(result.total_matches, Some(3));
+    assert!(result.truncated);
+    assert!(matches.iter().any(|path| path == "src/lib.rs"));
+    assert!(matches.iter().any(|path| path == "tests/mod.rs"));
+    assert!(!matches.iter().any(|path| path == "src/deep/mod.rs"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn execute_local_glob_returns_matches_relative_to_derived_walk_root() {
+    let root = make_temp_dir("glob-relative");
+    fs::create_dir_all(root.join("src").join("deep")).expect("dirs should be created");
+    fs::write(root.join("src").join("lib.rs"), "").expect("file should be written");
+    fs::write(root.join("src").join("deep").join("mod.rs"), "").expect("file should be written");
+
+    let result = execute_local_glob(LocalGlobRequest {
+        search_path: root.clone(),
+        pattern: "src/*.rs".to_string(),
+        limit: 10,
+    })
+    .expect("glob should succeed");
+
+    let matches = result
+        .matches
         .iter()
-        .any(|path| path.ends_with("/src/deep/mod.rs")));
+        .map(|path| normalized(path))
+        .collect::<Vec<_>>();
+    assert_eq!(normalized(&result.walk_root), normalized(&root.join("src")));
+    assert!(matches.iter().any(|path| path == "lib.rs"));
+    assert!(matches.iter().any(|path| path == "deep/mod.rs"));
+    assert!(matches.iter().all(|path| !path.starts_with("src/")));
+    assert_eq!(result.total_matches, Some(2));
+    assert!(!result.truncated);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn execute_local_glob_treats_rg_no_match_as_empty_result() {
+    let root = make_temp_dir("glob-empty");
+    fs::create_dir_all(root.join("empty-dir")).expect("empty dir should be created");
+
+    let result = execute_local_glob(LocalGlobRequest {
+        search_path: root.clone(),
+        pattern: "empty-dir/**/*".to_string(),
+        limit: 10,
+    })
+    .expect("empty glob should not fail");
+
+    assert!(result.matches.is_empty());
+    assert_eq!(result.total_matches, Some(0));
+    assert!(!result.truncated);
 
     let _ = fs::remove_dir_all(root);
 }
@@ -232,7 +282,97 @@ fn remote_glob_stdout_is_normalized_and_limited_by_tool_runtime() {
             .map(|path| normalized(&path))
             .collect::<Vec<_>>();
 
-    assert_eq!(matches, vec!["C:/repo/README.md", "C:/repo/src/lib.rs"]);
+    assert_eq!(matches, vec!["README.md", "src/lib.rs"]);
+}
+
+#[test]
+fn remote_glob_result_reports_exact_or_unknown_truncation() {
+    let exact = collect_remote_glob_result(
+        "C:/repo",
+        "./src/deep/mod.rs\nsrc/lib.rs\nREADME.md\n",
+        2,
+        true,
+    );
+    let exact_matches = exact
+        .matches
+        .iter()
+        .map(|path| normalized(path))
+        .collect::<Vec<_>>();
+    assert_eq!(exact_matches, vec!["README.md", "src/lib.rs"]);
+    assert_eq!(normalized(&exact.walk_root), "C:/repo");
+    assert_eq!(exact.total_matches, Some(3));
+    assert!(exact.truncated);
+
+    let unknown = collect_remote_glob_result(
+        "C:/repo",
+        "./src/deep/mod.rs\nsrc/lib.rs\nREADME.md\n",
+        2,
+        false,
+    );
+    assert_eq!(unknown.total_matches, None);
+    assert!(unknown.truncated);
+
+    let unknown_complete =
+        collect_remote_glob_result("C:/repo", "src/lib.rs\nREADME.md\n", 2, false);
+    assert_eq!(unknown_complete.total_matches, Some(2));
+    assert!(!unknown_complete.truncated);
+
+    let remote_find = collect_remote_glob_result(
+        "/home/user/repo/src",
+        "/home/user/repo/src/deep/mod.rs\n/home/user/repo/src/lib.rs\n",
+        10,
+        false,
+    );
+    let remote_find_matches = remote_find
+        .matches
+        .iter()
+        .map(|path| normalized(path))
+        .collect::<Vec<_>>();
+    assert_eq!(remote_find_matches, vec!["deep/mod.rs", "lib.rs"]);
+    assert_eq!(remote_find.total_matches, Some(2));
+    assert!(!remote_find.truncated);
+}
+
+#[test]
+fn remote_glob_result_ignores_walk_root_self_match() {
+    let result = collect_remote_glob_result(
+        "/home/user/repo/empty",
+        "/home/user/repo/empty\n",
+        10,
+        false,
+    );
+
+    assert!(result.matches.is_empty());
+    assert_eq!(result.total_matches, Some(0));
+    assert!(!result.truncated);
+
+    let matches =
+        collect_remote_glob_matches("/home/user/repo/empty", "/home/user/repo/empty\n", 10);
+    assert!(matches.is_empty());
+}
+
+#[test]
+fn remote_glob_commands_preprocess_static_pattern_prefix() {
+    let rg_command = build_remote_rg_command("/home/user/repo", "src/*.rs");
+    assert!(
+        rg_command.starts_with("cd '/home/user/repo/src' && rg --files --glob '*.rs'"),
+        "{rg_command}"
+    );
+    assert!(!rg_command.contains("--no-ignore"));
+    assert!(!rg_command.contains("--hidden"));
+    assert!(!rg_command.contains("--sort"));
+
+    let bitfun_rg_command = build_remote_rg_command("/home/user/repo", ".bitfun/**/*.json");
+    assert!(bitfun_rg_command.contains("--no-ignore"));
+    assert!(bitfun_rg_command.contains("--hidden"));
+    assert!(!bitfun_rg_command.contains("--sort"));
+
+    let find_command = build_remote_find_command("/home/user/repo", "src/*.rs", 100);
+    assert!(
+        find_command.starts_with("find '/home/user/repo/src' -maxdepth 10 -type f -name '*.rs'"),
+        "{find_command}"
+    );
+    assert!(find_command.ends_with("head -n 101"));
 }
 
 #[test]

--- a/src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use bitfun_services_core::filesystem::FileSearchOutcome;
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc, LazyLock,
@@ -669,16 +669,29 @@ impl RemoteWorkspaceSearchService {
     pub async fn glob(&self, request: GlobSearchRequest) -> Result<GlobSearchResult, String> {
         let repo_root = normalize_remote_workspace_path(&request.repo_root.to_string_lossy());
         let session = self.get_or_open_stdio_session(&repo_root).await?;
+        let search_path = request
+            .search_path
+            .as_deref()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_else(|| repo_root.clone());
+        let normalized_search_path = normalize_remote_glob_search_path(&repo_root, &search_path)?;
+        let (walk_root, pattern) =
+            derive_remote_glob_walk_root(&normalized_search_path, &request.pattern);
         let scope = build_remote_scope(
             &repo_root,
-            request.search_path.as_deref(),
-            vec![request.pattern],
+            Some(Path::new(&walk_root)),
+            vec![pattern],
             Vec::new(),
             Vec::new(),
         )?;
         let (repo_status, mut paths) = session.glob(scope).await?;
 
+        paths = paths
+            .into_iter()
+            .map(|path| relativize_remote_glob_result_path(&repo_root, &walk_root, &path))
+            .collect();
         paths.sort();
+        let total_matches = paths.len();
         if request.limit > 0 {
             paths.truncate(request.limit);
         } else {
@@ -687,6 +700,9 @@ impl RemoteWorkspaceSearchService {
 
         Ok(GlobSearchResult {
             paths,
+            matches_relative_to: walk_root,
+            total_matches: Some(total_matches),
+            truncated: total_matches > request.limit,
             repo_status: repo_status.into(),
         })
     }
@@ -994,6 +1010,123 @@ impl RemoteWorkspaceSearchService {
     }
 }
 
+fn extract_remote_glob_base_directory(pattern: &str) -> (String, String) {
+    let glob_start = pattern.find(['*', '?', '[', '{']);
+
+    match glob_start {
+        Some(index) => {
+            let static_prefix = &pattern[..index];
+            let last_separator = static_prefix
+                .char_indices()
+                .rev()
+                .find(|(_, ch)| *ch == '/' || *ch == '\\')
+                .map(|(idx, _)| idx);
+
+            if let Some(separator_index) = last_separator {
+                (
+                    static_prefix[..separator_index].to_string(),
+                    pattern[separator_index + 1..].to_string(),
+                )
+            } else {
+                (String::new(), pattern.to_string())
+            }
+        }
+        None => {
+            let trimmed = pattern.trim_end_matches(['/', '\\']);
+            let literal_path = Path::new(trimmed);
+            let base_dir = literal_path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty() && *parent != Path::new("."))
+                .map(|parent| parent.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let file_name = literal_path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| trimmed.to_string());
+
+            let relative_pattern = if pattern.ends_with('/') || pattern.ends_with('\\') {
+                format!("{}/", file_name)
+            } else {
+                file_name
+            };
+
+            (base_dir, relative_pattern)
+        }
+    }
+}
+
+fn is_safe_remote_relative_subpath(path: &Path) -> bool {
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+fn normalize_remote_glob_search_path(repo_root: &str, search_path: &str) -> Result<String, String> {
+    let normalized = if search_path.starts_with('/') {
+        normalize_remote_workspace_path(search_path)
+    } else {
+        join_remote_path(repo_root, search_path)
+    };
+    let repo_root_with_slash = format!("{}/", repo_root.trim_end_matches('/'));
+    if normalized != repo_root && !normalized.starts_with(&repo_root_with_slash) {
+        return Err(format!(
+            "Remote search path is outside workspace root: {normalized}"
+        ));
+    }
+    Ok(normalized)
+}
+
+fn derive_remote_glob_walk_root(search_path_abs: &str, pattern: &str) -> (String, String) {
+    let (base_dir, relative_pattern) = extract_remote_glob_base_directory(pattern);
+    let base_path = Path::new(&base_dir);
+
+    if base_dir.is_empty() || !is_safe_remote_relative_subpath(base_path) {
+        return (search_path_abs.to_string(), pattern.to_string());
+    }
+
+    let walk_root = join_remote_path(search_path_abs, &base_dir);
+    let search_path_with_slash = format!("{}/", search_path_abs.trim_end_matches('/'));
+    if walk_root == search_path_abs || walk_root.starts_with(&search_path_with_slash) {
+        (walk_root, relative_pattern)
+    } else {
+        (search_path_abs.to_string(), pattern.to_string())
+    }
+}
+
+fn relativize_remote_glob_result_path(repo_root: &str, walk_root: &str, path: &str) -> String {
+    let path = path.replace('\\', "/");
+    let normalized_path = if path.starts_with('/') {
+        normalize_remote_workspace_path(&path)
+    } else {
+        path.trim_start_matches("./").to_string()
+    };
+
+    let walk_root_with_slash = format!("{}/", walk_root.trim_end_matches('/'));
+    if let Some(relative) = normalized_path.strip_prefix(&walk_root_with_slash) {
+        return relative.to_string();
+    }
+    if normalized_path == walk_root {
+        return String::new();
+    }
+
+    let repo_root_with_slash = format!("{}/", repo_root.trim_end_matches('/'));
+    let walk_root_relative_to_repo = walk_root.strip_prefix(&repo_root_with_slash);
+    if let Some(base) = walk_root_relative_to_repo {
+        if !base.is_empty() {
+            let base_with_slash = format!("{}/", base.trim_end_matches('/'));
+            if normalized_path == base {
+                return String::new();
+            }
+            if let Some(relative) = normalized_path.strip_prefix(&base_with_slash) {
+                return relative.to_string();
+            }
+        }
+    }
+
+    normalized_path
+}
+
 fn remote_stdio_session_key(connection_id: &str, repo_root: &str) -> String {
     format!(
         "{connection_id}\0{}",
@@ -1119,6 +1252,48 @@ mod tests {
         assert_eq!(
             test_remote_search_context_key("conn-1", "/home/user/repo/"),
             "conn-1\0/home/user/repo"
+        );
+    }
+
+    #[test]
+    fn remote_glob_scope_preprocessing_extracts_static_pattern_prefix() {
+        let (walk_root, pattern) = derive_remote_glob_walk_root("/home/user/repo", "src/*.rs");
+
+        assert_eq!(walk_root, "/home/user/repo/src");
+        assert_eq!(pattern, "*.rs");
+
+        let (unsafe_walk_root, unsafe_pattern) =
+            derive_remote_glob_walk_root("/home/user/repo", "../*.rs");
+        assert_eq!(unsafe_walk_root, "/home/user/repo");
+        assert_eq!(unsafe_pattern, "../*.rs");
+    }
+
+    #[test]
+    fn remote_glob_results_are_relative_to_effective_walk_root() {
+        assert_eq!(
+            relativize_remote_glob_result_path(
+                "/home/user/repo",
+                "/home/user/repo/src",
+                "src/lib.rs",
+            ),
+            "lib.rs"
+        );
+        assert_eq!(
+            relativize_remote_glob_result_path(
+                "/home/user/repo",
+                "/home/user/repo/src",
+                "/home/user/repo/src/deep/mod.rs",
+            ),
+            "deep/mod.rs"
+        );
+        assert_eq!(
+            normalize_remote_glob_search_path("/home/user/repo", "src").unwrap(),
+            "/home/user/repo/src"
+        );
+        assert!(
+            normalize_remote_glob_search_path("/home/user/repo", "/home/user/other")
+                .unwrap_err()
+                .contains("outside workspace root")
         );
     }
 

--- a/src/crates/services/services-integrations/src/workspace_search/service.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/service.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bitfun_services_core::filesystem::FileSearchOutcome;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -291,27 +291,47 @@ impl WorkspaceSearchService {
         request: GlobSearchRequest,
     ) -> WorkspaceSearchResult<GlobSearchResult> {
         let repo_root = normalize_repo_root(&request.repo_root)?;
-        let scope = build_scope(
-            &repo_root,
-            request.search_path.as_deref(),
-            vec![request.pattern],
-            vec![],
-            vec![],
-        )?;
+        let search_path = request.search_path.as_deref().unwrap_or(&repo_root);
+        let normalized_search_path = normalize_scope_path(&repo_root, search_path)?;
+        let (walk_root, pattern) = derive_glob_walk_root(&normalized_search_path, &request.pattern);
+        if !walk_root.is_dir() {
+            let session = self.get_or_open_session(&repo_root).await?;
+            let repo_status = session
+                .status()
+                .await
+                .map_err(map_flashgrep_error("Glob status failed"))?;
+            return Ok(GlobSearchResult {
+                paths: Vec::new(),
+                matches_relative_to: path_to_string(&walk_root),
+                total_matches: Some(0),
+                truncated: false,
+                repo_status: repo_status.into(),
+            });
+        }
+        let scope = build_scope(&repo_root, Some(&walk_root), vec![pattern], vec![], vec![])?;
         let session = self.get_or_open_session(&repo_root).await?;
-        let mut outcome =
+        let outcome =
             FlashgrepRepoSession::glob(session.as_ref(), GlobRequest::new().with_scope(scope))
                 .await
                 .map_err(map_flashgrep_error("Glob search failed"))?;
-        outcome.paths.sort();
+        let mut paths = outcome
+            .paths
+            .into_iter()
+            .map(|path| relativize_glob_result_path(&repo_root, &walk_root, &path))
+            .collect::<Vec<_>>();
+        paths.sort();
+        let total_matches = paths.len();
         if request.limit > 0 {
-            outcome.paths.truncate(request.limit);
+            paths.truncate(request.limit);
         } else {
-            outcome.paths.clear();
+            paths.clear();
         }
 
         Ok(GlobSearchResult {
-            paths: outcome.paths,
+            paths,
+            matches_relative_to: path_to_string(&walk_root),
+            total_matches: Some(total_matches),
+            truncated: total_matches > request.limit,
             repo_status: outcome.status.into(),
         })
     }
@@ -782,6 +802,105 @@ fn build_scope(
     })
 }
 
+fn extract_glob_base_directory(pattern: &str) -> (String, String) {
+    let glob_start = pattern.find(['*', '?', '[', '{']);
+
+    match glob_start {
+        Some(index) => {
+            let static_prefix = &pattern[..index];
+            let last_separator = static_prefix
+                .char_indices()
+                .rev()
+                .find(|(_, ch)| *ch == '/' || *ch == '\\')
+                .map(|(idx, _)| idx);
+
+            if let Some(separator_index) = last_separator {
+                (
+                    static_prefix[..separator_index].to_string(),
+                    pattern[separator_index + 1..].to_string(),
+                )
+            } else {
+                (String::new(), pattern.to_string())
+            }
+        }
+        None => {
+            let trimmed = pattern.trim_end_matches(['/', '\\']);
+            let literal_path = Path::new(trimmed);
+            let base_dir = literal_path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty() && *parent != Path::new("."))
+                .map(|parent| parent.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let file_name = literal_path
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+                .unwrap_or_else(|| trimmed.to_string());
+
+            let relative_pattern = if pattern.ends_with('/') || pattern.ends_with('\\') {
+                format!("{}/", file_name)
+            } else {
+                file_name
+            };
+
+            (base_dir, relative_pattern)
+        }
+    }
+}
+
+fn is_safe_relative_subpath(path: &Path) -> bool {
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+fn derive_glob_walk_root(search_path_abs: &Path, pattern: &str) -> (PathBuf, String) {
+    let (base_dir, relative_pattern) = extract_glob_base_directory(pattern);
+    let base_path = Path::new(&base_dir);
+
+    if base_dir.is_empty() || !is_safe_relative_subpath(base_path) {
+        return (search_path_abs.to_path_buf(), pattern.to_string());
+    }
+
+    let walk_root = search_path_abs.join(base_path);
+    if walk_root.starts_with(search_path_abs) {
+        (walk_root, relative_pattern)
+    } else {
+        (search_path_abs.to_path_buf(), pattern.to_string())
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    dunce::simplified(path).to_string_lossy().replace('\\', "/")
+}
+
+fn relativize_glob_result_path(repo_root: &Path, walk_root: &Path, path: &str) -> String {
+    let path = path.replace('\\', "/");
+    let path_buf = PathBuf::from(&path);
+    if path_buf.is_absolute() {
+        return path_buf
+            .strip_prefix(walk_root)
+            .map(path_to_string)
+            .unwrap_or(path);
+    }
+
+    let walk_root_relative_to_repo = walk_root.strip_prefix(repo_root).ok();
+    if let Some(base) = walk_root_relative_to_repo {
+        if !base.as_os_str().is_empty() {
+            let base = path_to_string(base);
+            let base_with_slash = format!("{}/", base.trim_end_matches('/'));
+            if path == base {
+                return String::new();
+            }
+            if let Some(relative) = path.strip_prefix(&base_with_slash) {
+                return relative.to_string();
+            }
+        }
+    }
+
+    path
+}
+
 fn normalize_scope_path(repo_root: &Path, search_path: &Path) -> WorkspaceSearchResult<PathBuf> {
     let normalized = dunce::canonicalize(search_path).map_err(|error| {
         format!(
@@ -846,6 +965,40 @@ mod tests {
             ContentSearchOutputMode::FilesWithMatches.search_mode(),
             crate::workspace_search::flashgrep::SearchModeConfig::FilesWithMatches
         );
+    }
+
+    #[test]
+    fn glob_scope_preprocessing_extracts_static_pattern_prefix() {
+        let repo_root = std::env::temp_dir().join("bitfun-workspace-search-test-repo");
+        let search_path = repo_root.join("workspace");
+        let (walk_root, pattern) = derive_glob_walk_root(&search_path, "src/*.rs");
+
+        assert_eq!(walk_root, search_path.join("src"));
+        assert_eq!(pattern, "*.rs");
+
+        let (unsafe_walk_root, unsafe_pattern) = derive_glob_walk_root(&search_path, "../*.rs");
+        assert_eq!(unsafe_walk_root, search_path);
+        assert_eq!(unsafe_pattern, "../*.rs");
+    }
+
+    #[test]
+    fn glob_results_are_relative_to_effective_walk_root() {
+        let repo_root = std::env::temp_dir().join("bitfun-workspace-search-test-repo");
+        let walk_root = repo_root.join("src");
+
+        assert_eq!(
+            relativize_glob_result_path(&repo_root, &walk_root, "src/lib.rs"),
+            "lib.rs"
+        );
+        assert_eq!(
+            relativize_glob_result_path(
+                &repo_root,
+                &walk_root,
+                &path_to_string(&walk_root.join("deep/mod.rs")),
+            ),
+            "deep/mod.rs"
+        );
+        assert!(path_to_string(&walk_root).ends_with("/src"));
     }
 
     #[test]

--- a/src/crates/services/services-integrations/src/workspace_search/types.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/types.rs
@@ -373,6 +373,9 @@ pub struct ContentSearchResult {
 #[serde(rename_all = "camelCase")]
 pub struct GlobSearchResult {
     pub paths: Vec<String>,
+    pub matches_relative_to: String,
+    pub total_matches: Option<usize>,
+    pub truncated: bool,
     pub repo_status: WorkspaceSearchRepoStatus,
 }
 


### PR DESCRIPTION
## Summary

Enrich glob search results with effective scope, total-match metadata, and truncation state across local, workspace, and remote SSH paths. Also remove the model-controlled `limit` from the tool schema and align assistant-facing result text with the new metadata.

Fixes #

## Type and Areas

Type:

bug fix

Areas:

Rust core, execution, services integrations, assembly/core

## Motivation / Impact

Glob results were previously harder to interpret when the search scope was narrowed by a static prefix, and truncated results did not carry enough metadata to explain whether the list was complete. This change makes glob behavior consistent across local, workspace, and remote search backends, and keeps the assistant-visible output honest about truncation.

## Verification

- `cargo test -p bitfun-services-integrations --features workspace-search --lib glob -- --nocapture`  
  Passed: 2 tests
- `cargo test -p tool-runtime --test tool_io_contracts execute_local_glob_returns_matches_relative_to_derived_walk_root -- --nocapture`  
  Passed
- `cargo test -p tool-runtime --test tool_io_contracts execute_local_glob_treats_rg_no_match_as_empty_result -- --nocapture`  
  Passed
- `cargo test -p tool-runtime --test tool_io_contracts remote_glob_result_reports_exact_or_unknown_truncation -- --nocapture`  
  Passed
- `cargo test -p tool-runtime --test tool_io_contracts remote_glob_result_ignores_walk_root_self_match -- --nocapture`  
  Passed
- `cargo test -p tool-runtime --test tool_io_contracts remote_glob_commands_preprocess_static_pattern_prefix -- --nocapture`  
  Passed
- `cargo check -p bitfun-core`  
  Passed
- `cargo check -p tool-runtime`  
  Passed

## Reviewer Notes

Glob results now include:

- effective match scope
- `total_matches`
- `truncated`

Assistant-facing text now distinguishes complete vs truncated results, and the tool schema no longer exposes a user/model-controlled `limit`.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.