### PR TITLE
fix(flow-chat): stabilize history turn navigation

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -54,6 +54,9 @@ const searchStateMock = vi.hoisted(() => ({
 const headerPropsMock = vi.hoisted(() => ({
   latest: null as Record<string, unknown> | null,
 }));
+const virtualListPropsMock = vi.hoisted(() => ({
+  latest: null as Record<string, unknown> | null,
+}));
 const agentApiMock = vi.hoisted(() => ({
   listBackgroundCommandActivities: vi.fn(() => Promise.resolve({ activities: [] })),
 }));
@@ -120,7 +123,8 @@ vi.mock('../../store/modernFlowChatStore', () => ({
 }));
 
 vi.mock('./VirtualMessageList', () => ({
-  VirtualMessageList: React.forwardRef((_, ref) => {
+  VirtualMessageList: React.forwardRef((props: Record<string, unknown>, ref) => {
+    virtualListPropsMock.latest = props;
     React.useImperativeHandle(ref, () => virtualListMock);
     return (
       <div data-testid="virtual-list">
@@ -278,6 +282,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     searchStateMock.goToPrev.mockReset();
     searchStateMock.clearSearch.mockReset();
     headerPropsMock.latest = null;
+    virtualListPropsMock.latest = null;
     clearHistorySessionOpenTransition();
   });
 
@@ -942,15 +947,148 @@ describe('ModernFlowChatContainer historical empty state', () => {
     await act(async () => {
       root.render(<ModernFlowChatContainer />);
     });
+    flushAnimationFrame();
+
+    expect(virtualListMock.pinTurnToTop).toHaveBeenLastCalledWith('turn-1', {
+      behavior: 'auto',
+      pinMode: 'transient',
+    });
+    expect(headerPropsMock.latest).toMatchObject({
+      currentTurn: 2,
+      totalTurns: 2,
+    });
+
+    stateMocks.visibleTurnInfo = {
+      turnId: 'turn-1',
+      turnIndex: 1,
+      totalTurns: 2,
+      userMessage: 'Older prompt',
+    };
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    expect(headerPropsMock.latest).toMatchObject({
+      currentTurn: 1,
+      totalTurns: 2,
+    });
+  });
+
+  it('continues retrying an accepted header turn selection until the viewport reports the target turn', async () => {
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [
+        createTurn('turn-1', 'Older prompt'),
+        createTurn('turn-2', 'Latest prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest prompt' } },
+    ];
+    stateMocks.visibleTurnInfo = {
+      turnId: 'turn-2',
+      turnIndex: 2,
+      totalTurns: 2,
+      userMessage: 'Latest prompt',
+    };
+    virtualListMock.pinTurnToTop.mockReturnValue(true);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    await act(async () => {
+      (headerPropsMock.latest?.onJumpToTurn as ((turnId: string) => void) | undefined)?.('turn-1');
+    });
 
     expect(virtualListMock.pinTurnToTop).toHaveBeenLastCalledWith('turn-1', {
       behavior: 'smooth',
       pinMode: 'transient',
     });
     expect(headerPropsMock.latest).toMatchObject({
+      currentTurn: 2,
+      totalTurns: 2,
+    });
+
+    const acceptedCallCount = virtualListMock.pinTurnToTop.mock.calls.length;
+    flushAnimationFrame();
+    expect(virtualListMock.pinTurnToTop.mock.calls.length).toBeGreaterThan(acceptedCallCount);
+    expect(virtualListMock.pinTurnToTop).toHaveBeenLastCalledWith('turn-1', {
+      behavior: 'auto',
+      pinMode: 'transient',
+    });
+
+    stateMocks.visibleTurnInfo = {
+      turnId: 'turn-1',
+      turnIndex: 1,
+      totalTurns: 2,
+      userMessage: 'Older prompt',
+    };
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+    flushAnimationFrame();
+    expect(headerPropsMock.latest).toMatchObject({
       currentTurn: 1,
       totalTurns: 2,
     });
+    const settledCallCount = virtualListMock.pinTurnToTop.mock.calls.length;
+    flushAnimationFrame();
+    expect(virtualListMock.pinTurnToTop.mock.calls.length).toBe(settledCallCount);
+  });
+
+  it('cancels pending header turn retry when the user scrolls manually', async () => {
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [
+        createTurn('turn-1', 'Older prompt'),
+        createTurn('turn-2', 'Latest prompt'),
+      ],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Older prompt' } },
+      { type: 'user-message', turnId: 'turn-2', data: { id: 'user-turn-2', content: 'Latest prompt' } },
+    ];
+    stateMocks.visibleTurnInfo = {
+      turnId: 'turn-2',
+      turnIndex: 2,
+      totalTurns: 2,
+      userMessage: 'Latest prompt',
+    };
+    virtualListMock.pinTurnToTop.mockReturnValue(true);
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+
+    await act(async () => {
+      (headerPropsMock.latest?.onJumpToTurn as ((turnId: string) => void) | undefined)?.('turn-1');
+    });
+
+    expect(headerPropsMock.latest).toMatchObject({
+      currentTurn: 2,
+      totalTurns: 2,
+    });
+
+    flushAnimationFrame();
+    const retryCallCount = virtualListMock.pinTurnToTop.mock.calls.length;
+    expect(retryCallCount).toBeGreaterThan(1);
+
+    await act(async () => {
+      (virtualListPropsMock.latest?.onUserScrollIntent as (() => void) | undefined)?.();
+    });
+    expect(headerPropsMock.latest).toMatchObject({
+      currentTurn: 2,
+      totalTurns: 2,
+    });
+
+    flushAnimationFrame();
+    expect(virtualListMock.pinTurnToTop.mock.calls.length).toBe(retryCallCount);
   });
 
   it('does not expose previous navigation before the loaded tail range in partial history', async () => {

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -101,6 +101,7 @@ type BackgroundCommandSummary = {
 const LATEST_TURN_AUTO_PIN_MAX_ATTEMPTS = 8;
 const HISTORY_INITIAL_CONTENT_PAINT_MAX_ATTEMPTS = 30;
 const HISTORY_LOADING_LAYER_STALL_WARN_MS = 800;
+const HEADER_TURN_PIN_RETRY_MAX_ATTEMPTS = 120;
 const MOCK_BACKGROUND_ACTIVITIES_STORAGE_KEY = 'bitfun.flowChat.mockBackgroundActivities';
 
 const MOCK_BACKGROUND_SUBAGENTS: BackgroundSubagentSummary[] = [
@@ -242,6 +243,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const [isSendingBackgroundCommandInput, setIsSendingBackgroundCommandInput] = useState(false);
   const autoPinnedTurnKeyRef = useRef<string | null>(null);
   const releasedHistoryCompletionKeyRef = useRef<string | null>(null);
+  const visibleTurnInfoRef = useRef<VisibleTurnInfo | null>(visibleTurnInfo);
+  const turnSummariesRef = useRef<FlowChatHeaderTurnSummary[]>([]);
+  const requestHeaderTurnPinRef = useRef<((turnId: string, behavior?: ScrollBehavior) => boolean) | null>(null);
   const virtualListRef = useRef<VirtualMessageListRef>(null);
   const chatScopeRef = useRef<HTMLDivElement>(null);
   const [historyInitialContentReadyKey, setHistoryInitialContentReadyKey] = useState<string | null>(null);
@@ -593,35 +597,21 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const latestTurnUsesStickyPin = shouldUseStickyLatestPin(latestTurn);
 
   const navigationVisibleTurnInfo = useMemo<VisibleTurnInfo | null>(() => {
-    if (!pendingHeaderTurnId) {
-      if (!visibleTurnInfo) {
-        return null;
-      }
-
-      const localTurn = turnSummaries.find(turn => turn.turnId === visibleTurnInfo.turnId);
-      if (!localTurn) {
-        return visibleTurnInfo;
-      }
-
-      return {
-        ...visibleTurnInfo,
-        turnIndex: localTurn.turnIndex,
-        totalTurns: turnSummaries.length,
-      };
+    if (!visibleTurnInfo) {
+      return null;
     }
 
-    const targetTurn = turnSummaries.find(turn => turn.turnId === pendingHeaderTurnId);
-    if (!targetTurn) {
+    const localTurn = turnSummaries.find(turn => turn.turnId === visibleTurnInfo.turnId);
+    if (!localTurn) {
       return visibleTurnInfo;
     }
 
     return {
-      turnId: targetTurn.turnId,
-      turnIndex: targetTurn.turnIndex,
+      ...visibleTurnInfo,
+      turnIndex: localTurn.turnIndex,
       totalTurns: turnSummaries.length,
-      userMessage: targetTurn.title,
     };
-  }, [pendingHeaderTurnId, turnSummaries, visibleTurnInfo]);
+  }, [turnSummaries, visibleTurnInfo]);
   const effectiveVisibleTurnInfo = useMemo<VisibleTurnInfo | null>(() => {
     if (!navigationVisibleTurnInfo) {
       return null;
@@ -638,6 +628,14 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const canJumpToNextTurn = !!navigationVisibleTurnInfo &&
     navigationVisibleTurnInfo.turnIndex > 0 &&
     navigationVisibleTurnInfo.turnIndex < turnSummaries.length;
+
+  useEffect(() => {
+    visibleTurnInfoRef.current = visibleTurnInfo;
+  }, [visibleTurnInfo]);
+
+  useEffect(() => {
+    turnSummariesRef.current = turnSummaries;
+  }, [turnSummaries]);
 
   const currentHeaderMessage = useMemo(() => {
     const turnId = effectiveVisibleTurnInfo?.turnId;
@@ -666,7 +664,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     }
   }, [pendingHeaderTurnId, turnSummaries, visibleTurnInfo?.turnId]);
 
-  const requestHeaderTurnPin = useCallback((turnId: string) => {
+  const requestHeaderTurnPin = useCallback((turnId: string, behavior: ScrollBehavior = 'smooth') => {
     const isLatestTurn = turnSummaries[turnSummaries.length - 1]?.turnId === turnId;
     const targetTurn = findDialogTurn(activeSession?.dialogTurns, turnId);
     const pinMode = isLatestTurn && shouldUseStickyLatestPin(targetTurn)
@@ -674,37 +672,66 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       : 'transient';
 
     return virtualListRef.current?.pinTurnToTop(turnId, {
-      behavior: 'smooth',
+      behavior,
       pinMode,
     }) ?? false;
   }, [activeSession?.dialogTurns, turnSummaries]);
+  useEffect(() => {
+    requestHeaderTurnPinRef.current = requestHeaderTurnPin;
+  }, [requestHeaderTurnPin]);
+  const handleVirtualListUserScrollIntent = useCallback(() => {
+    setQueuedHeaderTurnPinId(null);
+    setPendingHeaderTurnId(null);
+  }, []);
 
   useEffect(() => {
     if (!queuedHeaderTurnPinId) return;
 
-    if (visibleTurnInfo?.turnId === queuedHeaderTurnPinId) {
-      setQueuedHeaderTurnPinId(null);
-      return;
-    }
+    let cancelled = false;
+    let frameId: number | null = null;
+    let attempts = 0;
 
-    const targetStillExists = turnSummaries.some(turn => turn.turnId === queuedHeaderTurnPinId);
-    if (!targetStillExists) {
-      setQueuedHeaderTurnPinId(null);
-      setPendingHeaderTurnId(null);
-      return;
-    }
+    const retry = () => {
+      if (cancelled) return;
 
-    const accepted = requestHeaderTurnPin(queuedHeaderTurnPinId);
-    if (!accepted) return;
+      if (visibleTurnInfoRef.current?.turnId === queuedHeaderTurnPinId) {
+        setQueuedHeaderTurnPinId(null);
+        setPendingHeaderTurnId(null);
+        return;
+      }
 
-    setQueuedHeaderTurnPinId(null);
-    setPendingHeaderTurnId(queuedHeaderTurnPinId);
+      const targetStillExists = turnSummariesRef.current.some(turn => turn.turnId === queuedHeaderTurnPinId);
+      if (!targetStillExists) {
+        setQueuedHeaderTurnPinId(null);
+        setPendingHeaderTurnId(null);
+        return;
+      }
+
+      const accepted = requestHeaderTurnPinRef.current?.(queuedHeaderTurnPinId, 'auto') ?? false;
+      if (accepted) {
+        setPendingHeaderTurnId(queuedHeaderTurnPinId);
+      }
+
+      attempts += 1;
+      if (attempts >= HEADER_TURN_PIN_RETRY_MAX_ATTEMPTS) {
+        setQueuedHeaderTurnPinId(null);
+        setPendingHeaderTurnId(null);
+        return;
+      }
+
+      frameId = requestAnimationFrame(retry);
+    };
+
+    frameId = requestAnimationFrame(retry);
+
+    return () => {
+      cancelled = true;
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+    };
   }, [
     queuedHeaderTurnPinId,
-    requestHeaderTurnPin,
-    turnSummaries,
-    virtualItems,
-    visibleTurnInfo?.turnId,
   ]);
 
   useLayoutEffect(() => {
@@ -987,7 +1014,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
     const accepted = requestHeaderTurnPin(turnId);
     if (accepted) {
-      setQueuedHeaderTurnPinId(null);
+      setQueuedHeaderTurnPinId(turnId);
       setPendingHeaderTurnId(turnId);
       return;
     }
@@ -1486,6 +1513,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
               <>
                 <VirtualMessageList
                   ref={virtualListRef}
+                  onUserScrollIntent={handleVirtualListUserScrollIntent}
                 />
               </>
             )}

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { VirtualMessageList } from './VirtualMessageList';
+import { VirtualMessageList, type VirtualMessageListRef } from './VirtualMessageList';
 import { activeSessionHistoryProjectionHandoff } from './historyProjectionHandoff';
 import type { Session } from '../../types/flow-chat';
 import type { VirtualItem } from '../../store/modernFlowChatStore';
@@ -23,6 +23,11 @@ const flowStoreMocks = vi.hoisted(() => ({
   requestSessionFullHistoryProjection: vi.fn(),
   revealPreviousSessionHistoryWindow: vi.fn(() => false),
   releaseSessionHistoryCompletionAfterInitialPaint: vi.fn(() => false),
+}));
+const inputStateMocks = vi.hoisted(() => ({
+  isActive: false,
+  isExpanded: false,
+  inputHeight: 0,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -106,11 +111,7 @@ vi.mock('../../hooks/useActiveSessionState', () => ({
 }));
 
 vi.mock('../../store/chatInputStateStore', () => ({
-  useChatInputState: (selector: (state: any) => unknown) => selector({
-    isActive: false,
-    isExpanded: false,
-    inputHeight: 0,
-  }),
+  useChatInputState: (selector: (state: any) => unknown) => selector(inputStateMocks),
 }));
 
 vi.mock('../../store/FlowChatStore', () => ({
@@ -136,8 +137,8 @@ vi.mock('./VirtualItemRenderer', () => ({
 }));
 
 vi.mock('../ScrollToLatestBar', () => ({
-  ScrollToLatestBar: ({ visible }: { visible: boolean }) => (
-    <div data-testid="scroll-to-latest" data-visible={visible ? 'true' : 'false'} />
+  ScrollToLatestBar: ({ visible, onClick }: { visible: boolean; onClick?: () => void }) => (
+    <button type="button" data-testid="scroll-to-latest" data-visible={visible ? 'true' : 'false'} onClick={onClick} />
   ),
 }));
 
@@ -213,6 +214,80 @@ function createItem(turnId: string): VirtualItem {
   } as VirtualItem;
 }
 
+function createModelItem(turnId: string): VirtualItem {
+  return {
+    type: 'model-round',
+    turnId,
+    isLastRound: true,
+    isTurnComplete: true,
+    data: {
+      id: `round-${turnId}`,
+      status: 'completed',
+      isStreaming: false,
+      items: [{
+        id: `text-${turnId}`,
+        type: 'text',
+        content: 'x'.repeat(2_000),
+        status: 'completed',
+        timestamp: 1,
+      }],
+    },
+  } as VirtualItem;
+}
+
+function createSessionWithTurns(sessionId: string, turnIds: string[], overrides: Partial<Session> = {}): Session {
+  return createSession(sessionId, turnIds[0] ?? 'turn-a', {
+    dialogTurns: turnIds.map((turnId, index) => ({
+      id: turnId,
+      sessionId,
+      userMessage: { id: `user-${turnId}`, content: turnId, timestamp: index + 1 },
+      modelRounds: [],
+      status: 'completed',
+      startTime: index + 1,
+    })),
+    ...overrides,
+  });
+}
+
+function setScrollerGeometry(scroller: HTMLElement, metrics: {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop?: number;
+}): void {
+  Object.defineProperty(scroller, 'scrollHeight', {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(scroller, 'clientHeight', {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  if (metrics.scrollTop !== undefined) {
+    scroller.scrollTop = metrics.scrollTop;
+  }
+}
+
+function createRect(overrides: Partial<DOMRect>): DOMRect {
+  const left = overrides.left ?? 0;
+  const top = overrides.top ?? 0;
+  const width = overrides.width ?? 0;
+  const height = overrides.height ?? 0;
+  const right = overrides.right ?? left + width;
+  const bottom = overrides.bottom ?? top + height;
+
+  return {
+    x: overrides.x ?? left,
+    y: overrides.y ?? top,
+    left,
+    top,
+    width,
+    height,
+    right,
+    bottom,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
 describe('VirtualMessageList session boundary', () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -252,6 +327,9 @@ describe('VirtualMessageList session boundary', () => {
     flowStoreMocks.revealPreviousSessionHistoryWindow.mockReturnValue(false);
     flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint.mockReset();
     flowStoreMocks.releaseSessionHistoryCompletionAfterInitialPaint.mockReturnValue(false);
+    inputStateMocks.isActive = false;
+    inputStateMocks.isExpanded = false;
+    inputStateMocks.inputHeight = 0;
   });
 
   afterEach(() => {
@@ -278,6 +356,363 @@ describe('VirtualMessageList session boundary', () => {
     });
 
     expect(container.querySelector('[data-testid="scroll-to-latest"]')?.getAttribute('data-visible')).toBe('false');
+  });
+
+  it('keeps static initial history position when background updates arrive after an upward scroll', () => {
+    let nowMs = 1_000;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+
+    try {
+      stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b'], {
+        isHistorical: false,
+        historyState: 'ready',
+        contextRestoreState: 'pending',
+        isPartial: true,
+      });
+      stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b')];
+
+      act(() => {
+        root.render(<VirtualMessageList />);
+      });
+
+      const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+      expect(scroller).not.toBeNull();
+      if (!scroller) {
+        return;
+      }
+
+      setScrollerGeometry(scroller, {
+        scrollHeight: 5_000,
+        clientHeight: 1_000,
+        scrollTop: 4_000,
+      });
+
+      act(() => {
+        scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+
+      act(() => {
+        scroller.dispatchEvent(new WheelEvent('wheel', {
+          deltaY: -720,
+          bubbles: true,
+        }));
+        scroller.scrollTop = 1_800;
+        scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      flushAnimationFrame();
+      expect(scroller.scrollTop).toBe(1_800);
+
+      nowMs = 2_000;
+      stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b', 'turn-c'], {
+        isHistorical: false,
+        historyState: 'ready',
+        contextRestoreState: 'pending',
+        isPartial: true,
+      });
+      stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b'), createItem('turn-c')];
+
+      act(() => {
+        root.render(<VirtualMessageList />);
+      });
+
+      expect(scroller.scrollTop).toBe(1_800);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('keeps a static initial history turn pin from being pulled back to bottom by the initial guard', () => {
+    let nowMs = 1_000;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+    const listRef = React.createRef<VirtualMessageListRef>();
+
+    try {
+      stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b'], {
+        isHistorical: false,
+        historyState: 'ready',
+        contextRestoreState: 'pending',
+        isPartial: true,
+      });
+      stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b')];
+
+      act(() => {
+        root.render(<VirtualMessageList ref={listRef} />);
+      });
+
+      const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+      const target = container.querySelector<HTMLElement>('[data-turn-id="turn-a"][data-item-type="user-message"]');
+      expect(scroller).not.toBeNull();
+      expect(target).not.toBeNull();
+      if (!scroller || !target) {
+        return;
+      }
+
+      setScrollerGeometry(scroller, {
+        scrollHeight: 5_000,
+        clientHeight: 1_000,
+        scrollTop: 4_000,
+      });
+      Object.defineProperty(scroller, 'scrollTo', {
+        configurable: true,
+        value: vi.fn((options?: ScrollToOptions) => {
+          if (typeof options?.top === 'number') {
+            scroller.scrollTop = options.top;
+          }
+        }),
+      });
+      vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+        top: 40,
+        bottom: 1_040,
+        height: 1_000,
+      }));
+      vi.spyOn(target, 'getBoundingClientRect').mockReturnValue(createRect({
+        top: -1_200,
+        bottom: -1_160,
+        height: 40,
+      }));
+
+      act(() => {
+        scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+
+      stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b', 'turn-c'], {
+        isHistorical: false,
+        historyState: 'ready',
+        contextRestoreState: 'pending',
+        isPartial: true,
+      });
+      stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b'), createItem('turn-c')];
+      setScrollerGeometry(scroller, {
+        scrollHeight: 5_200,
+        clientHeight: 1_000,
+      });
+
+      act(() => {
+        root.render(<VirtualMessageList ref={listRef} />);
+      });
+
+      expect(scroller.scrollTop).toBe(4_200);
+
+      let didPin = false;
+      act(() => {
+        didPin = listRef.current?.pinTurnToTop('turn-a', { behavior: 'auto' }) ?? false;
+      });
+
+      expect(didPin).toBe(true);
+      const pinnedScrollTop = scroller.scrollTop;
+      expect(pinnedScrollTop).toBeLessThan(4_200);
+
+      expect(rafCallbacks.length).toBeGreaterThan(0);
+      for (let frame = 0; frame < 4; frame += 1) {
+        nowMs += 16;
+        flushAnimationFrame();
+        expect(scroller.scrollTop).toBe(pinnedScrollTop);
+      }
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('keeps latest reachable after pinning an older turn outside the static initial tail', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const onUserScrollIntent = vi.fn();
+    const turnIds = Array.from({ length: 8 }, (_, index) => `turn-${index}`);
+    const targetTurnId = 'turn-1';
+    const latestTurnId = 'turn-7';
+
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} onUserScrollIntent={onUserScrollIntent} />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+    if (!scroller) {
+      return;
+    }
+
+    Object.defineProperty(scroller, 'clientHeight', {
+      configurable: true,
+      value: 1_000,
+    });
+    Object.defineProperty(scroller, 'scrollHeight', {
+      configurable: true,
+      get: () => (
+        container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)
+          ? 12_000
+          : 9_000
+      ),
+    });
+    scroller.scrollTop = 11_000;
+    Object.defineProperty(scroller, 'scrollTo', {
+      configurable: true,
+      value: vi.fn((options?: ScrollToOptions) => {
+        if (typeof options?.top === 'number') {
+          scroller.scrollTop = options.top;
+        }
+      }),
+    });
+
+    expect(container.querySelector(`[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`)).toBeNull();
+    expect(container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)).not.toBeNull();
+
+    let didPin = false;
+    act(() => {
+      didPin = listRef.current?.pinTurnToTop(targetTurnId, { behavior: 'auto' }) ?? false;
+    });
+
+    expect(didPin).toBe(true);
+    expect(container.querySelector(`[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`)).not.toBeNull();
+    expect(container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)).toBeNull();
+    expect(container.querySelector('[data-history-initial-render-tail-spacer="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="scroll-to-latest"]')?.getAttribute('data-visible')).toBe('true');
+
+    act(() => {
+      container.querySelector<HTMLElement>('[data-testid="scroll-to-latest"]')?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+
+    expect(onUserScrollIntent).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)).not.toBeNull();
+    expect(scroller.scrollTop).toBe(11_000);
+  });
+
+  it('keeps static initial history position when footer height changes after an upward scroll', () => {
+    let nowMs = 1_000;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+
+    try {
+      stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b'], {
+        isHistorical: false,
+        historyState: 'ready',
+        contextRestoreState: 'pending',
+        isPartial: true,
+      });
+      stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b')];
+
+      act(() => {
+        root.render(<VirtualMessageList />);
+      });
+
+      const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+      expect(scroller).not.toBeNull();
+      if (!scroller) {
+        return;
+      }
+
+      setScrollerGeometry(scroller, {
+        scrollHeight: 5_000,
+        clientHeight: 1_000,
+        scrollTop: 4_000,
+      });
+
+      act(() => {
+        scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+
+      act(() => {
+        scroller.dispatchEvent(new WheelEvent('wheel', {
+          deltaY: -720,
+          bubbles: true,
+        }));
+        scroller.scrollTop = 1_800;
+        scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+      flushAnimationFrame();
+      expect(scroller.scrollTop).toBe(1_800);
+
+      nowMs = 2_000;
+      inputStateMocks.isActive = true;
+      inputStateMocks.inputHeight = 320;
+      setScrollerGeometry(scroller, {
+        scrollHeight: 5_320,
+        clientHeight: 1_000,
+      });
+
+      act(() => {
+        root.render(<VirtualMessageList />);
+      });
+
+      expect(scroller.scrollTop).toBe(1_800);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('does not treat a collapse-compensated bottom as user-left-bottom', () => {
+    stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b'], {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b')];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+    if (!scroller) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 5_000,
+      clientHeight: 1_000,
+      scrollTop: 4_000,
+    });
+
+    act(() => {
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+      window.dispatchEvent(new CustomEvent('flowchat:tool-card-collapse-intent', {
+        detail: {
+          toolId: 'tool-a',
+          cardHeight: 300,
+          reason: 'test-collapse',
+        },
+      }));
+    });
+    setScrollerGeometry(scroller, {
+      scrollHeight: 5_300,
+      clientHeight: 1_000,
+      scrollTop: 4_000,
+    });
+
+    act(() => {
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+
+    stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b', 'turn-c'], {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = [createItem('turn-a'), createItem('turn-b'), createItem('turn-c')];
+    setScrollerGeometry(scroller, {
+      scrollHeight: 5_600,
+      clientHeight: 1_000,
+    });
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    expect(scroller.scrollTop).toBeGreaterThan(4_000);
+    expect(scroller.scrollTop).toBeLessThanOrEqual(4_600);
   });
 
   it('does not expose stale history projection handoff snapshots across sessions', () => {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -110,6 +110,10 @@ export interface VirtualMessageListRef {
   pinTurnToTop: (turnId: string, options?: { behavior?: ScrollBehavior; pinMode?: FlowChatPinTurnToTopMode }) => boolean;
 }
 
+export interface VirtualMessageListProps {
+  onUserScrollIntent?: () => void;
+}
+
 interface ScrollAnchorLockState {
   active: boolean;
   targetScrollTop: number;
@@ -177,6 +181,11 @@ interface PendingTurnPinState {
   attempts: number;
 }
 
+interface PendingStaticTurnPinState {
+  turnId: string;
+  behavior: ScrollBehavior;
+}
+
 function createInitialBottomReservationState(): BottomReservationState {
   return {
     collapse: {
@@ -219,6 +228,22 @@ function isUpwardScrollIntentKey(event: KeyboardEvent): boolean {
     event.key === 'PageUp' ||
     event.key === 'Home' ||
     (event.key === ' ' && event.shiftKey)
+  );
+}
+
+function isScrollIntentKey(event: KeyboardEvent): boolean {
+  if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) {
+    return false;
+  }
+
+  return (
+    event.key === 'ArrowUp' ||
+    event.key === 'ArrowDown' ||
+    event.key === 'PageUp' ||
+    event.key === 'PageDown' ||
+    event.key === 'Home' ||
+    event.key === 'End' ||
+    event.key === ' '
   );
 }
 
@@ -322,7 +347,9 @@ function getReservationConsumablePx(reservation: BottomReservationBase): number 
   return Math.max(0, reservation.px - reservation.floorPx);
 }
 
-const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => {
+const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessageListProps>(({
+  onUserScrollIntent,
+}, ref) => {
   const { t } = useTranslation('flow-chat');
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const virtualItems = useVirtualItems();
@@ -387,12 +414,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   const markedInitialHistoryRenderWindowKeyRef = useRef<string | null>(null);
   const autoScrolledInitialHistoryRenderKeyRef = useRef<string | null>(null);
   const useStaticInitialHistoryListRef = useRef(false);
+  const staticInitialHistoryUserLeftBottomRef = useRef(false);
   const pendingInitialHistoryExpansionRef = useRef<{
     scrollTop: number;
     scrollHeight: number;
     omittedEstimatedHeightPx: number;
     wasAtBottom: boolean;
   } | null>(null);
+  const pendingStaticTurnPinRef = useRef<PendingStaticTurnPinState | null>(null);
+  const pendingStaticLatestScrollBehaviorRef = useRef<('auto' | 'smooth') | null>(null);
   const initialHistoryRenderWindowCheckFrameRef = useRef<number | null>(null);
   const measureFrameRef = useRef<number | null>(null);
   const visibleTurnMeasureFrameRef = useRef<number | null>(null);
@@ -497,6 +527,39 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     };
   }, []);
 
+  const getEffectiveBottomScrollTop = useCallback((scroller: HTMLElement) => {
+    return Math.max(
+      0,
+      scroller.scrollHeight - scroller.clientHeight - getTotalBottomCompensationPx(),
+    );
+  }, [getTotalBottomCompensationPx]);
+
+  const isGeometryAtEffectiveBottom = useCallback((geometry: ScrollerGeometrySnapshot | null) => {
+    if (!geometry) {
+      return false;
+    }
+
+    const effectiveBottomScrollTop = Math.max(
+      0,
+      geometry.scrollHeight - geometry.clientHeight - getTotalBottomCompensationPx(),
+    );
+    return Math.abs(effectiveBottomScrollTop - geometry.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX;
+  }, [getTotalBottomCompensationPx]);
+
+  const recordStaticInitialHistoryBottomState = useCallback((scroller: HTMLElement) => {
+    if (!useStaticInitialHistoryListRef.current) {
+      staticInitialHistoryUserLeftBottomRef.current = false;
+      return;
+    }
+
+    const distanceFromBottom = Math.max(
+      0,
+      getEffectiveBottomScrollTop(scroller) - scroller.scrollTop,
+    );
+    staticInitialHistoryUserLeftBottomRef.current =
+      distanceFromBottom > LATEST_END_ANCHOR_STABLE_EPSILON_PX;
+  }, [getEffectiveBottomScrollTop]);
+
   const recordScrollerGeometryIfLayoutStable = useCallback((scroller: HTMLElement) => {
     const previousGeometry = previousScrollerGeometryRef.current;
     if (
@@ -510,6 +573,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     }
     recordScrollerGeometry(scroller);
   }, [recordScrollerGeometry]);
+
+  const notifyUserScrollIntent = useCallback(() => {
+    onUserScrollIntent?.();
+  }, [onUserScrollIntent]);
 
   const syncPhysicalBottomAfterViewportResize = useCallback((scroller: HTMLElement): boolean => {
     const previousGeometry = previousScrollerGeometryRef.current;
@@ -534,6 +601,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
     if (Math.abs(maxScrollTop - scroller.scrollTop) > COMPENSATION_EPSILON_PX) {
       scroller.scrollTop = maxScrollTop;
+      staticInitialHistoryUserLeftBottomRef.current = false;
     }
     previousScrollTopRef.current = scroller.scrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
@@ -555,10 +623,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return;
     }
 
-    const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
-    if (Math.abs(maxScrollTop - scroller.scrollTop) > LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
-      scroller.scrollTop = maxScrollTop;
-      previousScrollTopRef.current = maxScrollTop;
+    if (
+      staticInitialHistoryUserLeftBottomRef.current ||
+      pendingStaticTurnPinRef.current ||
+      staticAnchorWindowTurnId
+    ) {
+      return;
+    }
+
+    const effectiveBottomScrollTop = getEffectiveBottomScrollTop(scroller);
+    if (Math.abs(effectiveBottomScrollTop - scroller.scrollTop) > LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
+      scroller.scrollTop = effectiveBottomScrollTop;
+      staticInitialHistoryUserLeftBottomRef.current = false;
+      previousScrollTopRef.current = effectiveBottomScrollTop;
       previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
       recordScrollerGeometry(scroller);
     }
@@ -582,20 +659,24 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       if (
         !currentScroller ||
         !useStaticInitialHistoryListRef.current ||
+        staticInitialHistoryUserLeftBottomRef.current ||
+        pendingStaticTurnPinRef.current ||
+        staticAnchorWindowTurnId ||
         now <= userInitiatedUpwardScrollUntilMsRef.current
       ) {
         staticInitialHistoryBottomGuardUntilMsRef.current = 0;
         return;
       }
 
+      const currentEffectiveBottomScrollTop = getEffectiveBottomScrollTop(currentScroller);
       const distanceFromBottom = Math.max(
         0,
-        currentScroller.scrollHeight - currentScroller.clientHeight - currentScroller.scrollTop,
+        currentEffectiveBottomScrollTop - currentScroller.scrollTop,
       );
       if (distanceFromBottom > LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
-        const maxScrollTop = Math.max(0, currentScroller.scrollHeight - currentScroller.clientHeight);
-        currentScroller.scrollTop = maxScrollTop;
-        previousScrollTopRef.current = maxScrollTop;
+        currentScroller.scrollTop = currentEffectiveBottomScrollTop;
+        staticInitialHistoryUserLeftBottomRef.current = false;
+        previousScrollTopRef.current = currentEffectiveBottomScrollTop;
         previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(currentScroller);
       }
       recordScrollerGeometry(currentScroller);
@@ -604,7 +685,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     };
 
     staticInitialHistoryBottomGuardFrameRef.current = requestAnimationFrame(tick);
-  }, [recordScrollerGeometry, snapshotMeasuredContentHeight]);
+  }, [
+    getEffectiveBottomScrollTop,
+    recordScrollerGeometry,
+    snapshotMeasuredContentHeight,
+    staticAnchorWindowTurnId,
+  ]);
 
   const updateBottomReservationState = useCallback((
     updater: BottomReservationState | ((prev: BottomReservationState) => BottomReservationState),
@@ -1481,6 +1567,55 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     run(Math.max(1, frames));
   }, [reconcileStickyPinReservation]);
 
+  const scrollStaticTurnToTop = useCallback((turnId: string, behavior: ScrollBehavior) => {
+    const scroller = scrollerElementRef.current;
+    const targetElement = getRenderedUserMessageElement(turnId);
+    if (!scroller || !targetElement) {
+      return false;
+    }
+
+    const targetRect = targetElement.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    const targetScrollTop = Math.max(
+      0,
+      scroller.scrollTop + targetRect.top - scrollerRect.top - PINNED_TURN_VIEWPORT_OFFSET_PX,
+    );
+    cancelStaticInitialHistoryBottomGuard();
+    scroller.scrollTo({
+      top: targetScrollTop,
+      behavior,
+    });
+    previousScrollTopRef.current = targetScrollTop;
+    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    recordScrollerGeometry(scroller);
+    recordStaticInitialHistoryBottomState(scroller);
+    setIsAtBottom(false);
+    scheduleVisibleTurnMeasure(2);
+    return true;
+  }, [
+    cancelStaticInitialHistoryBottomGuard,
+    getRenderedUserMessageElement,
+    recordScrollerGeometry,
+    recordStaticInitialHistoryBottomState,
+    scheduleVisibleTurnMeasure,
+    snapshotMeasuredContentHeight,
+  ]);
+
+  useLayoutEffect(() => {
+    const pending = pendingStaticTurnPinRef.current;
+    if (!pending || pending.turnId !== staticAnchorWindowTurnId) {
+      return;
+    }
+
+    if (scrollStaticTurnToTop(pending.turnId, pending.behavior)) {
+      pendingStaticTurnPinRef.current = null;
+    }
+  }, [
+    scrollStaticTurnToTop,
+    staticAnchorWindowTurnId,
+    virtualItems,
+  ]);
+
   const tryResolvePendingTurnPin = useCallback((request: PendingTurnPinState) => {
     const scroller = scrollerElementRef.current;
     const virtuoso = virtuosoRef.current;
@@ -1931,6 +2066,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     };
     previousScrollerGeometryRef.current = null;
     pendingStaticAnchorTurnIdRef.current = null;
+    pendingStaticTurnPinRef.current = null;
     const currentSessionId = activeSession?.sessionId ?? null;
     const activeHandoff = historyProjectionHandoffRef.current;
     if (!activeHandoff || activeHandoff.sessionId !== currentSessionId) {
@@ -2176,6 +2312,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       }
       previousScrollTopRef.current = scrollerElement.scrollTop;
       recordScrollerGeometryIfLayoutStable(scrollerElement);
+      recordStaticInitialHistoryBottomState(scrollerElement);
       scheduleVisibleTurnMeasure();
       followOutputControllerRef.current.handleScroll();
       if (
@@ -2195,11 +2332,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
     const handleWheel = (event: WheelEvent) => {
       if (event.deltaY !== 0) {
+        notifyUserScrollIntent();
         clearTurnPinRequest();
         cancelLatestEndAnchorStabilization();
       }
 
       if (event.deltaY < 0) {
+        staticInitialHistoryUserLeftBottomRef.current = true;
         userInitiatedUpwardScrollUntilMsRef.current =
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
         schedulePreviousHistoryWindowForUserIntent('wheel-up');
@@ -2220,12 +2359,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       }
 
       if (Math.abs(currentY - startY) > TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX) {
+        notifyUserScrollIntent();
         clearTurnPinRequest();
         cancelLatestEndAnchorStabilization();
       }
 
       if (currentY - startY > TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX) {
         touchScrollIntentStartYRef.current = currentY;
+        staticInitialHistoryUserLeftBottomRef.current = true;
         userInitiatedUpwardScrollUntilMsRef.current =
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
         schedulePreviousHistoryWindowForUserIntent('touch-scroll-up');
@@ -2239,12 +2380,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isUpwardScrollIntentKey(event) || isEditableElement(event.target)) {
+      if (!isScrollIntentKey(event) || isEditableElement(event.target)) {
         return;
       }
 
+      notifyUserScrollIntent();
       clearTurnPinRequest();
       cancelLatestEndAnchorStabilization();
+
+      if (!isUpwardScrollIntentKey(event)) {
+        return;
+      }
+
+      staticInitialHistoryUserLeftBottomRef.current = true;
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
       schedulePreviousHistoryWindowForUserIntent('keyboard-scroll-up', { force: event.key === 'Home' });
@@ -2262,8 +2410,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       }
 
       scrollbarPointerInteractionActiveRef.current = true;
+      notifyUserScrollIntent();
       clearTurnPinRequest();
       cancelLatestEndAnchorStabilization();
+      staticInitialHistoryUserLeftBottomRef.current = true;
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
       schedulePreviousHistoryWindowForUserIntent('scrollbar-pointer-down');
@@ -2282,7 +2432,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       }
 
       clearTurnPinRequest();
+      notifyUserScrollIntent();
       cancelLatestEndAnchorStabilization();
+      staticInitialHistoryUserLeftBottomRef.current = true;
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
       schedulePreviousHistoryWindowForUserIntent('scrollbar-pointer-move');
@@ -2435,10 +2587,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     clearTurnPinRequest,
     getTotalBottomCompensationPx,
     latestTurnId,
+    notifyUserScrollIntent,
     pendingTurnPin?.pinMode,
     pendingTurnPin?.turnId,
     recordScrollerGeometry,
     recordScrollerGeometryIfLayoutStable,
+    recordStaticInitialHistoryBottomState,
     releaseAnchorLock,
     scheduleHeightMeasure,
     scheduleFollowToLatestWithViewportState,
@@ -2964,12 +3118,21 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         top: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
         behavior: 'auto',
       });
+      staticInitialHistoryUserLeftBottomRef.current = false;
     });
   }, [applyFooterCompensationNow, clearPinReservationForUserNavigation, isStreamingOutput, updateBottomReservationState]);
 
   const scrollToLatestEndPositionInternal = useCallback((behavior: 'auto' | 'smooth') => {
     const scroller = scrollerElementRef.current;
     if (!scroller) return;
+
+    if (useStaticInitialHistoryListRef.current && staticAnchorWindowTurnId) {
+      pendingStaticTurnPinRef.current = null;
+      pendingStaticAnchorTurnIdRef.current = null;
+      pendingStaticLatestScrollBehaviorRef.current = behavior;
+      setStaticAnchorWindowTurnId(null);
+      return;
+    }
 
     if (behavior === 'auto' && isStreamingOutputRef.current) {
       clearPinReservationForUserNavigation();
@@ -2998,7 +3161,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       // events.
       if (effectiveBottomTop - scroller.scrollTop > COMPENSATION_EPSILON_PX) {
         scroller.scrollTo({ top: effectiveBottomTop, behavior: 'auto' });
+        recordStaticInitialHistoryBottomState(scroller);
       }
+      setIsAtBottom(true);
       return;
     }
 
@@ -3007,7 +3172,28 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       top: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
       behavior,
     });
-  }, [clearAllBottomReservationsForUserNavigation, clearPinReservationForUserNavigation, getTotalBottomCompensationPx]);
+    staticInitialHistoryUserLeftBottomRef.current = false;
+    setIsAtBottom(true);
+  }, [
+    clearAllBottomReservationsForUserNavigation,
+    clearPinReservationForUserNavigation,
+    getTotalBottomCompensationPx,
+    recordStaticInitialHistoryBottomState,
+    staticAnchorWindowTurnId,
+  ]);
+  useLayoutEffect(() => {
+    const behavior = pendingStaticLatestScrollBehaviorRef.current;
+    if (!behavior || staticAnchorWindowTurnId || !useStaticInitialHistoryList) {
+      return;
+    }
+
+    pendingStaticLatestScrollBehaviorRef.current = null;
+    scrollToLatestEndPositionInternal(behavior);
+  }, [
+    scrollToLatestEndPositionInternal,
+    staticAnchorWindowTurnId,
+    useStaticInitialHistoryList,
+  ]);
 
   const requestTurnPinToTop = useCallback((turnId: string, options?: { behavior?: ScrollBehavior; pinMode?: FlowChatPinTurnToTopMode }) => {
     const requestedPinMode = options?.pinMode ?? 'transient';
@@ -3017,8 +3203,34 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return false;
     }
     const targetItem = userMessageItems.find(({ item }) => item.turnId === turnId);
-    if (!targetItem || !virtuosoRef.current) {
+    if (!targetItem) {
       return false;
+    }
+
+    if (!virtuosoRef.current) {
+      if (!useStaticInitialHistoryList) {
+        return false;
+      }
+
+      pendingStaticTurnPinRef.current = {
+        turnId,
+        behavior: requestedBehavior,
+      };
+
+      startupTrace.markPhase('flowchat_static_turn_pin_request', {
+        turnId,
+        pinMode: requestedPinMode,
+        targetIndex: targetItem.index,
+        userMessageCount: userMessageItems.length,
+      });
+
+      if (scrollStaticTurnToTop(turnId, requestedBehavior)) {
+        pendingStaticTurnPinRef.current = null;
+        return true;
+      }
+
+      setStaticAnchorWindowTurnId(turnId);
+      return true;
     }
 
     if (targetItem.index === 0 && requestedPinMode === 'transient') {
@@ -3064,7 +3276,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     clearTurnPinRequest,
     scheduleTransientTurnPinStabilization,
     scheduleVisibleTurnMeasure,
+    scrollStaticTurnToTop,
     tryResolvePendingTurnPin,
+    useStaticInitialHistoryList,
     userMessageItems,
   ]);
 
@@ -3397,9 +3611,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         top: nextScrollTop,
         behavior: 'auto',
       });
+      staticInitialHistoryUserLeftBottomRef.current = false;
       previousScrollTopRef.current = nextScrollTop;
       previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
       recordScrollerGeometry(scroller);
+      setIsAtBottom(true);
     }
   }, [clearAllBottomReservationsForUserNavigation, recordScrollerGeometry, snapshotMeasuredContentHeight]);
 
@@ -3495,6 +3711,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
           previousScrollTopRef.current = nextScrollTop;
           previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
           recordScrollerGeometry(scroller);
+          recordStaticInitialHistoryBottomState(scroller);
           staticState = readStaticTargetEndState();
         }
       }
@@ -3565,6 +3782,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     getRenderedVirtualItemElement,
     latestTurnId,
     recordScrollerGeometry,
+    recordStaticInitialHistoryBottomState,
     resolveLatestEndAnchorStabilization,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
@@ -3574,8 +3792,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   ]);
 
   const scrollToLatestEndPosition = useCallback(() => {
+    onUserScrollIntent?.();
     enterFollowOutput('jump-to-latest');
-  }, [enterFollowOutput]);
+  }, [enterFollowOutput, onUserScrollIntent]);
 
   useImperativeHandle(ref, () => ({
     scrollToTurn,
@@ -3804,6 +4023,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
         items: virtualItems,
         startIndex: 0,
         omittedEstimatedHeightPx: 0,
+        trailingOmittedEstimatedHeightPx: 0,
         renderedEstimatedHeightPx: 0,
         totalEstimatedHeightPx: 0,
         isWindowed: false,
@@ -3858,11 +4078,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     const omittedEstimatedHeightPx = virtualItems
       .slice(0, startIndex)
       .reduce((total, item) => total + estimateVirtualMessageItemHeight(item), 0);
+    const trailingOmittedEstimatedHeightPx = virtualItems
+      .slice(endIndex)
+      .reduce((total, item) => total + estimateVirtualMessageItemHeight(item), 0);
 
     return {
       items: virtualItems.slice(startIndex, endIndex),
       startIndex,
       omittedEstimatedHeightPx,
+      trailingOmittedEstimatedHeightPx,
       renderedEstimatedHeightPx,
       totalEstimatedHeightPx,
       isWindowed: startIndex > 0 || endIndex < virtualItems.length,
@@ -3886,6 +4110,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   const omittedInitialHistoryEstimatedHeightPx = isInitialHistoryRenderWindowExpanded
     ? 0
     : initialHistoryRenderWindow.omittedEstimatedHeightPx;
+  const trailingOmittedInitialHistoryEstimatedHeightPx = isInitialHistoryRenderWindowExpanded
+    ? 0
+    : initialHistoryRenderWindow.trailingOmittedEstimatedHeightPx;
   const getStaticAnchorScrollTop = useCallback((turnId: string) => {
     const scroller = scrollerElementRef.current;
     const targetElement = getRenderedUserMessageElement(turnId);
@@ -4014,9 +4241,25 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
     isInitialHistoryRenderWindowExpanded,
     useStaticInitialHistoryList,
   ]);
-  const handleInitialHistoryStaticScroll = useCallback(() => {
+  const handleInitialHistoryStaticScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const scroller = event.currentTarget;
+    const distanceFromBottom = Math.max(
+      0,
+      getEffectiveBottomScrollTop(scroller) - scroller.scrollTop,
+    );
+    const atBottom = distanceFromBottom <= 50;
+    setIsAtBottom(atBottom);
+    if (atBottom && staticAnchorWindowTurnId) {
+      pendingStaticTurnPinRef.current = null;
+      pendingStaticAnchorTurnIdRef.current = null;
+      setStaticAnchorWindowTurnId(null);
+    }
     expandInitialHistoryRenderWindowIfNeeded('scroll-near-omitted-history');
-  }, [expandInitialHistoryRenderWindowIfNeeded]);
+  }, [
+    expandInitialHistoryRenderWindowIfNeeded,
+    getEffectiveBottomScrollTop,
+    staticAnchorWindowTurnId,
+  ]);
   const handleInitialHistoryStaticWheelCapture = useCallback(() => {
     scheduleInitialHistoryRenderWindowCheck('wheel-near-omitted-history');
   }, [scheduleInitialHistoryRenderWindowCheck]);
@@ -4214,11 +4457,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   useLayoutEffect(() => {
     if (!useStaticInitialHistoryList) {
       autoScrolledInitialHistoryRenderKeyRef.current = null;
+      staticInitialHistoryUserLeftBottomRef.current = false;
       cancelStaticInitialHistoryBottomGuard();
       return;
     }
 
-    if (autoScrolledInitialHistoryRenderKeyRef.current === initialHistoryRenderKey) {
+    const previousAutoScrollKey = autoScrolledInitialHistoryRenderKeyRef.current;
+    if (previousAutoScrollKey === initialHistoryRenderKey) {
       return;
     }
 
@@ -4227,9 +4472,26 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return;
     }
 
+    if (previousAutoScrollKey !== null) {
+      const distanceFromBottom = Math.max(
+        0,
+        getEffectiveBottomScrollTop(scroller) - scroller.scrollTop,
+      );
+      const wasAtEffectiveBottom = isGeometryAtEffectiveBottom(previousScrollerGeometryRef.current);
+      if (
+        staticInitialHistoryUserLeftBottomRef.current ||
+        (!wasAtEffectiveBottom && distanceFromBottom > LATEST_END_ANCHOR_STABLE_EPSILON_PX)
+      ) {
+        staticInitialHistoryUserLeftBottomRef.current = true;
+        recordScrollerGeometry(scroller);
+        return;
+      }
+    }
+
     autoScrolledInitialHistoryRenderKeyRef.current = initialHistoryRenderKey;
-    const nextScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    const nextScrollTop = getEffectiveBottomScrollTop(scroller);
     scroller.scrollTop = nextScrollTop;
+    staticInitialHistoryUserLeftBottomRef.current = false;
     previousScrollTopRef.current = nextScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
     recordScrollerGeometry(scroller);
@@ -4238,7 +4500,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
   }, [
     activeSessionId,
     cancelStaticInitialHistoryBottomGuard,
+    getEffectiveBottomScrollTop,
     initialHistoryRenderKey,
+    isGeometryAtEffectiveBottom,
     latestTurnId,
     recordScrollerGeometry,
     scheduleVisibleTurnMeasure,
@@ -4261,20 +4525,37 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
       return;
     }
 
-    const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
-    if (Math.abs(maxScrollTop - scroller.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
+    const effectiveBottomScrollTop = getEffectiveBottomScrollTop(scroller);
+    if (Math.abs(effectiveBottomScrollTop - scroller.scrollTop) <= LATEST_END_ANCHOR_STABLE_EPSILON_PX) {
+      staticInitialHistoryUserLeftBottomRef.current = false;
       recordScrollerGeometry(scroller);
       return;
     }
 
-    scroller.scrollTop = maxScrollTop;
-    previousScrollTopRef.current = maxScrollTop;
+    if (staticInitialHistoryUserLeftBottomRef.current) {
+      recordScrollerGeometry(scroller);
+      return;
+    }
+
+    const previousWasAtBottom = isGeometryAtEffectiveBottom(previousScrollerGeometryRef.current);
+    if (!previousWasAtBottom) {
+      recordStaticInitialHistoryBottomState(scroller);
+      recordScrollerGeometry(scroller);
+      return;
+    }
+
+    scroller.scrollTop = effectiveBottomScrollTop;
+    staticInitialHistoryUserLeftBottomRef.current = false;
+    previousScrollTopRef.current = effectiveBottomScrollTop;
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
     recordScrollerGeometry(scroller);
   }, [
     footerHeightPx,
+    getEffectiveBottomScrollTop,
     initialHistoryRenderKey,
+    isGeometryAtEffectiveBottom,
     recordScrollerGeometry,
+    recordStaticInitialHistoryBottomState,
     snapshotMeasuredContentHeight,
     useStaticInitialHistoryList,
   ]);
@@ -4342,6 +4623,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
               />
             ))}
           </div>
+          {trailingOmittedInitialHistoryEstimatedHeightPx > 0 ? (
+            <div
+              className="virtual-message-list__initial-history-spacer"
+              data-history-initial-render-tail-spacer="true"
+              aria-hidden="true"
+              style={{
+                height: `${Math.round(trailingOmittedInitialHistoryEstimatedHeightPx)}px`,
+              }}
+            />
+          ) : null}
           <ProcessingIndicator visible={showBreathingIndicator} reserveSpace={reserveSpaceForIndicator} />
           <div
             ref={footerElementRef}
@@ -4501,11 +4792,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef>((_, ref) => 
 
 VirtualMessageListSession.displayName = 'VirtualMessageListSession';
 
-export const VirtualMessageList = forwardRef<VirtualMessageListRef>((_, ref) => {
+export const VirtualMessageList = forwardRef<VirtualMessageListRef, VirtualMessageListProps>((props, ref) => {
   const activeSession = useActiveSession();
   const sessionKey = activeSession?.sessionId ?? 'no-active-session';
 
-  return <VirtualMessageListSession key={sessionKey} ref={ref} />;
+  return <VirtualMessageListSession key={sessionKey} ref={ref} {...props} />;
 });
 
 VirtualMessageList.displayName = 'VirtualMessageList';

--- a/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
@@ -121,6 +121,7 @@ export interface InitialHistoryRenderWindow {
   items: VirtualItem[];
   startIndex: number;
   omittedEstimatedHeightPx: number;
+  trailingOmittedEstimatedHeightPx: number;
   renderedEstimatedHeightPx: number;
   totalEstimatedHeightPx: number;
   isWindowed: boolean;
@@ -213,6 +214,7 @@ export function selectInitialHistoryRenderWindow(
       items,
       startIndex: 0,
       omittedEstimatedHeightPx: 0,
+      trailingOmittedEstimatedHeightPx: 0,
       renderedEstimatedHeightPx: totalEstimatedHeightPx,
       totalEstimatedHeightPx,
       isWindowed: false,
@@ -252,6 +254,7 @@ export function selectInitialHistoryRenderWindow(
     items: items.slice(startIndex),
     startIndex,
     omittedEstimatedHeightPx,
+    trailingOmittedEstimatedHeightPx: 0,
     renderedEstimatedHeightPx,
     totalEstimatedHeightPx,
     isWindowed: startIndex > 0,

--- a/tests/e2e/specs/l1-chat-turn-navigation-release.spec.ts
+++ b/tests/e2e/specs/l1-chat-turn-navigation-release.spec.ts
@@ -1,0 +1,486 @@
+/**
+ * Release-compatible regression coverage for header turn navigation.
+ *
+ * This spec intentionally avoids Vite-only /src imports so it can run against
+ * the bundled release-fast desktop app with persisted long-session fixtures.
+ */
+import { $, browser, expect } from '@wdio/globals';
+import { openWorkspace } from '../helpers/workspace-helper';
+import { saveFailureScreenshot } from '../helpers/screenshot-utils';
+
+const SESSION_NAV_ITEM_SELECTOR =
+  '[data-testid="session-nav-item"], [data-testid="nav-session-item"]';
+const SESSION_NAV_TOGGLE_SELECTOR =
+  '[data-testid="session-nav-show-more"], [data-testid="nav-session-list-toggle"]';
+const DEFAULT_SESSION_ID = 'release-turn-nav-000';
+const DEFAULT_TARGET_TURN_INDEX = 2;
+
+type TurnViewportMetrics = {
+  rootExists: boolean;
+  scrollerExists: boolean;
+  targetExists: boolean;
+  targetVisible: boolean;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  maxScrollTop: number;
+  targetTop: number | null;
+  targetBottom: number | null;
+  scrollerTop: number | null;
+  scrollerBottom: number | null;
+  deltaToPinnedTop: number | null;
+  distanceFromBottom: number | null;
+  visibleTurnIds: string[];
+  activeTurnListText: string | null;
+};
+
+type SessionShellState = {
+  historyState: string | null;
+  contextRestoreState: string | null;
+  isPartial: boolean;
+  dialogTurnCount: number;
+  virtualItemCount: number;
+  hasPendingHistoryCompletion: boolean;
+  hasDeferredHistoryProjection: boolean;
+  latestTurnId: string | null;
+  turnListOpen: boolean;
+  turnListTexts: string[];
+};
+
+function escapeCssAttributeValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+async function findSessionItem(sessionId: string): Promise<WebdriverIO.Element | null> {
+  const targetSelector =
+    `[data-testid="session-nav-item"][data-session-id="${escapeCssAttributeValue(sessionId)}"], ` +
+    `[data-testid="nav-session-item"][data-session-id="${escapeCssAttributeValue(sessionId)}"]`;
+
+  const readVisibleSessionIds = async (): Promise<string[]> =>
+    browser.execute((selector) =>
+      Array.from(document.querySelectorAll(selector))
+        .map(element => element.getAttribute('data-session-id') || '')
+        .filter(Boolean),
+    SESSION_NAV_ITEM_SELECTOR);
+
+  const findTarget = async (): Promise<WebdriverIO.Element | null> => {
+    const item = await $(targetSelector);
+    return await item.isExisting() ? item : null;
+  };
+
+  const findExpandableToggles = async (): Promise<WebdriverIO.Element[]> => {
+    const toggles = await browser.$$(SESSION_NAV_TOGGLE_SELECTOR);
+    const expandable: WebdriverIO.Element[] = [];
+    for (const toggle of toggles) {
+      if (
+        !(await toggle.isExisting()) ||
+        !(await toggle.isDisplayed()) ||
+        !(await toggle.isEnabled())
+      ) {
+        continue;
+      }
+
+      const action = await toggle.getAttribute('data-session-nav-toggle-action').catch(() => null);
+      if (action === 'show-less') {
+        continue;
+      }
+      expandable.push(toggle);
+    }
+    return expandable;
+  };
+
+  let lastVisibleSessionIds: string[] = [];
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const existing = await findTarget();
+    if (existing) {
+      return existing;
+    }
+
+    lastVisibleSessionIds = await readVisibleSessionIds();
+    const toggles = await findExpandableToggles();
+    if (toggles.length === 0) {
+      break;
+    }
+
+    let clickedAny = false;
+    for (let toggleIndex = 0; toggleIndex < toggles.length; toggleIndex += 1) {
+      const item = await findTarget();
+      if (item) {
+        return item;
+      }
+
+      const currentToggles = await findExpandableToggles();
+      const toggle = currentToggles[toggleIndex];
+      if (!toggle) {
+        break;
+      }
+
+      const beforeCount = lastVisibleSessionIds.length;
+      clickedAny = true;
+      await toggle.click();
+      await browser.waitUntil(async () => {
+        if (await findTarget()) {
+          return true;
+        }
+        const ids = await readVisibleSessionIds();
+        const nextToggles = await findExpandableToggles();
+        return ids.length !== beforeCount || nextToggles.length !== toggles.length;
+      }, { timeout: 3000, interval: 100 }).catch(() => undefined);
+      lastVisibleSessionIds = await readVisibleSessionIds();
+    }
+
+    if (!clickedAny) {
+      break;
+    }
+  }
+
+  console.log('[ReleaseTurnNav] visible sessions while locating target', JSON.stringify({
+    target: sessionId,
+    visibleSessionIds: lastVisibleSessionIds.slice(0, 40),
+    visibleSessionCount: lastVisibleSessionIds.length,
+  }));
+  return null;
+}
+
+async function isSessionItemActive(item: WebdriverIO.Element): Promise<boolean> {
+  const className = await item.getAttribute('class') ?? '';
+  return className.split(/\s+/).includes('is-active');
+}
+
+async function readTurnViewportMetrics(targetTurnId: string): Promise<TurnViewportMetrics> {
+  return browser.execute((turnId) => {
+    const root = document.querySelector<HTMLElement>(
+      '.modern-flowchat-container__messages .virtual-message-list',
+    );
+    const scroller = root?.querySelector<HTMLElement>(
+      '[data-virtuoso-scroller="true"], [data-virtuoso-scroller], .virtual-message-list__static-scroller',
+    ) ?? null;
+    const wrappers = Array.from(root?.querySelectorAll<HTMLElement>(
+      '.virtual-item-wrapper[data-turn-id]',
+    ) ?? []);
+    const target = wrappers.find(element =>
+      element.dataset.turnId === turnId && element.dataset.itemType === 'user-message'
+    ) ?? null;
+    const scrollerRect = scroller?.getBoundingClientRect() ?? null;
+    const targetRect = target?.getBoundingClientRect() ?? null;
+    const visibleTurnIds = scrollerRect
+      ? wrappers
+        .filter(element => {
+          const rect = element.getBoundingClientRect();
+          return rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
+        })
+        .map(element => element.dataset.turnId || '')
+        .filter(Boolean)
+      : [];
+    const targetVisible = Boolean(
+      scrollerRect &&
+      targetRect &&
+      targetRect.bottom > scrollerRect.top &&
+      targetRect.top < scrollerRect.bottom
+    );
+    const activeTurnListItem = document.querySelector<HTMLElement>(
+      '.flowchat-header__turn-list-item--active',
+    );
+
+    return {
+      rootExists: Boolean(root),
+      scrollerExists: Boolean(scroller),
+      targetExists: Boolean(target),
+      targetVisible,
+      scrollTop: scroller?.scrollTop ?? 0,
+      scrollHeight: scroller?.scrollHeight ?? 0,
+      clientHeight: scroller?.clientHeight ?? 0,
+      maxScrollTop: scroller ? Math.max(0, scroller.scrollHeight - scroller.clientHeight) : 0,
+      targetTop: targetRect?.top ?? null,
+      targetBottom: targetRect?.bottom ?? null,
+      scrollerTop: scrollerRect?.top ?? null,
+      scrollerBottom: scrollerRect?.bottom ?? null,
+      deltaToPinnedTop: scrollerRect && targetRect ? targetRect.top - scrollerRect.top : null,
+      distanceFromBottom: scrollerRect && targetRect ? scrollerRect.bottom - targetRect.bottom : null,
+      visibleTurnIds: Array.from(new Set(visibleTurnIds)),
+      activeTurnListText: activeTurnListItem?.textContent?.trim() ?? null,
+    };
+  }, targetTurnId);
+}
+
+async function readSessionShellState(): Promise<SessionShellState> {
+  return browser.execute(() => {
+    const messages = document.querySelector<HTMLElement>(
+      '.modern-flowchat-container__messages',
+    );
+    const turnListItems = Array.from(document.querySelectorAll<HTMLElement>(
+      '.flowchat-header__turn-list-item',
+    ));
+    return {
+      historyState: messages?.dataset.historyState ?? null,
+      contextRestoreState: messages?.dataset.contextRestoreState ?? null,
+      isPartial: messages?.dataset.isPartial === 'true',
+      dialogTurnCount: Number(messages?.dataset.dialogTurnCount ?? 0),
+      virtualItemCount: Number(messages?.dataset.virtualItemCount ?? 0),
+      hasPendingHistoryCompletion: messages?.dataset.hasPendingHistoryCompletion === 'true',
+      hasDeferredHistoryProjection: messages?.dataset.hasDeferredHistoryProjection === 'true',
+      latestTurnId: messages?.dataset.latestTurnId || null,
+      turnListOpen: turnListItems.length > 0,
+      turnListTexts: turnListItems.map(item => item.textContent?.trim() ?? ''),
+    };
+  });
+}
+
+async function waitForSessionHydrated(): Promise<void> {
+  await browser.waitUntil(async () => {
+    const turnListButton = await $('[data-testid="flowchat-header-turn-list"]');
+    if (!(await turnListButton.isExisting()) || !(await turnListButton.isEnabled())) {
+      return false;
+    }
+    const state = await browser.execute(() => {
+      const root = document.querySelector<HTMLElement>(
+        '.modern-flowchat-container__messages .virtual-message-list',
+      );
+      const scroller = root?.querySelector<HTMLElement>(
+        '[data-virtuoso-scroller="true"], [data-virtuoso-scroller], .virtual-message-list__static-scroller',
+      ) ?? null;
+      const items = root?.querySelectorAll('.virtual-item-wrapper[data-turn-id]') ?? [];
+      return {
+        hasRoot: Boolean(root),
+        hasScroller: Boolean(scroller),
+        itemCount: items.length,
+      };
+    });
+    return state.hasRoot && state.hasScroller && state.itemCount > 0;
+  }, {
+    timeout: 30000,
+    interval: 200,
+    timeoutMsg: '[ReleaseTurnNav] generated session did not hydrate message list',
+  });
+}
+
+async function openHeaderTurnList(): Promise<void> {
+  const existingItems = await $$('.flowchat-header__turn-list-item');
+  if (existingItems.length > 0) {
+    return;
+  }
+
+  const turnListButton = await $('[data-testid="flowchat-header-turn-list"]');
+  await turnListButton.waitForClickable({ timeout: 10000 });
+  await turnListButton.click();
+  await browser.waitUntil(async () => {
+    const items = await $$('.flowchat-header__turn-list-item');
+    return items.length > 0;
+  }, {
+    timeout: 3000,
+    interval: 100,
+    timeoutMsg: '[ReleaseTurnNav] turn list did not open',
+  });
+}
+
+async function closeHeaderTurnList(): Promise<void> {
+  const items = await $$('.flowchat-header__turn-list-item');
+  if (items.length === 0) {
+    return;
+  }
+
+  const turnListButton = await $('[data-testid="flowchat-header-turn-list"]');
+  await turnListButton.click();
+  await browser.waitUntil(async () => {
+    const currentItems = await $$('.flowchat-header__turn-list-item');
+    return currentItems.length === 0;
+  }, { timeout: 3000, interval: 100 }).catch(() => undefined);
+}
+
+async function readHeaderTurnListTexts(): Promise<string[]> {
+  await openHeaderTurnList();
+  return browser.execute(() =>
+    Array.from(document.querySelectorAll<HTMLElement>('.flowchat-header__turn-list-item'))
+      .map(item => item.textContent?.trim() ?? ''),
+  );
+}
+
+async function scrollToPreviousHistoryBoundary(): Promise<void> {
+  await browser.execute(() => {
+    const scroller = document.querySelector<HTMLElement>(
+      '.modern-flowchat-container__messages .virtual-message-list [data-virtuoso-scroller="true"], ' +
+      '.modern-flowchat-container__messages .virtual-message-list [data-virtuoso-scroller], ' +
+      '.modern-flowchat-container__messages .virtual-message-list .virtual-message-list__static-scroller',
+    );
+    if (!scroller) {
+      return;
+    }
+    scroller.dispatchEvent(new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -1200,
+      deltaMode: 0,
+    }));
+    scroller.scrollTop = 0;
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+  });
+}
+
+async function revealHistoryUntilTurnListContains(targetTitle: string): Promise<{
+  attempts: number;
+  finalState: SessionShellState;
+}> {
+  let state = await readSessionShellState();
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const texts = await readHeaderTurnListTexts();
+    state = {
+      ...await readSessionShellState(),
+      turnListOpen: true,
+      turnListTexts: texts,
+    };
+    if (texts.some(text => text.includes(targetTitle))) {
+      return { attempts: attempt, finalState: state };
+    }
+
+    await closeHeaderTurnList();
+    if (!state.isPartial && !state.hasPendingHistoryCompletion && !state.hasDeferredHistoryProjection) {
+      break;
+    }
+
+    const beforeCount = state.dialogTurnCount;
+    await scrollToPreviousHistoryBoundary();
+    await browser.waitUntil(async () => {
+      const next = await readSessionShellState();
+      return (
+        next.dialogTurnCount > beforeCount ||
+        next.isPartial === false ||
+        next.hasDeferredHistoryProjection !== state.hasDeferredHistoryProjection ||
+        next.hasPendingHistoryCompletion !== state.hasPendingHistoryCompletion
+      );
+    }, { timeout: 6000, interval: 150 }).catch(() => undefined);
+    await browser.pause(500);
+  }
+
+  await openHeaderTurnList();
+  state = await readSessionShellState();
+  throw new Error(`[ReleaseTurnNav] target turn title not available in header list: ${JSON.stringify({
+    targetTitle,
+    state,
+  })}`);
+}
+
+async function scrollToLatest(targetTurnId: string): Promise<TurnViewportMetrics> {
+  await browser.execute(() => {
+    const scroller = document.querySelector<HTMLElement>(
+      '.modern-flowchat-container__messages .virtual-message-list [data-virtuoso-scroller="true"], ' +
+      '.modern-flowchat-container__messages .virtual-message-list [data-virtuoso-scroller], ' +
+      '.modern-flowchat-container__messages .virtual-message-list .virtual-message-list__static-scroller',
+    );
+    if (!scroller) {
+      return;
+    }
+    scroller.scrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+  });
+  await browser.pause(800);
+  return readTurnViewportMetrics(targetTurnId);
+}
+
+async function clickHeaderTurnListItemByTitle(targetTitle: string): Promise<{
+  itemCount: number;
+  itemTexts: string[];
+}> {
+  await openHeaderTurnList();
+  const items = await $$('.flowchat-header__turn-list-item');
+  const itemTexts: string[] = [];
+  let targetIndex = -1;
+  for (let index = 0; index < items.length; index += 1) {
+    const text = await items[index].getText();
+    itemTexts.push(text);
+    if (targetIndex < 0 && text.includes(targetTitle)) {
+      targetIndex = index;
+    }
+  }
+  if (targetIndex < 0) {
+    throw new Error(`[ReleaseTurnNav] turn list item not found: ${JSON.stringify({
+      targetTitle,
+      itemTexts,
+    })}`);
+  }
+  await items[targetIndex].click();
+  return { itemCount: items.length, itemTexts };
+}
+
+describe('Release long-session turn navigation', () => {
+  let hasWorkspace = false;
+
+  before(async function () {
+    const workspacePath = process.env.E2E_TEST_WORKSPACE;
+    if (!workspacePath) {
+      console.log('[ReleaseTurnNav] E2E_TEST_WORKSPACE is missing; skipping release fixture spec.');
+      return;
+    }
+    hasWorkspace = await openWorkspace(workspacePath, { requireWorkspaceLabel: true });
+  });
+
+  it('moves the real message viewport when selecting an older turn from the header list (#1281)', async function () {
+    if (!hasWorkspace) {
+      this.skip();
+      return;
+    }
+
+    const sessionId = process.env.BITFUN_E2E_TURN_NAV_SESSION_ID || DEFAULT_SESSION_ID;
+    const targetTurnIndex = Number(
+      process.env.BITFUN_E2E_TURN_NAV_TARGET_INDEX || DEFAULT_TARGET_TURN_INDEX,
+    );
+    const targetTurnId = `${sessionId}-turn-${String(targetTurnIndex).padStart(4, '0')}`;
+    const targetTitle = `Synthetic user turn ${targetTurnIndex}`;
+
+    const item = await findSessionItem(sessionId);
+    if (!item) {
+      throw new Error(`[ReleaseTurnNav] generated session not found: ${sessionId}`);
+    }
+    if (!(await isSessionItemActive(item))) {
+      await item.click();
+    }
+    await waitForSessionHydrated();
+
+    const before = await scrollToLatest(targetTurnId);
+    expect(before.scrollerExists).toBe(true);
+    expect(before.maxScrollTop).toBeGreaterThan(300);
+
+    const revealState = await revealHistoryUntilTurnListContains(targetTitle);
+    const clickResult = await clickHeaderTurnListItemByTitle(targetTitle);
+    expect(clickResult.itemCount).toBeGreaterThan(0);
+
+    let lastMetrics = await readTurnViewportMetrics(targetTurnId);
+    await browser.waitUntil(async () => {
+      const metrics = await readTurnViewportMetrics(targetTurnId);
+      lastMetrics = metrics;
+      return (
+        metrics.targetVisible &&
+        metrics.deltaToPinnedTop !== null &&
+        Math.abs(metrics.deltaToPinnedTop) <= 100
+      );
+    }, {
+      timeout: 8000,
+      interval: 150,
+      timeoutMsg: `[ReleaseTurnNav] selected turn did not move near the top of the message viewport: ${JSON.stringify({
+        targetTurnId,
+        targetTitle,
+        revealState,
+        clickResult,
+        lastMetrics,
+        shellState: await readSessionShellState(),
+      })}`,
+    });
+
+    await browser.pause(600);
+    const after = await readTurnViewportMetrics(targetTurnId);
+    const diagnostics = { sessionId, targetTurnId, targetTitle, revealState, clickResult, before, after };
+    console.log('[ReleaseTurnNav] diagnostics:', JSON.stringify(diagnostics));
+
+    expect(after.targetExists).toBe(true);
+    expect(after.targetVisible).toBe(true);
+    expect(after.deltaToPinnedTop).not.toBeNull();
+    expect(Math.abs(after.deltaToPinnedTop!)).toBeLessThanOrEqual(100);
+    expect(after.distanceFromBottom).not.toBeNull();
+    expect(after.distanceFromBottom!).toBeGreaterThan(200);
+  });
+
+  afterEach(async function () {
+    if (this.currentTest?.state === 'failed') {
+      await saveFailureScreenshot(`l1-chat-turn-navigation-release-${this.currentTest.title}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- keep header turn state tied to the real visible viewport while pending turn navigation retries in the background
- preserve static initial-history scroll ownership when users read older content, including bottom-guard, manual-scroll, and return-to-latest paths
- keep latest content reachable after static anchor-window jumps by preserving tail space and deferring latest scroll until the latest DOM is restored
- add release-compatible E2E coverage for long-session header turn navigation

## Validation
- pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx src/flow_chat/components/modern/VirtualMessageList.layout.test.ts src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
- pnpm run type-check:web
- pnpm run desktop:build:release-fast
- pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec ./specs/l1-chat-turn-navigation-release.spec.ts
- node tests/e2e/scripts/run-long-session-interaction-matrix.mjs --profile scroll
- final independent architecture/product subagent review: no remaining must-fix

Fixes #1281
Related to #1381