### PR TITLE
feat(remote-workspace): add transfer progress, cancellation, and directory support

### DIFF
--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -84,6 +84,8 @@ pub struct AppState {
     pub remote_terminal_manager: Arc<RwLock<Option<RemoteTerminalManager>>>,
     pub remote_workspace: Arc<RwLock<Option<RemoteWorkspace>>>,
     pub active_searches: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
+    /// Cancellation flags for active file transfers (download/upload), keyed by transfer_id.
+    pub active_transfers: Arc<Mutex<HashMap<String, Arc<AtomicBool>>>>,
     pub announcement_scheduler: Arc<announcement::AnnouncementScheduler>,
 }
 
@@ -307,6 +309,7 @@ impl AppState {
             remote_terminal_manager,
             remote_workspace,
             active_searches: Arc::new(Mutex::new(HashMap::new())),
+            active_transfers: Arc::new(Mutex::new(HashMap::new())),
             announcement_scheduler,
         };
 

--- a/src/apps/desktop/src/api/clipboard_file_api.rs
+++ b/src/apps/desktop/src/api/clipboard_file_api.rs
@@ -22,6 +22,7 @@ pub struct PasteFilesRequest {
 pub struct PasteFilesResponse {
     pub success_count: usize,
     pub failed_files: Vec<FailedFile>,
+    pub directory_count: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -317,6 +318,7 @@ pub async fn paste_files(request: PasteFilesRequest) -> Result<PasteFilesRespons
     }
 
     let mut success_count = 0;
+    let mut directory_count = 0;
     let mut failed_files = Vec::new();
 
     for source_path in &request.source_paths {
@@ -349,7 +351,8 @@ pub async fn paste_files(request: PasteFilesRequest) -> Result<PasteFilesRespons
             target_path
         };
 
-        let result = if source.is_dir() {
+        let is_dir = source.is_dir();
+        let result = if is_dir {
             copy_directory_recursive(source, &final_target)
         } else {
             std::fs::copy(source, &final_target)
@@ -360,9 +363,12 @@ pub async fn paste_files(request: PasteFilesRequest) -> Result<PasteFilesRespons
         match result {
             Ok(_) => {
                 success_count += 1;
+                if is_dir {
+                    directory_count += 1;
+                }
 
                 if request.is_cut {
-                    if source.is_dir() {
+                    if is_dir {
                         if let Err(e) = std::fs::remove_dir_all(source) {
                             log::warn!("Failed to remove source directory after cut: {}", e);
                         }
@@ -383,6 +389,7 @@ pub async fn paste_files(request: PasteFilesRequest) -> Result<PasteFilesRespons
     Ok(PasteFilesResponse {
         success_count,
         failed_files,
+        directory_count,
     })
 }
 

--- a/src/apps/desktop/src/api/ssh_api.rs
+++ b/src/apps/desktop/src/api/ssh_api.rs
@@ -2,8 +2,10 @@
 //!
 //! Tauri commands for SSH connection management and remote file operations.
 
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::api::app_state::SSHServiceError;
 use crate::startup_trace::DesktopStartupTrace;
@@ -330,19 +332,100 @@ pub async fn remote_rename(
         .map_err(|e| e.to_string())
 }
 
-/// Read a remote file via SFTP and write it to a local path (binary-safe).
+/// Payload emitted via `download_progress` events during a remote download.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgressPayload {
+    pub transfer_id: String,
+    pub downloaded: u64,
+    pub total: u64,
+}
+
+/// Read a remote file or directory via SFTP and write it to a local path.
+///
+/// If `remote_path` is a file, its bytes are read via SFTP and written to
+/// `local_path` (binary-safe). If it is a directory, the directory tree is
+/// recreated locally: subdirectories are created with `create_dir_all`, and
+/// each file is read via SFTP and written to disk.
+///
+/// Emits `download_progress` events with `{ transferId, downloaded, total }`
+/// (bytes) during the SFTP read so the frontend can render a determinate
+/// progress bar with speed display. The `transfer_id` lets the frontend
+/// distinguish concurrent downloads and cancel individual transfers. Events
+/// are throttled to at most one per 100 ms (plus a guaranteed final event) to
+/// avoid flooding the webview.
 #[tauri::command]
 pub async fn remote_download_to_local_path(
+    app_handle: tauri::AppHandle,
     state: State<'_, AppState>,
     connection_id: String,
     remote_path: String,
     local_path: String,
+    transfer_id: String,
 ) -> Result<(), String> {
     let remote_fs = state.get_remote_file_service_async().await?;
-    let bytes = remote_fs
-        .read_file(&connection_id, &remote_path)
+
+    // Register a cancellation flag for this transfer.
+    let cancel_flag = std::sync::Arc::new(AtomicBool::new(false));
+    {
+        let mut map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+        map.insert(transfer_id.clone(), cancel_flag.clone());
+    }
+
+    // Check if the remote path is a directory.
+    let is_dir = remote_fs
+        .is_dir(&connection_id, &remote_path)
         .await
         .map_err(|e| e.to_string())?;
+
+    if is_dir {
+        let dir_result = download_directory_from_remote(
+            &app_handle,
+            &state,
+            &connection_id,
+            &remote_path,
+            &local_path,
+            &transfer_id,
+            &cancel_flag,
+        )
+        .await;
+        // Clean up the cancellation flag.
+        {
+            let mut map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+            map.remove(&transfer_id);
+        }
+        return dir_result;
+    }
+
+    // Regular file: read via SFTP with progress.
+    let mut last_emit = Instant::now();
+    let result = remote_fs
+        .read_file_with_progress(&connection_id, &remote_path, &mut |downloaded, total| {
+            // Throttle: emit at most every 100 ms, plus the final 100% event.
+            let now = Instant::now();
+            if downloaded >= total || now.duration_since(last_emit).as_millis() >= 100 {
+                let _ = app_handle.emit(
+                    "download_progress",
+                    DownloadProgressPayload {
+                        transfer_id: transfer_id.clone(),
+                        downloaded,
+                        total,
+                    },
+                );
+                last_emit = now;
+            }
+            // Return false to abort the read if cancelled.
+            !cancel_flag.load(Ordering::Relaxed)
+        })
+        .await;
+
+    // Clean up the cancellation flag.
+    {
+        let mut map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+        map.remove(&transfer_id);
+    }
+
+    let bytes = result.map_err(|e| e.to_string())?;
 
     tokio::task::spawn_blocking(move || {
         let path = std::path::Path::new(&local_path);
@@ -357,24 +440,393 @@ pub async fn remote_download_to_local_path(
     .map_err(|e| e.to_string())?
 }
 
-/// Read a local file and write it to the remote path via SFTP (binary-safe).
+/// Recursively download a remote directory to a local path.
+///
+/// Pre-scans the remote tree to determine total file size, then walks the tree
+/// and downloads each file with chunked progress reporting. Emits cumulative
+/// `download_progress` events so the frontend can show overall directory
+/// download progress.
+async fn download_directory_from_remote(
+    app_handle: &tauri::AppHandle,
+    state: &State<'_, AppState>,
+    connection_id: &str,
+    remote_dir: &str,
+    local_dir: &str,
+    transfer_id: &str,
+    cancel_flag: &std::sync::Arc<AtomicBool>,
+) -> Result<(), String> {
+    let remote_fs = state.get_remote_file_service_async().await?;
+
+    // Create the top-level local directory.
+    let local_dir_path = std::path::PathBuf::from(local_dir);
+    tokio::task::spawn_blocking(move || {
+        std::fs::create_dir_all(&local_dir_path).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    // Pre-scan the remote directory to determine total bytes for progress reporting.
+    let mut total_bytes: u64 = 0;
+    let mut scan_stack = vec![remote_dir.to_string()];
+    while let Some(current) = scan_stack.pop() {
+        let entries = remote_fs
+            .read_dir(connection_id, &current)
+            .await
+            .map_err(|e| e.to_string())?;
+        for entry in entries {
+            if entry.is_dir {
+                scan_stack.push(entry.path);
+            } else if let Some(size) = entry.size {
+                total_bytes += size;
+            }
+        }
+    }
+
+    let mut downloaded: u64 = 0;
+    let mut last_emit = Instant::now();
+
+    // Walk the remote directory tree.
+    let mut stack: Vec<(String, std::path::PathBuf)> =
+        vec![(remote_dir.to_string(), std::path::PathBuf::from(local_dir))];
+
+    while let Some((remote_current, local_current)) = stack.pop() {
+        if cancel_flag.load(Ordering::Relaxed) {
+            return Err("Transfer cancelled".to_string());
+        }
+
+        let entries = remote_fs
+            .read_dir(connection_id, &remote_current)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        for entry in entries {
+            let remote_child = entry.path;
+            let local_child = local_current.join(&entry.name);
+
+            if entry.is_dir {
+                tokio::task::spawn_blocking({
+                    let local_child = local_child.clone();
+                    move || std::fs::create_dir_all(&local_child).map_err(|e| e.to_string())
+                })
+                .await
+                .map_err(|e| e.to_string())??;
+                stack.push((remote_child, local_child));
+            } else {
+                let base_downloaded = downloaded;
+                let bytes = remote_fs
+                    .read_file_with_progress(connection_id, &remote_child, &mut |read_bytes, _| {
+                        let cumulative = base_downloaded + read_bytes;
+                        let now = Instant::now();
+                        if cumulative >= total_bytes
+                            || now.duration_since(last_emit).as_millis() >= 100
+                        {
+                            let _ = app_handle.emit(
+                                "download_progress",
+                                DownloadProgressPayload {
+                                    transfer_id: transfer_id.to_string(),
+                                    downloaded: cumulative,
+                                    total: total_bytes,
+                                },
+                            );
+                            last_emit = now;
+                        }
+                        !cancel_flag.load(Ordering::Relaxed)
+                    })
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                let file_size = bytes.len() as u64;
+                let local_child_write = local_child.clone();
+                tokio::task::spawn_blocking(move || {
+                    if let Some(parent) = local_child_write.parent() {
+                        if !parent.as_os_str().is_empty() {
+                            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                        }
+                    }
+                    std::fs::write(&local_child_write, &bytes).map_err(|e| e.to_string())
+                })
+                .await
+                .map_err(|e| e.to_string())??;
+
+                downloaded += file_size;
+            }
+        }
+    }
+
+    // Final progress event.
+    let _ = app_handle.emit(
+        "download_progress",
+        DownloadProgressPayload {
+            transfer_id: transfer_id.to_string(),
+            downloaded: total_bytes,
+            total: total_bytes,
+        },
+    );
+
+    Ok(())
+}
+
+/// Result of uploading a local path to a remote server.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteUploadResult {
+    pub was_directory: bool,
+}
+
+/// Payload emitted via `upload_progress` events during a remote upload.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadProgressPayload {
+    pub transfer_id: String,
+    pub uploaded: u64,
+    pub total: u64,
+}
+
+/// Recursively scan a local directory and return the total size of all
+/// regular files in bytes. Used for pre-scanning before directory upload
+/// so that overall progress can be reported.
+fn scan_directory_total_size(dir: &std::path::Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        if let Ok(entries) = std::fs::read_dir(&current) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if let Ok(meta) = path.metadata() {
+                    total += meta.len();
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Upload a local file or directory tree to a remote path via SFTP.
+///
+/// If `local_path` is a file, its bytes are written to `remote_path`. If it is
+/// a directory, the directory tree is recreated on the remote side:
+/// subdirectories are created with `create_dir_all`, and each file is read
+/// locally and written via SFTP.
+///
+/// Emits `upload_progress` events with `{ transferId, uploaded, total }`
+/// (bytes) during the SFTP write so the frontend can render a determinate
+/// progress bar with speed display. The `transfer_id` lets the frontend
+/// distinguish concurrent uploads and cancel individual transfers. Events
+/// are throttled to at most one per 100 ms (plus a guaranteed final event).
 #[tauri::command]
 pub async fn remote_upload_from_local_path(
+    app_handle: tauri::AppHandle,
     state: State<'_, AppState>,
     connection_id: String,
     local_path: String,
     remote_path: String,
-) -> Result<(), String> {
-    let bytes =
-        tokio::task::spawn_blocking(move || std::fs::read(&local_path).map_err(|e| e.to_string()))
-            .await
-            .map_err(|e| e.to_string())??;
+    transfer_id: String,
+) -> Result<RemoteUploadResult, String> {
+    let local_path = std::path::Path::new(&local_path);
+
+    // Register a cancellation flag for this transfer.
+    let cancel_flag = std::sync::Arc::new(AtomicBool::new(false));
+    {
+        let mut map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+        map.insert(transfer_id.clone(), cancel_flag.clone());
+    }
+
+    // A directory needs to be walked locally and recreated on the remote side.
+    if local_path.is_dir() {
+        let dir_result = upload_directory_to_remote(
+            &app_handle,
+            &state,
+            &connection_id,
+            local_path,
+            &remote_path,
+            &transfer_id,
+            &cancel_flag,
+        )
+        .await;
+        // Clean up the cancellation flag.
+        {
+            let mut map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+            map.remove(&transfer_id);
+        }
+        dir_result?;
+        return Ok(RemoteUploadResult {
+            was_directory: true,
+        });
+    }
+
+    // Regular file: read locally, write via SFTP with progress.
+    let local_path_owned = local_path.to_path_buf();
+    let bytes = tokio::task::spawn_blocking(move || {
+        std::fs::read(&local_path_owned).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())??;
 
     let remote_fs = state.get_remote_file_service_async().await?;
+    let mut last_emit = Instant::now();
+    let write_result = remote_fs
+        .write_file_with_progress(
+            &connection_id,
+            &remote_path,
+            &bytes,
+            &mut |written, total| {
+                let now = Instant::now();
+                if written >= total || now.duration_since(last_emit).as_millis() >= 100 {
+                    let _ = app_handle.emit(
+                        "upload_progress",
+                        UploadProgressPayload {
+                            transfer_id: transfer_id.clone(),
+                            uploaded: written,
+                            total,
+                        },
+                    );
+                    last_emit = now;
+                }
+                !cancel_flag.load(Ordering::Relaxed)
+            },
+        )
+        .await;
+
+    // Clean up the cancellation flag.
+    {
+        let mut map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+        map.remove(&transfer_id);
+    }
+
+    write_result.map_err(|e| e.to_string())?;
+
+    Ok(RemoteUploadResult {
+        was_directory: false,
+    })
+}
+
+/// Recursively upload a local directory to a remote path.
+///
+/// Pre-scans the directory to determine total file size, then walks the tree
+/// and uploads each file with chunked progress reporting. Emits cumulative
+/// `upload_progress` events so the frontend can show overall directory upload
+/// progress.
+async fn upload_directory_to_remote(
+    app_handle: &tauri::AppHandle,
+    state: &State<'_, AppState>,
+    connection_id: &str,
+    local_dir: &std::path::Path,
+    remote_dir: &str,
+    transfer_id: &str,
+    cancel_flag: &std::sync::Arc<AtomicBool>,
+) -> Result<(), String> {
+    let remote_fs = state.get_remote_file_service_async().await?;
+
+    // Create the top-level remote directory.
     remote_fs
-        .write_file(&connection_id, &remote_path, &bytes)
+        .create_dir_all(connection_id, remote_dir)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+
+    // Pre-scan the directory to determine total bytes for progress reporting.
+    let local_dir_owned = local_dir.to_path_buf();
+    let total_bytes =
+        tokio::task::spawn_blocking(move || scan_directory_total_size(&local_dir_owned))
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let mut uploaded: u64 = 0;
+    let mut last_emit = Instant::now();
+
+    // Walk the local directory tree.
+    let mut stack: Vec<(std::path::PathBuf, String)> =
+        vec![(local_dir.to_path_buf(), remote_dir.to_string())];
+
+    while let Some((local_current, remote_current)) = stack.pop() {
+        let entries = tokio::task::spawn_blocking(move || {
+            std::fs::read_dir(&local_current)
+                .map_err(|e| e.to_string())
+                .and_then(|dir| {
+                    dir.collect::<Result<Vec<_>, _>>()
+                        .map_err(|e| e.to_string())
+                })
+        })
+        .await
+        .map_err(|e| e.to_string())??;
+
+        for entry in entries {
+            let entry_path = entry.path();
+            let file_name = match entry.file_name().into_string() {
+                Ok(name) => name,
+                Err(_) => continue,
+            };
+            let remote_child = if remote_current.ends_with('/') {
+                format!("{}{}", remote_current, file_name)
+            } else {
+                format!("{}/{}", remote_current, file_name)
+            };
+
+            if entry_path.is_dir() {
+                remote_fs
+                    .create_dir_all(connection_id, &remote_child)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                stack.push((entry_path, remote_child));
+            } else {
+                let local_file = entry_path.clone();
+                let bytes = tokio::task::spawn_blocking(move || {
+                    std::fs::read(&local_file).map_err(|e| e.to_string())
+                })
+                .await
+                .map_err(|e| e.to_string())??;
+
+                let file_size = bytes.len() as u64;
+                let base_uploaded = uploaded;
+                remote_fs
+                    .write_file_with_progress(
+                        connection_id,
+                        &remote_child,
+                        &bytes,
+                        &mut |written, _| {
+                            let cumulative = base_uploaded + written;
+                            let now = Instant::now();
+                            if cumulative >= total_bytes
+                                || now.duration_since(last_emit).as_millis() >= 100
+                            {
+                                let _ = app_handle.emit(
+                                    "upload_progress",
+                                    UploadProgressPayload {
+                                        transfer_id: transfer_id.to_string(),
+                                        uploaded: cumulative,
+                                        total: total_bytes,
+                                    },
+                                );
+                                last_emit = now;
+                            }
+                            !cancel_flag.load(Ordering::Relaxed)
+                        },
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?;
+                uploaded += file_size;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Cancel an in-progress file transfer by setting its cancellation flag.
+///
+/// The transfer will abort at the next chunk boundary and the original
+/// download/upload command will return an error.
+#[tauri::command]
+pub async fn cancel_transfer(
+    state: State<'_, AppState>,
+    transfer_id: String,
+) -> Result<(), String> {
+    let map = state.active_transfers.lock().map_err(|e| e.to_string())?;
+    if let Some(flag) = map.get(&transfer_id) {
+        flag.store(true, Ordering::Relaxed);
+    }
+    Ok(())
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1261,6 +1261,7 @@ pub async fn run() {
             api::ssh_api::remote_rename,
             api::ssh_api::remote_download_to_local_path,
             api::ssh_api::remote_upload_from_local_path,
+            api::ssh_api::cancel_transfer,
             api::ssh_api::remote_execute,
             api::ssh_api::remote_open_workspace,
             api::ssh_api::remote_close_workspace,

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -604,6 +604,14 @@ pub fn create_main_window(
     // Keep HTML5 drag-and-drop working inside the webview for desktop UI drag targets.
     builder = builder.disable_drag_drop_handler();
 
+    // Block webview reloads: allow only the first navigation (initial load),
+    // cancel all subsequent navigations (F5 / Ctrl+R / location.reload()).
+    // The app uses state-driven routing, not browser navigation, so there are
+    // no legitimate full-page navigations after the initial load.
+    let first_navigation = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+    builder = builder
+        .on_navigation(move |_| first_navigation.swap(false, std::sync::atomic::Ordering::SeqCst));
+
     #[cfg(target_os = "macos")]
     {
         builder = builder

--- a/src/crates/services/services-integrations/src/remote_ssh/disabled.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/disabled.rs
@@ -537,11 +537,30 @@ impl RemoteFileService {
         Err(unsupported())
     }
 
+    pub async fn read_file_with_progress(
+        &self,
+        _connection_id: &str,
+        _path: &str,
+        _on_progress: &mut impl FnMut(u64, u64) -> bool,
+    ) -> anyhow::Result<Vec<u8>> {
+        Err(unsupported())
+    }
+
     pub async fn write_file(
         &self,
         _connection_id: &str,
         _path: &str,
         _content: &[u8],
+    ) -> anyhow::Result<()> {
+        Err(unsupported())
+    }
+
+    pub async fn write_file_with_progress(
+        &self,
+        _connection_id: &str,
+        _path: &str,
+        _content: &[u8],
+        _on_progress: &mut impl FnMut(u64, u64) -> bool,
     ) -> anyhow::Result<()> {
         Err(unsupported())
     }

--- a/src/crates/services/services-integrations/src/remote_ssh/manager.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/manager.rs
@@ -2197,6 +2197,60 @@ impl SSHConnectionManager {
         Ok(buffer)
     }
 
+    /// Read a file via SFTP with chunked progress reporting.
+    ///
+    /// Reads the file in `chunk_size`-byte chunks, invoking `on_progress`
+    /// after each chunk with `(bytes_read, total_size)`. If the callback
+    /// returns `false`, the read is aborted. Returns the full file contents.
+    pub async fn sftp_read_with_progress(
+        &self,
+        connection_id: &str,
+        path: &str,
+        chunk_size: usize,
+        on_progress: &mut impl FnMut(u64, u64) -> bool,
+    ) -> anyhow::Result<Vec<u8>> {
+        let resolved = self.resolve_sftp_path(connection_id, path).await?;
+        let sftp = self.get_sftp(connection_id).await?;
+
+        // Determine file size from metadata for progress calculation.
+        let metadata = sftp
+            .as_ref()
+            .metadata(&resolved)
+            .await
+            .map_err(|e| anyhow!("Failed to stat '{}': {}", resolved, e))?;
+        let total = metadata.size.unwrap_or(0);
+
+        let mut file = sftp
+            .open(&resolved)
+            .await
+            .map_err(|e| anyhow!("Failed to open remote file '{}': {}", resolved, e))?;
+
+        let mut buffer = Vec::new();
+        let mut chunk = vec![0u8; chunk_size];
+        let mut bytes_read: u64 = 0;
+
+        use tokio::io::AsyncReadExt;
+        loop {
+            let n = file
+                .read(&mut chunk)
+                .await
+                .map_err(|e| anyhow!("Failed to read remote file '{}': {}", resolved, e))?;
+            if n == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&chunk[..n]);
+            bytes_read += n as u64;
+            if !on_progress(bytes_read, total) {
+                return Err(anyhow!("Transfer cancelled"));
+            }
+        }
+
+        // Ensure final 100% progress is reported even if metadata returned 0.
+        on_progress(bytes_read, total);
+
+        Ok(buffer)
+    }
+
     /// Write a file via SFTP
     pub async fn sftp_write(
         &self,
@@ -2215,6 +2269,47 @@ impl SSHConnectionManager {
         file.write_all(content)
             .await
             .map_err(|e| anyhow!("Failed to write remote file '{}': {}", path, e))?;
+
+        file.flush()
+            .await
+            .map_err(|e| anyhow!("Failed to flush remote file '{}': {}", path, e))?;
+
+        Ok(())
+    }
+
+    /// Write a file via SFTP with chunked progress reporting.
+    ///
+    /// Writes `content` in `chunk_size`-byte chunks, invoking `on_progress`
+    /// after each chunk with `(bytes_written, total_size)`. If the callback
+    /// returns `false`, the write is aborted.
+    pub async fn sftp_write_with_progress(
+        &self,
+        connection_id: &str,
+        path: &str,
+        content: &[u8],
+        chunk_size: usize,
+        on_progress: &mut impl FnMut(u64, u64) -> bool,
+    ) -> anyhow::Result<()> {
+        let path = self.resolve_sftp_path(connection_id, path).await?;
+        let sftp = self.get_sftp(connection_id).await?;
+        let mut file = sftp
+            .create(&path)
+            .await
+            .map_err(|e| anyhow!("Failed to create remote file '{}': {}", path, e))?;
+
+        use tokio::io::AsyncWriteExt;
+        let total = content.len() as u64;
+        let mut written: u64 = 0;
+
+        for chunk in content.chunks(chunk_size) {
+            file.write_all(chunk)
+                .await
+                .map_err(|e| anyhow!("Failed to write remote file '{}': {}", path, e))?;
+            written += chunk.len() as u64;
+            if !on_progress(written, total) {
+                return Err(anyhow!("Transfer cancelled"));
+            }
+        }
 
         file.flush()
             .await

--- a/src/crates/services/services-integrations/src/remote_ssh/remote_fs.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/remote_fs.rs
@@ -58,6 +58,21 @@ impl RemoteFileService {
         manager.sftp_read(connection_id, path).await
     }
 
+    /// Read a file from the remote server via SFTP with chunked progress
+    /// reporting. `on_progress` is called with `(bytes_read, total_size)`
+    /// after each chunk.
+    pub async fn read_file_with_progress(
+        &self,
+        connection_id: &str,
+        path: &str,
+        on_progress: &mut impl FnMut(u64, u64) -> bool,
+    ) -> anyhow::Result<Vec<u8>> {
+        let manager = self.get_manager(connection_id).await?;
+        manager
+            .sftp_read_with_progress(connection_id, path, 262_144, on_progress)
+            .await
+    }
+
     /// Write content to a remote file via SFTP
     pub async fn write_file(
         &self,
@@ -67,6 +82,22 @@ impl RemoteFileService {
     ) -> anyhow::Result<()> {
         let manager = self.get_manager(connection_id).await?;
         manager.sftp_write(connection_id, path, content).await
+    }
+
+    /// Write content to a remote file via SFTP with chunked progress
+    /// reporting. `on_progress` is called with `(bytes_written, total_size)`
+    /// after each chunk. Returns `false` from the callback to cancel.
+    pub async fn write_file_with_progress(
+        &self,
+        connection_id: &str,
+        path: &str,
+        content: &[u8],
+        on_progress: &mut impl FnMut(u64, u64) -> bool,
+    ) -> anyhow::Result<()> {
+        let manager = self.get_manager(connection_id).await?;
+        manager
+            .sftp_write_with_progress(connection_id, path, content, 262_144, on_progress)
+            .await
     }
 
     /// Check if a remote path exists

--- a/src/web-ui/src/app/components/panels/FilesPanel.scss
+++ b/src/web-ui/src/app/components/panels/FilesPanel.scss
@@ -330,20 +330,77 @@
     }
   }
 
-  &__transfer {
+  &__transfers {
     flex-shrink: 0;
-    padding: $size-gap-2 $size-gap-3;
+    max-height: 200px;
+    overflow-y: auto;
     border-top: 1px solid var(--border-base);
     background: var(--color-bg-secondary);
   }
 
+  &__transfer {
+    padding: $size-gap-2 $size-gap-3;
+
+    & + & {
+      border-top: 1px solid var(--border-base);
+    }
+  }
+
   &__transfer-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $size-gap-2;
     font-size: var(--font-size-xs);
     color: var(--color-text-secondary);
     margin-bottom: $size-gap-1;
+  }
+
+  &__transfer-label-text {
+    min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  &__transfer-stats {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  &__transfer-detail {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+    white-space: nowrap;
+    line-height: 20px;
+  }
+
+  &__transfer-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $size-gap-2;
+    margin-top: $size-gap-1;
+  }
+
+  &__transfer-stop {
+    flex-shrink: 0;
+    height: 20px;
+    padding: 0 $size-gap-2;
+    border: 1px solid var(--border-medium);
+    border-radius: $size-radius-sm;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 18px;
+    cursor: pointer;
+    transition: all $motion-base $easing-standard;
+
+    &:hover {
+      background: var(--element-bg-soft);
+      border-color: var(--color-error);
+      color: var(--color-error);
+    }
   }
 
   &__transfer-track {

--- a/src/web-ui/src/app/components/panels/FilesPanel.tsx
+++ b/src/web-ui/src/app/components/panels/FilesPanel.tsx
@@ -13,7 +13,7 @@ import {
   type FileExplorerToolbarHandlers,
 } from '@/tools/file-system';
 import { useExplorerSearch } from '@/tools/file-explorer';
-import { Search, IconButton, Tooltip, Badge } from '@/component-library';
+import { Search, IconButton, Tooltip, Badge, confirmWarning } from '@/component-library';
 import { FileSearchResults } from '@/tools/file-system/components/FileSearchResults';
 import { workspaceAPI } from '@/infrastructure/api';
 import type { FileSystemNode } from '@/tools/file-system/types';
@@ -46,12 +46,21 @@ import {
   type TransferProgressState,
 } from '@/tools/file-system/services/workspaceFileTransfer';
 import { useWorkspaceFileDrop } from '@/tools/file-system/hooks/useWorkspaceFileDrop';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
+import { sshApi } from '@/features/ssh-remote/sshApi';
+import { formatBytes } from '@/shared/utils/format';
 import '@/tools/file-system/styles/FileExplorer.scss';
 import './FilesPanel.scss';
 
 const log = createLogger('FilesPanel');
 const FOCUS_REFRESH_THROTTLE_MS = 1000;
 const REMOTE_REFRESH_POLL_MS = 15000;
+const LARGE_FILE_THRESHOLD_BYTES = 2 * 1024 * 1024;
+
+/** Format a byte-per-second speed value for display, e.g. "1.4 MB/s". */
+function formatSpeed(bytesPerSec: number): string {
+  return `${formatBytes(bytesPerSec)}/s`;
+}
 
 function getIndexPhaseBadgeVariant(phase?: WorkspaceSearchRepoPhase): 'neutral' | 'warning' | 'success' | 'error' | 'info' {
   switch (phase) {
@@ -113,7 +122,6 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
   const { workspace: currentWorkspace } = useCurrentWorkspace();
   
   const panelRef = useRef<HTMLDivElement>(null);
-  const pasteInFlightRef = useRef(false);
   const lastFocusRefreshAtRef = useRef<number>(0);
   const [internalViewMode, setInternalViewMode] = useState<'tree' | 'search'>('tree');
   const viewMode = externalViewMode !== undefined ? externalViewMode : internalViewMode;
@@ -151,7 +159,8 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
   });
 
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
-  const [transferProgress, setTransferProgress] = useState<TransferProgressState | null>(null);
+  const [transfers, setTransfers] = useState<Map<string, TransferProgressState>>(new Map());
+  const dropTransferIdRef = useRef<string | null>(null);
   const [fileDropHighlight, setFileDropHighlight] = useState(false);
   const [inputDialog, setInputDialog] = useState<{
     isOpen: boolean;
@@ -164,6 +173,65 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
   });
 
   const notification = useNotification();
+  const cancelledTransferIdsRef = useRef<Set<string>>(new Set());
+
+  /**
+   * Create a per-transfer onProgress callback that tracks a single transfer
+   * in the `transfers` Map by its unique ID. When `null` is received, the
+   * transfer is removed from the Map. Returns both the ID (for passing to
+   * the backend for cancellation) and the callback.
+   */
+  const createTransferProgress = useCallback(() => {
+    const id = crypto.randomUUID();
+    const onProgress = (state: TransferProgressState | null) => {
+      setTransfers((prev) => {
+        const next = new Map(prev);
+        if (state === null) {
+          next.delete(id);
+        } else {
+          next.set(id, state);
+        }
+        return next;
+      });
+    };
+    return { id, onProgress };
+  }, []);
+
+  /** Stop an in-progress transfer by its ID. */
+  const handleStopTransfer = useCallback((transferId: string) => {
+    cancelledTransferIdsRef.current.add(transferId);
+    void sshApi.cancelTransfer(transferId);
+    setTransfers((prev) => {
+      const next = new Map(prev);
+      next.delete(transferId);
+      return next;
+    });
+  }, []);
+
+  /**
+   * Stable callback for drag-and-drop file uploads. Uses a ref to track the
+   * current drop's transfer ID so each drop session gets its own entry in the
+   * `transfers` Map.
+   */
+  const handleDropProgress = useCallback((state: TransferProgressState | null) => {
+    setTransfers((prev) => {
+      const next = new Map(prev);
+      if (state === null) {
+        const id = dropTransferIdRef.current;
+        if (id) {
+          next.delete(id);
+          dropTransferIdRef.current = null;
+        }
+      } else {
+        if (!dropTransferIdRef.current) {
+          dropTransferIdRef.current = crypto.randomUUID();
+        }
+        next.set(dropTransferIdRef.current, state);
+      }
+      return next;
+    });
+  }, []);
+
   const searchLimitNotice =
     searchMode === 'content'
       ? contentTruncated
@@ -238,17 +306,47 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
   );
 
   // ===== File Operation Handlers =====
-  
+
+  const shouldOpenLargeFile = useCallback(async (filePath: string, nodeSize?: number): Promise<boolean> => {
+    let fileSize: number | undefined = nodeSize;
+
+    if (fileSize === undefined || fileSize === null) {
+      try {
+        const metadata = await workspaceAPI.getFileMetadata(filePath);
+        fileSize = metadata.size;
+      } catch (error) {
+        log.warn('Failed to get file metadata for size check, opening anyway', { filePath, error: String(error) });
+        return true;
+      }
+    }
+
+    if (fileSize === undefined || fileSize <= LARGE_FILE_THRESHOLD_BYTES) {
+      return true;
+    }
+
+    return confirmWarning(
+      t('dialog.largeFile.title'),
+      t('dialog.largeFile.message', { size: formatBytes(fileSize) }),
+      {
+        confirmText: t('dialog.largeFile.confirm'),
+        cancelText: t('dialog.largeFile.cancel'),
+      },
+    );
+  }, [t]);
+
   const handleOpenFile = useCallback((data: { path: string; line?: number; column?: number }) => {
     log.info('Opening file', { path: data.path, line: data.line, column: data.column });
 
-    openFileInBestTarget({
-      filePath: data.path,
-      workspacePath,
-      ...(data.line ? { jumpToLine: data.line } : {}),
-      ...(data.column ? { jumpToColumn: data.column } : {}),
+    void shouldOpenLargeFile(data.path).then((ok) => {
+      if (!ok) return;
+      openFileInBestTarget({
+        filePath: data.path,
+        workspacePath,
+        ...(data.line ? { jumpToLine: data.line } : {}),
+        ...(data.column ? { jumpToColumn: data.column } : {}),
+      });
     });
-  }, [workspacePath]);
+  }, [workspacePath, shouldOpenLargeFile]);
 
   const handleNewFile = useCallback((data: { parentPath: string }) => {
     setInputDialog({
@@ -381,17 +479,28 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
   }, [notification, t]);
 
   const handleFileDownload = useCallback(
-    async (data: { path: string }) => {
+    async (data: { path: string; isDirectory?: boolean }) => {
       const ws = workspaceManager.getState().currentWorkspace;
+      const { id, onProgress } = createTransferProgress();
       try {
-        await downloadWorkspaceFileToDisk(data.path, ws, setTransferProgress);
+        await downloadWorkspaceFileToDisk(
+          data.path,
+          ws,
+          onProgress,
+          id,
+          data.isDirectory,
+        );
       } catch (error) {
         log.error('Failed to download file', error);
-        setTransferProgress(null);
-        notification.error(t('transfer.failed', { error: String(error) }));
+        onProgress(null);
+        if (cancelledTransferIdsRef.current.has(id)) {
+          cancelledTransferIdsRef.current.delete(id);
+        } else {
+          notification.error(t('transfer.failed', { error: String(error) }));
+        }
       }
     },
-    [notification, t]
+    [notification, t, createTransferProgress]
   );
 
   const handleFileTreeRefresh = useCallback(() => {
@@ -509,12 +618,7 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
       return;
     }
 
-    if (pasteInFlightRef.current) {
-      return;
-    }
-
-    pasteInFlightRef.current = true;
-
+    const { id, onProgress } = createTransferProgress();
     try {
       let targetDirectory = resolvePasteTargetDirectory({
         workspacePath,
@@ -536,7 +640,8 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
       const result = await pasteClipboardFilesToWorkspaceDirectory(
         targetDirectory,
         currentWorkspace,
-        setTransferProgress
+        onProgress,
+        id
       );
 
       if (result.successCount === 0 && result.failedFiles.length === 0) {
@@ -545,7 +650,16 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
       }
 
       if (result.successCount > 0) {
-        notification.success(t('notifications.pasteSuccess', { count: result.successCount }));
+        const dirCount = result.directoryCount ?? 0;
+        let key: string;
+        if (dirCount === 0) {
+          key = 'notifications.pasteSuccessFiles';
+        } else if (dirCount === result.successCount) {
+          key = 'notifications.pasteSuccessFolders';
+        } else {
+          key = 'notifications.pasteSuccessItems';
+        }
+        notification.success(t(key, { count: result.successCount }));
         await loadFileTree(undefined, true);
 
         if (!pathsEquivalentFs(targetDirectory, workspacePath)) {
@@ -565,10 +679,12 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
       }
     } catch (error) {
       log.error('Failed to paste files', error);
-      setTransferProgress(null);
-      notification.error(t('notifications.pasteFailed', { count: 1 }));
-    } finally {
-      pasteInFlightRef.current = false;
+      onProgress(null);
+      if (cancelledTransferIdsRef.current.has(id)) {
+        cancelledTransferIdsRef.current.delete(id);
+      } else {
+        notification.error(t('notifications.pasteFailed', { count: 1 }));
+      }
     }
   }, [
     workspacePath,
@@ -580,40 +696,82 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
     expandFolder,
     findNode,
     t,
+    createTransferProgress,
   ]);
 
   const handlePasteFromContextMenu = useCallback((data: { targetDirectory: string }) => {
     executePaste(data.targetDirectory);
   }, [executePaste]);
 
-  const handlePasteFromKeyboard = useCallback(() => {
+  const handlePaste = useCallback(() => {
     executePaste();
   }, [executePaste]);
 
+  // Register paste as a filetree-scoped shortcut (Windows/Linux primary path).
+  useShortcut(
+    'filetree.paste',
+    { key: 'V', ctrl: true, scope: 'filetree' },
+    () => handlePaste(),
+    { enabled: Boolean(workspacePath) }
+  );
+
+  // macOS bridge: the native menu bar intercepts Cmd+V before the DOM sees a
+  // keydown event, so ShortcutManager never fires. In "System" edit-menu mode
+  // (the default when no text editor is focused) the menu tells the WebView to
+  // perform a native paste, which surfaces as a DOM `paste` event. In
+  // "Renderer" mode (when a Monaco editor was recently focused) the menu emits
+  // a Tauri `bitfun_menu_edit_paste` event. We listen to both so file-tree
+  // paste works regardless of which mode the menu is in.
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!panelRef.current?.contains(document.activeElement) && 
-          !panelRef.current?.contains(e.target as Node)) {
-        return;
-      }
+    if (!workspacePath) return;
 
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-        return;
-      }
-
-      if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
-        e.preventDefault();
-        e.stopPropagation();
-        handlePasteFromKeyboard();
-      }
+    const isPanelFocused = () => {
+      const el = document.activeElement;
+      return !!el && !!panelRef.current && panelRef.current.contains(el);
     };
 
-    document.addEventListener('keydown', handleKeyDown);
+    // DOM paste event — System menu mode path.
+    const handleDomPaste = (e: ClipboardEvent) => {
+      if (!isPanelFocused()) return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      handlePaste();
+    };
+    document.addEventListener('paste', handleDomPaste, true);
+
+    // Tauri menu event — Renderer menu mode path.
+    let unlistenTauri: (() => void) | null = null;
+    let cancelled = false;
+    if (typeof window !== 'undefined' && '__TAURI__' in window) {
+      (async () => {
+        try {
+          const { listen } = await import('@tauri-apps/api/event');
+          const unsubscribe = await listen('bitfun_menu_edit_paste', () => {
+            if (isPanelFocused()) {
+              handlePaste();
+            }
+          });
+          if (cancelled) {
+            unsubscribe();
+            return;
+          }
+          unlistenTauri = unsubscribe;
+        } catch {
+          // Non-Tauri environment or event module unavailable — ignore.
+        }
+      })();
+    }
+
     return () => {
-      document.removeEventListener('keydown', handleKeyDown);
+      cancelled = true;
+      document.removeEventListener('paste', handleDomPaste, true);
+      unlistenTauri?.();
     };
-  }, [handlePasteFromKeyboard]);
+  }, [workspacePath, handlePaste]);
 
   useEffect(() => {
     globalEventBus.on('file:open', handleOpenFile);
@@ -706,16 +864,16 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
   }, [workspacePath, loadFileTree, expandFolder]);
 
   const handleFileDropError = useCallback((error: unknown) => {
-    setTransferProgress(null);
+    handleDropProgress(null);
     setFileDropHighlight(false);
     notification.error(t('transfer.failed', { error: String(error) }));
-  }, [notification, t]);
+  }, [notification, t, handleDropProgress]);
 
   useWorkspaceFileDrop({
     workspacePath,
     panelRef,
     enabled: Boolean(workspacePath) && viewMode === 'tree',
-    onProgress: setTransferProgress,
+    onProgress: handleDropProgress,
     onDragOver: handleFileDropOver,
     onComplete: handleFileDropComplete,
     onError: handleFileDropError,
@@ -727,13 +885,16 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
     
     const selectedNode = findNode(fileTree, filePath);
     if (selectedNode && !selectedNode.isDirectory) {
-      openFileInBestTarget({
-        filePath,
-        fileName,
-        workspacePath,
-      }, { source: 'project-nav' });
+      void shouldOpenLargeFile(filePath, selectedNode.size).then((ok) => {
+        if (!ok) return;
+        openFileInBestTarget({
+          filePath,
+          fileName,
+          workspacePath,
+        }, { source: 'project-nav' });
+      });
     }
-  }, [selectFile, onFileSelect, workspacePath, fileTree, findNode]);
+  }, [selectFile, onFileSelect, workspacePath, fileTree, findNode, shouldOpenLargeFile]);
 
   const handleFileDoubleClick = useCallback((filePath: string) => {
     onFileDoubleClick?.(filePath);
@@ -1042,33 +1203,71 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
         </div>
       </div>
 
-      {transferProgress && (
-        <div className="bitfun-files-panel__transfer" role="status">
-          <div className="bitfun-files-panel__transfer-label">
-            {transferProgress.phase === 'download'
-              ? t('transfer.downloading')
-              : t('transfer.uploading')}
-            {transferProgress.label ? ` — ${transferProgress.label}` : ''}
-          </div>
-          <div
-            className={`bitfun-files-panel__transfer-track${
-              transferProgress.indeterminate ? ' bitfun-files-panel__transfer-track--indeterminate' : ''
-            }`}
-          >
-            <div
-              className="bitfun-files-panel__transfer-fill"
-              style={
-                transferProgress.indeterminate || !transferProgress.total
-                  ? undefined
-                  : {
-                      width: `${Math.min(
-                        100,
-                        Math.round((100 * transferProgress.current) / transferProgress.total)
-                      )}%`,
-                    }
-              }
-            />
-          </div>
+      {transfers.size > 0 && (
+        <div className="bitfun-files-panel__transfers">
+          {Array.from(transfers.entries()).map(([id, tp]) => (
+            <div className="bitfun-files-panel__transfer" role="status" key={id}>
+              <div className="bitfun-files-panel__transfer-label">
+                <span className="bitfun-files-panel__transfer-label-text">
+                  {tp.phase === 'download'
+                    ? t('transfer.downloading')
+                    : t('transfer.uploading')}
+                  {tp.label ? ` — ${tp.label}` : ''}
+                </span>
+                {!tp.indeterminate &&
+                tp.bytesTotal &&
+                tp.bytesTotal > 0 ? (
+                  <span className="bitfun-files-panel__transfer-stats">
+                    {Math.min(
+                      100,
+                      Math.round(
+                        (100 * (tp.bytesTransferred ?? tp.current)) /
+                          tp.bytesTotal,
+                      ),
+                    )}
+                    %
+                    {tp.speed ? ` · ${formatSpeed(tp.speed)}` : ''}
+                  </span>
+                ) : null}
+              </div>
+              <div
+                className={`bitfun-files-panel__transfer-track${
+                  tp.indeterminate ? ' bitfun-files-panel__transfer-track--indeterminate' : ''
+                }`}
+              >
+                <div
+                  className="bitfun-files-panel__transfer-fill"
+                  style={
+                    tp.indeterminate || !tp.total
+                      ? undefined
+                      : {
+                          width: `${Math.min(
+                            100,
+                            Math.round((100 * tp.current) / tp.total)
+                          )}%`,
+                        }
+                  }
+                />
+              </div>
+              <div className="bitfun-files-panel__transfer-bottom">
+                {!tp.indeterminate &&
+                tp.bytesTotal &&
+                tp.bytesTotal > 0 ? (
+                  <span className="bitfun-files-panel__transfer-detail">
+                    {formatBytes(tp.bytesTransferred ?? 0)} /{' '}
+                    {formatBytes(tp.bytesTotal)}
+                  </span>
+                ) : <span />}
+                <button
+                  className="bitfun-files-panel__transfer-stop"
+                  onClick={() => handleStopTransfer(id)}
+                  title={t('transfer.stop')}
+                >
+                  {t('transfer.stop')}
+                </button>
+              </div>
+            </div>
+          ))}
         </div>
       )}
 

--- a/src/web-ui/src/features/ssh-remote/sshApi.ts
+++ b/src/web-ui/src/features/ssh-remote/sshApi.ts
@@ -173,32 +173,100 @@ export const sshApi = {
 
   /**
    * Download a remote file to a local filesystem path (desktop; binary-safe).
+   *
+   * When `onProgress` is provided, listens for `download_progress` Tauri events
+   * emitted by the backend and invokes the callback with `(downloaded, total)`
+   * byte counts. A unique `transferId` is generated per call (or uses the one
+   * provided) so that concurrent downloads do not receive each other's progress
+   * events. The `transferId` can be passed to `cancelTransfer` to abort the
+   * download. The listener is cleaned up automatically on completion.
    */
   async downloadToLocalPath(
     connectionId: string,
     remotePath: string,
-    localPath: string
+    localPath: string,
+    onProgress?: (downloaded: number, total: number) => void,
+    transferId?: string,
   ): Promise<void> {
-    return api.invoke('remote_download_to_local_path', {
-      connectionId,
-      remotePath,
-      localPath,
-    });
+    const tid = transferId ?? crypto.randomUUID();
+    let unlisten: (() => void) | null = null;
+
+    if (onProgress) {
+      const { listen } = await import('@tauri-apps/api/event');
+      unlisten = await listen<{ transferId: string; downloaded: number; total: number }>(
+        'download_progress',
+        (event) => {
+          if (event.payload.transferId === tid) {
+            onProgress(event.payload.downloaded, event.payload.total);
+          }
+        },
+      );
+    }
+
+    try {
+      await api.invoke('remote_download_to_local_path', {
+        connectionId,
+        remotePath,
+        localPath,
+        transferId: tid,
+      });
+    } finally {
+      unlisten?.();
+    }
   },
 
   /**
-   * Upload a local file to a remote path (desktop; binary-safe).
+   * Upload a local file or directory to a remote path (desktop; binary-safe).
+   * Returns `{ wasDirectory: boolean }` indicating whether the uploaded path
+   * was a directory.
+   *
+   * When `onProgress` is provided, listens for `upload_progress` Tauri events
+   * emitted by the backend and invokes the callback with `(uploaded, total)`
+   * byte counts. A unique `transferId` is generated per call (or uses the one
+   * provided) so that concurrent uploads do not receive each other's progress
+   * events. The `transferId` can be passed to `cancelTransfer` to abort the
+   * upload. The listener is cleaned up automatically on completion.
    */
   async uploadFromLocalPath(
     connectionId: string,
     localPath: string,
-    remotePath: string
-  ): Promise<void> {
-    return api.invoke('remote_upload_from_local_path', {
-      connectionId,
-      localPath,
-      remotePath,
-    });
+    remotePath: string,
+    onProgress?: (uploaded: number, total: number) => void,
+    transferId?: string,
+  ): Promise<{ wasDirectory: boolean }> {
+    const tid = transferId ?? crypto.randomUUID();
+    let unlisten: (() => void) | null = null;
+
+    if (onProgress) {
+      const { listen } = await import('@tauri-apps/api/event');
+      unlisten = await listen<{ transferId: string; uploaded: number; total: number }>(
+        'upload_progress',
+        (event) => {
+          if (event.payload.transferId === tid) {
+            onProgress(event.payload.uploaded, event.payload.total);
+          }
+        },
+      );
+    }
+
+    try {
+      return await api.invoke('remote_upload_from_local_path', {
+        connectionId,
+        localPath,
+        remotePath,
+        transferId: tid,
+      });
+    } finally {
+      unlisten?.();
+    }
+  },
+
+  /**
+   * Cancel an in-progress file transfer (download or upload) by its transferId.
+   * The backend will abort the transfer at the next chunk boundary.
+   */
+  async cancelTransfer(transferId: string): Promise<void> {
+    return api.invoke('cancel_transfer', { transferId });
   },
 
   /**

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.scss
@@ -489,6 +489,16 @@
   &:hover {
     background: var(--element-bg-subtle);
   }
+
+  /* Collapsed (only child): match all card corners. */
+  &:last-child {
+    border-radius: var(--size-radius-md);
+  }
+
+  /* Expanded (has sibling below): match only top card corners. */
+  &:not(:last-child) {
+    border-radius: var(--size-radius-md) var(--size-radius-md) 0 0;
+  }
 }
 
 .summary-content {

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.scss
@@ -58,6 +58,8 @@
       var(--color-overlay-white-04) 100%
     );
     border-bottom: 1px solid var(--border-base);
+    /* Match parent .create-plan-display top corners (8px) */
+    border-radius: 8px 8px 0 0;
 
     .create-plan-header-main {
       display: flex;
@@ -339,6 +341,8 @@
     padding: var(--flowchat-card-pad-y) var(--flowchat-card-pad-x);
     border-top: 1px solid var(--border-base);
     background: var(--color-overlay-white-04);
+    /* Match parent .create-plan-display bottom corners (8px) */
+    border-radius: 0 0 8px 8px;
 
     &--generating-only {
       justify-content: flex-end;

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.scss
@@ -370,6 +370,9 @@
   .base-tool-card.status-error {
     border-color: var(--border-medium);
     background: var(--element-bg-elevated);
+    /* Match wrapper's top corners so the elevated background fills to the rounded border,
+       even when backdrop-filter interferes with overflow:hidden clipping. */
+    border-radius: var(--flowchat-card-radius) var(--flowchat-card-radius) 0 0;
   }
 }
 

--- a/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/GitToolDisplay.scss
@@ -58,6 +58,11 @@
   border-radius: 0 0 6px 6px;
 }
 
+/* Inside a rounded, clipping wrapper, match its radius to avoid corner gaps. */
+.base-tool-card-wrapper.git-tool-display .git-result-footer {
+  border-radius: 0 0 var(--flowchat-card-radius) var(--flowchat-card-radius);
+}
+
 /* Expanded + same shell as Terminal: match `terminal-result-footer` inset from `TerminalToolCard.scss`. */
 .base-tool-card-wrapper.terminal-tool-card.git-tool-display .git-result-footer {
   margin-left: -12px;

--- a/src/web-ui/src/flow_chat/tool-cards/MiniAppToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/MiniAppToolDisplay.scss
@@ -17,7 +17,7 @@
   margin-right: calc(-1 * var(--flowchat-card-expanded-pad-x));
   margin-bottom: calc(-1 * var(--flowchat-card-expanded-pad-y));
   padding: var(--flowchat-card-expanded-pad-y) var(--flowchat-card-expanded-pad-x);
-  border-radius: 0 0 7px 7px;
+  border-radius: 0 0 var(--flowchat-card-radius) var(--flowchat-card-radius);
 }
 
 .miniapp-tool-display {

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -73,7 +73,7 @@
   margin-right: calc(-1 * var(--flowchat-card-expanded-pad-x));
   margin-bottom: calc(-1 * var(--flowchat-card-expanded-pad-y));
   padding: var(--flowchat-inline-gap) var(--flowchat-card-expanded-pad-x);
-  border-radius: 0 0 6px 6px;
+  border-radius: 0 0 var(--flowchat-card-radius) var(--flowchat-card-radius);
 }
 
 /* ========== Fix scrollbar visibility on card hover ========== */

--- a/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.ts
@@ -983,7 +983,7 @@ export class WorkspaceAPI {
     sourcePaths: string[],
     targetDirectory: string,
     isCut: boolean = false
-  ): Promise<{ successCount: number; failedFiles: Array<{ path: string; error: string }> }> {
+  ): Promise<{ successCount: number; directoryCount: number; failedFiles: Array<{ path: string; error: string }> }> {
     try {
       return await api.invoke('paste_files', {
         request: {

--- a/src/web-ui/src/locales/en-US/panels/files.json
+++ b/src/web-ui/src/locales/en-US/panels/files.json
@@ -100,6 +100,12 @@
       "placeholder": "Enter folder name",
       "confirm": "Create",
       "cancel": "Cancel"
+    },
+    "largeFile": {
+      "title": "Large File",
+      "message": "The file is {{size}}, which exceeds 2 MB. Opening large files may cause the interface to freeze. Do you want to continue?",
+      "confirm": "Open Anyway",
+      "cancel": "Cancel"
     }
   },
   "validation": {
@@ -110,7 +116,8 @@
     "uploading": "Uploading",
     "missingConnection": "Remote workspace has no SSH connection id.",
     "failed": "File transfer failed: {{error}}",
-    "dropHint": "Drop files here to upload"
+    "dropHint": "Drop files here to upload",
+    "stop": "Stop"
   },
   "notifications": {
     "createFileSuccess": "File created successfully",
@@ -122,6 +129,9 @@
     "deleteSuccess": "Deleted successfully",
     "deleteFailed": "Failed to delete: {{error}}",
     "pasteSuccess": "Successfully pasted {{count}} files",
+    "pasteSuccessFiles": "Successfully pasted {{count}} files",
+    "pasteSuccessFolders": "Successfully pasted {{count}} folders",
+    "pasteSuccessItems": "Successfully pasted {{count}} items",
     "pasteFailed": "{{count}} files failed to paste",
     "pasteNoFiles": "No files in clipboard",
     "pastingFiles": "Pasting {{count}} files to {{target}}...",

--- a/src/web-ui/src/locales/en-US/settings.json
+++ b/src/web-ui/src/locales/en-US/settings.json
@@ -232,7 +232,8 @@
         "refresh": "Refresh",
         "newFile": "New File",
         "newFolder": "New Folder",
-        "collapseAll": "Collapse All"
+        "collapseAll": "Collapse All",
+        "paste": "Paste"
       },
       "git": {
         "commit": "Commit",

--- a/src/web-ui/src/locales/zh-CN/panels/files.json
+++ b/src/web-ui/src/locales/zh-CN/panels/files.json
@@ -100,6 +100,12 @@
       "placeholder": "请输入文件夹名",
       "confirm": "创建",
       "cancel": "取消"
+    },
+    "largeFile": {
+      "title": "文件较大",
+      "message": "文件大小为 {{size}}，超过 2 MB。打开大文件可能导致界面卡顿，是否继续打开？",
+      "confirm": "继续打开",
+      "cancel": "取消"
     }
   },
   "validation": {
@@ -110,7 +116,8 @@
     "uploading": "正在上传",
     "missingConnection": "远程工作区缺少 SSH 连接信息。",
     "failed": "文件传输失败：{{error}}",
-    "dropHint": "将文件拖放到此处以上传"
+    "dropHint": "将文件拖放到此处以上传",
+    "stop": "停止"
   },
   "notifications": {
     "createFileSuccess": "文件创建成功",
@@ -122,6 +129,9 @@
     "deleteSuccess": "删除成功",
     "deleteFailed": "删除失败: {{error}}",
     "pasteSuccess": "成功粘贴 {{count}} 个文件",
+    "pasteSuccessFiles": "成功粘贴 {{count}} 个文件",
+    "pasteSuccessFolders": "成功粘贴 {{count}} 个文件夹",
+    "pasteSuccessItems": "成功粘贴 {{count}} 项",
     "pasteFailed": "{{count}} 个文件粘贴失败",
     "pasteNoFiles": "剪贴板中没有文件",
     "pastingFiles": "正在粘贴 {{count}} 个文件到 {{target}}...",

--- a/src/web-ui/src/locales/zh-CN/settings.json
+++ b/src/web-ui/src/locales/zh-CN/settings.json
@@ -232,7 +232,8 @@
         "refresh": "刷新",
         "newFile": "新建文件",
         "newFolder": "新建文件夹",
-        "collapseAll": "折叠所有目录"
+        "collapseAll": "折叠所有目录",
+        "paste": "粘贴"
       },
       "git": {
         "commit": "提交",

--- a/src/web-ui/src/locales/zh-TW/panels/files.json
+++ b/src/web-ui/src/locales/zh-TW/panels/files.json
@@ -100,6 +100,12 @@
       "placeholder": "請輸入資料夾名",
       "confirm": "建立",
       "cancel": "取消"
+    },
+    "largeFile": {
+      "title": "檔案較大",
+      "message": "檔案大小為 {{size}}，超過 2 MB。開啟大檔案可能導致介面卡頓，是否繼續開啟？",
+      "confirm": "繼續開啟",
+      "cancel": "取消"
     }
   },
   "validation": {
@@ -110,7 +116,8 @@
     "uploading": "正在上傳",
     "missingConnection": "遠程工作區缺少 SSH 連接資訊。",
     "failed": "檔案傳輸失敗：{{error}}",
-    "dropHint": "將檔案拖放到此處以上傳"
+    "dropHint": "將檔案拖放到此處以上傳",
+    "stop": "停止"
   },
   "notifications": {
     "createFileSuccess": "檔案建立成功",
@@ -122,6 +129,9 @@
     "deleteSuccess": "刪除成功",
     "deleteFailed": "刪除失敗: {{error}}",
     "pasteSuccess": "成功粘貼 {{count}} 個檔案",
+    "pasteSuccessFiles": "成功粘貼 {{count}} 個檔案",
+    "pasteSuccessFolders": "成功粘貼 {{count}} 個資料夾",
+    "pasteSuccessItems": "成功粘貼 {{count}} 項",
     "pasteFailed": "{{count}} 個檔案粘貼失敗",
     "pasteNoFiles": "剪貼板中沒有檔案",
     "pastingFiles": "正在粘貼 {{count}} 個檔案到 {{target}}...",

--- a/src/web-ui/src/locales/zh-TW/settings.json
+++ b/src/web-ui/src/locales/zh-TW/settings.json
@@ -232,7 +232,8 @@
         "refresh": "重新整理",
         "newFile": "新增檔案",
         "newFolder": "新增資料夾",
-        "collapseAll": "摺疊所有目錄"
+        "collapseAll": "摺疊所有目錄",
+        "paste": "貼上"
       },
       "git": {
         "commit": "提交",

--- a/src/web-ui/src/shared/constants/shortcuts.ts
+++ b/src/web-ui/src/shared/constants/shortcuts.ts
@@ -263,6 +263,11 @@ export const FILETREE_SHORTCUTS: ShortcutDef[] = [
     config: mod('[', { shift: true, scope: 'filetree' }),
     descriptionKey: 'keyboard.shortcuts.filetree.collapseAll',
   },
+  {
+    id: 'filetree.paste',
+    config: mod('V', { scope: 'filetree' }),
+    descriptionKey: 'keyboard.shortcuts.filetree.paste',
+  },
 ];
 
 // ─── Git shortcuts (scope: 'git') ─────────────────────────────────────────

--- a/src/web-ui/src/shared/context-menu-system/providers/FileExplorerMenuProvider.ts
+++ b/src/web-ui/src/shared/context-menu-system/providers/FileExplorerMenuProvider.ts
@@ -116,21 +116,23 @@ export class FileExplorerMenuProvider implements IMenuProvider {
         });
       }
 
-      items.push({
-        id: 'file-download',
-        label: i18nService.t('common:file.download'),
-        icon: 'Download',
-        onClick: () => {
-          globalEventBus.emit('file:download', { path: fileContext.filePath });
-        }
-      });
-
-      items.push({
-        id: 'file-separator-1',
-        label: '',
-        separator: true
-      });
     }
+
+    // Download (available for both files and directories)
+    items.push({
+      id: 'file-download',
+      label: i18nService.t('common:file.download'),
+      icon: 'Download',
+      onClick: () => {
+        globalEventBus.emit('file:download', { path: fileContext.filePath, isDirectory });
+      }
+    });
+
+    items.push({
+      id: 'file-separator-1',
+      label: '',
+      separator: true
+    });
 
     
     if (!isReadOnly) {

--- a/src/web-ui/src/tools/file-system/services/workspaceFileTransfer.test.ts
+++ b/src/web-ui/src/tools/file-system/services/workspaceFileTransfer.test.ts
@@ -1,43 +1,60 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
   joinWorkspaceTargetPath,
   normalizeClipboardLocalPaths,
   resolvePasteTargetDirectory,
-} from './workspaceFileTransfer';
+} from "./workspaceFileTransfer";
 
-describe('workspaceFileTransfer', () => {
-  it('joins remote workspace paths with POSIX separators', () => {
-    expect(joinWorkspaceTargetPath('/home/user/project/', 'file.txt', true))
-      .toBe('/home/user/project/file.txt');
+describe("workspaceFileTransfer", () => {
+  it("joins remote workspace paths with POSIX separators", () => {
+    expect(
+      joinWorkspaceTargetPath("/home/user/project/", "file.txt", true),
+    ).toBe("/home/user/project/file.txt");
   });
 
-  it('joins local workspace paths with native separators', () => {
-    expect(joinWorkspaceTargetPath('/Users/dev/project', 'file.txt', false))
-      .toBe('/Users/dev/project/file.txt');
-    expect(joinWorkspaceTargetPath('C:\\dev\\project', 'file.txt', false))
-      .toBe('C:\\dev\\project\\file.txt');
+  it("joins local workspace paths with native separators", () => {
+    expect(
+      joinWorkspaceTargetPath("/Users/dev/project", "file.txt", false),
+    ).toBe("/Users/dev/project/file.txt");
+    expect(joinWorkspaceTargetPath("C:\\dev\\project", "file.txt", false)).toBe(
+      "C:\\dev\\project\\file.txt",
+    );
   });
 
-  it('normalizes clipboard file URLs and deduplicates paths', () => {
-    expect(normalizeClipboardLocalPaths([
-      'file:///tmp/a.txt',
-      ' /tmp/a.txt ',
-      '',
-    ])).toEqual(['/tmp/a.txt']);
+  it("normalizes clipboard file URLs and deduplicates paths", () => {
+    expect(
+      normalizeClipboardLocalPaths(["file:///tmp/a.txt", " /tmp/a.txt ", ""]),
+    ).toEqual(["/tmp/a.txt"]);
 
-    expect(normalizeClipboardLocalPaths([
-      'file:///C:/Users/dev/Documents/report.pdf',
-    ])).toEqual(['C:/Users/dev/Documents/report.pdf']);
+    expect(
+      normalizeClipboardLocalPaths([
+        "file:///C:/Users/dev/Documents/report.pdf",
+      ]),
+    ).toEqual(["C:/Users/dev/Documents/report.pdf"]);
   });
 
-  it('resolves paste target from selected directory node', () => {
+  it("strips trailing slashes from directory paths so the name is not empty", () => {
+    // macOS `POSIX path of` returns trailing slash for directories.
+    expect(normalizeClipboardLocalPaths(["/tmp/myfolder/"])).toEqual([
+      "/tmp/myfolder",
+    ]);
+
+    expect(
+      normalizeClipboardLocalPaths(["file:///home/user/myfolder/"]),
+    ).toEqual(["/home/user/myfolder"]);
+
+    // Multiple trailing slashes.
+    expect(normalizeClipboardLocalPaths(["/tmp/myfolder//"])).toEqual([
+      "/tmp/myfolder",
+    ]);
+  });
+
+  it("resolves paste target from selected directory node", () => {
     const fileTree = [
       {
-        path: '/tmp/project',
+        path: "/tmp/project",
         isDirectory: true,
-        children: [
-          { path: '/tmp/project/src', isDirectory: true },
-        ],
+        children: [{ path: "/tmp/project/src", isDirectory: true }],
       },
     ];
 
@@ -52,11 +69,13 @@ describe('workspaceFileTransfer', () => {
       return null;
     };
 
-    expect(resolvePasteTargetDirectory({
-      workspacePath: '/tmp/project',
-      selectedFile: '/tmp/project/src',
-      fileTree,
-      findNode,
-    })).toBe('/tmp/project/src');
+    expect(
+      resolvePasteTargetDirectory({
+        workspacePath: "/tmp/project",
+        selectedFile: "/tmp/project/src",
+        fileTree,
+        findNode,
+      }),
+    ).toBe("/tmp/project/src");
   });
 });

--- a/src/web-ui/src/tools/file-system/services/workspaceFileTransfer.ts
+++ b/src/web-ui/src/tools/file-system/services/workspaceFileTransfer.ts
@@ -2,32 +2,39 @@
  * Upload / download between workspace (local or remote SFTP) and local disk.
  */
 
-import { PhysicalPosition } from '@tauri-apps/api/dpi';
-import { sshApi } from '@/features/ssh-remote/sshApi';
-import { workspaceAPI } from '@/infrastructure/api';
-import { i18nService } from '@/infrastructure/i18n';
-import { isRemoteWorkspace, type WorkspaceInfo } from '@/shared/types';
+import { PhysicalPosition } from "@tauri-apps/api/dpi";
+import { sshApi } from "@/features/ssh-remote/sshApi";
+import { workspaceAPI } from "@/infrastructure/api";
+import { i18nService } from "@/infrastructure/i18n";
+import { isRemoteWorkspace, type WorkspaceInfo } from "@/shared/types";
 import {
   dirnameAbsolutePath,
   normalizeLocalPathForRename,
   normalizePath,
   normalizeRemoteWorkspacePath,
   pathsEquivalentFs,
-} from '@/shared/utils/pathUtils';
+} from "@/shared/utils/pathUtils";
 
-export type TransferPhase = 'download' | 'upload';
+export type TransferPhase = "download" | "upload";
 
 export interface TransferProgressState {
   phase: TransferPhase;
   current: number;
   total: number;
   label: string;
-  /** Single-file transfer: no byte-level progress from backend — show indeterminate bar */
+  /** No byte-level progress from backend — show indeterminate bar */
   indeterminate?: boolean;
+  /** Bytes transferred so far (for byte-level progress) */
+  bytesTransferred?: number;
+  /** Total file size in bytes */
+  bytesTotal?: number;
+  /** Transfer speed in bytes per second (smoothed) */
+  speed?: number;
 }
 
 export interface WorkspaceTransferResult {
   successCount: number;
+  directoryCount: number;
   failedFiles: Array<{ path: string; error: string }>;
 }
 
@@ -38,27 +45,41 @@ export interface UploadToWorkspaceOptions {
 function normalizeClipboardLocalPath(path: string): string {
   const trimmed = path.trim();
   if (!trimmed) {
-    return '';
+    return "";
   }
 
-  if (trimmed.startsWith('file://')) {
-    let normalized = normalizePath(trimmed);
+  let normalized: string;
+
+  if (trimmed.startsWith("file://")) {
+    normalized = normalizePath(trimmed);
     // file:///absolute/unix/path loses its leading slash in normalizePath.
     if (
-      /^file:\/\/\/(?!\/)/.test(trimmed)
-      && !/^[A-Za-z]:/.test(normalized)
-      && !normalized.startsWith('/')
+      /^file:\/\/\/(?!\/)/.test(trimmed) &&
+      !/^[A-Za-z]:/.test(normalized) &&
+      !normalized.startsWith("/")
     ) {
       normalized = `/${normalized}`;
     }
-    return normalized;
-  }
-
-  if (trimmed.startsWith('\\\\')) {
+  } else if (trimmed.startsWith("\\\\")) {
+    // UNC paths — return as-is (do not strip trailing backslash).
     return trimmed;
+  } else {
+    normalized = normalizeLocalPathForRename(trimmed);
   }
 
-  return normalizeLocalPathForRename(trimmed);
+  // Strip trailing slashes so that directory names are not empty when
+  // extracted via split(/[/\\]/).pop(). macOS `POSIX path of` returns a
+  // trailing slash for directories (e.g. /Users/test/myfolder/).
+  // Preserve root paths like "/" and "C:/".
+  if (normalized.length > 1) {
+    normalized = normalized.replace(/\/+$/, "");
+    // For Windows drive roots like "C:/", keep the slash.
+    if (/^[A-Za-z]:$/.test(normalized)) {
+      normalized = `${normalized}/`;
+    }
+  }
+
+  return normalized;
 }
 
 export function normalizeClipboardLocalPaths(paths: string[]): string[] {
@@ -66,7 +87,10 @@ export function normalizeClipboardLocalPaths(paths: string[]): string[] {
 
   for (const path of paths) {
     const next = normalizeClipboardLocalPath(path);
-    if (!next || normalized.some((existing) => pathsEquivalentFs(existing, next))) {
+    if (
+      !next ||
+      normalized.some((existing) => pathsEquivalentFs(existing, next))
+    ) {
       continue;
     }
     normalized.push(next);
@@ -76,10 +100,12 @@ export function normalizeClipboardLocalPaths(paths: string[]): string[] {
 }
 
 function isTauri(): boolean {
-  return typeof window !== 'undefined' && '__TAURI__' in window;
+  return typeof window !== "undefined" && "__TAURI__" in window;
 }
 
-export function resolvePasteTargetDirectory<T extends { path: string; isDirectory: boolean; children?: T[] }>(options: {
+export function resolvePasteTargetDirectory<
+  T extends { path: string; isDirectory: boolean; children?: T[] },
+>(options: {
   workspacePath: string;
   explicitTargetDir?: string;
   selectedFile?: string;
@@ -109,7 +135,7 @@ export function resolvePasteTargetDirectory<T extends { path: string; isDirector
 
 export function normalizeWorkspaceTargetDirectory(
   targetDirectory: string,
-  workspace: WorkspaceInfo | null
+  workspace: WorkspaceInfo | null,
 ): string {
   if (isRemoteWorkspace(workspace)) {
     return normalizeRemoteWorkspacePath(targetDirectory);
@@ -117,11 +143,15 @@ export function normalizeWorkspaceTargetDirectory(
   return normalizeLocalPathForRename(targetDirectory);
 }
 
-export function joinWorkspaceTargetPath(dir: string, fileName: string, remote = false): string {
-  const sep = remote ? '/' : (dir.includes('\\') ? '\\' : '/');
+export function joinWorkspaceTargetPath(
+  dir: string,
+  fileName: string,
+  remote = false,
+): string {
+  const sep = remote ? "/" : dir.includes("\\") ? "\\" : "/";
   const base = remote
     ? normalizeRemoteWorkspacePath(dir)
-    : dir.replace(/[/\\]+$/, '');
+    : dir.replace(/[/\\]+$/, "");
   return `${base}${sep}${fileName}`;
 }
 
@@ -129,14 +159,14 @@ export function resolveExplorerDropTargetDirectory(
   clientX: number,
   clientY: number,
   workspacePath: string,
-  boundary?: HTMLElement | null
+  boundary?: HTMLElement | null,
 ): string {
   const el = document.elementFromPoint(clientX, clientY);
   if (!el) {
     return workspacePath;
   }
 
-  const explorer = boundary ?? el.closest('.bitfun-file-explorer');
+  const explorer = boundary ?? el.closest(".bitfun-file-explorer");
   if (!explorer) {
     return workspacePath;
   }
@@ -145,16 +175,16 @@ export function resolveExplorerDropTargetDirectory(
     return workspacePath;
   }
 
-  const node = el.closest('[data-file-path]');
+  const node = el.closest("[data-file-path]");
   if (!node || !explorer.contains(node)) {
     return workspacePath;
   }
 
-  const path = node.getAttribute('data-file-path');
+  const path = node.getAttribute("data-file-path");
   if (!path) {
     return workspacePath;
   }
-  const isDir = node.getAttribute('data-is-directory') === 'true';
+  const isDir = node.getAttribute("data-is-directory") === "true";
   if (isDir) {
     return path;
   }
@@ -163,9 +193,11 @@ export function resolveExplorerDropTargetDirectory(
 
 function dragPositionToLogicalCandidates(
   position: { x: number; y: number },
-  scaleFactor: number
+  scaleFactor: number,
 ): { x: number; y: number }[] {
-  const logical = new PhysicalPosition(position.x, position.y).toLogical(scaleFactor);
+  const logical = new PhysicalPosition(position.x, position.y).toLogical(
+    scaleFactor,
+  );
   return [
     { x: logical.x, y: logical.y },
     { x: position.x, y: position.y },
@@ -181,15 +213,18 @@ export function resolveDropTargetDirectoryFromDragPosition(
   position: { x: number; y: number },
   scaleFactor: number,
   workspacePath: string,
-  boundary?: HTMLElement | null
+  boundary?: HTMLElement | null,
 ): string {
-  for (const { x, y } of dragPositionToLogicalCandidates(position, scaleFactor)) {
+  for (const { x, y } of dragPositionToLogicalCandidates(
+    position,
+    scaleFactor,
+  )) {
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
       continue;
     }
 
     const hit = document.elementFromPoint(x, y);
-    const explorer = boundary ?? hit?.closest('.bitfun-file-explorer');
+    const explorer = boundary ?? hit?.closest(".bitfun-file-explorer");
     if (!explorer) {
       continue;
     }
@@ -198,7 +233,12 @@ export function resolveDropTargetDirectoryFromDragPosition(
       continue;
     }
 
-    return resolveExplorerDropTargetDirectory(x, y, workspacePath, explorer as HTMLElement);
+    return resolveExplorerDropTargetDirectory(
+      x,
+      y,
+      workspacePath,
+      explorer as HTMLElement,
+    );
   }
 
   return workspacePath;
@@ -207,17 +247,25 @@ export function resolveDropTargetDirectoryFromDragPosition(
 export function isDragPositionOverElement(
   position: { x: number; y: number },
   scaleFactor: number,
-  element: HTMLElement | null
+  element: HTMLElement | null,
 ): boolean {
   if (!element) {
     return false;
   }
   const rect = element.getBoundingClientRect();
-  for (const { x, y } of dragPositionToLogicalCandidates(position, scaleFactor)) {
+  for (const { x, y } of dragPositionToLogicalCandidates(
+    position,
+    scaleFactor,
+  )) {
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
       continue;
     }
-    if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+    if (
+      x >= rect.left &&
+      x <= rect.right &&
+      y >= rect.top &&
+      y <= rect.bottom
+    ) {
       return true;
     }
   }
@@ -227,23 +275,41 @@ export function isDragPositionOverElement(
 export async function downloadWorkspaceFileToDisk(
   filePath: string,
   workspace: WorkspaceInfo | null,
-  onProgress: (state: TransferProgressState | null) => void
+  onProgress: (state: TransferProgressState | null) => void,
+  transferId?: string,
+  isDirectory?: boolean,
 ): Promise<void> {
   if (!isTauri()) {
-    throw new Error(i18nService.t('common:ssh.remote.transferNeedsDesktop'));
+    throw new Error(i18nService.t("common:ssh.remote.transferNeedsDesktop"));
   }
-  const { save } = await import('@tauri-apps/plugin-dialog');
-  const baseName = filePath.split(/[/\\]/).pop() || 'file';
-  const dest = await save({
-    title: i18nService.t('common:file.downloadSaveTitle'),
-    defaultPath: baseName,
-  });
+  const baseName = filePath.split(/[/\\]/).pop() || "file";
+  let dest: string | null;
+
+  if (isDirectory) {
+    // For directory downloads, ask the user to pick a destination folder,
+    // then append the folder name so the tree is recreated under it.
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const picked = await open({
+      title: i18nService.t("common:file.downloadSaveTitle"),
+      directory: true,
+    });
+    if (picked === null) {
+      return;
+    }
+    dest = `${picked}${picked.endsWith("/") ? "" : "/"}${baseName}`;
+  } else {
+    const { save } = await import("@tauri-apps/plugin-dialog");
+    dest = await save({
+      title: i18nService.t("common:file.downloadSaveTitle"),
+      defaultPath: baseName,
+    });
+  }
   if (dest === null) {
     return;
   }
 
   onProgress({
-    phase: 'download',
+    phase: "download",
     current: 0,
     total: 1,
     label: baseName,
@@ -253,14 +319,54 @@ export async function downloadWorkspaceFileToDisk(
     if (isRemoteWorkspace(workspace)) {
       const cid = workspace?.connectionId;
       if (!cid) {
-        throw new Error(i18nService.t('panels/files:transfer.missingConnection'));
+        throw new Error(
+          i18nService.t("panels/files:transfer.missingConnection"),
+        );
       }
-      await sshApi.downloadToLocalPath(cid, filePath, dest);
+
+      // Speed tracking state — EMA over per-event instantaneous speed.
+      let lastTime = 0;
+      let lastBytes = 0;
+      let smoothedSpeed = 0;
+      let isFirstEvent = true;
+
+      await sshApi.downloadToLocalPath(cid, filePath, dest, (downloaded, total) => {
+        const now = performance.now();
+
+        if (!isFirstEvent && now > lastTime) {
+          const elapsed = now - lastTime;
+          const bytesDiff = downloaded - lastBytes;
+          if (elapsed > 0 && bytesDiff > 0) {
+            const instantSpeed = (bytesDiff / elapsed) * 1000; // bytes/sec
+            smoothedSpeed = smoothedSpeed === 0
+              ? instantSpeed
+              : smoothedSpeed * 0.7 + instantSpeed * 0.3;
+          }
+        }
+
+        isFirstEvent = false;
+        lastTime = now;
+        lastBytes = downloaded;
+
+        // If total is 0, file size is unknown — keep indeterminate.
+        if (total > 0) {
+          onProgress({
+            phase: "download",
+            current: downloaded,
+            total,
+            label: baseName,
+            indeterminate: false,
+            bytesTransferred: downloaded,
+            bytesTotal: total,
+            speed: smoothedSpeed,
+          });
+        }
+      }, transferId);
     } else {
       await workspaceAPI.exportLocalFileToPath(filePath, dest);
     }
     onProgress({
-      phase: 'download',
+      phase: "download",
       current: 1,
       total: 1,
       label: baseName,
@@ -276,29 +382,34 @@ export async function uploadLocalPathsToWorkspaceDirectory(
   targetDirectory: string,
   workspace: WorkspaceInfo | null,
   onProgress: (state: TransferProgressState | null) => void,
-  options: UploadToWorkspaceOptions = {}
+  options: UploadToWorkspaceOptions = {},
+  transferId?: string,
 ): Promise<WorkspaceTransferResult> {
   if (!isTauri()) {
-    throw new Error(i18nService.t('common:ssh.remote.transferNeedsDesktop'));
+    throw new Error(i18nService.t("common:ssh.remote.transferNeedsDesktop"));
   }
 
   const normalizedLocalPaths = normalizeClipboardLocalPaths(localPaths);
   if (normalizedLocalPaths.length === 0) {
-    return { successCount: 0, failedFiles: [] };
+    return { successCount: 0, directoryCount: 0, failedFiles: [] };
   }
 
   const remote = isRemoteWorkspace(workspace);
-  const normalizedTargetDirectory = normalizeWorkspaceTargetDirectory(targetDirectory, workspace);
+  const normalizedTargetDirectory = normalizeWorkspaceTargetDirectory(
+    targetDirectory,
+    workspace,
+  );
   const isCut = options.isCut ?? false;
 
   if (remote) {
     const cid = workspace?.connectionId;
     if (!cid) {
-      throw new Error(i18nService.t('panels/files:transfer.missingConnection'));
+      throw new Error(i18nService.t("panels/files:transfer.missingConnection"));
     }
 
-    const failedFiles: WorkspaceTransferResult['failedFiles'] = [];
+    const failedFiles: WorkspaceTransferResult["failedFiles"] = [];
     let successCount = 0;
+    let directoryCount = 0;
     const total = normalizedLocalPaths.length;
 
     for (let i = 0; i < total; i++) {
@@ -308,18 +419,80 @@ export async function uploadLocalPathsToWorkspaceDirectory(
         continue;
       }
 
-      const destPath = joinWorkspaceTargetPath(normalizedTargetDirectory, name, true);
+      const destPath = joinWorkspaceTargetPath(
+        normalizedTargetDirectory,
+        name,
+        true,
+      );
+
+      // For single-item uploads, use byte-level progress from the backend.
+      // For multi-item uploads, use count-based progress per item.
+      const singleItem = total === 1;
+
       onProgress({
-        phase: 'upload',
+        phase: "upload",
         current: i,
         total,
-        label: name,
-        indeterminate: total === 1,
+        label: singleItem ? name : `${name} (${i + 1}/${total})`,
+        indeterminate: singleItem,
       });
 
       try {
-        await sshApi.uploadFromLocalPath(cid, localPath, destPath);
-        successCount += 1;
+        if (singleItem) {
+          // Speed tracking state — EMA over per-event instantaneous speed.
+          let lastTime = 0;
+          let lastBytes = 0;
+          let smoothedSpeed = 0;
+          let isFirstEvent = true;
+
+          const uploadResult = await sshApi.uploadFromLocalPath(
+            cid,
+            localPath,
+            destPath,
+            (uploaded, totalBytes) => {
+              const now = performance.now();
+
+              if (!isFirstEvent && now > lastTime) {
+                const elapsed = now - lastTime;
+                const bytesDiff = uploaded - lastBytes;
+                if (elapsed > 0 && bytesDiff > 0) {
+                  const instantSpeed = (bytesDiff / elapsed) * 1000;
+                  smoothedSpeed = smoothedSpeed === 0
+                    ? instantSpeed
+                    : smoothedSpeed * 0.7 + instantSpeed * 0.3;
+                }
+              }
+
+              isFirstEvent = false;
+              lastTime = now;
+              lastBytes = uploaded;
+
+              if (totalBytes > 0) {
+                onProgress({
+                  phase: "upload",
+                  current: uploaded,
+                  total: totalBytes,
+                  label: name,
+                  indeterminate: false,
+                  bytesTransferred: uploaded,
+                  bytesTotal: totalBytes,
+                  speed: smoothedSpeed,
+                });
+              }
+            },
+            transferId,
+          );
+          successCount += 1;
+          if (uploadResult.wasDirectory) {
+            directoryCount += 1;
+          }
+        } else {
+          const uploadResult = await sshApi.uploadFromLocalPath(cid, localPath, destPath);
+          successCount += 1;
+          if (uploadResult.wasDirectory) {
+            directoryCount += 1;
+          }
+        }
       } catch (error) {
         failedFiles.push({
           path: localPath,
@@ -329,43 +502,46 @@ export async function uploadLocalPathsToWorkspaceDirectory(
     }
 
     onProgress({
-      phase: 'upload',
+      phase: "upload",
       current: total,
       total,
-      label: '',
+      label: "",
       indeterminate: false,
     });
     window.setTimeout(() => onProgress(null), 450);
 
     if (successCount === 0 && failedFiles.length > 0) {
-      const details = failedFiles.map((entry) => `${entry.path}: ${entry.error}`).join('; ');
+      const details = failedFiles
+        .map((entry) => `${entry.path}: ${entry.error}`)
+        .join("; ");
       throw new Error(details);
     }
 
-    return { successCount, failedFiles };
+    return { successCount, directoryCount, failedFiles };
   }
 
   onProgress({
-    phase: 'upload',
+    phase: "upload",
     current: 0,
     total: normalizedLocalPaths.length,
-    label: normalizedLocalPaths.length === 1
-      ? (normalizedLocalPaths[0]?.split(/[/\\]/).pop() ?? '')
-      : '',
+    label:
+      normalizedLocalPaths.length === 1
+        ? (normalizedLocalPaths[0]?.split(/[/\\]/).pop() ?? "")
+        : "",
     indeterminate: normalizedLocalPaths.length === 1,
   });
 
   const result = await workspaceAPI.pasteFiles(
     normalizedLocalPaths,
     normalizedTargetDirectory,
-    isCut
+    isCut,
   );
 
   onProgress({
-    phase: 'upload',
+    phase: "upload",
     current: normalizedLocalPaths.length,
     total: normalizedLocalPaths.length,
-    label: '',
+    label: "",
     indeterminate: false,
   });
   window.setTimeout(() => onProgress(null), 450);
@@ -373,12 +549,13 @@ export async function uploadLocalPathsToWorkspaceDirectory(
   if (result.successCount === 0 && result.failedFiles.length > 0) {
     const details = result.failedFiles
       .map((entry) => `${entry.path}: ${entry.error}`)
-      .join('; ');
+      .join("; ");
     throw new Error(details);
   }
 
   return {
     successCount: result.successCount,
+    directoryCount: result.directoryCount,
     failedFiles: result.failedFiles,
   };
 }
@@ -386,7 +563,8 @@ export async function uploadLocalPathsToWorkspaceDirectory(
 export async function pasteClipboardFilesToWorkspaceDirectory(
   targetDirectory: string,
   workspace: WorkspaceInfo | null,
-  onProgress: (state: TransferProgressState | null) => void
+  onProgress: (state: TransferProgressState | null) => void,
+  transferId?: string,
 ): Promise<WorkspaceTransferResult> {
   const { files, isCut } = await workspaceAPI.getClipboardFiles();
   return uploadLocalPathsToWorkspaceDirectory(
@@ -394,6 +572,7 @@ export async function pasteClipboardFilesToWorkspaceDirectory(
     targetDirectory,
     workspace,
     onProgress,
-    { isCut }
+    { isCut },
+    transferId,
   );
 }

--- a/src/web-ui/src/tools/terminal/components/Terminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/Terminal.tsx
@@ -507,7 +507,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
     let currentHoverTarget: HTMLElement | null = null;
     const webLinksAddon = new WebLinksAddon(
       (event, uri) => {
-        if (event.ctrlKey) {
+        if (event.ctrlKey || event.metaKey) {
           systemAPI.openExternal(uri).catch((error) => {
             log.error('Failed to open external link', { uri, error });
           });
@@ -521,7 +521,8 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(({
               currentHoverTarget.removeAttribute('title');
             }
             currentHoverTarget = target;
-            target.title = 'Ctrl + click to open link';
+            const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+            target.title = isMac ? '\u2318 + click to open link' : 'Ctrl + click to open link';
           }
         },
         leave: (event, _text) => {


### PR DESCRIPTION
## Summary

- Add determinate upload/download progress events for remote SSH file transfers, with per-transfer cancellation via `transfer_id`.
- Support recursive directory upload and download between local and remote workspaces, including pre-scan sizing and cumulative progress reporting.
- Update Files panel UI, workspace transfer service, clipboard paste metadata, and i18n strings for transfer status, speed, and cancel actions.

## Test plan

- [x] `pnpm run type-check:web`
- [x] `cargo check -p bitfun-desktop`
- [x] `pnpm run i18n:audit`
- [x] `pnpm --dir src/web-ui run test:run src/tools/file-system/services/workspaceFileTransfer.test.ts`
- [ ] Manual: connect to a remote SSH workspace and download a single file; verify progress bar, speed, and cancel
- [ ] Manual: download a remote directory; verify recursive copy and overall progress
- [ ] Manual: upload a local file and directory to remote; verify progress and cancel
- [ ] Manual: paste/cut directories in local workspace; verify directory count in result