### PR TITLE
feat(web-ui): add new session action to chat input boost menu

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -2845,7 +2845,23 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     },
     [currentSessionId, isBtwSession, selectSlashCommandAction, t]
   );
-  
+
+  const handleBoostNewSession = useCallback(
+    async (e: React.SyntheticEvent) => {
+      e.stopPropagation();
+      dispatchMode({ type: 'CLOSE_DROPDOWN' });
+      try {
+        const sessionMode = currentSessionId
+          ? FlowChatStore.getInstance().getState().sessions.get(currentSessionId)?.mode
+          : undefined;
+        await FlowChatManager.getInstance().createChatSession({}, sessionMode);
+      } catch (error) {
+        log.error('Failed to create new session from boost menu', { error });
+      }
+    },
+    [currentSessionId]
+  );
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     // Local /btw shortcut (Ctrl/Cmd+Alt+B) should work even when ChatInput is focused.
     if ((e.ctrlKey || e.metaKey) && e.altKey && !e.shiftKey && e.key.toLowerCase() === 'b') {
@@ -3956,6 +3972,21 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                             </div>
                           </>
                         )}
+
+                        {(!currentSessionId || isBtwSession) && (
+                          <div className="bitfun-chat-input__boost-section-divider" aria-hidden />
+                        )}
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          className="bitfun-chat-input__boost-context-row"
+                          data-testid="chat-input-boost-new-session"
+                          onClick={handleBoostNewSession}
+                          onKeyDown={e => e.key === 'Enter' && handleBoostNewSession(e)}
+                        >
+                          <Plus size={14} className="bitfun-chat-input__boost-context-icon" aria-hidden />
+                          <span>{t('chatInput.boostNewSession')}</span>
+                        </div>
                       </div>
                     </div>
                   )}

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -555,6 +555,7 @@
     "boostSectionAgent": "Agent",
     "boostSectionContext": "Context",
     "boostStartBtw": "Start side question",
+    "boostNewSession": "New session",
     "boostAddContext": "Reference file or folder",
     "boostSkills": "Skills",
     "modeSection": "Modes",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -555,6 +555,7 @@
     "boostSectionAgent": "智能体",
     "boostSectionContext": "上下文",
     "boostStartBtw": "发起侧问",
+    "boostNewSession": "新建会话",
     "boostAddContext": "引用文件或文件夹",
     "boostSkills": "Skills",
     "modeSection": "模式",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -555,6 +555,7 @@
     "boostSectionAgent": "智能體",
     "boostSectionContext": "上下文",
     "boostStartBtw": "發起側問",
+    "boostNewSession": "新建會話",
     "boostAddContext": "引用檔案或資料夾",
     "boostSkills": "Skills",
     "modeSection": "模式",


### PR DESCRIPTION
## Summary
- Add a "New session" entry to the chat input boost dropdown menu
- Reuse the current session mode when creating the new session via `FlowChatManager.createChatSession`
- Add i18n strings for en-US, zh-CN, and zh-TW

## Test plan
- [ ] Open the chat input boost menu and verify "New session" appears at the bottom
- [ ] Click "New session" and confirm a new chat session is created
- [ ] Verify the divider shows correctly when no session is active or in btw session mode
- [ ] Confirm locale strings render correctly in zh-CN and zh-TW