### PR TITLE
docs(readme): add Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 </div>
 <div align="center">
 
+[![Trendshift](https://trendshift.io/api/badge/repositories/44672)](https://trendshift.io/repositories/44672)
+
 [![GitHub release](https://img.shields.io/github/v/release/GCWing/BitFun?style=flat-square&color=blue)](https://github.com/GCWing/BitFun/releases)
 [![Website](https://img.shields.io/badge/Website-openbitfun.com-6f42c1?style=flat-square)](https://openbitfun.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,8 @@
 </div>
 <div align="center">
 
+[![Trendshift](https://trendshift.io/api/badge/repositories/44672)](https://trendshift.io/repositories/44672)
+
 [![GitHub release](https://img.shields.io/github/v/release/GCWing/BitFun?style=flat-square&color=blue)](https://github.com/GCWing/BitFun/releases)
 [![Website](https://img.shields.io/badge/Website-openbitfun.com-6f42c1?style=flat-square)](https://openbitfun.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)


### PR DESCRIPTION
## Summary
- add the official Trendshift badge above the existing README badge row
- keep the English and Chinese READMEs aligned

## Validation
- git diff --check -- README.md README.zh-CN.md
- node scripts/check-repo-hygiene.mjs
- node scripts/check-github-config.mjs
- git diff --cached --check