### PR TITLE
refactor(theme): compress low-usage token contracts

### DIFF
--- a/docs/architecture/theme-token-optimization.md
+++ b/docs/architecture/theme-token-optimization.md
@@ -238,10 +238,10 @@ CLI/TUI 使用独立审计，不参与 CSS var root 计数：
 | non-contract dynamic inputs | 0 |
 | non-contract component-private vars | 0 |
 | runtime-only legacy required vars | 1 |
-| static root contract key | 320 |
-| static root contract external usage key | 320 |
+| static root contract key | 289 |
+| static root contract external usage key | 289 |
 | static root contract internal-only key | 0 |
-| static root contract low external usage key | 116 |
+| static root contract low external usage key | 86 |
 
 审计补充了机器可校验的治理契约，用于把“可删除债务”和“必须保留的兼容/边界”
 分开：
@@ -257,7 +257,7 @@ CLI/TUI 使用独立审计，不参与 CSS var root 计数：
 | compatibility alias family 直接使用次数 | 0 | generated widget payload 只暴露经过审核的 canonical 子集，iframe shell 通过 alias fallback 兼容 legacy family |
 | stale compatibility alias family contracts | 0 | 防止 family contract 指向缺失的 canonical family |
 | missing compatibility alias family canonicals | 0 | 防止新增 `--radius-x` / `--spacing-x` 但缺少对应 canonical key |
-| surface token rename contracts | 9 | 显式记录已迁移的 surface-local 旧 key、canonical 目标、owner 和命名边界 |
+| surface token rename contracts | 8 | 显式记录已迁移的 surface-local 旧 key、canonical 目标、owner 和命名边界 |
 | active surface token rename key | 0 | 防止 `--primary-color`、`--operation-color`、`--delay`、`--um-*` 等旧局部 key 回流 |
 | active surface token rename occurrences | 0 | 防止旧 key 在 SCSS、CSS 或 TSX inline style 中被重新定义或读取 |
 | surface token rename missing canonical | 0 | 防止 rename registry 指向不存在的 canonical key |
@@ -287,7 +287,7 @@ PR 通过而放宽 `appUi`、fallback、unresolved、non-contract 或 dynamic fa
 | 区域 | 当前出现次数 | 当前唯一色数 | 说明 |
 | --- | ---: | ---: | --- |
 | Theme presets | 168 | 115 | 主题个性与 palette 映射；跨主题深色 neutral、弱文本、非状态浅色背景和同概念 success 色已收敛；相邻 surface、主题识别主背景、状态色和 editor lineHighlight 继续保留 |
-| Token contracts | 94 | 84 | `tokens.scss` 等静态契约根；黑白 overlay alpha stop 继续保留相邻状态层级，未消费 legacy mixin、自引用别名和低复用单 surface helper 已移除，不按数值相近强行合并 |
+| Token contracts | 91 | 81 | `tokens.scss` 等静态契约根；黑白 overlay alpha stop 继续保留相邻状态层级，未消费 legacy mixin、自引用别名、死 Sass helper 和低复用单 surface helper 已移除，不按数值相近强行合并 |
 | Editor | 52 | 48 | Monaco/editor 专用域，不能直接泛化到 app token；被动 selection/word highlight 已收敛，但 diff text/line/gutter 继续保留用户可见层级 |
 | Mermaid | 53 | 48 | Mermaid 专用渲染域；status fallback 复用 app semantic status 默认值，pie 5-8 复用紧凑类别色，dark info/activation 恢复 accent 类别感；节点、边、cluster、note 文本和 light 高亮仍保留相邻层级差异。未接入当前 Markdown Mermaid 渲染路径的 SCSS token 文件已删除 |
 | Theme runtime | 27 | 26 | `ThemeService.ts` 运行时注入；黑白 overlay alpha 与静态 token、payload shell 保持相同 stop，避免 early render 与 runtime 状态层级漂移 |
@@ -342,10 +342,10 @@ fallback 收敛决策表：
 | 原 fallback token | 决策 | 依据 | 结果 |
 | --- | --- | --- | --- |
 | `--surface-stagger-index` | 上移默认值 | `tokens.scss` 已提供 `0` 默认值，TS inline style 仍可覆盖动画序号 | 移除 12 处 selector fallback |
-| `--mission-control-group-color` | 上移默认值并保留组别差异 | filter 仍由 inline style 驱动；thumbnail badge 的 primary/secondary/tertiary 默认值保持原 accent/success/warning 语义 | 移除 6 处背景 fallback，避免误把组别统一成同一颜色 |
+| `--mission-control-group-color` | 退役 root 默认并拆成组件私有变量 | filter 改为静态 modifier class；thumbnail badge 使用独立 `--private-thumbnail-group-color`，primary/secondary/tertiary 仍读 accent/success/warning | 移除背景 fallback 和非 contract 跨文件共享，避免误把组别统一成同一颜色 |
 | `--char-index` | 上移到组件根 | StreamText 根提供 `0`，每字符 inline style 仍可覆盖 | 移除 3 处 keyframe fallback |
-| `--gallery-grid-min` | 上移到根 token 默认值 | `tokens.scss` 提供 `320px`，祖先变量和 props inline style 仍可覆盖 | 移除 grid sizing fallback |
-| `--gallery-skeleton-height` | 上移到根 token 默认值 | `tokens.scss` 提供 `140px`，祖先变量和 props inline style 仍可覆盖 | 移除 skeleton height fallback |
+| `--gallery-grid-min` | 上移到 Gallery 组件默认值 | `GalleryLayout.scss` 提供 `320px`，祖先变量和 props inline style 仍可覆盖 | 移除 grid sizing fallback 且不暴露 root contract |
+| `--gallery-skeleton-height` | 上移到 Gallery 组件默认值 | `GalleryLayout.scss` 提供 `140px`，祖先变量和 props inline style 仍可覆盖 | 移除 skeleton height fallback 且不暴露 root contract |
 | `--primary-color` | 改为明确的 tool-card accent token | `--primary-color` 是历史 tool card 局部入口，不提升为全局 app token；BaseToolCard 现在通过 `--base-tool-card-accent-color` 映射到 `--markdown-primary-color` | 产品代码不再定义或读取旧 key，回流由 `surfaceTokenRenames` 拦截 |
 | `--scene-viewport-border-width` | 上移默认值 | 静态 token 提供 `1px`，ThemeService 继续按主题 layout 覆盖为 `1px` 或 `0` | 移除 viewport border fallback |
 
@@ -445,6 +445,8 @@ Phase 5 决策记录：
 
 | component layout contract compression | retire implementation/layout aliases | `tokens.scss`、`ThemeService.ts`、`Button.scss`、`Badge.scss`、`Markdown.scss`、`BaseToolCard.scss`、`SmoothHeightCollapse.*`、NavPanel workspace/session styles、`themePayload.ts`、`themePayloadCompatibility.ts` | 删除不承担主题语义的全局布局或实现 key：`--input-*` 改读 canonical element/border/text/accent token，`--panel-bg` 改读 `--color-bg-primary`，button height、badge font size、user message padding、Git tight card padding 和 nav row action size/offset/gap 改为组件局部尺寸；Markdown spacing 不回到 root theme key，改由本地 Sass partial 作为 Markdown surface owner，供 renderer、FlowChat thinking、Mermaid/code-vars 复用；`SmoothHeightCollapse` 的 duration prop 改为 inline transition duration，不再投影到 Web root；generated widget static shell 同步移除该实现 key，但 iframe compatibility alias 保留 `--smooth-height-collapse-duration -> --motion-slow`，避免历史 widget CSS 失去动画时长。Markdown accent 不再是 root theme key，但保留 renderer 局部默认和 BaseToolCard 嵌入覆盖，避免工具卡片语义 accent 被默认值吞掉。该轮不合并相邻可见 surface/status 颜色，也不触碰 card/tool-card 跨组件布局 key，避免相邻区域语义被误合并。普通 app raw、unresolved、fallback-only、non-contract 仍为 0。static root contract 352 -> 320，low external usage key 144 -> 116。 |
 
+| low-external implementation key compression | retire preview/editor/gallery/MissionControl/mobile helper keys | `tokens.scss`, Markdown editor/Tiptap styles, component preview CSS/examples, GalleryLayout, MissionControl, NavSearchDialog, ContextMenu, Select, config/profile form styles, `src/mobile-web/src/theme/presets/shared.ts`, mobile SCSS | 将只表达局部实现或严格同义的低外部使用 key 移出 static root：Markdown editor list/task sizing、Markdown line-number gutter、gallery grid/skeleton defaults、preview palette/timing、旧 `flowchat-card-header-pad-*` 别名、`border-focus` 同义别名、glass green/disabled helper、MissionControl group helper 和 slate22 shadow helper。MissionControl 的组别区分保留为组件私有 modifier class，并继续使用 accent/success/warning；active filter 和 thumbnail badge 使用中性底加彩色指示，避免小字号实底语义色造成对比或状态误解；preview 和 gallery 不作为主题扩展入口；`--easing-smooth` 与 `--easing-standard` 当前同值，统一读 standard；mobile-web 同步删除未使用的 `--motion-instant`、同值 `--easing-smooth` 和不应作为主题扩展入口的 `--easing-decelerate`，现有 decelerate 动画由 mobile-local Sass owner 承载并补齐 reduced-motion 覆盖。该轮不触碰 Git added/staged/deleted、button payload、z-index、card/tool-card 跨组件布局等仍可能承担主题或相邻区域语义的 key。static root contract 320 -> 289，low external usage key 116 -> 86；普通 app raw、unresolved、fallback-only、non-contract 均保持 0，mobile color audit 保持通过。 |
+
 Phase 6 防回退约束：
 
 | 约束 | 当前值 | baseline | 作用 |
@@ -455,18 +457,18 @@ Phase 6 防回退约束：
 | `colorDomainNearPairs.nearTotal` | 9 | 9 | 控制 theme preset/runtime/token/editor/Mermaid 等专用域 near 队列规模 |
 | `colorScopes.appUi.uniqueColors` | 0 | 0 | 阻止普通组件 raw color 唯一色回涨 |
 | `colorScopes.appUi.occurrences` | 0 | 0 | 阻止普通组件 raw color 出现次数回涨 |
-| `colorScopes.token.occurrences` | 295 | 295 | 阻止 token 层重新写回已归并的派生色、扩展名色或 preview RGB 字面量 |
-| `colorScopes.token.uniqueColors` | 184 | 184 | 控制 root/token 层唯一色数量，后续只允许在债务减少时下调 |
+| `colorScopes.token.occurrences` | 292 | 292 | 阻止 token 层重新写回已归并的派生色、扩展名色或 preview RGB 字面量 |
+| `colorScopes.token.uniqueColors` | 181 | 181 | 控制 root/token 层唯一色数量，后续只允许在债务减少时下调 |
 | `colorScopes.exception.uniqueColors` | 162 | 162 | 控制专用域/例外域总体规模；UI exception、syntax 和 language identity 已收敛，Mermaid status/pie fallback 已压缩且未接入 SCSS token 路径已退役，editor/terminal 仍按各自 owner 单独治理 |
-| `cssVarDefinitions.staticContractDefinedUnique` | 320 | 320 | 控制静态 root contract key 总量，避免新增主题时需要维护不可扩展的大型 CSS var 表 |
-| `cssVarDefinitions.staticContractExternalUsageUnique` | 320 | 320 | 跟踪真正被 root 外消费的 static contract key，防止删除 key 后遗漏调用点；generated widget payload 暴露给 iframe 的 key 也按外部消费计数 |
+| `cssVarDefinitions.staticContractDefinedUnique` | 289 | 289 | 控制静态 root contract key 总量，避免新增主题时需要维护不可扩展的大型 CSS var 表 |
+| `cssVarDefinitions.staticContractExternalUsageUnique` | 289 | 289 | 跟踪真正被 root 外消费的 static contract key，防止删除 key 后遗漏调用点；generated widget payload 暴露给 iframe 的 key 也按外部消费计数 |
 | `cssVarDefinitions.staticContractInternalOnlyUnique` | 0 | 0 | 暴露仅定义或内部派生的 root key；新增项必须删除、局部派生或证明是外部消费 contract |
-| `cssVarDefinitions.staticContractLowExternalUsageUnique` | 116 | 116 | 暴露低外部消费 key，作为后续继续压缩 root contract 的候选队列 |
+| `cssVarDefinitions.staticContractLowExternalUsageUnique` | 86 | 86 | 暴露低外部消费 key，作为后续继续压缩 root contract 的候选队列 |
 | `cssVarDefinitions.runtimeOnlyRequiredContractUnique` | 1 | 1 | 仅允许 `--window-control-close-hover-color` 作为 deprecated window close hover 覆盖，且由 baseline allowlist 锁定名称；默认路径不读取该 var，旧 custom theme 通过 `components.windowControls.close.hoverColor` 和 runtime attribute 激活 |
 | `colorDomainScopes.syntax.occurrences` | 16 | 16 | 阻止 Prism syntax palette 回到一 token class 一色的不可扩展模式，同时保留相邻 token 可读性边界 |
 | `colorDomainScopes.languageIdentity.uniqueColors` | 8 | 8 | 阻止 language/file identity 回到一语言一色或一扩展一色的不可扩展模式 |
-| `colorDomainScopes.tokenContract.occurrences` | 94 | 94 | 控制 token contract 域 raw color 出现次数，防止 root 派生色回流 |
-| `colorDomainScopes.tokenContract.uniqueColors` | 84 | 84 | 控制 token contract 域唯一色，确保新主题扩展不依赖额外静态色表 |
+| `colorDomainScopes.tokenContract.occurrences` | 91 | 91 | 控制 token contract 域 raw color 出现次数，防止 root 派生色回流 |
+| `colorDomainScopes.tokenContract.uniqueColors` | 81 | 81 | 控制 token contract 域唯一色，确保新主题扩展不依赖额外静态色表 |
 | `colorDomainScopes.boundaryFallback.occurrences` | 18 | 18 | 防止 iframe/mini app/截图兜底色重新散写；导出 key 可保留语义，实际字面值必须回到 boundary fallback palette |
 | `colorDomainScopes.mermaid.occurrences` | 53 | 53 | 控制 Mermaid 专用域 raw fallback 规模；status/pie 已压缩，未接入 SCSS token 路径已退役，节点/边/cluster/note 文本等相邻层级不能无证据合并 |
 | `colorDomainScopes.mermaid.uniqueColors` | 48 | 48 | 控制 Mermaid 专用域唯一色数量；新增类别色或状态色必须先复用现有 compact fallback，确有相邻可读性需求才新增 |
@@ -689,8 +691,8 @@ semantic token 描述产品级语义，应作为共享 UI 的默认使用层。
 - 文本：`--color-text-primary`、`--color-text-secondary`、
   `--color-text-muted`、`--color-text-disabled`；如果设计系统确实需要第三层
   文本强度，再将 `--color-text-tertiary` 转正。
-- 边框：`--border-base`、`--border-subtle`、`--border-emphasis`、
-  `--border-focus`。
+- 边框：`--border-base`、`--border-subtle`、`--border-strong`、
+  `--border-accent`。
 - 元素状态：`--element-bg-default`、`--element-bg-subtle`、
   `--element-bg-hover`、`--element-bg-active`、`--element-bg-selected`。
 - 意图色：`--color-success`、`--color-warning`、`--color-error`、
@@ -1047,7 +1049,7 @@ alpha 差异经常承担 elevation 和交互状态，不应全部压成一个值
 - `--color-primary`
 - `--color-accent-500`
 - `--color-info`
-- `--border-focus`
+- `--border-accent`
 - `--link-color`
 - `--selection-bg`
 

--- a/scripts/theme-color-governance-baseline.json
+++ b/scripts/theme-color-governance-baseline.json
@@ -105,10 +105,10 @@
       "max": 0
     },
     "colorScopes.token.occurrences": {
-      "max": 295
+      "max": 292
     },
     "colorScopes.token.uniqueColors": {
-      "max": 184
+      "max": 181
     },
     "colorScopes.exception.uniqueColors": {
       "max": 162
@@ -144,16 +144,16 @@
       "max": 0
     },
     "cssVarDefinitions.staticContractDefinedUnique": {
-      "max": 320
+      "max": 289
     },
     "cssVarDefinitions.staticContractExternalUsageUnique": {
-      "max": 320
+      "max": 289
     },
     "cssVarDefinitions.staticContractInternalOnlyUnique": {
       "max": 0
     },
     "cssVarDefinitions.staticContractLowExternalUsageUnique": {
-      "max": 116
+      "max": 86
     },
     "tokenAliasLiterals.occurrences": {
       "max": 0
@@ -273,10 +273,10 @@
       "max": 27
     },
     "colorDomainScopes.tokenContract.occurrences": {
-      "max": 94
+      "max": 91
     },
     "colorDomainScopes.tokenContract.uniqueColors": {
-      "max": 84
+      "max": 81
     },
     "colorDomainScopes.generatedWidget.occurrences": {
       "max": 0

--- a/src/mobile-web/src/styles/_motion.scss
+++ b/src/mobile-web/src/styles/_motion.scss
@@ -1,0 +1,1 @@
+$easing-decelerate: cubic-bezier(0, 0, 0.2, 1);

--- a/src/mobile-web/src/styles/components/chat.scss
+++ b/src/mobile-web/src/styles/components/chat.scss
@@ -1,3 +1,5 @@
+@use '../motion' as motion;
+
 .chat-page {
   display: flex;
   flex-direction: column;
@@ -368,7 +370,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--size-gap-3);
-  animation: menuSlideUp var(--motion-base) var(--easing-decelerate);
+  animation: menuSlideUp var(--motion-base) motion.$easing-decelerate;
 }
 
 .chat-msg__menu-handle {

--- a/src/mobile-web/src/styles/components/pairing.scss
+++ b/src/mobile-web/src/styles/components/pairing.scss
@@ -1,3 +1,5 @@
+@use '../motion' as motion;
+
 .pairing-page {
   position: relative;
   display: flex;
@@ -7,7 +9,7 @@
   height: 100%;
   gap: var(--size-gap-6);
   padding: var(--size-gap-8);
-  animation: fadeIn var(--motion-slow) var(--easing-decelerate);
+  animation: fadeIn var(--motion-slow) motion.$easing-decelerate;
 }
 
 .pairing-page__actions {
@@ -142,5 +144,12 @@
   &:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pairing-page,
+  .pairing-page__cube-inner {
+    animation: none;
   }
 }

--- a/src/mobile-web/src/styles/components/sessions.scss
+++ b/src/mobile-web/src/styles/components/sessions.scss
@@ -1,3 +1,5 @@
+@use '../motion' as motion;
+
 @mixin squircle($radius) {
   border-radius: $radius;
   corner-shape: squircle;
@@ -166,7 +168,7 @@
   cursor: pointer;
   transition: transform var(--motion-fast) var(--easing-standard),
     background var(--motion-fast) var(--easing-standard);
-  animation: sessionItemIn var(--motion-base) var(--easing-decelerate) both;
+  animation: sessionItemIn var(--motion-base) motion.$easing-decelerate both;
 
   &:active {
     transform: scale(0.985);
@@ -497,7 +499,7 @@
   text-align: left;
   transition: transform var(--motion-fast) var(--easing-standard),
     background var(--motion-fast) var(--easing-standard);
-  animation: sessionItemIn var(--motion-base) var(--easing-decelerate) both;
+  animation: sessionItemIn var(--motion-base) motion.$easing-decelerate both;
   box-shadow: var(--shadow-sm);
 
   &:active:not(:disabled) {
@@ -596,7 +598,7 @@
   cursor: pointer;
   transition: transform var(--motion-fast) var(--easing-standard),
     background var(--motion-fast) var(--easing-standard);
-  animation: sessionItemIn var(--motion-base) var(--easing-decelerate) both;
+  animation: sessionItemIn var(--motion-base) motion.$easing-decelerate both;
 
   @for $i from 1 through 20 {
     &:nth-child(#{$i}) {
@@ -719,7 +721,7 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  transition: height 0.2s var(--easing-decelerate);
+  transition: height 0.2s motion.$easing-decelerate;
 }
 
 .session-list__pull-spinner {
@@ -760,7 +762,7 @@
   background: var(--color-bg-elevated);
   border-radius: 20px 20px 0 0;
   overflow: hidden;
-  animation: slideUp var(--motion-base) var(--easing-decelerate);
+  animation: slideUp var(--motion-base) motion.$easing-decelerate;
 }
 
 .session-list__picker-header {
@@ -998,7 +1000,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--size-gap-3);
-  animation: slideUp var(--motion-base) var(--easing-decelerate);
+  animation: slideUp var(--motion-base) motion.$easing-decelerate;
 }
 
 .session-list__menu-handle {
@@ -1091,7 +1093,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--size-gap-4);
-  animation: slideUp var(--motion-base) var(--easing-decelerate);
+  animation: slideUp var(--motion-base) motion.$easing-decelerate;
 }
 
 .session-list__rename-title {
@@ -1168,7 +1170,7 @@
   align-items: center;
   gap: var(--size-gap-3);
   text-align: center;
-  animation: slideUp var(--motion-base) var(--easing-decelerate);
+  animation: slideUp var(--motion-base) motion.$easing-decelerate;
 }
 
 .session-list__confirm-icon {

--- a/src/mobile-web/src/styles/components/workspace.scss
+++ b/src/mobile-web/src/styles/components/workspace.scss
@@ -1,3 +1,5 @@
+@use '../motion' as motion;
+
 @mixin squircle($radius) {
   border-radius: $radius;
   corner-shape: squircle;
@@ -175,7 +177,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--size-gap-3);
-  animation: slideUp 0.3s var(--easing-decelerate) both;
+  animation: slideUp 0.3s motion.$easing-decelerate both;
 }
 
 .workspace-page__recent-empty {
@@ -204,7 +206,7 @@
   color: var(--color-text-primary);
   box-shadow: var(--shadow-xs);
   transition: all var(--motion-fast) var(--easing-standard);
-  animation: slideUp 0.3s var(--easing-decelerate) both;
+  animation: slideUp 0.3s motion.$easing-decelerate both;
 
   @for $i from 1 through 20 {
     &:nth-child(#{$i}) {
@@ -255,4 +257,15 @@
   padding: var(--size-gap-2) var(--size-gap-3);
   background: var(--color-error-bg);
   @include squircle(10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-page__recent,
+  .workspace-page__recent-item {
+    animation: none;
+  }
+
+  .workspace-page__recent-item {
+    transition: none;
+  }
 }

--- a/src/mobile-web/src/styles/global.scss
+++ b/src/mobile-web/src/styles/global.scss
@@ -1,3 +1,5 @@
+@use './motion' as motion;
+
 * {
   margin: 0;
   padding: 0;
@@ -94,7 +96,7 @@ body {
 
 // Page transition wrapper
 .page-transition {
-  animation: fadeIn var(--motion-base) var(--easing-decelerate);
+  animation: fadeIn var(--motion-base) motion.$easing-decelerate;
 }
 
 // Nav-stack page transitions (iOS-style push/pop)
@@ -140,6 +142,16 @@ body {
 @keyframes navPopOut {
   from { transform: translateX(0); }
   to   { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-transition,
+  .nav-push-enter,
+  .nav-push-exit,
+  .nav-pop-enter,
+  .nav-pop-exit {
+    animation: none;
+  }
 }
 
 // Spinner utility

--- a/src/mobile-web/src/theme/presets/shared.ts
+++ b/src/mobile-web/src/theme/presets/shared.ts
@@ -49,14 +49,11 @@ export const commonMobileThemeVars: MobileThemeVars = {
   '--size-gap-12': '48px',
   '--size-gap-16': '64px',
 
-  '--motion-instant': '0.1s',
   '--motion-fast': '0.15s',
   '--motion-base': '0.3s',
   '--motion-slow': '0.6s',
 
   '--easing-standard': 'cubic-bezier(0.4, 0, 0.2, 1)',
-  '--easing-decelerate': 'cubic-bezier(0, 0, 0.2, 1)',
-  '--easing-smooth': 'cubic-bezier(0.4, 0, 0.2, 1)',
 
   '--font-family-sans': "'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'SF Pro Display', Roboto, sans-serif",
   '--font-family-mono': "'Menlo', 'SF Mono', 'Cascadia Code', 'Consolas', 'Liberation Mono', 'Courier New', 'Noto Sans Mono CJK SC', 'Noto Sans Mono', monospace",

--- a/src/web-ui/src/app/components/GalleryLayout/GalleryLayout.scss
+++ b/src/web-ui/src/app/components/GalleryLayout/GalleryLayout.scss
@@ -152,6 +152,9 @@ $content-max: 1480px;
 }
 
 .gallery-grid {
+  --gallery-grid-min: 320px;
+  --gallery-skeleton-height: 140px;
+
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--gallery-grid-min), 1fr));
   gap: $size-gap-3;

--- a/src/web-ui/src/app/components/NavPanel/NavSearchDialog.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavSearchDialog.scss
@@ -26,7 +26,7 @@
     0 0 0 1px color-mix(in srgb, var(--color-text-primary) 4%, transparent),
     0 2px 4px var(--color-overlay-slate-04),
     0 8px 24px var(--color-overlay-slate-08),
-    0 24px 56px -12px var(--color-overlay-slate-22),
+    0 24px 56px -12px rgba(var(--color-overlay-slate-rgb), 0.22),
     0 48px 80px -24px var(--color-overlay-slate-12);
   overflow: hidden;
   display: flex;

--- a/src/web-ui/src/app/components/panels/content-canvas/mission-control/MissionControl.scss
+++ b/src/web-ui/src/app/components/panels/content-canvas/mission-control/MissionControl.scss
@@ -132,6 +132,8 @@
   }
 
   &__group-filter {
+    --private-mission-control-filter-color: var(--color-accent-600);
+
     position: relative;
     display: flex;
     align-items: center;
@@ -154,13 +156,23 @@
     }
 
     &.is-active {
-      background: var(--mission-control-group-color);
+      background: color-mix(in srgb, var(--element-bg-soft) 84%, var(--private-mission-control-filter-color) 16%);
       color: var(--color-text-primary);
-      box-shadow: 0 1px 3px var(--color-overlay-black-20);
+      box-shadow:
+        inset 0 0 0 1px var(--private-mission-control-filter-color),
+        0 1px 3px var(--color-overlay-black-20);
 
       .canvas-mission-control__group-filter-indicator {
-        opacity: 0;
+        opacity: 1;
       }
+    }
+
+    &--secondary {
+      --private-mission-control-filter-color: var(--color-success);
+    }
+
+    &--tertiary {
+      --private-mission-control-filter-color: var(--color-warning);
     }
 
     &-indicator {
@@ -170,7 +182,7 @@
       width: 6px;
       height: 6px;
       border-radius: 50%;
-      background: var(--mission-control-group-color);
+      background: var(--private-mission-control-filter-color);
       opacity: 0.6;
       transition: opacity 0.15s ease;
     }

--- a/src/web-ui/src/app/components/panels/content-canvas/mission-control/MissionControl.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/mission-control/MissionControl.tsx
@@ -233,22 +233,19 @@ export const MissionControl: React.FC<MissionControlProps> = ({
             {hasMultipleGroups && (
               <div className="canvas-mission-control__group-filters">
                 {[
-                  { id: 'primary' as EditorGroupId, labelKey: 'canvas.groupPrimaryFull', shortLabelKey: 'canvas.groupPrimary', color: 'var(--mission-control-group-primary-color)' },
-                  { id: 'secondary' as EditorGroupId, labelKey: 'canvas.groupSecondaryFull', shortLabelKey: 'canvas.groupSecondary', color: 'var(--mission-control-group-secondary-color)' },
-                  { id: 'tertiary' as EditorGroupId, labelKey: 'canvas.groupTertiaryFull', shortLabelKey: 'canvas.groupTertiary', color: 'var(--mission-control-group-tertiary-color)' },
-                ].map(({ id, labelKey, shortLabelKey, color }) => {
+                  { id: 'primary' as EditorGroupId, labelKey: 'canvas.groupPrimaryFull', shortLabelKey: 'canvas.groupPrimary' },
+                  { id: 'secondary' as EditorGroupId, labelKey: 'canvas.groupSecondaryFull', shortLabelKey: 'canvas.groupSecondary' },
+                  { id: 'tertiary' as EditorGroupId, labelKey: 'canvas.groupTertiaryFull', shortLabelKey: 'canvas.groupTertiary' },
+                ].map(({ id, labelKey, shortLabelKey }) => {
                   const hasTabs = organizedTabs[id as keyof typeof organizedTabs].length > 0;
                   if (!hasTabs) return null;
                   
                   return (
                     <button
                       key={id}
-                      className={`canvas-mission-control__group-filter ${selectedGroups.has(id) ? 'is-active' : ''}`}
+                      className={`canvas-mission-control__group-filter canvas-mission-control__group-filter--${id} ${selectedGroups.has(id) ? 'is-active' : ''}`}
                       onClick={() => toggleGroupFilter(id)}
                       title={t(labelKey)}
-                      style={{ 
-                        '--mission-control-group-color': color,
-                      } as React.CSSProperties}
                     >
                       <span className="canvas-mission-control__group-filter-indicator" />
                       <span className="canvas-mission-control__group-filter-text">{t(shortLabelKey)}</span>

--- a/src/web-ui/src/app/components/panels/content-canvas/mission-control/ThumbnailCard.scss
+++ b/src/web-ui/src/app/components/panels/content-canvas/mission-control/ThumbnailCard.scss
@@ -230,7 +230,7 @@
 
   // Editor group badge
   &__group-badge {
-    --mission-control-group-color: var(--color-accent-500);
+    --private-thumbnail-group-color: var(--color-accent-500);
 
     position: absolute;
     bottom: 6px;
@@ -239,23 +239,23 @@
     font-size: 9px;
     font-weight: 600;
     color: var(--color-text-primary);
-    background: var(--mission-control-group-color);
+    background: color-mix(in srgb, var(--color-bg-primary) 82%, var(--private-thumbnail-group-color) 18%);
+    border: 1px solid var(--private-thumbnail-group-color);
     border-radius: 3px;
     z-index: 1;
     box-shadow: 0 1px 3px var(--color-overlay-black-30);
     backdrop-filter: blur(4px);
-    text-shadow: 0 1px 2px var(--color-overlay-black-20);
 
     &--primary {
-      --mission-control-group-color: var(--color-accent-500);
+      --private-thumbnail-group-color: var(--color-accent-500);
     }
 
     &--secondary {
-      --mission-control-group-color: var(--color-success);
+      --private-thumbnail-group-color: var(--color-success);
     }
 
     &--tertiary {
-      --mission-control-group-color: var(--color-warning);
+      --private-thumbnail-group-color: var(--color-warning);
     }
   }
 }

--- a/src/web-ui/src/app/scenes/profile/views/AssistantQuickInput.scss
+++ b/src/web-ui/src/app/scenes/profile/views/AssistantQuickInput.scss
@@ -28,7 +28,7 @@
 
     &:focus-within {
       transform: translateY(-2px);
-      border-color: var(--border-focus);
+      border-color: var(--border-strong);
       background: var(--element-bg-soft);
       box-shadow:
         0 22px 52px -12px color-mix(in srgb, var(--color-accent-500) 18%, transparent),

--- a/src/web-ui/src/app/scenes/profile/views/NurseryView.scss
+++ b/src/web-ui/src/app/scenes/profile/views/NurseryView.scss
@@ -95,7 +95,7 @@ $nursery-scene-gutter: clamp(40px, 6vw, 80px);
     content: '';
     position: absolute;
     inset: 0;
-    background: linear-gradient(135deg, var(--glass-green-base) 0%, var(--color-accent-100) 100%);
+    background: linear-gradient(135deg, var(--color-success-bg) 0%, var(--color-accent-100) 100%);
     opacity: 0;
     transition: opacity 0.32s ease;
     pointer-events: none;
@@ -2497,8 +2497,8 @@ $nursery-scene-gutter: clamp(40px, 6vw, 80px);
     &--connected,
     &--healthy {
       color: var(--color-success);
-      background: var(--glass-green-base);
-      border-color: color-mix(in srgb, var(--color-success) 22%, transparent);
+      background: var(--color-success-bg);
+      border-color: var(--color-success-border);
     }
 
     &--starting,

--- a/src/web-ui/src/app/styles/components/forms.css
+++ b/src/web-ui/src/app/styles/components/forms.css
@@ -145,9 +145,9 @@
 .form-select.success:focus,
 .form-textarea.success:focus {
   box-shadow: 
-    0 4px 16px var(--glass-green-hover),
+    0 4px 16px var(--color-success-bg),
     0 2px 8px var(--color-overlay-black-08),
-    0 0 0 2px color-mix(in srgb, var(--color-success) 20%, transparent);
+    0 0 0 2px var(--color-success-border);
 }
 
 /* Disabled state */

--- a/src/web-ui/src/component-library/components/IconButton/IconButton.example.tsx
+++ b/src/web-ui/src/component-library/components/IconButton/IconButton.example.tsx
@@ -19,101 +19,104 @@ const HeartIcon = () => (
   </svg>
 );
 
+const previewBackground = 'color-mix(in srgb, var(--color-static-black) 90%, var(--color-static-white))';
+const previewTextMuted = 'color-mix(in srgb, var(--color-static-white) 63%, var(--color-static-black))';
+
 export const IconButtonExample: React.FC = () => {
   const { t } = useI18n('components');
 
   return (
-    <div style={{ padding: '24px', background: 'var(--preview-bg)', minHeight: '100vh' }}>
+    <div style={{ padding: '24px', background: previewBackground, minHeight: '100vh' }}>
       <h2 style={{ color: 'var(--color-static-white)', marginBottom: '24px' }}>
         {t('componentLibrary.iconButtonExample.title')}
       </h2>
       
       <div style={{ marginBottom: '32px' }}>
-        <h3 style={{ color: 'var(--preview-text-muted)', marginBottom: '16px' }}>
+        <h3 style={{ color: previewTextMuted, marginBottom: '16px' }}>
           {t('componentLibrary.iconButtonExample.sections.basic')}
         </h3>
         <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-          <IconButton variant="default" size="small">
+          <IconButton variant="default" size="small" aria-label="Add small">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="default" size="medium">
+          <IconButton variant="default" size="medium" aria-label="Add medium">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="default" size="large">
+          <IconButton variant="default" size="large" aria-label="Add large">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="default" size="medium" disabled>
+          <IconButton variant="default" size="medium" disabled aria-label="Add disabled">
             <PlusIcon />
           </IconButton>
         </div>
       </div>
 
       <div style={{ marginBottom: '32px' }}>
-        <h3 style={{ color: 'var(--preview-text-muted)', marginBottom: '16px' }}>
+        <h3 style={{ color: previewTextMuted, marginBottom: '16px' }}>
           {t('componentLibrary.iconButtonExample.sections.ghost')}
         </h3>
         <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-          <IconButton variant="ghost" size="small">
+          <IconButton variant="ghost" size="small" aria-label="Favorite small">
             <HeartIcon />
           </IconButton>
-          <IconButton variant="ghost" size="medium">
+          <IconButton variant="ghost" size="medium" aria-label="Favorite medium">
             <HeartIcon />
           </IconButton>
-          <IconButton variant="ghost" size="large">
+          <IconButton variant="ghost" size="large" aria-label="Favorite large">
             <HeartIcon />
           </IconButton>
         </div>
       </div>
 
       <div style={{ marginBottom: '32px' }}>
-        <h3 style={{ color: 'var(--preview-text-muted)', marginBottom: '16px' }}>
+        <h3 style={{ color: previewTextMuted, marginBottom: '16px' }}>
           {t('componentLibrary.iconButtonExample.sections.primary')}
         </h3>
         <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-          <IconButton variant="primary" size="small">
+          <IconButton variant="primary" size="small" aria-label="Create small">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="primary" size="medium">
+          <IconButton variant="primary" size="medium" aria-label="Create medium">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="primary" size="large">
+          <IconButton variant="primary" size="large" aria-label="Create large">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="primary" size="medium" disabled>
+          <IconButton variant="primary" size="medium" disabled aria-label="Create disabled">
             <PlusIcon />
           </IconButton>
         </div>
       </div>
 
       <div style={{ marginBottom: '32px' }}>
-        <h3 style={{ color: 'var(--preview-text-muted)', marginBottom: '16px' }}>
+        <h3 style={{ color: previewTextMuted, marginBottom: '16px' }}>
           {t('componentLibrary.iconButtonExample.sections.shape')}
         </h3>
         <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-          <IconButton variant="default" shape="circle" size="medium">
+          <IconButton variant="default" shape="circle" size="medium" aria-label="Add circle">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="primary" shape="circle" size="medium">
+          <IconButton variant="primary" shape="circle" size="medium" aria-label="Favorite circle">
             <HeartIcon />
           </IconButton>
         </div>
       </div>
 
       <div style={{ marginBottom: '32px' }}>
-        <h3 style={{ color: 'var(--preview-text-muted)', marginBottom: '16px' }}>
+        <h3 style={{ color: previewTextMuted, marginBottom: '16px' }}>
           {t('componentLibrary.iconButtonExample.sections.other')}
         </h3>
         <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-          <IconButton variant="danger" size="medium">
+          <IconButton variant="danger" size="medium" aria-label="Danger action">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="success" size="medium">
+          <IconButton variant="success" size="medium" aria-label="Success action">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="warning" size="medium">
+          <IconButton variant="warning" size="medium" aria-label="Warning action">
             <PlusIcon />
           </IconButton>
-          <IconButton variant="ai" size="medium">
+          <IconButton variant="ai" size="medium" aria-label="AI action">
             <PlusIcon />
           </IconButton>
         </div>
@@ -123,7 +126,7 @@ export const IconButtonExample: React.FC = () => {
         <h3 style={{ color: 'var(--color-static-white)', marginBottom: '12px' }}>
           {t('componentLibrary.iconButtonExample.sections.usage')}
         </h3>
-        <ul style={{ color: 'var(--preview-text-muted)', lineHeight: '1.8' }}>
+        <ul style={{ color: previewTextMuted, lineHeight: '1.8' }}>
           <li>
             <strong>{t('componentLibrary.iconButtonExample.usage.defaultGhost.label')}</strong>
             {t('componentLibrary.iconButtonExample.usage.defaultGhost.text')}

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -1058,8 +1058,8 @@ export const Markdown = React.memo<MarkdownProps>(({
         fontFamily: 'var(--font-family-mono)',
       };
       const gutterColor = isLight
-        ? 'rgb(var(--markdown-code-gutter-light-rgb))'
-        : 'rgb(var(--markdown-code-gutter-dark-rgb))';
+        ? 'color-mix(in srgb, var(--color-static-black) 40%, var(--color-static-white))'
+        : 'color-mix(in srgb, var(--color-static-white) 40%, var(--color-static-black))';
 
       return (
         <div className={`code-block-wrapper${hasMultipleLines ? '' : ' code-block-wrapper--single-line'}`}>

--- a/src/web-ui/src/component-library/components/Select/Select.scss
+++ b/src/web-ui/src/component-library/components/Select/Select.scss
@@ -240,7 +240,7 @@
     border-radius: 0 0 var(--size-radius-sm) var(--size-radius-sm);
     box-shadow: 0 4px 12px var(--color-overlay-black-40);
     z-index: tokens.$z-dropdown;
-    animation: select-dropdown-appear var(--motion-fast) var(--easing-decelerate);
+    animation: select-dropdown-appear var(--motion-fast) tokens.$easing-decelerate;
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/src/web-ui/src/component-library/components/registry.tsx
+++ b/src/web-ui/src/component-library/components/registry.tsx
@@ -41,6 +41,9 @@ import { TOOL_CARD_CONFIGS } from '@/flow_chat/tool-cards/toolCardMetadata';
 import { ModelThinkingDisplay } from '@/flow_chat/tool-cards/ModelThinkingDisplay';
 import { ReproductionStepsBlock } from '@components/Markdown/ReproductionStepsBlock';
 
+const previewTextSubtle = 'color-mix(in srgb, var(--color-static-white) 60%, var(--color-static-black))';
+const previewTextDisabled = 'color-mix(in srgb, var(--color-static-white) 40%, var(--color-static-black))';
+
 function createMockToolItem(
   toolName: string,
   input: any,
@@ -281,25 +284,25 @@ export const componentRegistry: ComponentCategory[] = [
           <div style={{ display: 'flex', flexDirection: 'column', gap: '32px', padding: '20px' }}>
             {}
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--preview-text-disabled)', marginBottom: '16px', fontWeight: 500 }}>尺寸</div>
+              <div style={{ fontSize: '12px', color: previewTextDisabled, marginBottom: '16px', fontWeight: 500 }}>尺寸</div>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '48px', alignItems: 'flex-end' }}>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '12px' }}>
                   <CubeLoading size="small" />
-                  <span style={{ fontSize: '12px', color: 'var(--preview-text-subtle)' }}>Small</span>
+                  <span style={{ fontSize: '12px', color: previewTextSubtle }}>Small</span>
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '12px' }}>
                   <CubeLoading size="medium" />
-                  <span style={{ fontSize: '12px', color: 'var(--preview-text-subtle)' }}>Medium</span>
+                  <span style={{ fontSize: '12px', color: previewTextSubtle }}>Medium</span>
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '12px' }}>
                   <CubeLoading size="large" />
-                  <span style={{ fontSize: '12px', color: 'var(--preview-text-subtle)' }}>Large</span>
+                  <span style={{ fontSize: '12px', color: previewTextSubtle }}>Large</span>
                 </div>
               </div>
             </div>
             {}
             <div>
-              <div style={{ fontSize: '12px', color: 'var(--preview-text-disabled)', marginBottom: '16px', fontWeight: 500 }}>With text</div>
+              <div style={{ fontSize: '12px', color: previewTextDisabled, marginBottom: '16px', fontWeight: 500 }}>With text</div>
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '48px', alignItems: 'flex-start' }}>
                 <CubeLoading text="加载中.." />
                 <CubeLoading size="large" text="加载中.." />

--- a/src/web-ui/src/component-library/preview/flowchat-cards-preview.css
+++ b/src/web-ui/src/component-library/preview/flowchat-cards-preview.css
@@ -5,6 +5,8 @@
 /* Preview-only tool card typography override. */
 :root {
   --tool-card-font-mono: 'SF Mono', 'Monaco', 'Cascadia Code', 'Cascadia Mono', Consolas, 'Inconsolata', 'Fira Code', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', 'Lucida Console', 'Courier New', monospace;
+  --private-flowchat-preview-border: color-mix(in srgb, var(--color-static-black) 90%, var(--color-static-white));
+  --private-flowchat-preview-text-muted: color-mix(in srgb, var(--color-static-white) 63%, var(--color-static-black));
 }
 
 .column-item-preview {
@@ -22,10 +24,10 @@
 .column-item-preview h3 {
   font-size: 14px;
   font-weight: 600;
-  color: var(--preview-text-muted);
+  color: var(--private-flowchat-preview-text-muted);
   margin: 0 0 12px 0;
   padding: 0;
-  border-bottom: 1px solid var(--preview-border);
+  border-bottom: 1px solid var(--private-flowchat-preview-border);
   padding-bottom: 8px;
 }
 

--- a/src/web-ui/src/component-library/preview/markdown-preview.css
+++ b/src/web-ui/src/component-library/preview/markdown-preview.css
@@ -6,11 +6,15 @@
   --private-markdown-preview-badge-bg: color-mix(in srgb, var(--color-accent-500) 20%, transparent);
   --private-markdown-preview-badge-border: color-mix(in srgb, var(--color-accent-500) 40%, transparent);
   --private-markdown-preview-badge-text: var(--color-accent-500);
+  --private-preview-panel-bg: color-mix(in srgb, var(--color-static-black) 96%, var(--color-static-white));
+  --private-preview-border: color-mix(in srgb, var(--color-static-black) 90%, var(--color-static-white));
+  --private-preview-text-primary: color-mix(in srgb, var(--color-static-white) 88%, var(--color-static-black));
+  --private-preview-text-disabled: color-mix(in srgb, var(--color-static-white) 40%, var(--color-static-black));
 
   min-height: 100vh;
   height: 100vh;
   background: var(--color-bg-primary);
-  color: var(--preview-text-primary);
+  color: var(--private-preview-text-primary);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -59,8 +63,8 @@
   align-items: center;
   gap: 32px;
   padding: 16px 32px;
-  background: var(--preview-panel-bg);
-  border-bottom: 1px solid var(--preview-border);
+  background: var(--private-preview-panel-bg);
+  border-bottom: 1px solid var(--private-preview-border);
 }
 
 .control-group {
@@ -106,7 +110,7 @@
   background: var(--color-overlay-white-04);
   border: 1px solid var(--color-overlay-white-08);
   border-radius: 8px;
-  color: var(--preview-text-primary);
+  color: var(--private-preview-text-primary);
   font-family: 'Courier New', Consolas, Monaco, monospace;
   font-size: 14px;
   line-height: 1.6;
@@ -122,13 +126,13 @@
 }
 
 .markdown-editor::placeholder {
-  color: var(--preview-text-disabled);
+  color: var(--private-preview-text-disabled);
 }
 
 .usage-guide {
   padding: 24px;
-  background: var(--preview-panel-bg);
-  border: 1px solid var(--preview-border);
+  background: var(--private-preview-panel-bg);
+  border: 1px solid var(--private-preview-border);
   border-radius: 12px;
   max-width: 900px;
   margin: 32px auto 0;

--- a/src/web-ui/src/component-library/preview/preview-common.css
+++ b/src/web-ui/src/component-library/preview/preview-common.css
@@ -4,7 +4,7 @@
   padding: 40px;
   max-width: 1400px;
   margin: 0 auto;
-  background: var(--preview-bg);
+  background: color-mix(in srgb, var(--color-static-black) 90%, var(--color-static-white));
   min-height: 100vh;
   color: var(--color-static-white);
 }
@@ -13,7 +13,7 @@
   font-size: 36px;
   font-weight: 700;
   margin-bottom: 40px;
-  background: var(--preview-heading-gradient);
+  background: linear-gradient(135deg, var(--color-accent-500) 0%, var(--color-purple-500) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -29,7 +29,7 @@
 .preview-container h3 {
   font-size: 18px;
   font-weight: 500;
-  color: var(--preview-text-primary);
+  color: color-mix(in srgb, var(--color-static-white) 88%, var(--color-static-black));
 }
 
 .preview-section {
@@ -41,7 +41,7 @@
 }
 
 .preview-description {
-  color: var(--preview-text-muted);
+  color: color-mix(in srgb, var(--color-static-white) 63%, var(--color-static-black));
   font-size: 14px;
   margin-bottom: 24px;
   font-style: italic;
@@ -75,7 +75,7 @@
 .preview-label {
   margin-top: 16px;
   font-size: 13px;
-  color: var(--preview-text-subtle);
+  color: color-mix(in srgb, var(--color-static-white) 60%, var(--color-static-black));
   font-weight: 500;
   text-transform: capitalize;
 }

--- a/src/web-ui/src/component-library/preview/preview.css
+++ b/src/web-ui/src/component-library/preview/preview.css
@@ -150,7 +150,7 @@ body {
   box-shadow: inset -1px 0 0 var(--border-subtle);
   overflow-y: auto;
   padding: 12px 10px;
-  transition: width var(--motion-fast) var(--easing-smooth);
+  transition: width var(--motion-fast) var(--easing-standard);
 }
 
 .preview-sidebar--collapsed {
@@ -186,9 +186,9 @@ body {
   color: var(--color-text-secondary);
   cursor: pointer;
   transition:
-    background var(--motion-fast) var(--easing-smooth),
-    color var(--motion-fast) var(--easing-smooth),
-    transform var(--motion-fast) var(--easing-smooth);
+    background var(--motion-fast) var(--easing-standard),
+    color var(--motion-fast) var(--easing-standard),
+    transform var(--motion-fast) var(--easing-standard);
 }
 
 .preview-sidebar-toggle:hover {
@@ -198,7 +198,7 @@ body {
 
 .preview-sidebar-toggle__icon {
   display: inline-flex;
-  transition: transform var(--motion-fast) var(--easing-smooth);
+  transition: transform var(--motion-fast) var(--easing-standard);
 }
 
 .preview-sidebar-toggle__icon.is-collapsed {
@@ -230,10 +230,10 @@ body {
   font-weight: 600;
   color: var(--color-text-secondary);
   transition:
-    background var(--motion-fast) var(--easing-smooth),
-    color var(--motion-fast) var(--easing-smooth),
-    transform var(--motion-fast) var(--easing-smooth),
-    box-shadow var(--motion-fast) var(--easing-smooth);
+    background var(--motion-fast) var(--easing-standard),
+    color var(--motion-fast) var(--easing-standard),
+    transform var(--motion-fast) var(--easing-standard),
+    box-shadow var(--motion-fast) var(--easing-standard);
   text-align: left;
 }
 
@@ -315,9 +315,9 @@ body {
   border: 1px solid var(--border-subtle);
   overflow: visible;
   transition:
-    border-color var(--motion-fast) var(--easing-smooth),
-    box-shadow var(--motion-fast) var(--easing-smooth),
-    transform var(--motion-fast) var(--easing-smooth);
+    border-color var(--motion-fast) var(--easing-standard),
+    box-shadow var(--motion-fast) var(--easing-standard),
+    transform var(--motion-fast) var(--easing-standard);
   display: flex;
   flex-direction: column;
   box-shadow: var(--shadow-sm);

--- a/src/web-ui/src/component-library/styles/tokens.scss
+++ b/src/web-ui/src/component-library/styles/tokens.scss
@@ -4,8 +4,6 @@
 // ==================== Primitive color literals ====================
 $color-static-white: #ffffff;
 $color-static-black: #000000;
-$color-static-emerald: #10b981;
-$color-static-orange: #f97316;
 
 $overlay-white-04: rgba(255, 255, 255, 0.04);
 $overlay-white-08: rgba(255, 255, 255, 0.08);
@@ -142,7 +140,6 @@ $border-medium: $overlay-white-24;
 $border-strong: $overlay-white-32;
 $border-prominent: $overlay-white-40;
 
-$border-focus: $border-strong;
 $border-accent-soft: $color-blue-600-a30;
 $border-accent-subtle: $color-blue-600-a15;
 $border-accent: $color-blue-600-a40;
@@ -187,16 +184,11 @@ $glass-base: linear-gradient(135deg,
   $overlay-white-04 50%,
   $overlay-white-04 100%);
 
-$glass-disabled: $overlay-white-04;
-
 $glass-blue-subtle: $color-blue-600-a08;
 
 $glass-red-subtle: rgba(239, 68, 68, 0.05);
 $glass-red-base: $color-error-bg;
 $glass-red-hover: rgba(239, 68, 68, 0.15);
-
-$glass-green-base: $color-success-bg;
-$glass-green-hover: rgba(52, 211, 153, 0.15);
 
 // ==================== Sizing system ====================
 
@@ -377,7 +369,6 @@ $badge-info-text: $color-info;
   --color-overlay-slate-04: rgba(var(--color-overlay-slate-rgb), 0.04);
   --color-overlay-slate-08: rgba(var(--color-overlay-slate-rgb), 0.08);
   --color-overlay-slate-12: rgba(var(--color-overlay-slate-rgb), 0.12);
-  --color-overlay-slate-22: rgba(var(--color-overlay-slate-rgb), 0.22);
   --color-bg-secondary: #{$color-bg-secondary};
   --color-bg-tertiary: #{$color-bg-tertiary};
   --color-bg-quaternary: #{$color-bg-quaternary};
@@ -455,7 +446,6 @@ $badge-info-text: $color-info;
   --border-medium: #{$border-medium};
   --border-strong: #{$border-strong};
   --border-prominent: #{$border-prominent};
-  --border-focus: #{$border-focus};
   --border-accent-soft: #{$border-accent-soft};
   --border-accent-subtle: #{$border-accent-subtle};
   --border-accent: #{$border-accent};
@@ -496,29 +486,9 @@ $badge-info-text: $color-info;
   --btn-ghost-hover-bg: var(--color-overlay-white-08);
   --btn-ghost-hover-color: #b8b8b8;
   --btn-ghost-hover-border: transparent;
-  --mission-control-group-primary-color: var(--color-accent-600);
-  --mission-control-group-secondary-color: #{$color-static-emerald};
-  --mission-control-group-tertiary-color: var(--color-warning);
-  --markdown-code-gutter-light-rgb: 153, 153, 153;
-  --markdown-code-gutter-dark-rgb: 102, 102, 102;
-  --preview-bg: color-mix(in srgb, var(--color-static-black) 90%, var(--color-static-white));
-  --preview-panel-bg: color-mix(in srgb, var(--color-static-black) 96%, var(--color-static-white));
-  --preview-border: color-mix(in srgb, var(--color-static-black) 90%, var(--color-static-white));
-  --preview-text-primary: color-mix(in srgb, var(--color-static-white) 88%, var(--color-static-black));
-  --preview-text-muted: color-mix(in srgb, var(--color-static-white) 63%, var(--color-static-black));
-  --preview-text-subtle: color-mix(in srgb, var(--color-static-white) 60%, var(--color-static-black));
-  --preview-text-disabled: color-mix(in srgb, var(--color-static-white) 40%, var(--color-static-black));
-  --preview-heading-gradient: linear-gradient(135deg, var(--color-accent-500) 0%, var(--color-purple-500) 100%);
   --surface-stagger-index: 0;
-  --mission-control-group-color: var(--color-accent-500);
   --scene-viewport-border-width: 1px;
-  --gallery-grid-min: 320px;
-  --gallery-skeleton-height: 140px;
   --inline-context-tag-color: var(--color-accent-500);
-  --markdown-editor-list-indent: 1.75rem;
-  --markdown-editor-list-marker-width: 1.25rem;
-  --markdown-editor-list-gap: 0.25rem;
-  --markdown-editor-task-checkbox-size: 1rem;
   --config-page-content-inline-padding: clamp(16px, 2.2vw, 28px);
   --config-page-content-max-width: 600px;
   --profile-acp-left-inline-pad: var(--size-gap-6);
@@ -526,19 +496,16 @@ $badge-info-text: $color-info;
 
   --glow-shadow-blue: #{$glow-shadow-blue};
 
-  --glass-disabled: #{$glass-disabled};
   --glass-blue-subtle: #{$glass-blue-subtle};
   --glass-red-subtle: #{$glass-red-subtle};
   --glass-red-base: #{$glass-red-base};
   --glass-red-hover: #{$glass-red-hover};
-  --glass-green-base: #{$glass-green-base};
-  --glass-green-hover: #{$glass-green-hover};
   --glass-bg-base: #{$glass-base};
   --glass-bg-hover: var(--element-bg-medium);
   --glass-bg-active: var(--element-bg-strong);
   --glass-border-base: var(--border-base);
   --glass-border-hover: var(--border-medium);
-  --glass-border-focus: var(--border-focus);
+  --glass-border-focus: var(--border-strong);
   --glass-blur-sm: #{$blur-subtle};
   --glass-blur-base: #{$blur-base};
   --glass-shadow-sm: var(--shadow-sm);
@@ -565,13 +532,10 @@ $badge-info-text: $color-info;
   --size-gap-12: #{$size-gap-12};
   --size-gap-16: #{$size-gap-16};
 
-  --motion-instant: #{$motion-instant};
   --motion-fast: #{$motion-fast};
   --motion-base: #{$motion-base};
 
   --easing-standard: #{$easing-standard};
-  --easing-decelerate: #{$easing-decelerate};
-  --easing-smooth: #{$easing-smooth};
 
   --font-family-sans: #{$font-family-sans};
   --font-family-mono: #{$font-family-mono};
@@ -620,14 +584,11 @@ $badge-info-text: $color-info;
   --flowchat-card-radius: 8px;
   --flowchat-card-pad-y: 0.625rem;
   --flowchat-card-pad-x: 0.75rem;
-  --flowchat-card-header-pad-y: 0.44rem;
-  --flowchat-card-header-pad-x: 0;
-  --flowchat-card-header-pad-right: 0.625rem;
   --flowchat-card-expanded-pad-y: 0.5rem;
   --flowchat-card-expanded-pad-x: 0.625rem;
-  --tool-card-header-pad-y: var(--flowchat-card-header-pad-y);
-  --tool-card-header-pad-x: var(--flowchat-card-header-pad-x);
-  --tool-card-header-pad-right: var(--flowchat-card-header-pad-right);
+  --tool-card-header-pad-y: 0.44rem;
+  --tool-card-header-pad-x: 0;
+  --tool-card-header-pad-right: 0.625rem;
   --tool-card-header-icon-rail: 24px;
   --tool-card-header-icon-slot: calc(var(--tool-card-header-icon-rail) + 10px);
   --tool-card-icon-size: 16px;

--- a/src/web-ui/src/flow_chat/tool-cards/_tool-card-common.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/_tool-card-common.scss
@@ -57,10 +57,6 @@
 
 /* ========== Shared header icon variables ========== */
 :root {
-  --tool-card-header-pad-y: var(--flowchat-card-header-pad-y);
-  --tool-card-header-pad-x: var(--flowchat-card-header-pad-x);
-  --tool-card-header-pad-right: var(--flowchat-card-header-pad-right);
-
   /* Shared icon & text sizing — dense-command variants only override spacing, not these */
   --tool-card-action-font-size: var(--flowchat-font-size-sm);
   --tool-card-action-line-height: var(--flowchat-support-line-height);

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -607,7 +607,7 @@
     white-space: nowrap;
 
     &--default {
-      background: var(--glass-green-base);
+      background: var(--color-success-bg);
       color: var(--color-success);
     }
 

--- a/src/web-ui/src/infrastructure/config/components/ConfigForm.scss
+++ b/src/web-ui/src/infrastructure/config/components/ConfigForm.scss
@@ -112,7 +112,7 @@ $config-input-height: 32px;
   &:disabled {
     opacity: var(--opacity-disabled) !important;
     cursor: default !important;
-    background: var(--glass-disabled) !important;
+    background: var(--color-overlay-white-04) !important;
     border-color: var(--border-subtle) !important;
   }
 }

--- a/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.scss
+++ b/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.scss
@@ -272,7 +272,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .context-menu {
-    transition: opacity var(--motion-instant) ease;
+    transition: opacity $motion-instant ease;
     transform: none;
   }
 
@@ -281,7 +281,7 @@
   }
 
   .context-menu-item {
-    transition: background-color var(--motion-instant) ease, color var(--motion-instant) ease;
+    transition: background-color $motion-instant ease, color $motion-instant ease;
   }
 }
 

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.scss
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.scss
@@ -1,4 +1,5 @@
 @use '../../../component-library/styles/tokens.scss' as *;
+@use '../styles/markdown-editor-layout' as markdownLayout;
 
 .bitfun-markdown-editor {
   display: flex;
@@ -318,7 +319,7 @@
     list-style: none;
     position: relative;
     margin-bottom: $size-gap-1;
-    padding-left: calc(var(--markdown-editor-list-marker-width) + var(--markdown-editor-list-gap));
+    padding-left: calc(#{markdownLayout.$list-marker-width} + #{markdownLayout.$list-gap});
   }
 
   > ul:not(.contains-task-list) > li::before,
@@ -326,7 +327,7 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: var(--markdown-editor-list-marker-width);
+    width: markdownLayout.$list-marker-width;
     color: var(--color-text-primary);
     font-weight: $font-weight-medium;
   }
@@ -353,7 +354,7 @@
   li > ol {
     margin-top: $size-gap-1;
     margin-bottom: 0;
-    padding-left: var(--markdown-editor-list-indent);
+    padding-left: markdownLayout.$list-indent;
   }
 
   li {
@@ -538,24 +539,24 @@
   > ul.contains-task-list > .task-list-item {
     list-style: none;
     position: relative;
-    padding-left: calc(var(--markdown-editor-list-marker-width) + var(--markdown-editor-list-gap));
+    padding-left: calc(#{markdownLayout.$list-marker-width} + #{markdownLayout.$list-gap});
     margin-bottom: $size-gap-1;
   }
 
   > ul.contains-task-list > .task-list-item > input[type="checkbox"] {
     position: absolute;
-    left: calc((var(--markdown-editor-list-marker-width) - var(--markdown-editor-task-checkbox-size)) / 2);
+    left: calc((#{markdownLayout.$list-marker-width} - #{markdownLayout.$task-checkbox-size}) / 2);
     top: 0.15rem;
     margin: 0;
-    width: var(--markdown-editor-task-checkbox-size);
-    height: var(--markdown-editor-task-checkbox-size);
+    width: markdownLayout.$task-checkbox-size;
+    height: markdownLayout.$task-checkbox-size;
   }
 
   .task-list-item > ul,
   .task-list-item > ol {
     margin-top: $size-gap-1;
     margin-bottom: 0;
-    padding-left: var(--markdown-editor-list-indent);
+    padding-left: markdownLayout.$list-indent;
   }
 
   // KaTeX math formula styles

--- a/src/web-ui/src/tools/editor/components/StatusBarPopovers/StatusBarPopovers.scss
+++ b/src/web-ui/src/tools/editor/components/StatusBarPopovers/StatusBarPopovers.scss
@@ -23,7 +23,7 @@
    font-family: $font-family-sans;
    color: var(--color-text-primary);
    transform: translateY(-100%);
-   animation: status-bar-popover-enter 0.15s cubic-bezier(0, 0, 0.2, 1) forwards;
+   animation: status-bar-popover-enter 0.15s $easing-decelerate forwards;
 
    &__input-wrap {
      padding: 8px 10px;

--- a/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.scss
+++ b/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.scss
@@ -1,4 +1,5 @@
 @use '../../../../component-library/styles/tokens.scss' as *;
+@use '../../styles/markdown-editor-layout' as markdownLayout;
 
 .m-editor-tiptap {
   --private-markdown-editor-highlight-rgb: 255, 213, 79;
@@ -343,7 +344,7 @@
       list-style: none;
       position: relative;
       margin-bottom: $size-gap-1;
-      padding-left: calc(var(--markdown-editor-list-marker-width) + var(--markdown-editor-list-gap));
+      padding-left: calc(#{markdownLayout.$list-marker-width} + #{markdownLayout.$list-gap});
     }
 
     > ul:not([data-type='taskList']) > li::before,
@@ -351,7 +352,7 @@
       position: absolute;
       left: 0;
       top: 0;
-      width: var(--markdown-editor-list-marker-width);
+      width: markdownLayout.$list-marker-width;
       color: var(--color-text-primary);
       font-weight: $font-weight-medium;
     }
@@ -378,7 +379,7 @@
     li > ol:not([data-type='taskList']) {
       margin-top: $size-gap-1;
       margin-bottom: 0;
-      padding-left: var(--markdown-editor-list-indent);
+      padding-left: markdownLayout.$list-indent;
     }
 
     > ul[data-type='taskList'] {
@@ -389,14 +390,14 @@
 
     > ul[data-type='taskList'] > li {
       display: grid;
-      grid-template-columns: var(--markdown-editor-list-marker-width) 1fr;
-      column-gap: var(--markdown-editor-list-gap);
+      grid-template-columns: markdownLayout.$list-marker-width 1fr;
+      column-gap: markdownLayout.$list-gap;
       align-items: start;
       margin-bottom: $size-gap-1;
     }
 
     > ul[data-type='taskList'] > li > label {
-      width: var(--markdown-editor-list-marker-width);
+      width: markdownLayout.$list-marker-width;
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -405,8 +406,8 @@
 
     > ul[data-type='taskList'] > li > label > input[type='checkbox'] {
       margin: 0;
-      width: var(--markdown-editor-task-checkbox-size);
-      height: var(--markdown-editor-task-checkbox-size);
+      width: markdownLayout.$task-checkbox-size;
+      height: markdownLayout.$task-checkbox-size;
     }
 
     > ul[data-type='taskList'] > li > label > span {
@@ -422,7 +423,7 @@
     ul[data-type='taskList'] li > ol {
       margin-top: $size-gap-1;
       margin-bottom: 0;
-      padding-left: var(--markdown-editor-list-indent);
+      padding-left: markdownLayout.$list-indent;
     }
 
     li > p {

--- a/src/web-ui/src/tools/editor/styles/_markdown-editor-layout.scss
+++ b/src/web-ui/src/tools/editor/styles/_markdown-editor-layout.scss
@@ -1,0 +1,4 @@
+$list-indent: 1.75rem;
+$list-marker-width: 1.25rem;
+$list-gap: 0.25rem;
+$task-checkbox-size: 1rem;


### PR DESCRIPTION
## 概要
- 压缩低外部使用的 web-ui root token contract：移除 preview/editor/gallery/MissionControl/glass/focus/motion 等只承担局部实现或严格同义的 helper key。
- 将 MissionControl 组别色从动态 inline CSS var 改为有限枚举 modifier；subagent 复审后进一步调整为中性底色 + 有色指示，避免小字号文本对比不足或把组别色误读为状态色。
- 同步收敛 mobile-web motion/easing 主题入口：删除未使用或不应扩展的别名，保留 decelerate 为 mobile 本地 Sass owner，并补齐相关 reduced-motion 覆盖。
- 更新主题治理文档和 baseline：web static root contract 320 -> 289，low external usage 116 -> 86。

## 复审后修复
- 将剩余 success/glass/focus 近义使用回收到既有语义 token，避免继续散落 `color-mix(success ...)` 的临时实现。
- 将 Markdown 编辑器列表/任务尺寸抽到 editor-local Sass partial，避免恢复 root token 但仍消除双份 Sass 常量。
- 将 web-ui 和 mobile-web 的 decelerate 字面量收敛到对应 owner，保留 TS 主题 preset 和 canonical token 作为扩展入口。
- 为 IconButton 示例补齐 icon-only `aria-label`，避免示例代码传播无障碍缺口。

## 验证
- `pnpm run theme:color-audit:all`
- `pnpm run theme:visual-contract`
- `pnpm run theme:color-audit:test`（46 tests passed）
- `pnpm run type-check:web`
- `pnpm run lint:web`（0 errors，保留既有 8 warnings）
- `pnpm --dir src/web-ui run test:run`（238 files / 1379 tests passed）
- `pnpm --dir src/mobile-web run type-check`
- `pnpm run build:web`（构建通过，保留既有 Vite import/chunk warnings）
- `pnpm run build:mobile-web`（构建通过，保留既有 Vite large chunk warning）
- `git diff --check`（仅 CRLF 提示）

## 风险与边界
- Markdown code gutter 改为不透明等价值 `color-mix`，避免透明叠色造成背景相关的对比漂移。
- preview/gallery 仍为局部默认，不作为主题扩展入口；组件 props/inline style 覆盖能力保留。
- MissionControl 的组别区分继续保留 accent/success/warning 的视觉提示，但不再用大面积实底色承载小文本。
- 本轮不合并 Git 状态色、button payload、z-index、card/tool-card 跨组件布局等仍可能承担相邻区域语义的 key。