### PR TITLE
fix(flow-chat): stabilize /btw side question lifecycle

### DIFF
--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -5562,10 +5562,33 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
 
         let turn_id = format!("btw-turn-{}", request_id.trim());
-        let user_message_metadata = Some(serde_json::json!({
+        let mut user_message_metadata = serde_json::json!({
             "kind": "btw",
             "parentSessionId": parent_session_id,
-        }));
+        });
+        if let Some(images) = image_contexts.as_ref().filter(|images| !images.is_empty()) {
+            user_message_metadata["images"] = serde_json::Value::Array(
+                images
+                    .iter()
+                    .map(|image| {
+                        let name = image
+                            .metadata
+                            .as_ref()
+                            .and_then(|metadata| metadata.get("name"))
+                            .and_then(|value| value.as_str())
+                            .filter(|name| !name.trim().is_empty())
+                            .unwrap_or("image");
+                        serde_json::json!({
+                            "id": image.id,
+                            "name": name,
+                            "data_url": image.data_url,
+                            "image_path": image.image_path,
+                            "mime_type": image.mime_type,
+                        })
+                    })
+                    .collect(),
+            );
+        }
 
         let (user_input, prepended_messages) = build_btw_user_input(question);
 
@@ -5581,7 +5604,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             child_session.config.remote_ssh_host.clone(),
             DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopApi)
                 .with_skip_tool_confirmation(true),
-            user_message_metadata,
+            Some(user_message_metadata),
             prepended_messages,
             true,
         )

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -1994,7 +1994,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         parentSessionId: currentSessionId,
         workspacePath,
         question,
-        modelId: 'fast',
+        modelId: imagesForBtw.length > 0
+          ? currentSession?.config?.modelName
+          : 'fast',
         imagePayload,
       });
       imagesForBtw.forEach(image => removeContext(image.id));
@@ -2012,7 +2014,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       pendingLargePastesRef.current = originalPendingLargePastes;
       dispatchInput({ type: 'SET_VALUE', payload: originalMessage });
     }
-  }, [clearPendingLargePastes, currentSessionId, derivedState, expandComposerSpecialTokens, imageContexts, inputState.value, isBtwSession, removeContext, setQueuedInput, t, workspacePath]);
+  }, [clearPendingLargePastes, currentSession?.config?.modelName, currentSessionId, derivedState, expandComposerSpecialTokens, imageContexts, inputState.value, isBtwSession, removeContext, setQueuedInput, t, workspacePath]);
 
   const submitCompactFromInput = useCallback(async () => {
     if (!effectiveTargetSessionId || !effectiveTargetSession) {
@@ -2500,8 +2502,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   ]);
 
   const handleCancelCurrentTask = useCallback(async () => {
+    if (effectiveTargetSessionId) {
+      await FlowChatManager.getInstance().cancelSessionTask(effectiveTargetSessionId);
+      return;
+    }
     await FlowChatManager.getInstance().cancelCurrentTask();
-  }, []);
+  }, [effectiveTargetSessionId]);
 
   const handleModelLoadingChange = useCallback((loading: boolean) => {
     setIsModelSwitching(loading);

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.test.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.test.ts
@@ -7,6 +7,11 @@ const mockUpdateSessionRelationship = vi.fn();
 const mockUpdateSessionBtwOrigin = vi.fn();
 const mockAddBtwThreadMarker = vi.fn();
 const mockUpdateSessionModelName = vi.fn();
+const mockAddDialogTurn = vi.fn();
+const mockDeleteDialogTurn = vi.fn();
+const mockCancelSessionTask = vi.fn();
+const mockBtwCancel = vi.fn();
+const mockTransition = vi.fn();
 
 const sessions = new Map<string, any>();
 
@@ -16,6 +21,7 @@ vi.mock('@/infrastructure/api', () => ({
   },
   btwAPI: {
     askStream: (...args: any[]) => mockAskStream(...args),
+    cancel: (...args: any[]) => mockBtwCancel(...args),
   },
 }));
 
@@ -27,16 +33,24 @@ vi.mock('../store/FlowChatStore', () => ({
     updateSessionBtwOrigin: (...args: any[]) => mockUpdateSessionBtwOrigin(...args),
     addBtwThreadMarker: (...args: any[]) => mockAddBtwThreadMarker(...args),
     updateSessionModelName: (...args: any[]) => mockUpdateSessionModelName(...args),
+    addDialogTurn: (...args: any[]) => mockAddDialogTurn(...args),
+    deleteDialogTurn: (...args: any[]) => mockDeleteDialogTurn(...args),
+    cancelSessionTask: (...args: any[]) => mockCancelSessionTask(...args),
   },
 }));
 
 vi.mock('../state-machine', () => ({
+  SessionExecutionEvent: {
+    START: 'start',
+    FINISHING_SETTLED: 'finishing_settled',
+  },
   stateMachineManager: {
     get: () => ({
       getContext: () => ({
         currentDialogTurnId: 'turn-parent-1',
       }),
     }),
+    transition: (...args: any[]) => mockTransition(...args),
   },
 }));
 
@@ -52,7 +66,11 @@ vi.mock('@/shared/notification-system', () => ({
   },
 }));
 
-import { createBtwChildSession, sendMessageToTransientBtwSession } from './BtwThreadService';
+import {
+  cancelTransientBtwSession,
+  createBtwChildSession,
+  sendMessageToTransientBtwSession,
+} from './BtwThreadService';
 
 describe('BtwThreadService', () => {
   beforeEach(() => {
@@ -74,6 +92,8 @@ describe('BtwThreadService', () => {
       ],
     });
     mockAskStream.mockResolvedValue({ ok: true });
+    mockBtwCancel.mockResolvedValue(undefined);
+    mockTransition.mockResolvedValue(true);
     mockCreateSession.mockResolvedValue({
       sessionId: 'child-1',
     });
@@ -159,6 +179,129 @@ describe('BtwThreadService', () => {
           }),
         ],
       }),
+    );
+    expect(mockAddDialogTurn).toHaveBeenCalledWith(
+      'btw-child',
+      expect.objectContaining({
+        id: expect.stringMatching(/^btw-turn-/),
+        sessionId: 'btw-child',
+        userMessage: expect.objectContaining({
+          content: 'What is in this image?',
+          hasImages: true,
+          images: [
+            expect.objectContaining({
+              id: 'img-1',
+              name: 'clip.png',
+              imagePath: 'C:/tmp/clip.png',
+            }),
+          ],
+        }),
+        status: 'pending',
+      }),
+    );
+    expect(mockUpdateSessionBtwOrigin).toHaveBeenCalledWith(
+      'btw-child',
+      expect.objectContaining({
+        requestId: expect.any(String),
+        parentSessionId: 'parent-1',
+      }),
+      'btw',
+    );
+  });
+
+  it('cancels transient /btw sessions through the desktop /btw API', async () => {
+    sessions.set('btw-child', {
+      sessionId: 'btw-child',
+      title: 'Side question',
+      isTransient: true,
+      sessionKind: 'btw',
+      agentBackedTransient: false,
+      config: { modelName: 'fast' },
+      btwOrigin: {
+        parentSessionId: 'parent-1',
+        requestId: 'req-1',
+      },
+    });
+
+    await expect(cancelTransientBtwSession('btw-child')).resolves.toBe(true);
+
+    expect(mockBtwCancel).toHaveBeenCalledWith({ requestId: 'req-1' });
+    expect(mockCancelSessionTask).not.toHaveBeenCalled();
+  });
+
+  it('removes the pending local turn and settles the state machine when /btw send fails', async () => {
+    const error = new Error('backend refused');
+    mockAskStream.mockRejectedValueOnce(error);
+    sessions.set('btw-child', {
+      sessionId: 'btw-child',
+      title: 'Side question',
+      isTransient: true,
+      sessionKind: 'btw',
+      agentBackedTransient: false,
+      config: { modelName: 'fast' },
+      dialogTurns: [],
+    });
+
+    await expect(sendMessageToTransientBtwSession({
+      parentSessionId: 'parent-1',
+      childSessionId: 'btw-child',
+      question: 'Will this send?',
+    })).rejects.toThrow('backend refused');
+
+    expect(mockAddDialogTurn).toHaveBeenCalledWith(
+      'btw-child',
+      expect.objectContaining({
+        id: expect.stringMatching(/^btw-turn-/),
+      }),
+    );
+    const [, localTurn] = mockAddDialogTurn.mock.calls.at(-1)!;
+    expect(mockDeleteDialogTurn).toHaveBeenCalledWith('btw-child', localTurn.id);
+    expect(mockTransition).toHaveBeenCalledWith('btw-child', 'finishing_settled');
+  });
+
+  it('uses the provided parent model for image /btw sends instead of forcing fast', async () => {
+    sessions.set('btw-child', {
+      sessionId: 'btw-child',
+      title: 'Side question',
+      isTransient: true,
+      sessionKind: 'btw',
+      agentBackedTransient: false,
+      config: { modelName: 'parent-multimodal-model' },
+      dialogTurns: [],
+    });
+
+    await sendMessageToTransientBtwSession({
+      parentSessionId: 'parent-1',
+      childSessionId: 'btw-child',
+      question: 'What is in this image?',
+      modelId: 'parent-multimodal-model',
+      imagePayload: {
+        imageContexts: [
+          {
+            id: 'img-1',
+            image_path: '/tmp/clip.png',
+            mime_type: 'image/png',
+          },
+        ],
+        imageDisplayData: [
+          {
+            id: 'img-1',
+            name: 'clip.png',
+            imagePath: '/tmp/clip.png',
+            mimeType: 'image/png',
+          },
+        ],
+      },
+    });
+
+    expect(mockAskStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: 'parent-multimodal-model',
+      }),
+    );
+    expect(mockUpdateSessionModelName).toHaveBeenCalledWith(
+      'btw-child',
+      'parent-multimodal-model',
     );
   });
 });

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.ts
@@ -1,9 +1,9 @@
 import { agentAPI, btwAPI } from '@/infrastructure/api';
 import { notificationService } from '@/shared/notification-system';
 import { flowChatStore } from '../store/FlowChatStore';
-import { stateMachineManager } from '../state-machine';
+import { SessionExecutionEvent, stateMachineManager } from '../state-machine';
 import { flowChatManager } from './FlowChatManager';
-import type { Session } from '../types/flow-chat';
+import type { DialogTurn, Session } from '../types/flow-chat';
 import type { SessionKind, SessionRelationship } from '@/shared/types/session-history';
 import type { ReviewTeamRunManifest } from '@/shared/services/reviewTeamService';
 import type { ImagePayload } from '../utils/imagePayload';
@@ -51,6 +51,47 @@ function requireSession(sessionId: string): Session {
     throw new Error(`Session not found: ${sessionId}`);
   }
   return session;
+}
+
+function createPendingBtwTurn(params: {
+  childSessionId: string;
+  requestId: string;
+  question: string;
+  imagePayload?: ImagePayload;
+}): string {
+  const dialogTurnId = `btw-turn-${params.requestId.trim()}`;
+  const existingSession = flowChatStore.getState().sessions.get(params.childSessionId);
+  if (existingSession?.dialogTurns?.some(turn => turn.id === dialogTurnId)) {
+    return dialogTurnId;
+  }
+
+  const hasImages = (params.imagePayload?.imageContexts.length ?? 0) > 0;
+  const dialogTurn: DialogTurn = {
+    id: dialogTurnId,
+    sessionId: params.childSessionId,
+    kind: 'user_dialog',
+    userMessage: {
+      id: `user_btw_${Date.now()}`,
+      content: params.question,
+      timestamp: Date.now(),
+      hasImages,
+      images: params.imagePayload?.imageDisplayData,
+      metadata: {
+        kind: 'btw',
+        requestId: params.requestId,
+      },
+    },
+    modelRounds: [],
+    status: 'pending',
+    startTime: Date.now(),
+  };
+
+  flowChatStore.addDialogTurn(params.childSessionId, dialogTurn);
+  void stateMachineManager.transition(params.childSessionId, SessionExecutionEvent.START, {
+    taskId: params.childSessionId,
+    dialogTurnId,
+  });
+  return dialogTurnId;
 }
 
 export function isTransientBtwSession(session: Session | undefined): boolean {
@@ -238,20 +279,52 @@ export async function sendMessageToTransientBtwSession(params: {
   }
 
   const requestId = safeUuid('btw');
-  await btwAPI.askStream({
+  flowChatStore.updateSessionBtwOrigin(params.childSessionId, {
+    ...(childSession.btwOrigin || {}),
     requestId,
-    sessionId: params.parentSessionId,
+    parentSessionId: params.parentSessionId,
+  }, 'btw');
+  const localTurnId = createPendingBtwTurn({
     childSessionId: params.childSessionId,
-    childSessionName: params.childSessionName || childSession.title || 'Side thread',
+    requestId,
     question,
-    modelId: params.modelId ?? childSession.config.modelName ?? 'fast',
-    imageContexts: params.imagePayload?.imageContexts,
+    imagePayload: params.imagePayload,
   });
+  try {
+    await btwAPI.askStream({
+      requestId,
+      sessionId: params.parentSessionId,
+      childSessionId: params.childSessionId,
+      childSessionName: params.childSessionName || childSession.title || 'Side thread',
+      question,
+      modelId: params.modelId ?? childSession.config.modelName ?? 'fast',
+      imageContexts: params.imagePayload?.imageContexts,
+    });
+  } catch (error) {
+    flowChatStore.deleteDialogTurn(params.childSessionId, localTurnId);
+    await stateMachineManager.transition(params.childSessionId, SessionExecutionEvent.FINISHING_SETTLED);
+    throw error;
+  }
   if (params.modelId?.trim()) {
     flowChatStore.updateSessionModelName(params.childSessionId, params.modelId.trim());
   }
 
   return { requestId };
+}
+
+export async function cancelTransientBtwSession(sessionId: string): Promise<boolean> {
+  const session = flowChatStore.getState().sessions.get(sessionId);
+  if (!session || !isTransientBtwSession(session)) {
+    return false;
+  }
+
+  const requestId = session.btwOrigin?.requestId?.trim();
+  if (!requestId) {
+    return false;
+  }
+
+  await btwAPI.cancel({ requestId });
+  return true;
 }
 
 export async function startBtwThread(params: {

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
@@ -63,6 +63,7 @@ vi.mock('./flow-chat-manager', () => ({
   cleanupSessionBuffers: vi.fn(),
   sendMessage: vi.fn(),
   cancelCurrentTask: vi.fn(),
+  cancelSessionTask: vi.fn(),
   installPendingQueueDrainListener: vi.fn(),
   drainPendingQueue: vi.fn(),
   initializeEventListeners: storeMocks.initializeEventListeners,

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -37,6 +37,7 @@ import {
   cleanupSessionBuffers,
   sendMessage as sendMessageModule,
   cancelCurrentTask as cancelCurrentTaskModule,
+  cancelSessionTask as cancelSessionTaskModule,
   installPendingQueueDrainListener,
   drainPendingQueue,
   initializeEventListeners,
@@ -615,6 +616,10 @@ export class FlowChatManager {
 
   async cancelCurrentTask(): Promise<boolean> {
     return cancelCurrentTaskModule(this.context);
+  }
+
+  async cancelSessionTask(sessionId: string): Promise<boolean> {
+    return cancelSessionTaskModule(this.context, sessionId);
   }
 
   public async saveAllInProgressTurns(): Promise<void> {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cancelSessionTask } from './MessageModule';
+import { SessionExecutionEvent } from '../../state-machine/types';
+
+const mockCancelTransientBtwSession = vi.fn();
+const mockTransition = vi.fn();
+
+vi.mock('../BtwThreadService', () => ({
+  cancelTransientBtwSession: (...args: any[]) => mockCancelTransientBtwSession(...args),
+  isTransientBtwSession: (session: any) =>
+    session?.isTransient === true &&
+    session?.sessionKind === 'btw' &&
+    session?.agentBackedTransient !== true,
+  sendMessageToTransientBtwSession: vi.fn(),
+}));
+
+vi.mock('../../state-machine', () => ({
+  SessionExecutionEvent: {
+    FINISHING_SETTLED: 'finishing_settled',
+    USER_CANCEL: 'user_cancel',
+  },
+  SessionExecutionState: {
+    PROCESSING: 'processing',
+  },
+  stateMachineManager: {
+    getCurrentState: vi.fn(() => 'processing'),
+    transition: (...args: any[]) => mockTransition(...args),
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: {},
+}));
+
+vi.mock('@/infrastructure/api/service-api/ACPClientAPI', () => ({
+  ACPClientAPI: {},
+}));
+
+vi.mock('@/infrastructure/config/services/ConfigManager', () => ({
+  configManager: {},
+}));
+
+vi.mock('../../../shared/notification-system', () => ({
+  notificationService: {
+    error: vi.fn(),
+  },
+}));
+
+describe('MessageModule cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCancelTransientBtwSession.mockResolvedValue(true);
+    mockTransition.mockResolvedValue(true);
+  });
+
+  it('cancels transient /btw sessions locally and through the /btw API path', async () => {
+    const session = {
+      sessionId: 'btw-child',
+      isTransient: true,
+      sessionKind: 'btw',
+      agentBackedTransient: false,
+      dialogTurns: [],
+      config: {},
+    };
+    const mockStoreCancelSessionTask = vi.fn();
+    const contentBuffers = new Map([['btw-child', new Map([['round-1', 'text']])]]);
+    const activeTextItems = new Map([['btw-child', new Map([['round-1', 'item-1']])]]);
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({
+          activeSessionId: 'parent',
+          sessions: new Map([['btw-child', session]]),
+        }),
+        cancelSessionTask: mockStoreCancelSessionTask,
+      },
+      userCancelledSessionIds: new Set<string>(),
+      eventBatcher: {
+        getBufferSize: vi.fn(() => 0),
+        clear: vi.fn(),
+      },
+      pendingTurnCompletions: new Map(),
+      runtimeStatusTimers: new Map(),
+      handledTerminalTurnEvents: new Set<string>(),
+      contentBuffers,
+      activeTextItems,
+    };
+
+    await expect(cancelSessionTask(context, 'btw-child')).resolves.toBe(true);
+
+    expect(mockStoreCancelSessionTask).toHaveBeenCalledWith('btw-child');
+    expect(mockTransition).toHaveBeenCalledWith(
+      'btw-child',
+      SessionExecutionEvent.FINISHING_SETTLED,
+    );
+    expect(mockCancelTransientBtwSession).toHaveBeenCalledWith('btw-child');
+    expect(context.userCancelledSessionIds.has('btw-child')).toBe(true);
+    expect(contentBuffers.has('btw-child')).toBe(false);
+    expect(activeTextItems.has('btw-child')).toBe(false);
+  });
+});

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -22,6 +22,7 @@ import {
   type FlowChatPinTurnToTopRequest,
 } from '../../events/flowchatNavigation';
 import {
+  cancelTransientBtwSession,
   isTransientBtwSession,
   sendMessageToTransientBtwSession,
 } from '../BtwThreadService';
@@ -422,14 +423,25 @@ function handleTitleGeneration(
   context.flowChatStore.updateSessionTitle(sessionId, tempTitle, 'generating');
 }
 
-export async function cancelCurrentTask(context: FlowChatContext): Promise<boolean> {
+export async function cancelSessionTask(context: FlowChatContext, requestedSessionId?: string): Promise<boolean> {
   try {
     const state = context.flowChatStore.getState();
-    const sessionId = state.activeSessionId;
+    const sessionId = requestedSessionId || state.activeSessionId;
     
     if (!sessionId) {
       log.debug('No active session to cancel');
       return false;
+    }
+
+    const session = state.sessions.get(sessionId);
+    if (isTransientBtwSession(session)) {
+      context.userCancelledSessionIds.add(sessionId);
+      context.flowChatStore.cancelSessionTask(sessionId);
+      markCurrentTurnItemsAsCancelled(context, sessionId);
+      cleanupSessionBuffers(context, sessionId);
+      await stateMachineManager.transition(sessionId, SessionExecutionEvent.FINISHING_SETTLED);
+      const success = await cancelTransientBtwSession(sessionId);
+      return success;
     }
 
     const currentState = stateMachineManager.getCurrentState(sessionId);
@@ -449,6 +461,10 @@ export async function cancelCurrentTask(context: FlowChatContext): Promise<boole
     log.error('Failed to cancel current task', error);
     return false;
   }
+}
+
+export async function cancelCurrentTask(context: FlowChatContext): Promise<boolean> {
+  return cancelSessionTask(context);
 }
 
 /**

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
@@ -43,6 +43,7 @@ export {
 export {
   sendMessage,
   cancelCurrentTask,
+  cancelSessionTask,
   markCurrentTurnItemsAsCancelled,
   drainPendingQueue,
   installPendingQueueDrainListener


### PR DESCRIPTION
## Summary
- create local pending turns for transient /btw sends so side questions show immediate state and image thumbnails
- preserve /btw image metadata through backend DialogTurnStarted events
- cancel the active /btw child session by requestId instead of the main session
- inherit the parent model for image /btw sends while keeping text-only /btw on fast
- settle failed /btw sends to avoid stuck processing state

Fixes #1411

## Verification
- pnpm --dir src/web-ui run test:run src/flow_chat/services/BtwThreadService.test.ts src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
- pnpm run type-check:web
- pnpm run fmt:rs
- cargo check -p bitfun-core
- git diff --check