### PR TITLE
feat(miniapp): personalize daily divination fortune per user

### DIFF
--- a/src/crates/assembly/core/builtin_skills/miniapp-dev/references/examples/builtin-daily-divination/ui.js
+++ b/src/crates/assembly/core/builtin_skills/miniapp-dev/references/examples/builtin-daily-divination/ui.js
@@ -1016,10 +1016,22 @@ function pickIndices(rand, len, n) {
 }
 
 // ── Fortune generation ───────────────────────────────
-// `generateFortune` returns INDICES + raw stars. Localization happens at render
+// `generateFortuneIndices` returns INDICES + raw stars. Localization happens at render
 // time so changing language re-renders the same reading in another tongue.
+//
+// The seed mixes the date with a per-user identifier (appDataDir, which embeds
+// the OS user name) so different users get different readings on the same day,
+// while a single user's result stays stable throughout the day.
+function userSalt() {
+  try {
+    return (window.app && window.app.appDataDir) || 'shared';
+  } catch (_e) {
+    return 'shared';
+  }
+}
+
 function generateFortuneIndices(date) {
-  const seed = hashSeed('bitfun-divination-' + date);
+  const seed = hashSeed(userSalt() + '|bitfun-divination|' + date);
   const rand = mulberry32(seed);
 
   const cardIdx = Math.floor(rand() * CARD_VISUALS.length);

--- a/src/crates/contracts/product-domains/src/miniapp/builtin.rs
+++ b/src/crates/contracts/product-domains/src/miniapp/builtin.rs
@@ -121,7 +121,7 @@ pub const BUILTIN_APPS: &[BuiltinMiniAppBundle] = &[
     },
     BuiltinMiniAppBundle {
         id: "builtin-daily-divination",
-        version: 21,
+        version: 22,
         meta_json: include_str!("builtin/assets/divination/meta.json"),
         html: include_str!("builtin/assets/divination/index.html"),
         css: include_str!("builtin/assets/divination/style.css"),

--- a/src/crates/contracts/product-domains/src/miniapp/builtin/assets/divination/ui.js
+++ b/src/crates/contracts/product-domains/src/miniapp/builtin/assets/divination/ui.js
@@ -1016,10 +1016,22 @@ function pickIndices(rand, len, n) {
 }
 
 // ── Fortune generation ───────────────────────────────
-// `generateFortune` returns INDICES + raw stars. Localization happens at render
+// `generateFortuneIndices` returns INDICES + raw stars. Localization happens at render
 // time so changing language re-renders the same reading in another tongue.
+//
+// The seed mixes the date with a per-user identifier (appDataDir, which embeds
+// the OS user name) so different users get different readings on the same day,
+// while a single user's result stays stable throughout the day.
+function userSalt() {
+  try {
+    return (window.app && window.app.appDataDir) || 'shared';
+  } catch (_e) {
+    return 'shared';
+  }
+}
+
 function generateFortuneIndices(date) {
-  const seed = hashSeed('bitfun-divination-' + date);
+  const seed = hashSeed(userSalt() + '|bitfun-divination|' + date);
   const rand = mulberry32(seed);
 
   const cardIdx = Math.floor(rand() * CARD_VISUALS.length);


### PR DESCRIPTION
## Summary

- Add a per-user salt (`appDataDir`) to the daily divination fortune seed so different users get distinct readings on the same day.
- Keep each user's fortune stable for the entire day (seed still includes the date).
- Bump `builtin-daily-divination` bundle version to 22 for asset refresh.

## Test plan

- [ ] Open the daily divination miniapp as two different OS users (or simulate different `appDataDir` values) on the same date and confirm readings differ.
- [ ] Reload the miniapp multiple times within the same day for one user and confirm the reading stays the same.
- [ ] Change locale and confirm localized rendering still works from the same indices.