### PR TITLE
fix(skills): align opencode and agents user skill roots

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/skills/registry.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/skills/registry.rs
@@ -14,11 +14,11 @@ use crate::util::errors::{BitFunError, BitFunResult};
 use bitfun_agent_runtime::skills::{
     annotate_shadowed_skills, build_mode_skill_infos, filter_candidates_for_mode,
     normalize_local_skill_dir_name, normalize_remote_skill_dir_name, normalize_skill_keys,
-    resolve_default_hidden_builtin_for_explicit_invocation, resolve_visible_skills,
-    sort_skill_candidates_by_dir, sort_skills, ExplicitSkillInvocationResolution, SkillCandidate,
-    BITFUN_SYSTEM_SKILL_DIR, BITFUN_SYSTEM_SKILL_SLOT, BITFUN_USER_SKILL_SLOT,
-    PROJECT_SKILL_KEY_PREFIX, PROJECT_SKILL_ROOTS, USER_CONFIG_SKILL_ROOTS, USER_HOME_SKILL_ROOTS,
-    USER_SKILL_KEY_PREFIX,
+    resolve_default_hidden_builtin_for_explicit_invocation, resolve_user_config_skill_root,
+    resolve_visible_skills, sort_skill_candidates_by_dir, sort_skills,
+    ExplicitSkillInvocationResolution, SkillCandidate, BITFUN_SYSTEM_SKILL_DIR,
+    BITFUN_SYSTEM_SKILL_SLOT, BITFUN_USER_SKILL_SLOT, PROJECT_SKILL_KEY_PREFIX,
+    PROJECT_SKILL_ROOTS, USER_CONFIG_SKILL_ROOTS, USER_HOME_SKILL_ROOTS, USER_SKILL_KEY_PREFIX,
 };
 use log::{debug, error};
 use std::collections::HashSet;
@@ -76,6 +76,7 @@ impl SkillRegistry {
     fn get_possible_paths_for_workspace(workspace_root: Option<&Path>) -> Vec<SkillRootEntry> {
         let mut entries = Vec::new();
         let mut priority = 0usize;
+        let mut deferred_home_entries = Vec::new();
 
         if let Some(workspace_path) = workspace_root {
             for spec in PROJECT_SKILL_ROOTS {
@@ -93,10 +94,14 @@ impl SkillRegistry {
             }
         }
 
-        if let Some(home) = dirs::home_dir() {
+        let home_dir = dirs::home_dir();
+
+        if let Some(home) = home_dir.as_deref() {
             for spec in USER_HOME_SKILL_ROOTS {
                 let path = home.join(spec.parent).join(spec.subdir);
-                if path.exists() && path.is_dir() {
+                if spec.parent == ".opencode" {
+                    deferred_home_entries.push((path, spec.slot));
+                } else if path.exists() && path.is_dir() {
                     entries.push(SkillRootEntry {
                         path,
                         level: SkillLocation::User,
@@ -109,7 +114,7 @@ impl SkillRegistry {
             }
         }
 
-        // BitFun's own user-defined skills sit between home slots and config slots.
+        // BitFun's own user-defined skills sit between most home slots and config slots.
         // This lets other agent directories (e.g. ~/.claude/skills) take precedence
         // while still keeping config-level overrides after BitFun defaults.
         let path_manager = get_path_manager_arc();
@@ -139,7 +144,7 @@ impl SkillRegistry {
 
         if let Some(config_dir) = dirs::config_dir() {
             for spec in USER_CONFIG_SKILL_ROOTS {
-                let path = config_dir.join(spec.parent).join(spec.subdir);
+                let path = resolve_user_config_skill_root(spec, &config_dir, home_dir.as_deref());
                 if path.exists() && path.is_dir() {
                     entries.push(SkillRootEntry {
                         path,
@@ -151,6 +156,19 @@ impl SkillRegistry {
                 }
                 priority += 1;
             }
+        }
+
+        for (path, slot) in deferred_home_entries {
+            if path.exists() && path.is_dir() {
+                entries.push(SkillRootEntry {
+                    path,
+                    level: SkillLocation::User,
+                    slot,
+                    priority,
+                    is_builtin: false,
+                });
+            }
+            priority += 1;
         }
 
         entries

--- a/src/crates/execution/agent-runtime/src/skills/mod.rs
+++ b/src/crates/execution/agent-runtime/src/skills/mod.rs
@@ -20,10 +20,10 @@ pub use resolver::{
     resolve_skill_state_for_mode, ModeSkillState, UserModeSkillOverrides,
 };
 pub use roots::{
-    normalize_local_skill_dir_name, normalize_remote_skill_dir_name, SkillRootSpec,
-    BITFUN_SYSTEM_SKILL_DIR, BITFUN_SYSTEM_SKILL_SLOT, BITFUN_USER_SKILL_SLOT,
-    PROJECT_SKILL_KEY_PREFIX, PROJECT_SKILL_ROOTS, USER_CONFIG_SKILL_ROOTS, USER_HOME_SKILL_ROOTS,
-    USER_SKILL_KEY_PREFIX,
+    normalize_local_skill_dir_name, normalize_remote_skill_dir_name,
+    resolve_user_config_skill_root, SkillRootSpec, BITFUN_SYSTEM_SKILL_DIR,
+    BITFUN_SYSTEM_SKILL_SLOT, BITFUN_USER_SKILL_SLOT, PROJECT_SKILL_KEY_PREFIX,
+    PROJECT_SKILL_ROOTS, USER_CONFIG_SKILL_ROOTS, USER_HOME_SKILL_ROOTS, USER_SKILL_KEY_PREFIX,
 };
 pub use selection::{
     annotate_shadowed_skills, build_mode_skill_infos, filter_candidates_for_mode,

--- a/src/crates/execution/agent-runtime/src/skills/roots.rs
+++ b/src/crates/execution/agent-runtime/src/skills/roots.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub const USER_SKILL_KEY_PREFIX: &str = "user";
 pub const PROJECT_SKILL_KEY_PREFIX: &str = "project";
@@ -63,24 +63,36 @@ pub const USER_HOME_SKILL_ROOTS: &[SkillRootSpec] = &[
         slot: "home.cursor",
     },
     SkillRootSpec {
+        parent: ".opencode",
+        subdir: "skills",
+        slot: "home.opencode",
+    },
+    SkillRootSpec {
         parent: ".agents",
         subdir: "skills",
         slot: "home.agents",
     },
 ];
 
-pub const USER_CONFIG_SKILL_ROOTS: &[SkillRootSpec] = &[
-    SkillRootSpec {
-        parent: "opencode",
-        subdir: "skills",
-        slot: "config.opencode",
-    },
-    SkillRootSpec {
-        parent: "agents",
-        subdir: "skills",
-        slot: "config.agents",
-    },
-];
+pub const USER_CONFIG_SKILL_ROOTS: &[SkillRootSpec] = &[SkillRootSpec {
+    parent: "opencode",
+    subdir: "skills",
+    slot: "config.opencode",
+}];
+
+pub fn resolve_user_config_skill_root(
+    spec: &SkillRootSpec,
+    config_dir: &Path,
+    home_dir: Option<&Path>,
+) -> PathBuf {
+    if cfg!(target_os = "windows") && spec.parent == "opencode" {
+        if let Some(home_dir) = home_dir {
+            return home_dir.join(".config").join(spec.parent).join(spec.subdir);
+        }
+    }
+
+    config_dir.join(spec.parent).join(spec.subdir)
+}
 
 pub fn normalize_local_skill_dir_name(path: &Path) -> Option<String> {
     path.file_name()

--- a/src/crates/execution/agent-runtime/tests/skill_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/skill_contracts.rs
@@ -1,14 +1,15 @@
 use std::collections::HashSet;
+use std::path::PathBuf;
 
 use bitfun_agent_runtime::skills::{
     annotate_shadowed_skills, build_mode_skill_infos, builtin_skill_group_key,
     filter_candidates_for_mode, render_loaded_skill_for_assistant, resolve_builtin_default_enabled,
     resolve_default_hidden_builtin_for_explicit_invocation, resolve_skill_default_enabled_for_mode,
-    resolve_skill_state_for_mode, resolve_visible_skills, sort_skills,
-    ExplicitSkillInvocationResolution, ModeSkillStateReason, SkillCandidate, SkillData, SkillInfo,
-    SkillLocation, UserModeSkillOverrides, BITFUN_SYSTEM_SKILL_DIR, BITFUN_SYSTEM_SKILL_SLOT,
-    BITFUN_USER_SKILL_SLOT, PROJECT_SKILL_KEY_PREFIX, PROJECT_SKILL_ROOTS, USER_CONFIG_SKILL_ROOTS,
-    USER_HOME_SKILL_ROOTS, USER_SKILL_KEY_PREFIX,
+    resolve_skill_state_for_mode, resolve_user_config_skill_root, resolve_visible_skills,
+    sort_skills, ExplicitSkillInvocationResolution, ModeSkillStateReason, SkillCandidate,
+    SkillData, SkillInfo, SkillLocation, UserModeSkillOverrides, BITFUN_SYSTEM_SKILL_DIR,
+    BITFUN_SYSTEM_SKILL_SLOT, BITFUN_USER_SKILL_SLOT, PROJECT_SKILL_KEY_PREFIX,
+    PROJECT_SKILL_ROOTS, USER_CONFIG_SKILL_ROOTS, USER_HOME_SKILL_ROOTS, USER_SKILL_KEY_PREFIX,
 };
 
 fn builtin_skill(dir_name: &str) -> SkillInfo {
@@ -129,9 +130,48 @@ fn skill_discovery_root_facts_are_runtime_owned() {
     assert!(USER_HOME_SKILL_ROOTS
         .iter()
         .any(|root| root.parent == ".codex" && root.slot == "home.codex"));
+    assert!(USER_HOME_SKILL_ROOTS
+        .iter()
+        .any(|root| root.parent == ".opencode" && root.slot == "home.opencode"));
+    assert!(USER_HOME_SKILL_ROOTS
+        .iter()
+        .any(|root| root.parent == ".agents" && root.slot == "home.agents"));
     assert!(USER_CONFIG_SKILL_ROOTS
         .iter()
         .any(|root| root.parent == "opencode" && root.slot == "config.opencode"));
+    assert!(!USER_CONFIG_SKILL_ROOTS
+        .iter()
+        .any(|root| root.parent == "agents"));
+}
+
+#[test]
+fn user_config_skill_root_resolution_matches_platform_contract() {
+    let opencode = USER_CONFIG_SKILL_ROOTS
+        .iter()
+        .find(|root| root.parent == "opencode")
+        .expect("opencode config root should exist");
+
+    if cfg!(target_os = "windows") {
+        let resolved = resolve_user_config_skill_root(
+            opencode,
+            std::path::Path::new(r"C:\Users\tester\AppData\Roaming"),
+            Some(std::path::Path::new(r"C:\Users\tester")),
+        );
+        assert_eq!(
+            resolved,
+            PathBuf::from(r"C:\Users\tester\.config\opencode\skills")
+        );
+    } else {
+        let resolved = resolve_user_config_skill_root(
+            opencode,
+            std::path::Path::new("/home/tester/.config"),
+            Some(std::path::Path::new("/home/tester")),
+        );
+        assert_eq!(
+            resolved,
+            PathBuf::from("/home/tester/.config/opencode/skills")
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Align user-level skill discovery with upstream client conventions for `agents` and `opencode`.

Fixes #

## Type and Areas

Type:

bug fix

Areas:

Rust core, agent runtime

## Motivation / Impact

This fixes user-level skill discovery paths that did not match the expected upstream locations.

Changes in this PR:
- `agents` user skills now resolve from `~/.agents/skills` instead of config-based `agents` roots.
- `opencode` config skills now resolve to `~/.config/opencode/skills` on Windows as well.
- `~/.opencode/skills` is also supported, but with lower priority than the config directory so config-installed skills win on name conflicts.
- Runtime skill root contract tests were updated to lock these behaviors in.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-agent-runtime --test skill_contracts`
- `cargo check --workspace`

Results:
- All listed commands passed.
- `cargo check --workspace` still reports two pre-existing unrelated warnings in:
  - `src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs`
  - `src/apps/desktop/src/computer_use/windows_wgc_capture.rs`

## Reviewer Notes

This change only adjusts skill root discovery and precedence. No product logic outside skill path resolution was changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.