### PR TITLE
fix(desktop): gate cron startup on FlowChat readiness

### DIFF
--- a/src/apps/desktop/src/api/cron_api.rs
+++ b/src/apps/desktop/src/api/cron_api.rs
@@ -101,3 +101,14 @@ pub async fn delete_cron_job(request: DeleteCronJobRequest) -> Result<bool, Stri
         format!("Failed to delete scheduled job: {}", error)
     })
 }
+
+#[tauri::command]
+pub async fn notify_cron_host_ready() -> Result<(), String> {
+    debug!("Received scheduled job host ready signal");
+
+    let service = cron_service()?;
+    // `start` is idempotent, so the frontend readiness signal can safely race
+    // with the desktop fallback timer.
+    service.start();
+    Ok(())
+}

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::Emitter;
 use tauri::Manager;
 
@@ -85,6 +85,7 @@ static MAIN_WINDOW_HIDDEN_ON_MACOS: AtomicBool = AtomicBool::new(false);
 static MAIN_WINDOW_CLOSE_PENDING_ON_MACOS: AtomicBool = AtomicBool::new(false);
 
 const MAIN_WINDOW_CLOSE_REQUESTED_EVENT: &str = "bitfun_main_window_close_requested";
+const CRON_DESKTOP_START_FALLBACK_DELAY: Duration = Duration::from_secs(120);
 
 #[cfg(target_os = "macos")]
 const MAIN_WINDOW_CLOSE_FALLBACK_HIDE_MS: u64 = 2_500;
@@ -1120,6 +1121,7 @@ pub async fn run() {
             create_cron_job,
             update_cron_job,
             delete_cron_job,
+            notify_cron_host_ready,
             api::config_api::canonicalize_agent_profile_configs,
             api::terminal_api::terminal_get_shells,
             api::terminal_api::terminal_create,
@@ -1421,9 +1423,22 @@ async fn init_agentic_system() -> anyhow::Result<(
         cron_service.clone(),
     ));
     event_router.subscribe_internal("cron_jobs".to_string(), cron_subscriber);
-    cron_service.start();
+    {
+        let cron_service_for_fallback = cron_service.clone();
+        // Desktop cron runs can emit FlowChat events immediately. Prefer the
+        // frontend readiness handshake, but keep a fallback so cron is not left
+        // disabled if the web host never reaches the ready path.
+        tokio::spawn(async move {
+            tokio::time::sleep(CRON_DESKTOP_START_FALLBACK_DELAY).await;
+            log::info!(
+                "Ensuring cron service is started after desktop fallback delay: delay_seconds={}",
+                CRON_DESKTOP_START_FALLBACK_DELAY.as_secs()
+            );
+            cron_service_for_fallback.start();
+        });
+    }
 
-    log::info!("Cron service initialized and subscriber registered");
+    log::info!("Cron service initialized and waiting for desktop host readiness");
     log::info!("Agentic system initialized");
     Ok((
         coordinator,

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -348,6 +348,13 @@ export class FlowChatManager {
 
       this.eventListenerCleanup = cleanup;
       this.eventListenerInitialized = true;
+      // Cron startup is gated on FlowChat listener readiness so startup-time
+      // scheduled runs do not emit into an unregistered desktop event bridge.
+      void import('@/infrastructure/api/service-api/CronAPI')
+        .then(({ cronAPI }) => cronAPI.notifyHostReady())
+        .catch(error => {
+          log.warn('Failed to notify cron host readiness', error);
+        });
     })();
 
     try {

--- a/src/web-ui/src/infrastructure/api/adapters/base.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/base.ts
@@ -10,6 +10,12 @@ export interface ITransportAdapter {
   
    
   listen<T>(event: string, callback: (data: T) => void): () => void;
+
+  /**
+   * Resolves after listener registration requests already issued to the
+   * transport have settled. Synchronous transports can keep the default no-op.
+   */
+  waitForListenerRegistrations?(): Promise<void>;
   
    
   disconnect(): Promise<void>;

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
@@ -32,6 +32,7 @@ export class TauriTransportAdapter implements ITransportAdapter {
   private connected: boolean = false;
   private invokeFn: ((action: string, params?: any) => Promise<any>) | null = null;
   private initPromise: Promise<void> | null = null;
+  private listenerRegistrationPromises = new Set<Promise<void>>();
 
   // Lazy initialize Tauri API
   private async ensureInitialized() {
@@ -120,7 +121,7 @@ export class TauriTransportAdapter implements ITransportAdapter {
     let unlistenFn: UnlistenFn | null = null;
     let isUnlistened = false;
 
-    listen<T>(event, (e) => {
+    const registration = listen<T>(event, (e) => {
       if (!isUnlistened) {
         try {
           callback(e.payload);
@@ -137,7 +138,10 @@ export class TauriTransportAdapter implements ITransportAdapter {
       }
     }).catch(error => {
       log.error('Failed to listen event', { event, error: sanitizeErrorForLog(error) });
+    }).finally(() => {
+      this.listenerRegistrationPromises.delete(registration);
     });
+    this.listenerRegistrationPromises.add(registration);
 
     return () => {
       isUnlistened = true;
@@ -166,6 +170,12 @@ export class TauriTransportAdapter implements ITransportAdapter {
   isConnected(): boolean {
     return this.connected;
   }
+
+  async waitForListenerRegistrations(): Promise<void> {
+    while (this.listenerRegistrationPromises.size > 0) {
+      // Listener registration is async, and settling one registration can reveal
+      // another registration issued in the same initialization wave.
+      await Promise.allSettled(Array.from(this.listenerRegistrationPromises));
+    }
+  }
 }
-
-

--- a/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
@@ -197,6 +197,10 @@ export class ApiClient implements IApiClient {
     return this.adapter;
   }
 
+  async waitForListenerRegistrations(): Promise<void> {
+    await this.adapter.waitForListenerRegistrations?.();
+  }
+
   private createRequest(type: 'tauri' | 'http', config: TauriCommandConfig | HttpRequestConfig): ApiRequest {
     return {
       id: `${type}-${Date.now()}-${Math.random()}`,
@@ -576,6 +580,9 @@ export const api = {
 
   
   getStats: (): ApiStats => apiClient.getStats(),
+
+  waitForListenerRegistrations: (): Promise<void> =>
+    apiClient.waitForListenerRegistrations(),
   
   
   getAdapter: (): ITransportAdapter => apiClient.getAdapter()

--- a/src/web-ui/src/infrastructure/api/service-api/CronAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/CronAPI.ts
@@ -1,5 +1,6 @@
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
+import { isTauriRuntime } from '@/infrastructure/runtime';
 
 export type CronJobRunStatus = 'queued' | 'running' | 'ok' | 'error' | 'cancelled';
 export type CronJobTargetKind = 'session' | 'workspace';
@@ -102,6 +103,21 @@ export interface UpdateCronJobRequest {
 }
 
 export class CronAPI {
+  async notifyHostReady(): Promise<void> {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    try {
+      // Tauri listener registration is async. Wait for listeners already issued
+      // by FlowChat before allowing cron to emit startup events.
+      await api.waitForListenerRegistrations();
+      await api.invoke<void>('notify_cron_host_ready');
+    } catch (error) {
+      throw createTauriCommandError('notify_cron_host_ready', error);
+    }
+  }
+
   async listJobs(request: ListCronJobsRequest = {}): Promise<CronJob[]> {
     try {
       return await api.invoke<CronJob[]>('list_cron_jobs', { request });


### PR DESCRIPTION
## Summary

Delay desktop cron startup until the FlowChat frontend listener stack is ready, with a fallback timer so cron is not left disabled if the frontend never signals readiness.

Fixes #

## Type and Areas

Type:

bug fix

Areas:

desktop/Tauri, web UI

## Motivation / Impact

Desktop cron jobs could start immediately after backend initialization, before the frontend had registered the event listeners needed to receive streamed agent events. Startup-time scheduled runs could therefore emit into an unready desktop event bridge and lose events.

This change gates desktop cron startup on a frontend readiness signal sent after FlowChat listener initialization, waits for pending Tauri listener registrations before notifying the backend, and keeps a 120s fallback path for resilience.

## Verification

- `cargo check -p bitfun-desktop` passed
- `.\node_modules\.bin\pnpm.cmd run type-check:web` passed
- `.\node_modules\.bin\pnpm.cmd --dir src/web-ui run test:run src/flow_chat/services/FlowChatManager.test.ts src/infrastructure/api/adapters/tauri-adapter.test.ts` passed
- `git diff --check` passed

## Reviewer Notes

Server cron startup remains unchanged and still starts immediately. The desktop ready signal and fallback both call the same idempotent cron `start()` path, so racing readiness/fallback startup is safe.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.