### PR TITLE
chore(memories): change default memory config to opt-in

### DIFF
--- a/src/crates/assembly/core/src/agentic/memories/runner.rs
+++ b/src/crates/assembly/core/src/agentic/memories/runner.rs
@@ -188,8 +188,15 @@ impl MemoryPhase2Runner {
     }
 
     pub async fn run_once(&self) -> BitFunResult<Option<Phase2RunReport>> {
-        let started_at = std::time::Instant::now();
         let config = get_phase2_runtime_config().await;
+        self.run_once_with_config(config).await
+    }
+
+    async fn run_once_with_config(
+        &self,
+        config: crate::service::config::types::GlobalConfig,
+    ) -> BitFunResult<Option<Phase2RunReport>> {
+        let started_at = std::time::Instant::now();
         info!(
             "Memory phase2 run started: generate_memories={}, limit={}, max_unused_days={}, phase2_lease_seconds={}, phase2_success_cooldown_seconds={}, phase2_retry_delay_seconds={}, memory_root={}",
             config.memories.generate_memories,
@@ -530,6 +537,14 @@ impl MemoryPhase2Runner {
         }))
     }
 
+    #[cfg(test)]
+    async fn run_once_with_config_for_tests(
+        &self,
+        config: crate::service::config::types::GlobalConfig,
+    ) -> BitFunResult<Option<Phase2RunReport>> {
+        self.run_once_with_config(config).await
+    }
+
     async fn select_enabled_rows(
         &self,
         rows: &[MemoryPhase2CandidateRow],
@@ -776,6 +791,7 @@ mod tests {
     use crate::agentic::memories::db::{MemoryDatabase, MemoryRow};
     use crate::agentic::persistence::PersistenceManager;
     use crate::infrastructure::app_paths::PathManager;
+    use crate::service::config::types::GlobalConfig;
     use crate::service::session::{SessionMemoryMode, SessionMetadata};
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -826,6 +842,12 @@ mod tests {
             memory_root,
             Arc::new(FakeConsolidator),
         )
+    }
+
+    fn phase2_enabled_test_config() -> GlobalConfig {
+        let mut config = GlobalConfig::default();
+        config.memories.generate_memories = true;
+        config
     }
 
     async fn save_memory_row_metadata(
@@ -945,7 +967,11 @@ mod tests {
             runner.db.upsert_memory(&row).await.unwrap();
         }
 
-        let report = runner.run_once().await.unwrap().expect("phase2 report");
+        let report = runner
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
+            .await
+            .unwrap()
+            .expect("phase2 report");
         assert_eq!(report.selected_count, 2);
 
         let job = runner
@@ -1006,7 +1032,11 @@ mod tests {
             .await
             .unwrap());
 
-        assert!(runner.run_once().await.unwrap().is_none());
+        assert!(runner
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -1022,7 +1052,11 @@ mod tests {
         let runner =
             runner_with_fake_consolidator(Arc::new(db), persistence, temp.path().join("memories"));
 
-        assert!(runner.run_once().await.unwrap().is_none());
+        assert!(runner
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
+            .await
+            .unwrap()
+            .is_none());
 
         let job = runner
             .db
@@ -1075,7 +1109,7 @@ mod tests {
         .unwrap();
 
         let report = runner
-            .run_once()
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
             .await
             .unwrap()
             .expect("ad-hoc note should trigger phase2 consolidation");
@@ -1120,7 +1154,7 @@ mod tests {
         runner.db.upsert_memory(&row).await.unwrap();
 
         let first_report = runner
-            .run_once()
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
             .await
             .unwrap()
             .expect("first phase2 report");
@@ -1143,7 +1177,7 @@ mod tests {
             .await
             .expect("polluted selected session should enqueue phase2");
         let second_report = runner
-            .run_once()
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
             .await
             .unwrap()
             .expect("pollution should enqueue phase2");
@@ -1209,7 +1243,11 @@ mod tests {
         save_memory_row_metadata(&persistence, &row, SessionMemoryMode::Enabled).await;
         runner.db.upsert_memory(&row).await.unwrap();
 
-        let report = runner.run_once().await.unwrap().expect("phase2 report");
+        let report = runner
+            .run_once_with_config_for_tests(phase2_enabled_test_config())
+            .await
+            .unwrap()
+            .expect("phase2 report");
         assert!(!report.consolidation_output.trim().is_empty());
         let summary = tokio::fs::read_to_string(
             crate::agentic::memories::workspace::memory_summary_file(&temp.path().join("memories")),

--- a/src/crates/assembly/core/src/service/config/manager.rs
+++ b/src/crates/assembly/core/src/service/config/manager.rs
@@ -821,10 +821,14 @@ mod tests {
         let value =
             config_value_for_persistence(&config).expect("config should serialize for persistence");
 
+        let memories = value
+            .get("memories")
+            .and_then(|value| value.as_object())
+            .expect("memories config should persist as an object");
+        assert!(!memories.contains_key("generate_memories"));
         assert_eq!(
             value.get("memories"),
             Some(&serde_json::json!({
-                "generate_memories": false,
                 "max_rollouts_per_startup": 12
             }))
         );

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -783,7 +783,7 @@ fn default_memory_max_rollout_age_days() -> i64 {
 }
 
 fn default_memory_max_rollouts_per_startup() -> usize {
-    5
+    2
 }
 
 fn default_memory_max_rollouts_scan_limit() -> usize {
@@ -1554,8 +1554,8 @@ impl Default for AIConfig {
 impl Default for MemoriesConfig {
     fn default() -> Self {
         Self {
-            generate_memories: true,
-            use_memories: true,
+            generate_memories: false,
+            use_memories: false,
             external_context_policy: MemoryExternalContextPolicy::ClearToolResults,
             max_raw_memories_for_consolidation: default_memory_max_raw_memories_for_consolidation(),
             max_unused_days: default_memory_max_unused_days(),
@@ -2106,8 +2106,8 @@ mod tests {
     fn default_global_config_includes_enabled_memories_config() {
         let config = GlobalConfig::default();
 
-        assert!(config.memories.generate_memories);
-        assert!(config.memories.use_memories);
+        assert!(!config.memories.generate_memories);
+        assert!(!config.memories.use_memories);
         assert_eq!(
             config.memories.external_context_policy,
             MemoryExternalContextPolicy::ClearToolResults
@@ -2115,7 +2115,7 @@ mod tests {
         assert_eq!(config.memories.max_raw_memories_for_consolidation, 64);
         assert_eq!(config.memories.max_unused_days, 30);
         assert_eq!(config.memories.max_rollout_age_days, 10);
-        assert_eq!(config.memories.max_rollouts_per_startup, 5);
+        assert_eq!(config.memories.max_rollouts_per_startup, 2);
         assert_eq!(config.memories.max_rollouts_scan_limit, 2_000);
         assert_eq!(config.memories.min_rollout_idle_hours, 6);
         assert_eq!(config.memories.phase1_max_concurrency, 1);


### PR DESCRIPTION
- set generate_memories default to false
- set use_memories default to false
- reduce max_rollouts_per_startup default from 5 to 2
- update default config assertions in tests
