### PR TITLE
refactor(product): remove unused UI extension placeholder

### DIFF
--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -43,6 +43,10 @@
 
 目标：为插件 UI contribution 提供声明式 descriptor，并明确不同交付形态的支持、禁用和降级行为。
 
+准入：本阶段不得只新增 descriptor、registry 或 matrix。任何 UI Extension Contract 代码都必须绑定至少一条既有
+实际消费方或旧路径迁移，例如输入框命令、settings entry、状态投影或插件候选 UI 的实际接入，并同步删除或显著简化旧
+实现；否则只允许保留在设计文档中。
+
 范围：
 
 - 定义 slot、route、command/keymap、prompt augmentation、dialog/toast、settings entry、state view descriptor。
@@ -50,7 +54,7 @@
 - Product Assembly 维护 UI contribution registry、capability matrix 和 unsupported/unavailable fallback。
 - 建立 Desktop、Web、CLI、Server、Remote、ACP、SDK、Mobile Web 的插件能力矩阵。
 
-当前 UI Extension 形态矩阵：
+Stage D 目标 UI Extension 形态矩阵：
 
 | 形态 | UI Extension 状态 | 降级要求 |
 |---|---|---|

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -3579,6 +3579,12 @@ export const requiredContentRules = [
       },
       {
         regex:
+          /canvas-runtime = \[[\s\S]*"product-domains"[\s\S]*"bitfun-services-integrations\/canvas-runtime"[\s\S]*\]/,
+        message:
+          'core canvas-runtime feature must explicitly aggregate product domains and the canvas service owner feature',
+      },
+      {
+        regex:
           /bitfun-product-domains = \{ path = "\.\.\/\.\.\/contracts\/product-domains", default-features = false, optional = true \}/,
         message:
           'bitfun-product-domains dependency must stay optional and not force product-full outside the core feature graph',
@@ -7315,7 +7321,7 @@ export const requiredContentRules = [
         message: 'missing Multitask runtime default model mapping',
       },
       {
-        regex: /builtin_agent_spec\(\s*"GeneralPurpose",\s*SubAgent,\s*"fast"/,
+        regex: /builtin_agent_spec\(\s*"GeneralPurpose",\s*SubAgent,\s*"primary"/,
         message: 'missing GeneralPurpose runtime default model mapping',
       },
       {

--- a/src/crates/assembly/product-capabilities/src/lib.rs
+++ b/src/crates/assembly/product-capabilities/src/lib.rs
@@ -12,7 +12,7 @@ use bitfun_harness::{
 };
 use bitfun_runtime_ports::{
     PluginRuntimeAvailability, PluginRuntimeBinding, PluginRuntimeUnavailableReason,
-    RuntimeServiceCapability, UiExtensionAvailability,
+    RuntimeServiceCapability,
 };
 use bitfun_runtime_services::RuntimeServices;
 pub use bitfun_tool_packs::ToolProviderGroupPlanSelectionError as ProductCapabilityBuildError;
@@ -635,10 +635,7 @@ impl ProductAssembler {
         }
 
         let plan = assembly.plan().clone().with_extension_capabilities(
-            ProductExtensionCapabilitySet::new(
-                plugin_runtime_availability,
-                assembly.plan().extension_capabilities().ui_extensions(),
-            ),
+            ProductExtensionCapabilitySet::new(plugin_runtime_availability),
         );
 
         Ok(ProductRuntimeParts {
@@ -867,26 +864,15 @@ impl ProductCapabilityRegistry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProductExtensionCapabilitySet {
     plugin_runtime: PluginRuntimeAvailability,
-    ui_extensions: UiExtensionAvailability,
 }
 
 impl ProductExtensionCapabilitySet {
-    pub fn new(
-        plugin_runtime: PluginRuntimeAvailability,
-        ui_extensions: UiExtensionAvailability,
-    ) -> Self {
-        Self {
-            plugin_runtime,
-            ui_extensions,
-        }
+    pub fn new(plugin_runtime: PluginRuntimeAvailability) -> Self {
+        Self { plugin_runtime }
     }
 
     pub const fn plugin_runtime(&self) -> PluginRuntimeAvailability {
         self.plugin_runtime
-    }
-
-    pub const fn ui_extensions(&self) -> UiExtensionAvailability {
-        self.ui_extensions
     }
 }
 
@@ -906,22 +892,7 @@ pub fn product_extension_capabilities_for_profile(
         }
     };
 
-    let ui_extension_reason = match profile {
-        DeliveryProfile::ProductFull
-        | DeliveryProfile::Desktop
-        | DeliveryProfile::Web
-        | DeliveryProfile::MobileWeb => PluginRuntimeUnavailableReason::NotBuilt,
-        DeliveryProfile::Cli
-        | DeliveryProfile::Server
-        | DeliveryProfile::Remote
-        | DeliveryProfile::Acp
-        | DeliveryProfile::Sdk => PluginRuntimeUnavailableReason::UnsupportedProfile,
-    };
-
-    ProductExtensionCapabilitySet::new(
-        PluginRuntimeAvailability::disabled(plugin_runtime_reason),
-        UiExtensionAvailability::disabled(ui_extension_reason),
-    )
+    ProductExtensionCapabilitySet::new(PluginRuntimeAvailability::disabled(plugin_runtime_reason))
 }
 
 fn feature_groups_from_tool_provider_group_plan(

--- a/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
+++ b/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
@@ -11,7 +11,7 @@ use bitfun_product_capabilities::{
 use bitfun_runtime_ports::{
     PluginDispatchEnvelope, PluginResponseEnvelope, PluginRuntimeAvailability,
     PluginRuntimeBinding, PluginRuntimeClient, PluginRuntimeUnavailableReason, PortResult,
-    RuntimeServiceCapability, UiExtensionAvailability,
+    RuntimeServiceCapability,
 };
 use bitfun_runtime_services::test_support::FakeRuntimeServicesProvider;
 use bitfun_runtime_services::{
@@ -73,6 +73,7 @@ fn default_capability_registry_preserves_product_tool_provider_order() {
         vec![
             "core.basic",
             "core.agent",
+            "core.canvas",
             "core.session",
             "core.integration",
         ]
@@ -147,7 +148,13 @@ fn capability_packs_describe_service_tool_and_harness_requirements() {
         .collect::<Vec<_>>();
     assert_eq!(
         capability_ids,
-        vec!["code-agent", "deep-review", "deep-research", "miniapp"]
+        vec![
+            "code-agent",
+            "deep-review",
+            "deep-research",
+            "miniapp",
+            "canvas"
+        ]
     );
 
     let service_capabilities = registry.required_service_capabilities();
@@ -196,10 +203,17 @@ fn capability_packs_describe_service_tool_and_harness_requirements() {
 
 #[test]
 fn product_assembly_plan_keeps_full_capabilities_only_for_core_compatibility_profiles() {
-    let expected_capabilities = vec!["code-agent", "deep-review", "deep-research", "miniapp"];
+    let expected_capabilities = vec![
+        "code-agent",
+        "deep-review",
+        "deep-research",
+        "miniapp",
+        "canvas",
+    ];
     let expected_tool_groups = vec![
         "core.basic",
         "core.agent",
+        "core.canvas",
         "core.session",
         "core.integration",
     ];
@@ -401,16 +415,11 @@ fn product_assembly_plan_keeps_plugin_runtime_disabled_until_host_exists() {
             false,
             "{profile} must not imply executable plugin runtime support"
         );
-        assert_eq!(
-            extension_capabilities.ui_extensions().is_executable(),
-            false,
-            "{profile} must not imply UI extension rendering support"
-        );
     }
 }
 
 #[test]
-fn product_assembly_plan_distinguishes_extension_unavailable_reasons_by_profile() {
+fn product_assembly_plan_distinguishes_plugin_runtime_unavailable_reasons_by_profile() {
     assert_eq!(
         product_assembly_plan_for_profile(DeliveryProfile::Desktop)
             .extension_capabilities()
@@ -427,22 +436,6 @@ fn product_assembly_plan_distinguishes_extension_unavailable_reasons_by_profile(
             reason: PluginRuntimeUnavailableReason::UnsupportedProfile
         }
     );
-    assert_eq!(
-        product_assembly_plan_for_profile(DeliveryProfile::Desktop)
-            .extension_capabilities()
-            .ui_extensions(),
-        UiExtensionAvailability::Disabled {
-            reason: PluginRuntimeUnavailableReason::NotBuilt
-        }
-    );
-    assert_eq!(
-        product_assembly_plan_for_profile(DeliveryProfile::Cli)
-            .extension_capabilities()
-            .ui_extensions(),
-        UiExtensionAvailability::Disabled {
-            reason: PluginRuntimeUnavailableReason::UnsupportedProfile
-        }
-    );
 }
 
 #[test]
@@ -454,6 +447,7 @@ fn product_assembly_plan_exposes_build_feature_groups_explicitly() {
         &[
             ProductFeatureGroup::Basic,
             ProductFeatureGroup::AgentControl,
+            ProductFeatureGroup::Canvas,
             ProductFeatureGroup::BrowserWeb,
             ProductFeatureGroup::Mcp,
             ProductFeatureGroup::Git,
@@ -467,6 +461,7 @@ fn product_assembly_plan_exposes_build_feature_groups_explicitly() {
         vec![
             "basic",
             "agent-control",
+            "canvas",
             "browser-web",
             "mcp",
             "git",
@@ -740,7 +735,13 @@ fn default_capability_assembly_keeps_service_tool_and_harness_facts_together() {
         .collect::<Vec<_>>();
     assert_eq!(
         capability_ids,
-        vec!["code-agent", "deep-review", "deep-research", "miniapp"]
+        vec![
+            "code-agent",
+            "deep-review",
+            "deep-research",
+            "miniapp",
+            "canvas"
+        ]
     );
 
     let service_capabilities = assembly.required_service_capabilities();
@@ -769,6 +770,7 @@ fn default_capability_assembly_keeps_service_tool_and_harness_facts_together() {
         vec![
             "core.basic",
             "core.agent",
+            "core.canvas",
             "core.session",
             "core.integration"
         ]

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -157,7 +157,6 @@ impl ExtensionCapabilityAvailability {
 }
 
 pub type PluginRuntimeAvailability = ExtensionCapabilityAvailability;
-pub type UiExtensionAvailability = ExtensionCapabilityAvailability;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -64,7 +64,7 @@ pub use bitfun_runtime_ports::{
     RemoteWorkspaceRuntimeHost, RemoteWorkspaceUpdate, RuntimeEventEnvelope, RuntimeEventSink,
     RuntimeEventType, RuntimeServiceCapability, RuntimeServicePort, SessionStorageKind,
     SessionStoragePathRequest, SessionStoragePathResolution, SessionStorePort, TerminalPort,
-    ThreadGoal, ThreadGoalStatus, UiExtensionAvailability, WorkspacePort,
+    ThreadGoal, ThreadGoalStatus, WorkspacePort,
 };
 pub use bitfun_runtime_services::{
     CapabilityAvailability, RuntimeServices, RuntimeServicesBuilder, RuntimeServicesError,


### PR DESCRIPTION
﻿## Summary
- Remove the unused UI extension availability placeholder from Product Assembly, runtime-ports, and the Agent Runtime SDK surface so only the currently wired plugin runtime availability remains exposed.
- Update product-capabilities focused tests for the current Canvas capability, tool-provider group, and feature-group baseline.
- Align core-boundary guards for Canvas runtime feature aggregation and the GeneralPurpose default model mapping.
- Add a plan guard that UI Extension Contract code must land with a real consumer or old-path migration, not standalone descriptor/registry scaffolding.

## Boundary and risk notes
- This PR does not add UI contribution descriptors, registries, plugin UI rendering, plugin host execution, JS/TS runtime, React/DOM/Tauri handles, or ecosystem adapters.
- The SDK/API surface is intentionally reduced: `UiExtensionAvailability` had no in-repo producer or consumer after Product Assembly stopped reporting UI extension availability.
- Future UI Extension Contract work remains planned, but code must be tied to an actual product consumer or migration path before landing.

## Verification
- `cargo fmt -p bitfun-runtime-ports -p bitfun-agent-runtime -p bitfun-product-capabilities`
- `cargo test -p bitfun-product-capabilities --tests`
- `cargo check -p bitfun-product-capabilities`
- `cargo check -p bitfun-agent-runtime`
- `cargo check -p bitfun-core --no-default-features`
- `node scripts/check-core-boundaries.mjs`
- `node --test scripts/check-core-boundaries.test.mjs`
- `git diff --check`