### PR TITLE
evals: bundle CA roots for rustls client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ encoding_rs = "0.8.35"
 
 # HTTP client
 reqwest = { version = "0.13.4", default-features = false, features = ["native-tls", "rustls", "json", "stream", "multipart", "query", "form"] }
+webpki-root-certs = "1.0.8"
 
 # Debug Log HTTP Server
 axum = { version = "0.8", features = ["json", "ws"] }

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -1126,7 +1126,8 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
         ai_config,
         None,
         stream_options,
-    );
+    )
+    .map_err(|e| format!("Failed to initialize AI client: {}", e))?;
 
     {
         let mut ai_client_guard = state.ai_client.write().await;
@@ -1170,13 +1171,12 @@ async fn create_transient_ai_client_for_config(
         None
     };
 
-    Ok(
-        bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(
-            ai_config,
-            proxy_config,
-            stream_options,
-        ),
+    bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(
+        ai_config,
+        proxy_config,
+        stream_options,
     )
+    .map_err(|e| format!("Failed to initialize AI client: {}", e))
 }
 
 #[tauri::command]

--- a/src/crates/adapters/ai-adapters/Cargo.toml
+++ b/src/crates/adapters/ai-adapters/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 urlencoding = { workspace = true }
+webpki-root-certs = { workspace = true }
 
 [dev-dependencies]
 axum = { workspace = true }

--- a/src/crates/adapters/ai-adapters/src/client.rs
+++ b/src/crates/adapters/ai-adapters/src/client.rs
@@ -72,12 +72,12 @@ impl AIClient {
     pub(crate) const HTTP_TCP_KEEPALIVE_SECS: u64 = 60;
 
     /// Create an AIClient without proxy.
-    pub fn new(config: AIConfig) -> Self {
+    pub fn new(config: AIConfig) -> Result<Self> {
         Self::new_with_runtime_options(config, None, StreamOptions::default())
     }
 
     /// Create an AIClient with proxy configuration.
-    pub fn new_with_proxy(config: AIConfig, proxy_config: Option<ProxyConfig>) -> Self {
+    pub fn new_with_proxy(config: AIConfig, proxy_config: Option<ProxyConfig>) -> Result<Self> {
         Self::new_with_runtime_options(config, proxy_config, StreamOptions::default())
     }
 
@@ -86,13 +86,13 @@ impl AIClient {
         config: AIConfig,
         proxy_config: Option<ProxyConfig>,
         stream_options: StreamOptions,
-    ) -> Self {
-        let client = http::create_http_client(proxy_config, config.skip_ssl_verify);
-        Self {
+    ) -> Result<Self> {
+        let client = http::create_http_client(proxy_config, config.skip_ssl_verify)?;
+        Ok(Self {
             client,
             config,
             stream_options,
-        }
+        })
     }
 
     /// Returns the configured idle timeout between streamed chunks, if any.

--- a/src/crates/adapters/ai-adapters/src/client/http.rs
+++ b/src/crates/adapters/ai-adapters/src/client/http.rs
@@ -2,12 +2,16 @@ use crate::client::AIClient;
 use crate::types::ProxyConfig;
 use anyhow::{anyhow, Result};
 use log::{debug, error, info, warn};
-use reqwest::{Client, Proxy};
+use reqwest::{Certificate, Client, Proxy};
+use std::error::Error as StdError;
 
 pub(crate) fn create_http_client(
     proxy_config: Option<ProxyConfig>,
     skip_ssl_verify: bool,
-) -> Client {
+) -> Result<Client> {
+    let proxy_enabled = proxy_config
+        .as_ref()
+        .is_some_and(|proxy_cfg| proxy_cfg.enabled && !proxy_cfg.url.is_empty());
     let mut builder = Client::builder()
         .use_rustls_tls()
         .connect_timeout(std::time::Duration::from_secs(
@@ -23,15 +27,19 @@ pub(crate) fn create_http_client(
         )))
         .danger_accept_invalid_certs(skip_ssl_verify);
 
+    if !skip_ssl_verify {
+        builder = builder.tls_certs_only(webpki_root_certificates()?);
+    }
+
     if skip_ssl_verify {
         warn!(
             "SSL certificate verification disabled - security risk, use only in test environments"
         );
     }
 
-    if let Some(proxy_cfg) = proxy_config {
+    if let Some(proxy_cfg) = proxy_config.as_ref() {
         if proxy_cfg.enabled && !proxy_cfg.url.is_empty() {
-            match build_proxy(&proxy_cfg) {
+            match build_proxy(proxy_cfg) {
                 Ok(proxy) => {
                     info!("Using proxy: {}", proxy_cfg.url);
                     builder = builder.proxy(proxy);
@@ -52,15 +60,45 @@ pub(crate) fn create_http_client(
     }
 
     match builder.build() {
-        Ok(client) => client,
+        Ok(client) => Ok(client),
         Err(e) => {
             error!(
-                "HTTP client initialization failed: {}, using default client",
-                e
+                "HTTP client initialization failed: {}; debug={:?}; source_chain={}; proxy_enabled={}; skip_ssl_verify={}",
+                e,
+                e,
+                format_error_chain(&e),
+                proxy_enabled,
+                skip_ssl_verify
             );
-            Client::new()
+            Err(anyhow!(
+                "HTTP client initialization failed: {}; source_chain={}",
+                e,
+                format_error_chain(&e)
+            ))
         }
     }
+}
+
+fn webpki_root_certificates() -> Result<Vec<Certificate>> {
+    webpki_root_certs::TLS_SERVER_ROOT_CERTS
+        .iter()
+        .map(|cert| {
+            Certificate::from_der(cert.as_ref())
+                .map_err(|e| anyhow!("Failed to load bundled webpki root certificate: {}", e))
+        })
+        .collect()
+}
+
+fn format_error_chain(error: &(dyn StdError + 'static)) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+
+    while let Some(err) = source {
+        parts.push(err.to_string());
+        source = err.source();
+    }
+
+    parts.join(" | caused by: ")
 }
 
 fn build_proxy(config: &ProxyConfig) -> Result<Proxy> {

--- a/src/crates/adapters/ai-adapters/src/providers/openai/responses.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/responses.rs
@@ -187,6 +187,7 @@ mod tests {
             custom_request_body: None,
             custom_request_body_mode: None,
         })
+        .expect("test AI client should initialize")
     }
 
     #[test]

--- a/src/crates/assembly/core/src/function_agents/port_adapters.rs
+++ b/src/crates/assembly/core/src/function_agents/port_adapters.rs
@@ -308,27 +308,30 @@ mod tests {
     };
 
     fn test_ai_client() -> Arc<super::AIClient> {
-        Arc::new(super::AIClient::new(AIConfig {
-            name: "test".to_string(),
-            base_url: "http://127.0.0.1".to_string(),
-            request_url: "http://127.0.0.1".to_string(),
-            api_key: "test".to_string(),
-            model: "test-model".to_string(),
-            format: "openai".to_string(),
-            context_window: 8192,
-            max_tokens: None,
-            temperature: None,
-            top_p: None,
-            reasoning_mode: ReasoningMode::Default,
-            inline_think_in_text: false,
-            custom_headers: None,
-            custom_headers_mode: None,
-            skip_ssl_verify: false,
-            reasoning_effort: None,
-            thinking_budget_tokens: None,
-            custom_request_body: None,
-            custom_request_body_mode: None,
-        }))
+        Arc::new(
+            super::AIClient::new(AIConfig {
+                name: "test".to_string(),
+                base_url: "http://127.0.0.1".to_string(),
+                request_url: "http://127.0.0.1".to_string(),
+                api_key: "test".to_string(),
+                model: "test-model".to_string(),
+                format: "openai".to_string(),
+                context_window: 8192,
+                max_tokens: None,
+                temperature: None,
+                top_p: None,
+                reasoning_mode: ReasoningMode::Default,
+                inline_think_in_text: false,
+                custom_headers: None,
+                custom_headers_mode: None,
+                skip_ssl_verify: false,
+                reasoning_effort: None,
+                thinking_budget_tokens: None,
+                custom_request_body: None,
+                custom_request_body_mode: None,
+            })
+            .expect("test AI client should initialize"),
+        )
     }
 
     #[test]

--- a/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
@@ -205,7 +205,7 @@ impl AIClientFactory {
             ai_config,
             proxy_config,
             stream_options,
-        ));
+        )?);
 
         {
             let mut cache = match self.client_cache.write() {


### PR DESCRIPTION
## Summary
- add bundled webpki root certificates to the rustls reqwest client so static/containerized builds do not depend on system CA stores
- return HTTP client initialization errors instead of silently falling back to a default client
- propagate AI client construction failures to desktop and cached client callers

## Verification
- cargo check -p bitfun-ai-adapters
- cargo check -p bitfun-cli
- reran 4 previously failing Terminal Bench cases; no `failed after 10 attempts`, CA certificate, or HTTP client initialization errors were observed