### PR TITLE
ci: combine Rust test invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,8 @@ jobs:
       - name: Check compilation
         run: cargo check --workspace --exclude bitfun-cli
 
-      - name: Run core Rust tests
-        run: cargo test --locked -p bitfun-core
-
-      - name: Run desktop Rust tests
-        run: cargo test --locked -p bitfun-desktop
+      - name: Run core and desktop Rust tests
+        run: cargo test --locked -p bitfun-core -p bitfun-desktop
 
   # ── Frontend: build ────────────────────────────────────────────────
   frontend-build:


### PR DESCRIPTION
## Summary
- combine the core and desktop Rust test steps into one Cargo invocation
- keep the same packages and matrix coverage while reducing duplicate Cargo scheduling/build planning work

## Validation
- `pnpm run check:github-config`
- `git diff --check -- .github/workflows/ci.yml`
- Attempted `cargo check --workspace --exclude bitfun-cli` and `cargo test --locked -p bitfun-core -p bitfun-desktop --no-run`; both are blocked locally by `rustc 1.94.1` on third-party `oxc_transformer` usage of `if let` guards. CI uses a newer stable toolchain and remains the authoritative Rust validation for this workflow-only change.