### PR TITLE
fix(web-ui): improve terminal input reliability and companion unread handling

### DIFF
--- a/src/web-ui/src/app/services/openAgentCompanionSession.test.ts
+++ b/src/web-ui/src/app/services/openAgentCompanionSession.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { openAgentCompanionSession } from './openAgentCompanionSession';
 import type { Session } from '@/flow_chat/types/flow-chat';
 
@@ -6,12 +6,21 @@ const mocks = vi.hoisted(() => ({
   openBtwSessionInAuxPane: vi.fn(),
   openMainSession: vi.fn(() => Promise.resolve()),
   activateMainSession: vi.fn(() => Promise.resolve(true)),
+  clearSessionUnreadCompletion: vi.fn(),
+  clearSessionNeedsAttention: vi.fn(),
   sessions: new Map<string, Session>(),
   openedWorkspaces: new Map<string, { id: string; rootPath: string }>(),
   activeWorkspaceId: null as string | null,
   sessionBelongsToWorkspaceNavRow: vi.fn(() => false),
   setActiveWorkspace: vi.fn((id: string) => Promise.resolve({ id })),
 }));
+
+let animationFrameCallbacks: FrameRequestCallback[] = [];
+
+function flushDoubleRequestAnimationFrame(): void {
+  animationFrameCallbacks.shift()?.(0);
+  animationFrameCallbacks.shift()?.(16);
+}
 
 vi.mock('@/flow_chat/services/btwSessionPane', () => ({
   openBtwSessionInAuxPane: (...args: unknown[]) => mocks.openBtwSessionInAuxPane(...args),
@@ -28,6 +37,10 @@ vi.mock('@/flow_chat/store/FlowChatStore', () => ({
       getState: () => ({
         sessions: mocks.sessions,
       }),
+      clearSessionUnreadCompletion: (...args: unknown[]) =>
+        mocks.clearSessionUnreadCompletion(...args),
+      clearSessionNeedsAttention: (...args: unknown[]) =>
+        mocks.clearSessionNeedsAttention(...args),
     }),
   },
 }));
@@ -66,12 +79,23 @@ describe('openAgentCompanionSession', () => {
     mocks.openBtwSessionInAuxPane.mockClear();
     mocks.openMainSession.mockClear();
     mocks.activateMainSession.mockClear();
+    mocks.clearSessionUnreadCompletion.mockClear();
+    mocks.clearSessionNeedsAttention.mockClear();
     mocks.setActiveWorkspace.mockClear();
     mocks.sessions.clear();
     mocks.openedWorkspaces.clear();
     mocks.activeWorkspaceId = null;
     mocks.sessionBelongsToWorkspaceNavRow.mockClear();
     mocks.sessionBelongsToWorkspaceNavRow.mockReturnValue(false);
+    animationFrameCallbacks = [];
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('opens deep review child sessions in the aux pane instead of switching to the child chat', async () => {
@@ -109,6 +133,9 @@ describe('openAgentCompanionSession', () => {
     });
     expect(mocks.activateMainSession).not.toHaveBeenCalled();
     expect(mocks.openBtwSessionInAuxPane).not.toHaveBeenCalled();
+    flushDoubleRequestAnimationFrame();
+    expect(mocks.clearSessionUnreadCompletion).toHaveBeenCalledWith('session-1');
+    expect(mocks.clearSessionNeedsAttention).toHaveBeenCalledWith('session-1');
   });
 
   it('activates the session workspace when it differs from the current workspace', async () => {
@@ -170,5 +197,21 @@ describe('openAgentCompanionSession', () => {
 
     expect(opened).toBe(false);
     expect(mocks.openMainSession).not.toHaveBeenCalled();
+    expect(animationFrameCallbacks).toHaveLength(0);
+  });
+
+  it('clears unread and attention marks after opening a main session', async () => {
+    mocks.sessions.set('session-1', createSession({ sessionId: 'session-1' }));
+
+    await openAgentCompanionSession('session-1');
+
+    expect(mocks.clearSessionUnreadCompletion).not.toHaveBeenCalled();
+    expect(mocks.clearSessionNeedsAttention).not.toHaveBeenCalled();
+    expect(animationFrameCallbacks).toHaveLength(1);
+
+    flushDoubleRequestAnimationFrame();
+
+    expect(mocks.clearSessionUnreadCompletion).toHaveBeenCalledWith('session-1');
+    expect(mocks.clearSessionNeedsAttention).toHaveBeenCalledWith('session-1');
   });
 });

--- a/src/web-ui/src/app/services/openAgentCompanionSession.ts
+++ b/src/web-ui/src/app/services/openAgentCompanionSession.ts
@@ -78,5 +78,18 @@ export async function openAgentCompanionSession(sessionId: string): Promise<bool
     workspaceId,
     activateWorkspace,
   });
+
+  // When the session was already active before the pet bubble was clicked,
+  // activateMainSession takes an early-return path that does not call
+  // switchChatSession, so `bitfun:session-switched` is never dispatched and
+  // SessionsSection's listener never clears the unread marks. Clear them
+  // explicitly here so the bubble and workspace dot dismiss reliably.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      flowChatStore.clearSessionUnreadCompletion(sessionId);
+      flowChatStore.clearSessionNeedsAttention(sessionId);
+    });
+  });
+
   return true;
 }

--- a/src/web-ui/src/flow_chat/components/RichTextInput.scss
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.scss
@@ -25,6 +25,14 @@
   cursor: text;
   box-shadow: none !important;
 
+  // Hide scrollbars while keeping scroll functionality
+  scrollbar-width: none; // Firefox
+  -ms-overflow-style: none; // IE/Edge legacy
+
+  &::-webkit-scrollbar {
+    display: none; // Chrome, Safari, Edge
+  }
+
   // Fallback placeholder via CSS :empty (may not work after browser inserts a <br>)
   &:empty::before {
     content: attr(data-placeholder);

--- a/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
@@ -11,6 +11,7 @@ import { registerTerminalActions, unregisterTerminalActions } from '../services/
 import {
   POWERSHELL_READLINE_PASTE_SEQUENCE,
   ResizeRepaintGuard,
+  TerminalInputQueue,
   createResizeRepaintScreenSnapshot,
   resolveTerminalPaste,
   shouldUsePowerShellReadlinePaste,
@@ -279,14 +280,31 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
     onReplay: handleReplay,
   });
 
+  // Keep latest write in a ref so the input queue closure stays stable without
+  // recreating the queue on every render.
+  const writeRef = useRef(write);
+  writeRef.current = write;
+
+  // Coalesce rapid keystrokes into batched, sequentially-ordered IPC writes.
+  // Without this, each keystroke fires a separate fire-and-forget
+  // `invoke('terminal_write')`, which on macOS can lose characters due to IPC
+  // latency and lack of ordering guarantees for concurrent async command
+  // handlers. The queue buffers input and flushes it as a single batched write,
+  // with only one flush in flight at a time.
+  const inputQueueRef = useRef<TerminalInputQueue | null>(null);
+  if (!inputQueueRef.current) {
+    inputQueueRef.current = new TerminalInputQueue(
+      (data) => writeRef.current(data),
+      (err) => log.error('Write failed', { sessionId, error: err }),
+    );
+  }
+
   const handleData = useCallback((data: string) => {
     if (!isExited) {
       resizeRepaintGuardRef.current.clear();
-      write(data).catch(err => {
-        log.error('Write failed', { sessionId, error: err });
-      });
+      inputQueueRef.current?.enqueue(data);
     }
-  }, [write, isExited, sessionId]);
+  }, [isExited]);
 
   const handleResize = useCallback((cols: number, rows: number) => {
     const lastSize = lastSentSizeRef.current;
@@ -349,9 +367,9 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
       return false;
     }
 
-    await write(POWERSHELL_READLINE_PASTE_SEQUENCE);
+    inputQueueRef.current?.enqueue(POWERSHELL_READLINE_PASTE_SEQUENCE);
     return true;
-  }, [initialSession?.shellType, isExited, session?.shellType, write]);
+  }, [initialSession?.shellType, isExited, session?.shellType]);
 
   // Handle paste with VS Code-style multi-line safety policy.
   const handlePaste = useCallback(async (
@@ -394,6 +412,13 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
       }
     }
   }, [session]);
+
+  // Discard pending input when the terminal exits to avoid cascading write errors.
+  useEffect(() => {
+    if (isExited) {
+      inputQueueRef.current?.clear();
+    }
+  }, [isExited]);
 
   const terminalId = `terminal-${sessionId}`;
 

--- a/src/web-ui/src/tools/terminal/components/Terminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/Terminal.tsx
@@ -243,6 +243,12 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
   const onPasteRef = useRef(onPaste);
   const resizeSuspendedRef = useRef(resizeSuspended);
   const pendingFitAfterSuspendRef = useRef(false);
+  // Track key-pressed state to mirror xterm's internal _keyDownSeen flag.
+  // Used by the input-event safety net (see below).
+  const keyDownSeenRef = useRef(false);
+  // Track whether keypress already handled the character, mirroring xterm's
+  // _keyPressHandled, to avoid duplicates in the safety net.
+  const keyPressHandledRef = useRef(false);
   const [isReady, setIsReady] = useState(false);
   const currentTheme = themeService.getCurrentTheme();
   const initialFontWeights = getXtermFontWeights(currentTheme.type);
@@ -656,7 +662,16 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
 
     // Intercept paste (Ctrl+V / Ctrl+Shift+V) so callers can apply the same
     // policy as context-menu paste before xterm normalizes/sends the data.
+    // Also track key-pressed state and bypass keyCode 229 for the input-event
+    // safety net below.
     terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+      if (event.type === 'keydown') {
+        keyDownSeenRef.current = true;
+      } else if (event.type === 'keyup') {
+        keyDownSeenRef.current = false;
+        keyPressHandledRef.current = false;
+      }
+
       if (event.type === 'keydown' && event.ctrlKey && (event.key === 'v' || event.key === 'V')) {
         event.preventDefault();
         
@@ -684,9 +699,61 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
         
         return false;
       }
-      
+
+      // When an IME is active (even in ASCII mode), keydown events may carry
+      // keyCode 229. xterm.js delegates these to _handleAnyTextareaChanges
+      // (setTimeout(0) — racy during key rollover) and _inputEvent (skipped
+      // when _keyDownSeen is true). Both paths can lose the character.
+      //
+      // Bypass xterm entirely for keyCode 229: return false without
+      // preventDefault(), so the browser inserts the character into the
+      // textarea and fires an input event. The safety-net listener below
+      // catches that event synchronously — no setTimeout race, no duplicates.
+      // During active IME composition, compositionstart/compositionend events
+      // still fire and xterm handles them normally; this only affects the
+      // non-composition passthrough path.
+      if (event.type === 'keydown' && event.keyCode === 229) {
+        return false;
+      }
+
       return true;
     });
+
+    // Input-event safety net for key rollover with an active IME.
+    //
+    // Because we bypass keyCode 229 in the custom key handler above, xterm's
+    // _handleAnyTextareaChanges (setTimeout(0)) is never called for those keys.
+    // Instead, the browser inserts the character and fires an input event.
+    //
+    // xterm's own _inputEvent handler skips events where (composed && keyDownSeen)
+    // — exactly the key-rollover case. This listener catches those skipped
+    // insertText events and forwards them via onData, preventing character loss.
+    // It only fires when xterm would skip (composed + keyDownSeen) and keypress
+    // didn't already handle the character, so it never causes duplicates.
+    const textareaEl = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea');
+    let textareaKeyPressHandler: (() => void) | null = null;
+    let textareaInputHandler: ((ev: Event) => void) | null = null;
+    if (textareaEl) {
+      textareaKeyPressHandler = () => {
+        keyPressHandledRef.current = true;
+      };
+      textareaInputHandler = (ev: Event) => {
+        const inputEvent = ev as InputEvent;
+        if (
+          inputEvent.data &&
+          inputEvent.inputType === 'insertText' &&
+          inputEvent.composed === true &&
+          keyDownSeenRef.current &&
+          !keyPressHandledRef.current
+        ) {
+          // xterm's _inputEvent will skip this (composed + keyDownSeen).
+          // Forward the character to prevent loss during key rollover.
+          onDataRef.current?.(inputEvent.data);
+        }
+      };
+      textareaEl.addEventListener('keypress', textareaKeyPressHandler);
+      textareaEl.addEventListener('input', textareaInputHandler, true);
+    }
 
     const resizeObserver = new ResizeObserver(() => {
       requestAnimationFrame(() => {
@@ -746,6 +813,12 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
       binaryDisposable.dispose();
       titleDisposable.dispose();
       container.removeEventListener('paste', handleNativePaste, true);
+      if (textareaEl && textareaKeyPressHandler) {
+        textareaEl.removeEventListener('keypress', textareaKeyPressHandler);
+      }
+      if (textareaEl && textareaInputHandler) {
+        textareaEl.removeEventListener('input', textareaInputHandler, true);
+      }
       resizeObserver.disconnect();
       intersectionObserver.disconnect();
       fontLoadCancelled = true;

--- a/src/web-ui/src/tools/terminal/utils/TerminalInputQueue.test.ts
+++ b/src/web-ui/src/tools/terminal/utils/TerminalInputQueue.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TerminalInputQueue } from './TerminalInputQueue';
+
+/** Flush all pending microtasks by waiting for the next macrotask. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('TerminalInputQueue', () => {
+  it('batches multiple synchronous enqueue calls into a single write', async () => {
+    const write = vi.fn((_data: string): Promise<void> => Promise.resolve());
+    const onError = vi.fn();
+    const queue = new TerminalInputQueue(write, onError);
+
+    queue.enqueue('1');
+    queue.enqueue('2');
+    queue.enqueue('3');
+
+    // Microtask hasn't run yet — no writes should have occurred.
+    expect(write).not.toHaveBeenCalled();
+
+    await flushMicrotasks();
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith('123');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('does not start a second write while the first is in flight', async () => {
+    let resolveFirst: () => void = () => {};
+    const write = vi.fn((data: string): Promise<void> => {
+      if (data === 'first') {
+        return new Promise<void>(resolve => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+    const onError = vi.fn();
+    const queue = new TerminalInputQueue(write, onError);
+
+    queue.enqueue('first');
+    await flushMicrotasks();
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenLastCalledWith('first');
+
+    // Enqueue more data while the first write is still in flight.
+    queue.enqueue('A');
+    queue.enqueue('B');
+
+    expect(write).toHaveBeenCalledTimes(1); // Still only one call.
+
+    // Resolve the first write — the queued data should flush as a single batch.
+    resolveFirst();
+    await flushMicrotasks();
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenLastCalledWith('AB');
+  });
+
+  it('preserves ordering across multiple flush cycles', async () => {
+    const writtenData: string[] = [];
+    const write = vi.fn((data: string): Promise<void> => {
+      writtenData.push(data);
+      return Promise.resolve();
+    });
+    const onError = vi.fn();
+    const queue = new TerminalInputQueue(write, onError);
+
+    // First batch
+    queue.enqueue('a');
+    queue.enqueue('b');
+    await flushMicrotasks();
+
+    // Second batch
+    queue.enqueue('c');
+    queue.enqueue('d');
+    await flushMicrotasks();
+
+    expect(writtenData).toEqual(['ab', 'cd']);
+  });
+
+  it('reports write errors to onError and continues processing', async () => {
+    const write = vi.fn((_data: string): Promise<void> => Promise.resolve());
+    write.mockRejectedValueOnce(new Error('boom'));
+    const onError = vi.fn();
+    const queue = new TerminalInputQueue(write, onError);
+
+    queue.enqueue('data');
+    await flushMicrotasks();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('boom');
+
+    // Queue should still accept new data after an error.
+    queue.enqueue('more');
+    await flushMicrotasks();
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenLastCalledWith('more');
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('clear() discards buffered data that has not been flushed', async () => {
+    const write = vi.fn((_data: string): Promise<void> => Promise.resolve());
+    const onError = vi.fn();
+    const queue = new TerminalInputQueue(write, onError);
+
+    queue.enqueue('pending');
+    queue.clear();
+
+    await flushMicrotasks();
+
+    // The microtask still runs drain(), but the buffer was cleared,
+    // so data is empty and write should not be called.
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('clear() does not affect data already mid-flush', async () => {
+    let resolveWrite: () => void = () => {};
+    const write = vi.fn((_data: string): Promise<void> =>
+      new Promise<void>(resolve => {
+        resolveWrite = resolve;
+      }),
+    );
+    const onError = vi.fn();
+    const queue = new TerminalInputQueue(write, onError);
+
+    queue.enqueue('in-flight');
+    await flushMicrotasks();
+
+    expect(write).toHaveBeenCalledWith('in-flight');
+
+    // Data that arrives after the flush started but before it completes.
+    queue.enqueue('queued');
+    // Clear should discard 'queued' but not affect 'in-flight'.
+    queue.clear();
+
+    resolveWrite();
+    await flushMicrotasks();
+
+    // Only 'in-flight' was written; 'queued' was discarded.
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenLastCalledWith('in-flight');
+  });
+});

--- a/src/web-ui/src/tools/terminal/utils/TerminalInputQueue.ts
+++ b/src/web-ui/src/tools/terminal/utils/TerminalInputQueue.ts
@@ -1,0 +1,82 @@
+/**
+ * Coalesces terminal input into batched, sequentially-ordered writes.
+ *
+ * Problem: xterm.js fires `onData` once per keystroke. If each call triggers a
+ * separate fire-and-forget `invoke('terminal_write')`, rapid typing creates a
+ * burst of concurrent IPC calls. On macOS (WKWebView) this can cause character
+ * loss because:
+ *  - concurrent async command handlers are not guaranteed FIFO ordering after
+ *    the `get_or_init_api` mutex releases,
+ *  - WKWebView IPC has higher latency and bursts of concurrent invokes can
+ *    interfere with each other.
+ *
+ * Solution: buffer incoming data and flush it as a single batched write. Only
+ * one flush is in flight at a time, so ordering is guaranteed and IPC overhead
+ * is reduced. The first keystroke is dispatched via a microtask (near-zero
+ * latency); subsequent keystrokes that arrive while a flush is in flight are
+ * automatically coalesced into the next flush.
+ *
+ * IME safety: xterm.js fires `onData` only after IME composition completes, so
+ * this queue never interferes with input-method candidate selection or the
+ * Enter-key guard in chat input components.
+ */
+export class TerminalInputQueue {
+  private buffer = '';
+  private flushing = false;
+  private readonly write: (data: string) => Promise<void>;
+  private readonly onError: (error: unknown) => void;
+
+  constructor(
+    write: (data: string) => Promise<void>,
+    onError: (error: unknown) => void,
+  ) {
+    this.write = write;
+    this.onError = onError;
+  }
+
+  /**
+   * Append data to the buffer and schedule a flush if one is not already in
+   * progress.
+   */
+  enqueue(data: string): void {
+    this.buffer += data;
+    if (!this.flushing) {
+      this.flushing = true;
+      queueMicrotask(() => {
+        void this.drain();
+      });
+    }
+  }
+
+  /**
+   * Flush the current buffer contents to the write function. After the write
+   * completes, if more data arrived during the flush, drain again; otherwise
+   * mark the queue as idle.
+   */
+  private async drain(): Promise<void> {
+    const data = this.buffer;
+    this.buffer = '';
+    try {
+      if (data) {
+        await this.write(data);
+      }
+    } catch (err) {
+      this.onError(err);
+    } finally {
+      if (this.buffer) {
+        // More data arrived during the flush — drain again.
+        void this.drain();
+      } else {
+        this.flushing = false;
+      }
+    }
+  }
+
+  /**
+   * Discard any buffered data that has not been flushed yet. Data that is
+   * already mid-flush is unaffected.
+   */
+  clear(): void {
+    this.buffer = '';
+  }
+}

--- a/src/web-ui/src/tools/terminal/utils/index.ts
+++ b/src/web-ui/src/tools/terminal/utils/index.ts
@@ -2,6 +2,7 @@
  * Terminal utilities.
  */
 
+export { TerminalInputQueue } from './TerminalInputQueue';
 export { TerminalResizeDebouncer } from './TerminalResizeDebouncer';
 export type { ResizeCallback, ResizeDebounceOptions } from './TerminalResizeDebouncer';
 export { ResizeRepaintGuard, createResizeRepaintScreenSnapshot } from './resizeRepaintGuard';


### PR DESCRIPTION
## Summary
- Add `TerminalInputQueue` to batch terminal keystrokes into sequential IPC writes, preventing character loss during rapid typing on macOS/WKWebView
- Add xterm IME key-rollover safety net for keyCode 229 and composed insertText events that xterm would otherwise skip
- Clear companion session unread/attention marks when clicking the pet bubble on an already-active session (where `activateMainSession` short-circuits without dispatching `bitfun:session-switched`)
- Hide rich text input scrollbars while keeping scroll functionality

## Test plan
- [ ] Rapidly type in a terminal on macOS desktop and confirm no dropped characters
- [ ] Type with IME active (including key rollover) and verify characters are not lost or duplicated
- [ ] Click the companion pet bubble when the target session is already active; verify unread dot and bubble dismiss
- [ ] Paste multi-line content in terminal and confirm PowerShell readline paste still works
- [ ] Verify rich text chat input scrolls but does not show scrollbars
- [ ] `pnpm --dir src/web-ui run test:run src/tools/terminal/utils/TerminalInputQueue.test.ts`