### PR TITLE
feat(web-ui): surface AskUserQuestion attention in agent companion pet

### DIFF
--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -135,6 +135,7 @@
     color: var(--bitfun-agent-companion-bubble-fg);
     backdrop-filter: blur(10px);
     cursor: pointer;
+    position: relative;
 
     &:hover {
       transform: translateY(-1px);
@@ -211,10 +212,22 @@
   }
 
   &__bubble--attention {
-    border-color: rgba(var(--bitfun-agent-companion-warning-rgb), 0.55);
-    background: rgba(var(--bitfun-agent-companion-warning-bg-rgb), 0.97);
+    border-color: rgba(var(--bitfun-agent-companion-warning-rgb), 0.75);
+    background: rgba(var(--bitfun-agent-companion-warning-bg-rgb), 0.98);
     box-shadow: 0 0 0 0 rgba(var(--bitfun-agent-companion-warning-rgb), 0.5);
-    animation: bitfun-agent-companion-attention-pulse 1.6s ease-in-out infinite !important;
+    animation: bitfun-agent-companion-attention-pulse 1.5s ease-in-out infinite !important;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: rgb(var(--bitfun-agent-companion-warning-rgb));
+      animation: bitfun-agent-companion-attention-dot 1.5s ease-in-out infinite;
+    }
   }
 
   &__bubble--waiting {
@@ -262,8 +275,21 @@
   }
 
   50% {
-    box-shadow: 0 0 0 6px rgba(var(--bitfun-agent-companion-warning-rgb), 0);
+    box-shadow: 0 0 0 8px rgba(var(--bitfun-agent-companion-warning-rgb), 0);
     transform: translateY(-2px);
+  }
+}
+
+@keyframes bitfun-agent-companion-attention-dot {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  50% {
+    transform: scale(1.5);
+    opacity: 0.65;
   }
 }
 

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.test.ts
@@ -132,6 +132,59 @@ async function putStateMachineInStreaming(): Promise<void> {
   await stateMachineManager.transition('session-1', SessionExecutionEvent.TEXT_CHUNK_RECEIVED);
 }
 
+function createAskUserQuestionSession(): Session {
+  const turn = createTurn('processing');
+  turn.modelRounds = [{
+    id: 'round-1',
+    index: 0,
+    items: [{
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'AskUserQuestion',
+      timestamp: 1500,
+      status: 'running',
+      toolCall: {
+        id: 'tool-call-1',
+        input: {
+          questions: [{
+            header: 'Auth method',
+            question: 'Which library should we use for date formatting?',
+            options: [
+              { label: 'date-fns', description: 'Lightweight modular utilities' },
+              { label: 'moment', description: 'Legacy but well-known' },
+            ],
+          }],
+        },
+      },
+      requiresConfirmation: false,
+      isParamsStreaming: false,
+    }],
+    isStreaming: false,
+    isComplete: false,
+    status: 'running',
+    startTime: 1500,
+  }];
+
+  return {
+    ...createSession('processing'),
+    dialogTurns: [turn],
+  };
+}
+
+function createAskUserQuestionSessionWithTrailingText(): Session {
+  const session = createAskUserQuestionSession();
+  const turn = session.dialogTurns[0];
+  turn.modelRounds[0].items.push({
+    id: 'text-1',
+    type: 'text',
+    timestamp: 1600,
+    status: 'streaming',
+    content: '让我用 AskUserQuestion 工具问几个有用的问题，了解用户的需求和意图。',
+    isStreaming: true,
+  });
+  return session;
+}
+
 describe('buildAgentCompanionActivity', () => {
   afterEach(() => {
     resetState();
@@ -241,5 +294,94 @@ describe('buildAgentCompanionActivity', () => {
 
     expect(activity.tasks).toHaveLength(1);
     expect(activity.tasks[0]?.sessionId).toBe('session-1');
+  });
+
+  it('shows attention state when the active turn is waiting on AskUserQuestion', async () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createAskUserQuestionSession()]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks).toHaveLength(1);
+    expect(activity.tasks[0]).toMatchObject({
+      sessionId: 'session-1',
+      state: 'attention',
+      labelKey: 'agentCompanion.activity.needsInput',
+      latestOutput: 'Which library should we use for date formatting?',
+    });
+  });
+
+  it('shows attention state even when trailing assistant text is still streaming', async () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createAskUserQuestionSessionWithTrailingText()]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks).toHaveLength(1);
+    expect(activity.tasks[0]).toMatchObject({
+      sessionId: 'session-1',
+      state: 'attention',
+      labelKey: 'agentCompanion.activity.needsInput',
+      latestOutput: 'Which library should we use for date formatting?',
+    });
+  });
+
+  it('gives needsUserAttention priority over an active running task', async () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', createStreamingSessionWithText('Still thinking...')]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    flowChatStore.setSessionNeedsAttention('session-1', 'ask_user');
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks).toHaveLength(1);
+    expect(activity.tasks[0]).toMatchObject({
+      sessionId: 'session-1',
+      state: 'attention',
+      labelKey: 'agentCompanion.activity.needsInput',
+    });
+  });
+
+  it('does not show attention for a completed AskUserQuestion tool', async () => {
+    const session = createAskUserQuestionSession();
+    session.dialogTurns[0].modelRounds[0].items[0].status = 'completed';
+
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', session]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks).toHaveLength(1);
+    expect(activity.tasks[0].state).not.toBe('attention');
+  });
+
+  it('does not show attention while AskUserQuestion params are still streaming', async () => {
+    const session = createAskUserQuestionSession();
+    const tool = session.dialogTurns[0].modelRounds[0].items[0];
+    tool.status = 'streaming';
+    tool.isParamsStreaming = true;
+
+    flowChatStore.setState(() => ({
+      sessions: new Map([['session-1', session]]),
+      activeSessionId: 'session-1',
+    }));
+    await putStateMachineInStreaming();
+
+    const activity = buildAgentCompanionActivity();
+
+    expect(activity.tasks).toHaveLength(1);
+    expect(activity.tasks[0].state).not.toBe('attention');
   });
 });

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
@@ -2,7 +2,7 @@ import { FlowChatStore } from '../store/FlowChatStore';
 import { stateMachineManager } from '../state-machine/SessionStateMachineManager';
 import { ProcessingPhase, type SessionStateMachine } from '../state-machine/types';
 import { deriveChatInputPetMood, type ChatInputPetMood } from './chatInputPetMood';
-import type { DialogTurn, FlowTextItem, FlowThinkingItem, Session } from '../types/flow-chat';
+import type { DialogTurn, FlowToolItem, FlowTextItem, FlowThinkingItem, Session } from '../types/flow-chat';
 import { resolveSessionRelationship } from './sessionMetadata';
 import { toWellFormedText } from '@/shared/utils/wellFormedText';
 
@@ -48,6 +48,12 @@ const TRANSIENT_TURN_STATUSES = new Set<DialogTurn['status']>([
   'cancelling',
 ]);
 const LATEST_OUTPUT_MAX_CHARS = 512;
+const TERMINAL_TOOL_STATUSES = new Set<FlowToolItem['status']>([
+  'completed',
+  'error',
+  'cancelled',
+  'rejected',
+]);
 
 function ensureTaskOrder(sessionId: string): number {
   const existingOrder = taskOrderBySessionId.get(sessionId);
@@ -126,6 +132,77 @@ function latestAssistantSnippet(turn: DialogTurn | undefined): string | undefine
   }
 
   return undefined;
+}
+
+function extractAskUserQuestionText(tool: FlowToolItem): string | undefined {
+  const input = tool.toolCall?.input;
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+
+  const questions = input.questions;
+  if (!Array.isArray(questions) || questions.length === 0) {
+    return undefined;
+  }
+
+  const firstQuestion = questions[0]?.question;
+  if (typeof firstQuestion === 'string' && firstQuestion.trim()) {
+    return truncateLatestOutput(firstQuestion);
+  }
+
+  return undefined;
+}
+
+function findPendingAskUserQuestion(
+  turn: DialogTurn | undefined,
+): FlowToolItem | undefined {
+  if (!turn || !TRANSIENT_TURN_STATUSES.has(turn.status)) {
+    return undefined;
+  }
+
+  for (let roundIndex = turn.modelRounds.length - 1; roundIndex >= 0; roundIndex -= 1) {
+    const round = turn.modelRounds[roundIndex];
+    for (let itemIndex = round.items.length - 1; itemIndex >= 0; itemIndex -= 1) {
+      const item = round.items[itemIndex];
+      if (
+        item.type === 'tool'
+        && item.toolName === 'AskUserQuestion'
+        && !TERMINAL_TOOL_STATUSES.has(item.status)
+        && !item.isParamsStreaming
+      ) {
+        const input = item.toolCall?.input;
+        const questions = input && typeof input === 'object' ? input.questions : undefined;
+        if (Array.isArray(questions) && questions.length > 0) {
+          return item;
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function askUserQuestionAttentionTask(
+  session: Session,
+  snapshot: SessionStateMachine | null,
+): AgentCompanionTaskStatus | null {
+  const turn = trackedDialogTurn(session, snapshot);
+  const pendingTool = findPendingAskUserQuestion(turn);
+  if (!pendingTool) {
+    return null;
+  }
+
+  return {
+    sessionId: session.sessionId,
+    title: sessionTitle(session),
+    mood: 'waiting',
+    state: 'attention',
+    labelKey: 'agentCompanion.activity.needsInput',
+    defaultLabel: 'Needs input',
+    latestOutput: extractAskUserQuestionText(pendingTool) ?? latestAssistantSnippet(turn),
+    startedAt: snapshot?.context.stats.startTime || session.lastActiveAt || session.updatedAt || session.createdAt,
+    updatedAt: snapshot?.context.lastUpdateTime || session.updatedAt || session.lastActiveAt || session.createdAt,
+  };
 }
 
 function trackedDialogTurn(
@@ -209,7 +286,12 @@ function runningLabel(snapshot: SessionStateMachine | null): {
   }
 }
 
-function attentionTask(session: Session): AgentCompanionTaskStatus | null {
+function attentionTask(
+  session: Session,
+  snapshot: SessionStateMachine | null,
+): AgentCompanionTaskStatus | null {
+  const latestOutput = latestAssistantSnippet(trackedDialogTurn(session, snapshot));
+
   if (session.needsUserAttention === 'ask_user') {
     return {
       sessionId: session.sessionId,
@@ -218,6 +300,7 @@ function attentionTask(session: Session): AgentCompanionTaskStatus | null {
       state: 'attention',
       labelKey: 'agentCompanion.activity.needsInput',
       defaultLabel: 'Needs input',
+      latestOutput,
       startedAt: session.lastActiveAt || session.updatedAt || session.createdAt,
       updatedAt: session.updatedAt || session.lastActiveAt || session.createdAt,
     };
@@ -231,12 +314,20 @@ function attentionTask(session: Session): AgentCompanionTaskStatus | null {
       state: 'attention',
       labelKey: 'agentCompanion.activity.needsApproval',
       defaultLabel: 'Needs approval',
+      latestOutput,
       startedAt: session.lastActiveAt || session.updatedAt || session.createdAt,
       updatedAt: session.updatedAt || session.lastActiveAt || session.createdAt,
     };
   }
 
   return null;
+}
+
+function resolveAttentionTask(
+  session: Session,
+  snapshot: SessionStateMachine | null,
+): AgentCompanionTaskStatus | null {
+  return attentionTask(session, snapshot) ?? askUserQuestionAttentionTask(session, snapshot);
 }
 
 function completionTask(session: Session): AgentCompanionTaskStatus | null {
@@ -315,6 +406,12 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
       ? deriveChatInputPetMood(snapshot)
       : 'rest';
 
+    const attention = resolveAttentionTask(session, snapshot);
+    if (attention) {
+      tasks.push(attention);
+      return;
+    }
+
     if (mood !== 'rest') {
       const label = runningLabel(snapshot);
       const turn = trackedDialogTurn(session, snapshot);
@@ -329,12 +426,6 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
         startedAt: snapshot?.context.stats.startTime || session.lastActiveAt || session.updatedAt || session.createdAt,
         updatedAt: snapshot?.context.lastUpdateTime || session.updatedAt || session.lastActiveAt || session.createdAt,
       });
-      return;
-    }
-
-    const attention = attentionTask(session);
-    if (attention) {
-      tasks.push(attention);
       return;
     }
 


### PR DESCRIPTION
## Summary

- Detect pending `AskUserQuestion` tool calls in `buildAgentCompanionActivity` and surface an `attention` task with the first question text as `latestOutput`.
- Prioritize user-attention states (including `needsUserAttention`) ahead of active running tasks so the desktop pet prompts when input is required.
- Strengthen attention bubble styling with a warning indicator dot and slightly stronger pulse animation.

## Test plan

- [x] `pnpm --dir src/web-ui run test:run src/flow_chat/utils/agentCompanionActivity.test.ts`
- [x] `pnpm run type-check:web`
- [ ] Manually trigger `AskUserQuestion` in a session and confirm the desktop pet shows attention state with the question text
- [ ] Confirm attention clears after the tool completes or params finish streaming