### PR TITLE
feat: support images in /btw side questions

### DIFF
--- a/src/apps/desktop/src/api/btw_api.rs
+++ b/src/apps/desktop/src/api/btw_api.rs
@@ -13,6 +13,7 @@ use tauri::State;
 use crate::api::app_state::AppState;
 
 use bitfun_core::agentic::coordination::ConversationCoordinator;
+use bitfun_core::agentic::image_analysis::ImageContextData;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -24,6 +25,8 @@ pub struct BtwAskStreamRequest {
     pub child_session_name: Option<String>,
     /// Optional model id override. Supports "fast"/"primary" aliases.
     pub model_id: Option<String>,
+    #[serde(default)]
+    pub image_contexts: Option<Vec<ImageContextData>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -88,15 +91,20 @@ pub async fn btw_ask_stream(
     if child_session_id.is_empty() {
         return Err("childSessionId is required".to_string());
     }
+    let child_session_id = child_session_id.to_string();
+    let child_session_name = request.child_session_name.clone();
+    let model_id = request.model_id.clone();
+    let image_contexts = request.image_contexts;
 
     let turn_id = coordinator
         .start_hidden_btw_turn(
             &request.request_id,
             &request.session_id,
-            child_session_id,
-            request.child_session_name.as_deref(),
+            &child_session_id,
+            child_session_name.as_deref(),
             &request.question,
-            request.model_id.as_deref(),
+            model_id.as_deref(),
+            image_contexts,
         )
         .await
         .map_err(|e| e.to_string())?;
@@ -105,13 +113,13 @@ pub async fn btw_ask_stream(
         .side_question_runtime
         .register_btw_turn(
             request.request_id.clone(),
-            child_session_id.to_string(),
+            child_session_id.clone(),
             turn_id.clone(),
         )
         .await;
     let runtime = state.side_question_runtime.clone();
     let request_id = request.request_id.clone();
-    let child_session_id = child_session_id.to_string();
+    let child_session_id = child_session_id;
     let turn_id = turn_id;
     let coordinator = coordinator.inner().clone();
     tokio::spawn(async move {

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -5410,6 +5410,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         child_session_name: Option<&str>,
         question: &str,
         model_id: Option<&str>,
+        image_contexts: Option<Vec<ImageContextData>>,
     ) -> BitFunResult<String> {
         if request_id.trim().is_empty() {
             return Err(BitFunError::Validation(
@@ -5455,7 +5456,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             child_session_id.to_string(),
             user_input,
             Some(question.trim().to_string()),
-            None,
+            image_contexts,
             Some(turn_id.clone()),
             child_session.agent_type.clone(),
             child_session.config.workspace_path.clone(),

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -39,6 +39,7 @@ import { useChatInputState } from '../store/chatInputStateStore';
 import { useInputHistoryStore } from '../store/inputHistoryStore';
 import { startBtwThread } from '../services/BtwThreadService';
 import { runUsageReportCommand } from '../services/usageReportService';
+import { buildImagePayload } from '../utils/imagePayload';
 import { isGoalSlashCommand, parseGoalCommand } from '../services/goalService';
 import {
   getHistorySessionOpenTransitionSnapshot,
@@ -1914,6 +1915,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     const message = expandComposerSpecialTokens(originalMessage);
     const messageCharCount = getCharacterCount(message);
     const question = stripSlashCommand(message, '/btw').trim();
+    const imagesForBtw = [...imageContexts];
 
     // Clear input without adding to main history.
     dispatchInput({ type: 'CLEAR_VALUE' });
@@ -1941,12 +1943,26 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
 
     try {
+      let imagePayload: Awaited<ReturnType<typeof buildImagePayload>>;
+      try {
+        imagePayload = await buildImagePayload(imagesForBtw);
+      } catch (error) {
+        log.error('Failed to upload images for /btw thread', {
+          imageCount: imagesForBtw.length,
+          error,
+        });
+        notificationService.error('Image upload failed. Please try again.', { duration: 3000 });
+        throw error;
+      }
+
       const { childSessionId } = await startBtwThread({
         parentSessionId: currentSessionId,
         workspacePath,
         question,
         modelId: 'fast',
+        imagePayload,
       });
+      imagesForBtw.forEach(image => removeContext(image.id));
       openBtwSessionInAuxPane({
         childSessionId,
         parentSessionId: currentSessionId,
@@ -1961,7 +1977,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       pendingLargePastesRef.current = originalPendingLargePastes;
       dispatchInput({ type: 'SET_VALUE', payload: originalMessage });
     }
-  }, [clearPendingLargePastes, currentSessionId, derivedState, expandComposerSpecialTokens, inputState.value, isBtwSession, setQueuedInput, t, workspacePath]);
+  }, [clearPendingLargePastes, currentSessionId, derivedState, expandComposerSpecialTokens, imageContexts, inputState.value, isBtwSession, removeContext, setQueuedInput, t, workspacePath]);
 
   const submitCompactFromInput = useCallback(async () => {
     if (!effectiveTargetSessionId || !effectiveTargetSession) {

--- a/src/web-ui/src/flow_chat/hooks/useMessageSender.ts
+++ b/src/web-ui/src/flow_chat/hooks/useMessageSender.ts
@@ -14,6 +14,7 @@ import { notificationService } from '@/shared/notification-system';
 import type { ContextItem, ImageContext } from '@/shared/types/context';
 import { createLogger } from '@/shared/utils/logger';
 import { formatContextForPrompt } from '@/shared/utils/contextPrompt';
+import { buildImagePayload } from '../utils/imagePayload';
 
 const log = createLogger('FlowChat');
 
@@ -103,50 +104,21 @@ export function useMessageSender(props: UseMessageSenderProps): UseMessageSender
       }
 
       const imageContexts = contexts.filter(ctx => ctx.type === 'image') as ImageContext[];
-      const clipboardImages = imageContexts.filter(ctx => !ctx.isLocal && ctx.dataUrl);
-      const uploadedImagePaths = new Map<string, string>();
-
-      if (clipboardImages.length > 0) {
-        try {
-          const { api } = await import('@/infrastructure/api/service-api/ApiClient');
-          const uploadData = {
-            request: {
-              images: clipboardImages.map(ctx => ({
-                id: ctx.id,
-                image_path: ctx.imagePath || null,
-                data_url: ctx.dataUrl || null,
-                mime_type: ctx.mimeType,
-                image_name: ctx.imageName,
-                file_size: ctx.fileSize,
-                width: ctx.width || null,
-                height: ctx.height || null,
-                source: ctx.source,
-              }))
-            }
-          };
-
-          const uploadResults = await api.invoke<Array<{ id: string; image_path?: string | null }>>(
-            'upload_image_contexts',
-            uploadData
-          );
-          for (const result of uploadResults) {
-            if (result.image_path) {
-              uploadedImagePaths.set(result.id, result.image_path);
-            }
-          }
-          log.debug('Clipboard images uploaded', {
-            imageCount: clipboardImages.length,
-            ids: clipboardImages.map(img => img.id),
-            pathCount: uploadedImagePaths.size,
-          });
-        } catch (error) {
-          log.error('Failed to upload clipboard images', {
-            imageCount: clipboardImages.length,
-            error: (error as Error)?.message ?? 'unknown',
-          });
-          notificationService.error('Image upload failed. Please try again.', { duration: 3000 });
-          throw error;
-        }
+      let imagePayload: Awaited<ReturnType<typeof buildImagePayload>>;
+      try {
+        imagePayload = await buildImagePayload(imageContexts);
+        log.debug('Image payload prepared', {
+          imageCount: imageContexts.length,
+          ids: imageContexts.map(img => img.id),
+          pathCount: imagePayload?.imageContexts.filter(img => img.image_path).length ?? 0,
+        });
+      } catch (error) {
+        log.error('Failed to upload clipboard images', {
+          imageCount: imageContexts.filter(ctx => !ctx.isLocal && ctx.dataUrl).length,
+          error: (error as Error)?.message ?? 'unknown',
+        });
+        notificationService.error('Image upload failed. Please try again.', { duration: 3000 });
+        throw error;
       }
 
       let fullMessage = aiTrimmedMessage;
@@ -160,38 +132,13 @@ export function useMessageSender(props: UseMessageSenderProps): UseMessageSender
 
       // Always pass imageContexts to the backend; the coordinator decides
       // whether to pre-analyse via a vision model or attach directly.
-      const imageContextsForBackend = imageContexts.length > 0
-        ? {
-            imageContexts: imageContexts.map(ctx => ({
-              id: ctx.id,
-              image_path: ctx.isLocal ? ctx.imagePath : uploadedImagePaths.get(ctx.id),
-              data_url: undefined,
-              mime_type: ctx.mimeType,
-              metadata: {
-                name: ctx.imageName,
-                width: ctx.width,
-                height: ctx.height,
-                file_size: ctx.fileSize,
-                source: ctx.source,
-              },
-            })),
-            imageDisplayData: imageContexts.map(ctx => ({
-              id: ctx.id,
-              name: ctx.imageName || 'Image',
-              dataUrl: ctx.dataUrl,
-              imagePath: ctx.isLocal ? ctx.imagePath : uploadedImagePaths.get(ctx.id),
-              mimeType: ctx.mimeType,
-            })),
-          }
-        : undefined;
-
       await flowChatManager.sendMessage(
         fullMessage,
         sessionId || undefined,
         displayMessage,
         agentTypeForSend,
         undefined,
-        imageContextsForBackend
+        imagePayload
       );
 
       onClearContexts();

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.test.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.test.ts
@@ -6,6 +6,7 @@ const mockAddExternalSession = vi.fn();
 const mockUpdateSessionRelationship = vi.fn();
 const mockUpdateSessionBtwOrigin = vi.fn();
 const mockAddBtwThreadMarker = vi.fn();
+const mockUpdateSessionModelName = vi.fn();
 
 const sessions = new Map<string, any>();
 
@@ -25,7 +26,7 @@ vi.mock('../store/FlowChatStore', () => ({
     updateSessionRelationship: (...args: any[]) => mockUpdateSessionRelationship(...args),
     updateSessionBtwOrigin: (...args: any[]) => mockUpdateSessionBtwOrigin(...args),
     addBtwThreadMarker: (...args: any[]) => mockAddBtwThreadMarker(...args),
-    updateSessionModelName: vi.fn(),
+    updateSessionModelName: (...args: any[]) => mockUpdateSessionModelName(...args),
   },
 }));
 
@@ -51,7 +52,7 @@ vi.mock('@/shared/notification-system', () => ({
   },
 }));
 
-import { createBtwChildSession } from './BtwThreadService';
+import { createBtwChildSession, sendMessageToTransientBtwSession } from './BtwThreadService';
 
 describe('BtwThreadService', () => {
   beforeEach(() => {
@@ -72,6 +73,7 @@ describe('BtwThreadService', () => {
         },
       ],
     });
+    mockAskStream.mockResolvedValue({ ok: true });
     mockCreateSession.mockResolvedValue({
       sessionId: 'child-1',
     });
@@ -106,6 +108,56 @@ describe('BtwThreadService', () => {
           parentTurnIndex: 1,
         },
         deepReviewRunManifest,
+      }),
+    );
+  });
+
+  it('passes image contexts through to the desktop /btw API', async () => {
+    sessions.set('btw-child', {
+      sessionId: 'btw-child',
+      title: 'Side question',
+      isTransient: true,
+      sessionKind: 'btw',
+      agentBackedTransient: false,
+      config: { modelName: 'fast' },
+    });
+
+    await sendMessageToTransientBtwSession({
+      parentSessionId: 'parent-1',
+      childSessionId: 'btw-child',
+      question: 'What is in this image?',
+      imagePayload: {
+        imageContexts: [
+          {
+            id: 'img-1',
+            image_path: 'C:/tmp/clip.png',
+            mime_type: 'image/png',
+            metadata: { name: 'clip.png' },
+          },
+        ],
+        imageDisplayData: [
+          {
+            id: 'img-1',
+            name: 'clip.png',
+            imagePath: 'C:/tmp/clip.png',
+            mimeType: 'image/png',
+          },
+        ],
+      },
+    });
+
+    expect(mockAskStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'parent-1',
+        childSessionId: 'btw-child',
+        question: 'What is in this image?',
+        imageContexts: [
+          expect.objectContaining({
+            id: 'img-1',
+            image_path: 'C:/tmp/clip.png',
+            mime_type: 'image/png',
+          }),
+        ],
       }),
     );
   });

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.ts
@@ -6,6 +6,7 @@ import { flowChatManager } from './FlowChatManager';
 import type { Session } from '../types/flow-chat';
 import type { SessionKind, SessionRelationship } from '@/shared/types/session-history';
 import type { ReviewTeamRunManifest } from '@/shared/services/reviewTeamService';
+import type { ImagePayload } from '../utils/imagePayload';
 
 function safeUuid(prefix = 'btw'): string {
   try {
@@ -223,6 +224,7 @@ export async function sendMessageToTransientBtwSession(params: {
   question: string;
   childSessionName?: string;
   modelId?: string;
+  imagePayload?: ImagePayload;
 }): Promise<{ requestId: string }> {
   const question = params.question.trim();
   if (!question) {
@@ -243,6 +245,7 @@ export async function sendMessageToTransientBtwSession(params: {
     childSessionName: params.childSessionName || childSession.title || 'Side thread',
     question,
     modelId: params.modelId ?? childSession.config.modelName ?? 'fast',
+    imageContexts: params.imagePayload?.imageContexts,
   });
   if (params.modelId?.trim()) {
     flowChatStore.updateSessionModelName(params.childSessionId, params.modelId.trim());
@@ -256,6 +259,7 @@ export async function startBtwThread(params: {
   workspacePath: string;
   question: string;
   modelId?: string;
+  imagePayload?: ImagePayload;
 }): Promise<{ requestId: string; childSessionId: string }> {
   const question = params.question.trim();
   if (!question) {
@@ -277,6 +281,7 @@ export async function startBtwThread(params: {
       question,
       childSessionName,
       modelId: params.modelId,
+      imagePayload: params.imagePayload,
     });
     return { requestId, childSessionId };
   } catch (error) {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -219,10 +219,6 @@ export async function sendMessage(
     }
 
     if (isTransientBtwSession(refreshedSession)) {
-      if ((options?.imageContexts?.length ?? 0) > 0) {
-        throw new Error('Transient /btw sessions do not support image attachments yet');
-      }
-
       const parentSessionId = refreshedSession.parentSessionId?.trim();
       if (!parentSessionId) {
         throw new Error(`Transient /btw session is missing parentSessionId: ${sessionId}`);
@@ -234,6 +230,12 @@ export async function sendMessage(
         question: message,
         childSessionName: refreshedSession.title,
         modelId: refreshedSession.config.modelName,
+        imagePayload: options?.imageContexts
+          ? {
+              imageContexts: options.imageContexts,
+              imageDisplayData: options.imageDisplayData ?? [],
+            }
+          : undefined,
       });
       return;
     }

--- a/src/web-ui/src/flow_chat/utils/imagePayload.ts
+++ b/src/web-ui/src/flow_chat/utils/imagePayload.ts
@@ -1,0 +1,75 @@
+import type { ImageContext } from '@/shared/types/context';
+import type { ImageContextData as ImageInputContextData } from '@/infrastructure/api/service-api/ImageContextTypes';
+import { api } from '@/infrastructure/api/service-api/ApiClient';
+
+export interface ImageDisplayData {
+  id: string;
+  name: string;
+  dataUrl?: string;
+  imagePath?: string;
+  mimeType?: string;
+}
+
+export interface ImagePayload {
+  imageContexts: ImageInputContextData[];
+  imageDisplayData: ImageDisplayData[];
+}
+
+export async function buildImagePayload(imageContexts: ImageContext[]): Promise<ImagePayload | undefined> {
+  if (imageContexts.length === 0) {
+    return undefined;
+  }
+
+  const clipboardImages = imageContexts.filter(ctx => !ctx.isLocal && ctx.dataUrl);
+  const uploadedImagePaths = new Map<string, string>();
+
+  if (clipboardImages.length > 0) {
+    const uploadResults = await api.invoke<Array<{ id: string; image_path?: string | null }>>(
+      'upload_image_contexts',
+      {
+        request: {
+          images: clipboardImages.map(ctx => ({
+            id: ctx.id,
+            image_path: ctx.imagePath || null,
+            data_url: ctx.dataUrl || null,
+            mime_type: ctx.mimeType,
+            image_name: ctx.imageName,
+            file_size: ctx.fileSize,
+            width: ctx.width || null,
+            height: ctx.height || null,
+            source: ctx.source,
+          })),
+        },
+      }
+    );
+
+    for (const result of uploadResults) {
+      if (result.image_path) {
+        uploadedImagePaths.set(result.id, result.image_path);
+      }
+    }
+  }
+
+  return {
+    imageContexts: imageContexts.map(ctx => ({
+      id: ctx.id,
+      image_path: ctx.isLocal ? ctx.imagePath : uploadedImagePaths.get(ctx.id),
+      data_url: undefined,
+      mime_type: ctx.mimeType,
+      metadata: {
+        name: ctx.imageName,
+        width: ctx.width,
+        height: ctx.height,
+        file_size: ctx.fileSize,
+        source: ctx.source,
+      },
+    })),
+    imageDisplayData: imageContexts.map(ctx => ({
+      id: ctx.id,
+      name: ctx.imageName || 'Image',
+      dataUrl: ctx.dataUrl,
+      imagePath: ctx.isLocal ? ctx.imagePath : uploadedImagePaths.get(ctx.id),
+      mimeType: ctx.mimeType,
+    })),
+  };
+}

--- a/src/web-ui/src/infrastructure/api/service-api/BtwAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/BtwAPI.ts
@@ -1,5 +1,6 @@
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
+import type { ImageContextData as ImageInputContextData } from './ImageContextTypes';
 
 export interface BtwAskStreamRequest {
   requestId: string;
@@ -8,6 +9,7 @@ export interface BtwAskStreamRequest {
   modelId?: string;
   childSessionId: string;
   childSessionName?: string;
+  imageContexts?: ImageInputContextData[];
 }
 
 export interface BtwAskStreamResponse {


### PR DESCRIPTION
## Summary
- support image attachments in transient `/btw` side questions
- reuse the regular chat image payload builder for uploaded and clipboard images
- forward image contexts through the web API, desktop API, and coordinator path

## Verification
- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run src/flow_chat/services/BtwThreadService.test.ts
- cargo check -p bitfun-desktop