### PR TITLE
docs: clarify plugin runtime P0 plan

### DIFF
--- a/docs/architecture/plugin-runtime-host-design.md
+++ b/docs/architecture/plugin-runtime-host-design.md
@@ -30,6 +30,8 @@ Product Assembly 能力模型和领域对象；第 7-14 节说明运行时、IPC
 - 保持 Kernel 是任务状态、事件和审计事实的权威源；Execution 是工具结果权威源；Security Boundary 是权限权威源。
   插件只能返回候选效果。
 - 让 Desktop、CLI、Server、Remote、ACP、Web、Mobile Web 和 SDK 显式启用、禁用或降级插件能力。
+- 当前 P0 只实现 Desktop/CLI 的 OpenCode-compatible plugin 垂直切片；Server、Remote、ACP、Web、Mobile Web
+  和 SDK 的 full plugin runtime 均按第 12 节进入 P0+。
 - 支持插件在已声明 extension point 上追加或覆写贡献，但覆写必须由 Product Assembly、能力 owner 和安全控制面共同约束。
 
 非目标：
@@ -45,7 +47,7 @@ Product Assembly 能力模型和领域对象；第 7-14 节说明运行时、IPC
 ### 2.1 产品形态、运行策略与扩展贡献
 
 `ProductProfile`、`CapabilityPack`、`CapabilitySet` 和 `OverridePoint` 的权威定义见
-[`product-architecture.md`](product-architecture.md#3-产品如何成形)。本文限定说明插件运行时涉及的子集：
+[`product-architecture.md`](product-architecture.md#5-产品如何成形)。本文限定说明插件运行时涉及的子集：
 
 | 类别 | 进入 BitFun 的方式 | 插件运行时关系 |
 |---|---|---|
@@ -299,6 +301,7 @@ interface PluginResponseEnvelope {
   completed_at_ms: number;
   effects: PluginEffectCandidate[];
   diagnostics: PluginDiagnostic[];
+  quarantine?: PluginQuarantineState;
   observed_epochs: {
     project_epoch: number;
     trust_epoch: number;
@@ -315,6 +318,7 @@ interface PluginEffectBase {
   data_classification: DataClassification;
   risk_level: "low" | "medium" | "high";
   requires_permission: boolean;
+  permission_prompt?: PermissionPromptDescriptor;
   source_ref: PluginSourceRef;
 }
 
@@ -369,7 +373,7 @@ interface UiContributionDescriptor {
   data_refs: PayloadRef[];
   allowed_actions: ProductCommandRef[];
   required_capabilities: CapabilityId[];
-  permission_prompt?: PermissionPromptDescriptor;
+  permission_prompt_ref?: PermissionPromptRef;
   fallback: {
     mode: "hide" | "disabled" | "text_projection" | "unsupported_message";
     message_key?: string;
@@ -380,10 +384,110 @@ interface UiContributionDescriptor {
   };
   i18n_namespaces: string[];
 }
+
+interface PermissionPromptRef {
+  effect_id: string;
+  audit_ref: {
+    correlation_id: string;
+    event_id?: string;
+  };
+}
+
+type PermissionPromptEffectKind =
+  | "suggestion"
+  | "evidence_candidate"
+  | "tool_input_patch_candidate"
+  | "tool_provider_candidate"
+  | "post_tool_evidence_candidate"
+  | "permission_candidate"
+  | "ui_contribution_candidate"
+  | "event_subscription_candidate";
+
+interface PermissionPromptDescriptor {
+  descriptor_version: 1;
+  plugin_id: string;
+  source_ref: PluginSourceRef;
+  source_hash: string;
+  requested_capability: CapabilityId;
+  requested_effect: PermissionPromptEffectKind;
+  target_ref: TargetRef;
+  risk_level: "low" | "medium" | "high";
+  owner: CapabilityOwnerRef;
+  rollback: "none" | "automatic" | "manual";
+  deny_result: "no_state_change" | "candidate_discarded" | "temporarily_unavailable" | "policy_denied";
+  audit_ref: {
+    correlation_id: string;
+    event_id?: string;
+  };
+}
+
+interface PluginDiagnosticBase {
+  diagnostic_id: string;
+  severity: "info" | "warning" | "error";
+  plugin_id: string;
+  source_ref: PluginSourceRef;
+  action_hints: RecoveryAction[];
+  audit_ref: {
+    correlation_id: string;
+    event_id?: string;
+  };
+}
+
+type PluginDiagnostic =
+  | (PluginDiagnosticBase & {
+      kind: "trust_config";
+      trust_result: "trusted" | "untrusted" | "revoked" | "requires_confirmation";
+      config_validation: "valid" | "invalid" | "missing" | "unsupported";
+    })
+  | (PluginDiagnosticBase & {
+      kind: "manifest";
+      manifest_validation_error: string;
+    })
+  | (PluginDiagnosticBase & {
+      kind: "host_availability";
+      host_availability_reason: string;
+    })
+  | (PluginDiagnosticBase & {
+      kind: "deadline";
+      deadline_reason: string;
+    })
+  | (PluginDiagnosticBase & {
+      kind: "quarantine";
+      quarantine_reason: PluginQuarantineState["reason"];
+      quarantine_scope: PluginQuarantineState["scope"];
+    });
+
+type RecoveryAction =
+  | "retry"
+  | "disable"
+  | "retrust"
+  | "open_log"
+  | "clear_quarantine";
+
+interface PluginQuarantineState {
+  state_version: 1;
+  plugin_id: string;
+  source_ref: PluginSourceRef;
+  scope: "plugin" | "source" | "capability" | "command" | "execution_domain";
+  reason: "crash" | "deadline" | "manifest_invalid" | "trust_revoked" | "policy_denied" | "protocol_error";
+  clear_condition: "manual" | "manifest_changed" | "trust_renewed" | "host_restarted" | "policy_changed";
+  action_hints: RecoveryAction[];
+  log_ref?: PayloadRef;
+  audit_ref: {
+    correlation_id: string;
+    event_id?: string;
+  };
+}
 ```
 
 `unknown` 只能出现在带 `schema_version`、`data_classification` 和 `redaction` 的 canonical payload 内部。不得在公共
 API 中绕过 schema 传递裸 JSON。
+
+`PermissionPromptDescriptor`、`PermissionPromptRef`、`PluginDiagnostic` 和 `PluginQuarantineState` 是 Desktop settings、permission prompt、
+CLI diagnostics 和审计记录共享的结构化合同。`requires_permission=true` 的 effect candidate 必须携带
+`permission_prompt`；UI contribution 只能携带 `permission_prompt_ref`，并且必须引用同一个 effect id / audit ref。
+Desktop prompt、CLI diagnostics 和 audit 必须消费同一对象；prompt mismatch 必须让 descriptor 校验失败。Host
+不得只返回本地化文案或不可解析错误来表达权限确认、诊断、隔离状态或恢复动作。
 
 `UiContributionDescriptor` 不得包含 React component、HTML script、DOM selector、Tauri command、store mutation
 或任意可执行代码。未知 slot、未知 action 或缺失 capability 时，入口必须按 fallback 降级。
@@ -474,25 +578,31 @@ DTO。
 
 ## 12. 产品形态与降级
 
+本节能力矩阵是长期设计边界，不是 P0 验收范围。P0 override 以
+[`product-architecture.md`](product-architecture.md) 为准：P0 只验收 Desktop settings/command + CLI diagnostics 的同一条
+OpenCode-compatible plugin 垂直切片；ACP、Server、Remote、Web、Mobile Web 和 SDK minimal 在 P0 中只能是
+typed unsupported、unavailable、projection-only 或 status-only。Server / Remote Host、ACP capability / permission bridge
+和其他入口的 full plugin runtime 必须进入 P0+，并具备单独产品决策、迁移/回滚和验证指标。
+
 | 产品形态 | 插件运行时策略 | UI 策略 | 失败语义 |
 |---|---|---|---|
 | Desktop / product-full | 可启用本地 Host；高风险能力按 trust policy 提权 | 渲染已校验 descriptor | host crash 或 timeout 不影响默认任务 |
 | CLI | 可启用本地 Host 或只读投影 | 文本 descriptor / warning | unsupported 明确输出，不静默忽略 |
-| Server | 默认受控启用或 disabled stub，取决于部署策略 | API 返回 typed unsupported 或 descriptor projection | 不自动启动本地 JS/TS runtime |
-| Remote | Host 靠近远端执行域 | UI 只接收 logical path 和 descriptor | 不回落到本地路径执行 |
-| ACP | 以 protocol adapter 暴露可组合 capability | 以 ACP 能力或 unsupported 表达 | 不将插件失败解释为 agent 失败 |
+| Server | P0 为 typed unsupported / projection-only；P0+ 才可按部署策略受控启用 | API 返回 typed unsupported 或 descriptor projection | 不自动启动本地 JS/TS runtime |
+| Remote | P0 为 unavailable / projection-only；P0+ 才可让 Host 靠近远端执行域 | UI 只接收 logical path 和 descriptor | 不回落到本地路径执行 |
+| ACP | P0 为 status-only / projection-only / typed unsupported；P0+ 才可暴露 capability 或 permission bridge | 以 ACP 状态或 unsupported 表达 | 不将插件失败解释为 agent 失败 |
 | Web / Mobile Web | 不启动本地 Host | 只消费后端投影 descriptor | 不持有插件执行单元 |
-| SDK minimal | disabled stub 或调用方注入 fake/client | 无默认 UI host | 不牵引 product-full 或 concrete provider |
+| SDK minimal | P0 仅 disabled stub 或测试 fake/client；生产可执行 client 注入属于 P0+ | 无默认 UI host | 不牵引 product-full 或 concrete provider |
 
 能力矩阵：
 
 | 能力 | Desktop / product-full | CLI | Server | Remote | ACP | Web / Mobile Web | SDK minimal |
 |---|---|---|---|---|---|---|---|
-| discovery | 支持本地/项目发现 | 支持本地/项目发现 | 由部署策略启用 | 在远端执行域发现 | 通过 ACP capability 暴露 | 只消费后端投影 | 调用方注入或 disabled |
-| read-only event hook | 支持候选建议/证据 | 支持文本诊断 | 支持 API diagnostic | 靠近远端 Host 执行 | 映射为 ACP event/capability | 只展示投影 | fake/client 可选 |
-| tool provider candidate | 支持，必须经 Tool ABI | 支持，必须经 Tool ABI | 默认受部署策略限制 | 绑定远端 execution domain | 只作为 external tool capability | 不执行 | 默认 disabled |
-| permission candidate | 只作建议，最终由安全边界决策 | 只作建议 | 只作 API 候选 | 绑定远端 trust/policy epoch | 映射为 ACP permission bridge | 只展示状态 | 默认 disabled |
-| UI contribution | descriptor 渲染 | 文本或命令投影 | API projection / unsupported | 只使用 logical path | ACP 能力或 unsupported | descriptor 投影 | 默认无 UI host |
+| discovery | 支持本地/项目发现 | 支持本地/项目发现 | P0 projection/unsupported；P0+ 由部署策略启用 | P0 projection/unavailable；P0+ 在远端执行域发现 | P0 status/projection/unsupported；P0+ 通过 ACP capability 暴露 | 只消费后端投影 | 调用方注入或 disabled |
+| read-only event hook | 支持候选建议/证据 | 支持文本诊断 | P0 diagnostic projection；P0+ 支持 API diagnostic | P0 只读投影；P0+ 靠近远端 Host 执行 | P0 status-only；P0+ 映射为 ACP event/capability | 只展示投影 | fake/client 可选 |
+| tool provider candidate | 支持，必须经 Tool ABI | 支持，必须经 Tool ABI | P0 不执行；P0+ 受部署策略限制 | P0 不执行；P0+ 绑定远端 execution domain | P0 不执行；P0+ 只作为 external tool capability | 不执行 | 默认 disabled |
+| permission candidate | 只作建议，最终由安全边界决策 | 只作建议 | P0 不产生候选；P0+ 只作 API 候选 | P0 不产生候选；P0+ 绑定远端 trust/policy epoch | P0 不接入 permission bridge；P0+ 映射为 ACP permission bridge | 只展示状态 | 默认 disabled |
+| UI contribution | descriptor 渲染 | 文本或命令投影 | P0 API projection / unsupported；P0+ 受控 API projection | P0 只使用 logical path 投影；P0+ 受控远端投影 | P0 unsupported/status-only；P0+ ACP 能力或 unsupported | descriptor 投影 | 默认无 UI host |
 | shell helper | 默认禁用，可映射为 tool request 候选 | 默认禁用 | 默认禁用 | 只允许远端策略批准 | 不直接暴露 shell | 不执行 | disabled |
 | read-only state view | 支持脱敏投影 | 支持文本投影 | 支持 API 投影 | 支持远端脱敏投影 | 映射为 protocol state | 支持只读投影 | fake/client 可选 |
 | writable JS/TS runtime | 非默认能力，需独立安全评审 | 非默认能力 | 非默认能力 | 非默认能力 | 不作为默认能力 | 不执行 | disabled |
@@ -519,16 +629,20 @@ DTO。
 
 ## 14. 验证矩阵
 
+可执行验证目标以 [`../plans/core-decomposition-plan.md#8-验证矩阵`](../plans/core-decomposition-plan.md#8-验证矩阵)
+为准。Host、adapter、product-shape 或 SDK minimal 相关 PR 必须更新并运行其中固定命令；本节只说明覆盖面，不能用临时测试或
+PR 文案替代执行计划里的固定目标。
+
 | 验证面 | 必须覆盖 |
 |---|---|
 | 主体进程 API | 只暴露 runtime client、binding、envelope、candidate、trust 和 descriptor |
-| schema | dispatch / response / effect candidate serialization round-trip |
+| schema | dispatch / response / effect candidate / permission prompt / diagnostic / quarantine state serialization round-trip |
 | 时序 | initialize、deadline、cancel、stale epoch、idempotency key |
-| 权限 | plugin 不能 approve、不能写审计、不能伪造 tool result |
+| 权限 | plugin 不能 approve、不能写审计、不能伪造 tool result；permission prompt 字段必须覆盖 source/hash、effect、target、risk、owner、rollback、deny result 和 audit ref |
 | 工具 | tool provider candidate 经 Tool ABI 和 permission gate 后才能 materialize |
 | UI | descriptor 校验、未知 contribution fallback、无直接 UI state mutation |
 | 安全 | 未信任插件不执行、hash 变化重新信任、secret/network/shell 默认拒绝 |
-| 崩溃 | host、worker、subprocess 或 adapter failure 不影响默认任务 |
+| 崩溃 | host、worker、subprocess 或 adapter failure 不影响默认任务；quarantine state 必须提供 scope、reason、clear condition、action hints、log ref 和 audit ref |
 | 远程 | logical path、remote execution domain 和权限范围不泄漏本地路径 |
 | 产品形态 | Desktop、CLI、Server、Remote、ACP、Web、Mobile Web、SDK 的 unsupported 行为明确 |
 

--- a/docs/architecture/product-architecture.md
+++ b/docs/architecture/product-architecture.md
@@ -1,215 +1,279 @@
 # BitFun 产品运行时架构
 
-本文作为 BitFun 产品运行时架构入口，说明三件事：产品能力如何组合，代理运行时如何保持稳定，插件和外部生态如何受控接入。
-执行计划见 [`../plans/core-decomposition-plan.md`](../plans/core-decomposition-plan.md)；接口、产品组装和扩展注册开发约束见
-[`agent-runtime-services-design.md`](agent-runtime-services-design.md)；插件运行时、IPC、待确认效果和外部生态适配契约见
-[`plugin-runtime-host-design.md`](plugin-runtime-host-design.md)。
+本文是 BitFun 产品运行时架构的主口径。它回答当前产品运行时应该优先保护什么、插件生态如何进入、哪些边界必须收敛，
+以及哪些复杂度不能提前扩张。
 
-本文不记录实现进度，不展开 crate 内部设计，也不复述外部产品调研。本文聚焦职责和约束，细节文档补充接口形态、模块归属和验证要求。
+执行计划见 [`../plans/core-decomposition-plan.md`](../plans/core-decomposition-plan.md)；接口与 crate 约束见
+[`agent-runtime-services-design.md`](agent-runtime-services-design.md)；插件运行时、IPC、候选效果和外部生态适配合同见
+[`plugin-runtime-host-design.md`](plugin-runtime-host-design.md)。当详细设计与本文冲突时，以本文为准。
 
-## 1. 要解决的问题
+本文不记录实现进度，不展开 crate 内部设计，也不复述外部产品调研。本文聚焦关键交付场景、职责边界和降低复杂性的规则。
+
+## 1. 当前要解决的问题
 
 `bitfun-core` 曾同时承担兼容入口、完整运行时组装、代理循环、服务接线、工具注册、产品命令和部分领域逻辑。
 该形态能够支撑现有产品，但会让后续演进成本持续升高：
 
-- 新产品形态容易被完整桌面产品能力牵引，无法清晰裁剪。
-- `/goal`、DeepReview、MiniApp、工具、MCP、内置 hook、插件 hook 和界面扩展缺少统一能力边界。
-- 权限、事件、产物（artifact）、远程执行和审计事实分散在多条路径中，难以证明行为等价。
-- 插件或外部生态如果直接进入内部状态，会反向改写产品形态和安全边界。
+- 插件、MCP、ACP 外部代理、工具、hook、UI contribution 和外部生态适配没有一条统一进入路径，容易绕过权限、审计或产品能力边界。
+- 产品命令、DeepReview、MiniApp、工具、MCP、ACP 与远程能力容易通过多层透传互相依赖，形成 A 模块依赖 B 模块再依赖 C 模块的链式依赖。
+- 新入口容易被完整桌面产品能力牵引，无法清晰裁剪或降级。
+- 权限、事件、产物、远程执行和审计事实分散在多条路径中，难以证明行为等价。
 
-目标是将 BitFun 从“一个完整运行时中心”调整为“可组合的产品运行时”。这不是增加更多抽象，而是明确三条主线：
+当前第一优先级是插件生态和扩展能力支撑。降低复杂性不是把插件生态后置，而是把它收敛为一条最小、受控、可验证的扩展主线：
 
-1. **产品成形路径**：产品入口声明自身约束，产品组装选择内置能力（first-party）和服务实现，产品能力负责体验与验证。
-2. **任务运行路径**：代理内核维护会话、任务、权限事实和事件，通过注入端口调用执行能力和平台能力。
-3. **扩展接入路径**：插件、MCP、ACP 外部代理/工具桥接和外部生态只能提交能力声明或待确认效果，不能直接写最终状态。
+1. **扩展能力优先闭环**：先形成 Extension Contract、Plugin Runtime Host、候选效果、安全校验、能力可用性和同一条 OpenCode-compatible plugin 真实生态适配消费路径。
+2. **关键产品路径稳定**：ProductFull、Desktop、CLI 和 ACP 保持完整 Agent、工具、MCP、终端、Git、文件、session、远程和既有产品能力等价。
+3. **运行时边界变窄**：Agent Kernel 只维护任务事实；Execution 执行工具和工作流；平台适配负责外部系统；Product Assembly 负责一次性组装。
+4. **非必要矩阵暂缓**：暂缓全量生态兼容、全入口 UI Extension 矩阵、任意可写 transform 和无真实消费方 descriptor；不暂缓插件生态主线本身。
 
-## 2. 总体结构
+## 2. 当前聚焦场景
 
-逻辑视图只保留三条主线。每条主线内部有必要的职责角色，但不要求读者先理解全部 crate。
+| 场景 | 当前主线 | 不应提前扩张 |
+|---|---|---|
+| 插件运行时 MVP | `PluginRuntimeClient`、binding、typed envelope、lifecycle、deadline、diagnostics、disabled/projection/host availability | 任意插件直接写 kernel state、permission decision、audit、tool result 或 UI implementation |
+| Extension Contract | extension point、capability/effect descriptor、trust/source、UI contribution descriptor、unsupported/unavailable/fallback | 没有消费方的全量 descriptor registry、跨所有入口的一次性大矩阵 |
+| 外部生态适配 | P0 固定首条路径是 OpenCode-compatible plugin 最小垂直切片；ACP 外部 agent/tool bridge 可复用合同但不能替代这条插件体验 | 同时承诺 OpenCode、Claude Code、Codex 和所有社区插件完整兼容 |
+| ProductFull / Desktop | 完整产品能力、桌面宿主、Tauri 命令、Web UI 状态展示、平台服务注入 | 由插件替换 first-party 能力；运行时临时选择产品形态 |
+| CLI | 完整 Agent 能力、终端/文件/Git/MCP/模型服务等端口注入、清晰 typed error | 复用桌面 UI 或桌面-only provider；隐式加载 Web UI 能力 |
+| ACP | ACP 协议入口、外部 agent 启动探测、工作区选择、权限/事件桥接 | 把 ACP allow/ask 当作 BitFun 最终安全判定 |
+| Web / Mobile Web / Server / Remote / SDK | 对扩展能力给出明确 `unsupported`、`unavailable`、`projection-only` 或只读投影 | 默默继承完整桌面插件能力或加载桌面/Web-only 实现 |
+
+任何新增抽象都必须服务上述场景之一，并同步删除、迁移或显著简化旧路径。只新增 facade、descriptor、registry、matrix 或空接口，
+但没有真实消费路径和旧路径收敛，不算架构进展。
+
+P0 第一条插件体验必须是单一可验收的垂直切片，而不是多个候选方向并列推进：
+
+1. 用户能从 OpenCode 兼容来源或本地路径注册插件，Desktop settings 支持启用、禁用、信任确认和配置校验；CLI diagnostics 必须能展示同一 OpenCode-compatible plugin manifest、source、trust 和状态。
+2. Product Assembly 选择 host availability，Plugin Runtime Host 校验 source、manifest、trust policy、deadline、配置和 execution domain。
+3. 插件贡献一个 command descriptor，并由该 command 调用 plugin-provided tool；hook 和 readonly state view 只作为可选扩展，未实现时返回 typed unsupported。
+4. 用户触发 command contribution 后进入 BitFun permission/effect gate；插件只能返回 provider candidate、descriptor 或 `PluginEffectCandidate`。
+5. permission prompt 必须展示最小决策信息：plugin id/source/hash、requested capability/effect、target/artifact、risk level、owner、可回滚性、deny 后状态和 audit/event id。
+6. 用户确认后，能力 owner 和安全控制面 materialize effect，并在 Desktop 可见结果、artifact/status、audit 和 CLI diagnostics 中闭环；用户拒绝、超时、policy-denied 或 host failure 时不得写最终状态或成功审计。
+7. failure quarantine 必须有 scope、清除条件和用户可执行恢复动作，例如 retry、disable、retrust、open log 或 clear quarantine。
+8. P0 必选面只包含 Desktop settings/command 与 CLI diagnostics。ACP 在 P0 只能做 canonical availability/diagnostics projection 或 typed unsupported/status-only，不参与 command/effect 闭环；Web、Mobile Web、Server、Remote、SDK 必须返回 typed unsupported、unavailable 或 projection-only。
+
+ACP 外部 agent/tool bridge 是 P0+ 的互操作路径。它可以复用 Extension Contract、permission bridge 和 diagnostics，
+但不能替代 P0 的 OpenCode-compatible plugin 体验验收。
+
+## 3. 总体结构
+
+逻辑视图保留产品、运行、扩展和边界四条主线。扩展主线是一等主线，不是附属研究；但它只能通过稳定合同和安全控制进入产品。
 
 ```mermaid
 flowchart TB
   subgraph Product["产品主线：决定交付形态"]
     Surface["产品入口"]
-    Assembly["产品组装"]
-    Capability["产品能力"]
+    Assembly["Product Assembly"]
+    Feature["产品能力"]
   end
 
-  subgraph Runtime["运行主线：处理任务事实"]
-    Kernel["代理内核"]
-    Execution["执行层"]
-    Extension["扩展治理"]
+  subgraph Runtime["运行主线：维护任务事实"]
+    Kernel["Agent Kernel"]
+    Execution["Execution"]
   end
 
-  Guard["共同规则\n稳定契约、安全决策、DTO、端口、产物和审计"]
-
-  subgraph Boundary["边界主线：调用外部系统"]
-    Adapter["平台适配"]
+  subgraph Extension["扩展主线：受控接入生态"]
+    ExtContract["Extension Contract"]
+    PluginHost["Plugin Runtime Host"]
+    AdapterBridge["Compatibility Adapter"]
   end
 
-  External[("外部资源")]
+  subgraph Boundary["边界主线：访问外部系统"]
+    Platform["平台适配"]
+  end
+
+  Contract["稳定契约与安全控制\nDTO / 事件 / 端口 / 权限 / 产物 / 审计"]
+  External[("OS / Git / MCP / Model / Remote / ACP / Plugin Ecosystem")]
 
   Surface --> Assembly
-  Assembly --> Capability
+  Assembly --> Feature
   Assembly --> Kernel
   Assembly --> Execution
-  Assembly --> Extension
-  Assembly --> Adapter
-  Capability --> Kernel
+  Assembly --> ExtContract
+  Assembly --> PluginHost
+  Assembly --> Platform
+  Feature --> Kernel
   Kernel --> Execution
-  Kernel --> Extension
-  Execution --> Adapter
-  Extension --> Adapter
-  Assembly --> Guard
-  Capability --> Guard
-  Kernel --> Guard
-  Execution --> Guard
-  Extension --> Guard
-  Adapter --> Guard
-  Adapter -. "边界外调用" .-> External
+  Kernel --> ExtContract
+  Kernel --> PluginHost
+  Execution --> Platform
+  Execution --> ExtContract
+  PluginHost --> AdapterBridge
+  AdapterBridge --> External
+  Platform -. "边界外调用" .-> External
+  Surface --> Contract
+  Assembly --> Contract
+  Feature --> Contract
+  Kernel --> Contract
+  Execution --> Contract
+  ExtContract --> Contract
+  PluginHost --> Contract
+  AdapterBridge --> Contract
+  Platform --> Contract
 ```
 
-| 职责角色 | 负责 | 不负责 |
+| 职责角色 | 当前负责 | 复杂性红线 |
 |---|---|---|
-| 产品入口 | 桌面、CLI、Web、Server、Remote、ACP、SDK 的交互、协议转换和状态展示 | 选择完整产品形态；创建具体服务实现 |
-| 产品组装 | 根据产品配置和入口约束选择能力包、服务实现、插件绑定和默认策略 | 实现代理内核状态机；在任务运行时临时查找服务 |
-| 产品能力 | 维护用户可见功能的命令、界面贡献、权限/副作用、产物、降级和验证责任 | 直接执行系统 I/O；拥有代理内核状态；实现具体 UI/React/Tauri 组件 |
-| 代理内核 | 维护会话、工作区、任务、权限事实、事件、hook 事实、上下文、记忆和调度 | 依赖 Tauri、React、ACP 协议、模型客户端或文件系统具体实现 |
-| 执行层 | 执行工具、技能、MCP 工具、沙箱和评审工作流 | 决定产品形态；直接授权 |
-| 扩展治理 | 管理插件、外部 hook 贡献、外部生态适配和待确认效果 | 绕过安全控制；写审计或最终状态；改写内核 hook 顺序、超时或错误策略 |
-| 平台适配 | 实现文件、终端、Git、远程、模型服务、MCP 连接等外部系统调用 | 决定产品能力；要求普通模块直接依赖具体实现 |
-| 稳定契约与安全控制 | 定义跨产品、运行和边界的 DTO、事件、端口、能力/副作用、权限、审计、产物和类型化错误 | 依赖上层实现；承载具体界面或具体策略实现 |
+| 产品入口 | 桌面、CLI、ACP、Web、Server、Remote、SDK 等入口的交互、协议转换和状态展示 | 不能选择完整产品形态；不能直接创建 concrete provider 或插件运行单元 |
+| Product Assembly | 根据入口和发布配置选择能力包、服务实现、策略、extension binding 和 plugin host binding | 不能成为运行时 service locator；不能在任务中临时查找全局服务 |
+| 产品能力 | 维护用户可见功能的命令、权限/副作用、产物、降级和验证责任 | 不能拥有 Agent Kernel 状态机；不能直接执行系统 I/O |
+| Agent Kernel | 维护 session、workspace、turn、权限事实、事件、上下文、调度和审计事实 | 不能依赖 Tauri、React、ACP 协议、模型 provider、文件系统实现或具体插件生态对象 |
+| Execution | 执行工具、skills、MCP 工具、sandbox 和评审工作流 | 不能决定产品形态；不能直接授权或写产品状态 |
+| Extension Contract | 定义 extension point、descriptor、effect candidate、trust/source、UI contribution 和 availability | 不能携带 React/Tauri implementation、runtime handle 或具体生态对象 |
+| Plugin Runtime Host | 管理插件生命周期、隔离域、IPC、deadline、epoch、diagnostics、adapter registry 和候选效果路由 | 不能直接写内核权威状态、权限结果、审计事实、工具结果或 UI implementation |
+| Compatibility Adapter | 将 OpenCode、ACP 外部 agent/tool bridge、Claude Code、Codex 或 BitFun native plugin API 映射为 BitFun 稳定合同 | 不能成为产品能力 owner；不能绕过 host、contract 和安全控制 |
+| 平台适配 | 实现文件、终端、Git、远程、模型服务、MCP 连接等外部系统调用 | 不能要求上层依赖 concrete provider；不能表达产品策略 |
+| 稳定契约与安全控制 | 定义跨主线 DTO、事件、端口、能力/副作用、权限、审计、产物和 typed error | 不能依赖上层实现；不能承载具体界面或 concrete 策略 |
 
-依赖方向只允许流向稳定契约或注入端口。运行时可以从代理内核调用执行端口、从执行层调用平台端口，但这不等于编译期依赖具体实现。
-稳定契约与安全控制不是外部调用的子层，而是三条主线都要遵守的共同规则。除产品组装边界外，普通模块不应同时认识接口和
-具体服务实现（provider）。
+普通模块不应出现 `A -> B -> C` 的纯透传依赖：如果 A 的真实需求是 C 的稳定接口，A 应直接依赖 C 的 contract/port，
+而不是通过 B 暴露一次薄转发。例外只限于兼容门面、多实现反腐层、Product Assembly、Plugin Runtime Host 边界或带删除计划的迁移期 facade。
 
-划分原则：
+## 4. 插件和扩展如何进入
 
-- 先按责任划分，再映射到 crate；不要用当前目录结构反推架构边界。
-- 用户可见能力归产品能力；会话、任务、权限事实和事件归代理内核；外部系统调用归平台适配。
-- 产品差异在产品入口、产品组装和产品能力中表达，不进入代理内核和执行层的通用逻辑。
-- 能力是否启用、降级或替换，由产品组装、安全控制面和对应能力责任方共同决定。
+插件生态进入 BitFun 只能走一条路径：声明能力、通过 Host 隔离执行、返回 descriptor 或 candidate effect、再由安全控制面和能力责任方裁决。
 
-依赖关系：
+最小闭环对象：
 
-- 产品组装是组装入口，可以选择具体服务实现，并把稳定端口注入代理内核、执行层、扩展治理和平台适配。
-- 代理内核只通过端口调用执行层；执行层和扩展治理只通过端口访问平台适配。
-- 稳定契约与安全控制为所有层提供共同语言；它定义 DTO、事件、端口、权限、审计和产物，不承载具体业务实现。
-- 外部资源只能通过平台适配进入系统；其他层不得直接调用 OS、Git、MCP server、模型服务或远程主机。
-
-## 3. 产品如何成形
-
-产品形态由组装期决定，不由运行时插件或 Cargo feature 单独决定。核心对象如下：
-
-| 概念 | 含义 |
+| 概念 | 当前含义 |
 |---|---|
-| `SurfaceContract` | 产品入口声明：入口类型、宿主/协议、执行域、展示能力、权限和产物展示方式。它不选择完整产品形态。 |
-| `ProductProfile` | 产品配置：构建、发布或白标配置选择的内置能力、默认服务、默认策略和裁剪范围。 |
-| `CapabilityPack` | 能力包：一个产品能力的最小声明单元，包含命令、界面贡献、权限/副作用、产物、工具或服务实现需求。 |
-| `DeliveryProfile` | 组装结果：产品组装消费 `ProductProfile` 与 `SurfaceContract` 后生成的当前入口交付形态。 |
-| `CapabilityPlan` | 组装期能力计划：当前产品形态准备注册哪些能力、命令、服务和扩展入口。 |
-| `CapabilityAvailabilitySet` | 运行时可用性：当前环境、策略、授权状态和服务健康状态下哪些能力可用，哪些需要降级。 |
-| `CapabilitySet` | 产品组装输出的能力集合视图：由 `CapabilityPlan` 和 `CapabilityAvailabilitySet` 组成，用于策略判断和插件运行时绑定；不作为第三套权威来源。 |
-| `OverridePoint` | 显式覆写点：允许插件或能力包替换已声明扩展点时，必须声明稳定 id、责任方、适用入口、冲突策略、回退、权限/副作用、验证和回滚方式。 |
+| `ExtensionPoint` | 稳定扩展点：id、owner、适用入口、输入输出、权限/副作用、默认行为、fallback 和验证责任 |
+| `PluginRuntimeBinding` | Product Assembly 注入的插件运行时绑定：disabled、projection-only 或 host client |
+| `PluginDispatchEnvelope` / `PluginResponseEnvelope` | Kernel / Execution / Host 边界的 typed envelope，包含 epoch、deadline、diagnostics 和 idempotency 信息 |
+| `PluginEffectCandidate` | 插件候选效果；必须经过权限、安全、能力 owner 和审计路径后才能生效 |
+| `ProviderCandidate` | 插件贡献 tool/MCP provider 的候选声明；包含 source、capability、owner、Tool ABI、permission/effect gate、materialize 条件和拒绝审计，不能直接成为 provider 权威源 |
+| `PluginTrustPolicy` / `PluginSourceRef` | 插件来源、hash、信任状态、数据类别、执行域和能力范围 |
+| `UiContributionDescriptor` | 声明式 UI contribution；只描述 slot、command、settings entry、state view、fallback，不携带可执行 UI |
+| `CompatibilityAdapterManifest` | 外部生态适配声明：支持的 hook/tool/event/UI/effect 能力、不可用原因和降级方式 |
+
+进入流程：
+
+1. Product Assembly 根据交付形态、策略和工作区事实选择 `PluginRuntimeBinding`、trust policy、adapter set 和 extension availability。
+2. Plugin Runtime Host 加载或连接受控插件运行单元，校验 source、manifest、capability、data category、deadline 和 execution domain。
+3. Compatibility Adapter 将外部生态 API 映射成 BitFun 的 descriptor、provider candidate、event subscription 或 `PluginEffectCandidate`。
+4. Agent Kernel 和 Execution 只通过 typed envelope 与 Host 通信；Host 不能直接写 kernel state、permission decision、audit event 或 tool result。
+5. 安全控制面和能力 owner 对 candidate effect 做最终判断；产品入口只展示 descriptor、状态、错误、产物和确认选项。
+
+当前必须优先建立的能力：
+
+- 可执行 Host 的最小生命周期：init、manifest、dispatch、deadline、dispose、failure quarantine、diagnostics。
+- disabled / projection-only / host 三类 runtime binding 与产品能力状态的一致映射。
+- effect candidate 的权限、副作用、审计和回滚语义。
+- 同一条 OpenCode-compatible plugin 真实消费路径，避免只做空 registry。P0 必须覆盖 source 注册/启用、Desktop command/settings、permission 确认、effect materialize、CLI diagnostics 和拒绝路径；ACP 外部 agent/tool bridge 只能复用合同，不作为 P0 验收替代。
+- 最小 UI contribution descriptor，只覆盖当前消费方需要的 slot / command / settings / readonly state view；其他 UI 能力返回 typed unsupported。
+
+暂不提前展开的复杂度：
+
+- 同时兼容多个生态的完整插件 API。
+- 所有入口一次性支持完整 UI Extension Contract。
+- 插件直接覆写 first-party 能力，除非存在明确 `OverridePoint`、owner、冲突策略、回滚和验证。
+- 任意可写 transform、无限制 JS/TS runtime、localhost 无约束 API 或插件直接调用内部 service manager。
+
+MCP 的原生路径和插件路径必须拆开：
+
+| 能力来源 | Owner | 是否经过 Plugin Runtime Host | 结果形态 |
+|---|---|---|---|
+| 用户配置的原生 MCP server | Platform Adapter + Execution + Stable Contracts | 否 | MCP tool/resource/prompt 按既有 Tool ABI 执行 |
+| 插件贡献的 MCP/tool provider | Plugin Runtime Host + Compatibility Adapter + Execution | 是 | 先产出 provider candidate，再由 Tool ABI、permission/effect gate 和 owner 裁决后 materialize |
+| ACP 外部 agent/tool bridge | Interfaces/acp + Extension Contract | 不作为 P0 插件体验；可复用权限和诊断合同 | 协议描述符、权限桥接和候选效果，不直接写最终状态 |
+
+能力状态只允许一个 owner 做权威判断，其他层做投影：
+
+| 层级状态 | Owner | 可投影为产品状态 | 是否进入 wire contract |
+|---|---|---|---|
+| `PluginRuntimeBinding::Disabled` | Product Assembly | `unsupported` 或 `temporarily-unavailable`，取决于 reason | 只投影 availability，不暴露内部 binding |
+| `PluginRuntimeBinding::ProjectionOnly` | Product Assembly + Host boundary | `projection-only` 或 `status-only` | 是，作为只读能力事实 |
+| Host available | Product Assembly + Plugin Runtime Host | `full`，但仅对已声明 extension point 生效 | 是，必须带 host diagnostics 和 source facts |
+| `PluginEffectCandidate` pending | Security Control Plane + capability owner | `temporarily-unavailable`（reason: `pending-confirmation`）或 `policy-denied` | 是，必须可审计 |
+| Unsupported surface | Product Assembly | `unsupported` | 是，入口只能展示，不得自行改写 |
+
+## 5. 产品如何成形
+
+产品形态由组装期决定，不由任务运行时、插件配置或单个 Cargo feature 临时决定。
+
+| 概念 | 当前含义 |
+|---|---|
+| `DeliveryProfile` | 入口交付形态，例如 ProductFull、Desktop、CLI、ACP、Web、MobileWeb、Server、Remote、SDK |
+| `ProductCapabilityId` / `CapabilityPack` | first-party 能力声明单元，例如 CodeAgent、DeepReview、DeepResearch、MiniApp、Canvas |
+| `CapabilityPlan` | 组装期准备注册的 first-party 能力、命令、服务和扩展入口 |
+| `CapabilityAvailabilitySet` | 运行时环境、策略、授权和服务健康状态下的可用、降级或不可用事实 |
+| `OverridePoint` | 允许插件或能力包替换已声明扩展点时必须具备的显式合同；默认不存在覆写权 |
 
 组装流程：
 
-1. 产品入口提供 `SurfaceContract`，发布或白标配置选择 `ProductProfile`。
-2. 产品组装校验能力包的依赖、冲突、适用入口、服务实现需求、权限/副作用和覆写规则。
-3. 产品组装生成 `DeliveryProfile`、`CapabilityPlan`、`CapabilityAvailabilitySet`，并以 `CapabilitySet` 暴露能力集合视图。
-4. 产品组装注入稳定端口、服务实现、工具注册表、界面贡献、插件运行时绑定和安全策略。
+1. 产品入口声明自身入口类型和约束，发布配置选择目标 `DeliveryProfile`。
+2. Product Assembly 校验 first-party 能力包和 extension contribution 的依赖、冲突、适用入口、服务需求、权限/副作用和降级语义。
+3. Product Assembly 生成 `CapabilityPlan`、`CapabilityAvailabilitySet`、extension availability 和 plugin runtime binding。
+4. Agent Kernel、Execution、产品能力、Plugin Runtime Host 和平台适配只消费注入后的稳定对象，不反向读取产品入口或 concrete provider。
 
 必须保持的规则：
 
-- 内置功能通过 `ProductProfile` 与 `CapabilityPack` 加入或裁剪；插件不是裁剪内置功能的主要机制。
-- 产品能力是 `/goal`、DeepReview、MiniApp、设置、评审入口等用户功能的责任方；它维护体验边界和验证责任，但不拥有内核状态机。
-- 运行时策略、授权状态和服务健康状态只能让能力降级，不能启用构建包里不存在的能力。
-- 能力事实不能散落在 Rust feature、前端路由、Tauri command、工具注册表和插件配置里各自维护；至少要有共同的能力 id、
-  责任方、依赖/冲突、适用入口、权限/副作用、产物、降级语义和验证责任方。
+- first-party 能力通过 Product Assembly 加入或裁剪；插件不是裁剪内置功能的主要机制。
+- 运行时策略、授权状态和服务健康状态只能让能力降级，不能启用构建包里不存在的 first-party 能力。
+- 插件可以追加 contribution 或返回 candidate effect；替换已声明行为必须走 `OverridePoint`。
+- 能力事实不能散落在 Rust feature、前端路由、Tauri command、工具注册表和插件配置里各自维护；至少要共享能力 id、责任方、入口适用性、权限/副作用、产物、降级语义和验证责任。
+- 兼容 facade 必须减少调用方迁移成本或保护外部 API；如果 facade 只做无语义透传，应优先删除或让调用方直接依赖 stable contract。
 
-## 4. 任务如何运行
+## 6. 任务如何运行
 
-产品入口只负责把用户动作转换成稳定请求；代理内核负责维护任务事实；执行、扩展和平台访问都通过注入端口完成。
+产品入口只负责把用户动作转换成稳定请求；Agent Kernel 负责维护任务事实；执行、扩展和平台访问都通过注入端口完成。
 
 运行步骤：
 
-1. 产品入口把命令、设置或界面贡献映射为稳定请求。
-2. 代理内核产生事件、权限请求、工具请求、任务状态、hook 事实和审计事实。
-3. 执行层处理工具、技能、MCP 工具、沙箱和评审工作流；执行前必须消费权限、沙箱和能力事实。
-4. 扩展治理处理插件生命周期、外部生态适配和待确认效果；待确认效果必须回到安全控制面后才能生效。
-5. 平台适配通过稳定端口访问文件、终端、Git、远程、MCP 服务端、模型服务等外部资源。
-6. 产品入口只展示状态、产物、错误和确认选项，不成为最终授权或审计来源。
+1. 产品入口把命令、设置或协议请求映射为稳定 request。
+2. Agent Kernel 产生 event、permission request、tool request、task state、hook facts 和 audit facts。
+3. Execution 在执行工具、skills、MCP 工具、sandbox 或评审工作流前，消费权限、沙箱和能力事实。
+4. Plugin Runtime Host 只通过 typed envelope 接收事件、hook 或 tool 调用，返回 descriptor、provider candidate 或 candidate effect。
+5. 平台适配通过 stable port 访问文件、终端、Git、远程、MCP server、模型服务等外部资源。
+6. 安全控制面和能力 owner 决定 candidate effect 是否生效；产品入口只展示状态、产物、错误和确认选项。
 
 跨入口能力不要求界面完全一致，但降级语义必须一致。每个能力在每个入口上只能落入以下状态之一：`full`、
-`artifact-only`、`status-only`、`temporarily-unavailable`、`unsupported` 或 `policy-denied`。入口只能展示这些状态，
-不能自行发明新的状态；产物降级必须能追踪产出方和执行域。
+`projection-only`、`artifact-only`、`status-only`、`temporarily-unavailable`、`unsupported` 或 `policy-denied`。
+入口只能展示这些状态，不能自行发明新的状态；产物降级必须能追踪产出方和执行域。
 
-## 5. 扩展如何进入
+## 7. 安全、依赖和风险控制
 
-插件、MCP、ACP 外部代理/工具桥接和外部生态都属于边界能力，不得直接成为内部最终责任方。
-
-| 入口 | 正确位置 | 边界 |
-|---|---|---|
-| 插件运行时 | 扩展治理 | 管理插件生命周期、隔离执行域和待确认效果；不写代理内核状态、权限结果或审计事实。 |
-| 外部生态适配 | 扩展治理 | 把 OpenCode、Claude Code、Codex 等外部 API 映射为 BitFun 稳定描述符和待确认贡献。 |
-| MCP | 平台适配 + 执行层 + 稳定契约 | MCP 连接和目录在平台适配；tool/resource/prompt 的展示和执行映射在执行层和稳定契约。 |
-| ACP 协议入口 | 产品入口与接口责任方 | 拥有协议层请求/响应、客户端生命周期、启动探测和工作区选择。 |
-| ACP 外部 agent/tool bridge | 扩展治理 | 只暴露外部代理/工具描述符和权限/事件桥接，不写最终状态。 |
-
-插件和兼容适配默认只能追加贡献或产出待确认效果。只有产品明确声明 `OverridePoint` 时，才允许替换已声明扩展点。
-最终排序、冲突处理、回滚和审计必须由产品组装、安全控制面和能力责任方共同裁决。ACP 的 allow/ask 只能表达授权事实，
-不能替代 BitFun 对文件、shell、网络、凭据、远程执行和本地平台动作的安全判定。
-
-扩展点设计原则：
-
-- 每个扩展点必须有稳定 id、责任方、适用入口和默认行为。
-- 扩展点必须声明输入、输出、权限、副作用、数据类别和执行域。
-- 扩展点必须定义冲突处理、排序、回退和回滚方式；未定义时只能追加，不能替换。
-- 插件或外部生态只能返回待确认效果；最终是否生效由安全控制面和能力责任方判断。
-- 每个扩展点都必须能被测试和审计；不支持的入口必须返回明确的不可用或不支持状态。
-
-## 6. 安全与风险
-
-安全边界贯穿三条主线：产品主线声明能力和入口约束，运行主线消费权限和能力事实，边界主线执行外部调用并保留审计。
-每次工具、MCP、插件、hook、shell、网络、文件、浏览器/桌面或远程动作，都必须归一为能力、副作用和安全决策事实。
+安全边界贯穿所有主线：产品主线声明能力和入口约束，运行主线消费权限和能力事实，扩展主线产出受控贡献，
+边界主线执行外部调用并保留审计。每次工具、MCP、ACP、plugin、hook、shell、网络、文件、浏览器/桌面或远程动作，
+都必须归一为能力、副作用和安全决策事实。
 
 关键约束：
 
-- 代理内核维护可审计事实：session、workspace、turn、agent/subagent、权限来源、执行域、事件序列、
-  hook 顺序/超时/错误策略、取消、恢复/检查点和可诊断性事实（DFX facts）。
-- 执行层在工具、MCP、skills、评审工作流执行前消费权限、沙箱和能力事实。
-- 扩展治理声明来源、hash、能力、数据类别、副作用、执行域和界面贡献范围；未知或声明不完整的能力默认受限。
-- 平台适配表达执行位置和降级原因，例如本地主机、远程 SSH、容器、ACP client、MCP server、plugin domain。
-- 界面只展示安全状态和用户选项；组织策略、安全拒绝和凭据保护不能被本地确认绕过。
+- Agent Kernel 维护可审计事实：session、workspace、turn、agent/subagent、权限来源、执行域、事件序列、hook 顺序/超时/错误策略、取消、恢复/检查点和诊断事实。
+- Execution 在工具、MCP、skills、评审工作流执行前消费权限、沙箱和能力事实。
+- Plugin Runtime Host 声明来源、hash、能力、数据类别、副作用、执行域和 UI contribution 范围；未知或声明不完整的能力默认受限。
+- 平台适配表达执行位置和降级原因，例如本地主机、远程 SSH、容器、ACP client、MCP server 或 plugin execution domain。
 - 注册尽量在组装期完成；任务运行期间避免临时查找全局服务、修改全局注册表或做高成本扫描。
+- 默认保持当前能力、权限、工具、事件、session、remote 和 release 形态等价。若 P0 插件体验需要改变这些行为，必须先记录产品决策、用户影响、迁移/回滚方案、指标和验证，而不是用兼容 facade 永久冻结旧路径。
 
-默认不变要求是：除非经过单独设计评审并明确记录影响，迁移必须保持默认能力集合、权限语义、工具曝光、事件语义、
-session 生命周期、remote 行为和 release 构建形态等价。
+公开接口预算：
 
-主要风险与保护方式：
+- 新增 public type / trait / module 前，必须写明唯一 owner、当前消费方、P0 插件体验关系、wire contract 影响和退场条件。
+- public API budget 不能只写在 PR 正文；必须落在 crate-local budget/allowlist 或 `scripts/core-boundaries/rules/**` 可检查规则中。跨 crate 插件 descriptor、envelope、host API 或 availability API 必须有边界脚本阻断 raw JSON ABI、无 consumer API 和 product-full 回流。
+- Plugin Runtime Contract 不得把 `serde_json::Value` 作为长期稳定 ABI。JSON payload 只能是生态 adapter 内部解析细节；跨 Host 边界必须补齐 extension point、source、capability、deadline、epoch、data category、side effects、idempotency 和 diagnostics。
+- `runtime-ports` 可以继续作为 crate 边界，但不能继续作为单文件语义抽屉；新增插件合同前应先按 plugin、agent_session、remote、tool_provider、events、session_store、service_capability 拆分模块。
+- `bitfun-core`、LSP/Git/service facade 和旧 import 兼容路径只能服务迁移；新调用方不得通过它们引入 owner crate 已暴露的 stable contract。
 
-| 风险 | 保护方式 |
-|---|---|
-| 代理内核膨胀为新的巨型核心 | 内核只拥有平台无关任务状态；产品功能、工具具体实现、平台适配和界面留在对应边界 |
-| 产品组装变成全局状态中心 | 组装只输出不可变运行时部件；产品状态归入口、能力责任方或代理内核 |
-| 产品配置、Cargo feature、运行时可用性和插件配置互相替代 | 明确区分构建期产品形态、构建依赖、运行时状态和扩展贡献 |
-| 插件反向改变产品形态 | 插件默认只追加或产出待确认效果；覆写只能发生在显式 `OverridePoint` |
-| 外部系统被当成底层依赖层 | 外部资源只在平台适配输入输出边界出现；普通层依赖端口 / 契约 |
-| 权限、工具、MCP、ACP 语义迁移后不等价 | 保留兼容门面，补安全决策、事件映射、能力清单快照和产品形态检查 |
+链式依赖整改规则：
 
-## 7. 完成判定
+| 问题形态 | 判断 | 整改方向 |
+|---|---|---|
+| A 只通过 B 调 C，B 没有策略、校验、缓存、反腐或多实现选择 | 不合理透传 | A 直接依赖 C 的 stable contract/port，删除 B 的薄转发 |
+| B 是 Product Assembly、Plugin Runtime Host、兼容 facade 或协议反腐层 | 可以保留 | 明确 B 的责任和删除/稳定边界，不让它继续堆叠下一层 facade |
+| 新 descriptor/registry/matrix 没有当前消费方 | 过早抽象 | 等待真实消费路径；若已进入代码，必须绑定 owner 和验证 |
+| 迁移只新增新路径但旧 core 主体仍完整存在 | 不算收敛 | 同步删除、迁移或显著简化旧路径，并补边界验证 |
 
-- `bitfun-core` 不再是事实上的完整运行时权威入口，而是兼容门面、`product-full` 组装边界和迁移期适配。
-- 代理内核能在不依赖 app crate、Tauri、Web UI 或服务具体实现的情况下完成最小 session / turn / event stream。
-- `/goal`、DeepReview、MiniApp 等产品功能通过能力包组装，不拥有代理内核状态机。
-- 内置能力通过 `ProductProfile` 和 `CapabilityPack` 加入或裁剪；运行时可用性通过 `CapabilityPlan`、
-  `CapabilityAvailabilitySet`、服务健康状态和策略结果表达。
-- 产品 API 同时包含 Rust 内核 API 和界面扩展契约；OpenCode、ACP 外部代理/工具桥接和 plugin adapter 通过扩展治理映射到这些 API。
-- 工具、MCP、skills、sandbox、local/remote runtime 和 harness 执行能力归执行层；具体 OS、服务实现和远程实现归平台适配层。
-- Desktop、CLI、Web、Server、ACP、Remote 和独立 SDK 都通过产品组装显式选择能力，不通过下层 `if desktop/cli/web/server`
-  分支表达差异。
-- 所有会影响默认能力、权限、工具、事件、session、remote 或 release 形态的迁移，都有行为等价保护、依赖边界检查、
-  产品形态验证和必要的性能/构建影响说明。
+## 8. 完成判定
+
+当前阶段完成以“插件生态最小闭环 + 关键产品路径复杂度下降”判定：
+
+- Extension Contract、Plugin Runtime Host、effect candidate、trust policy、typed availability 和同一条 OpenCode-compatible plugin Desktop command/settings + CLI diagnostics 垂直切片形成闭环；ACP 外部 agent/tool bridge 不能满足该完成项。
+- 插件、ACP 外部 agent/tool bridge、hook、插件贡献的 tool provider 和 UI contribution 都通过稳定 descriptor / envelope / candidate effect 进入，不能直接写内核权威状态；原生 MCP 继续走 Execution + Platform Adapter。
+- `bitfun-core` 收敛为 compatibility facade、`product-full` 组装边界和少量迁移期 adapter，不再是事实上的完整运行时权威入口。
+- ProductFull、Desktop、CLI 和 ACP 的默认能力、权限、工具、事件、session、remote 和 release 形态默认保持等价；P0 插件必选面只由 Desktop/CLI 验收，若主动改变 ACP 或其他入口行为，必须进入 P0+ 决策并记录影响说明、迁移/回滚和验证指标。
+- Agent Kernel 能在不依赖 app crate、Tauri、Web UI、ACP 协议、concrete service manager 或具体插件生态对象的情况下完成最小 session / turn / event stream。
+- `/goal`、DeepReview、MiniApp、Canvas 等产品功能通过能力包和产品能力责任边界组装，不拥有 Agent Kernel 状态机。
+- 工具、MCP、skills、sandbox、local/remote runtime 和 harness 执行能力归 Execution；具体 OS、服务实现和远程实现归平台适配。
+- Web、Mobile Web、Server、Remote 和 SDK 不默默继承完整产品或插件能力；P0 中不得为这些入口声明 `full` 插件能力，只能显式表达 projection-only、artifact-only、status-only、temporarily-unavailable、unsupported 或 policy-denied；P0+ 若进入 `full` 必须有单独决策、迁移/回滚和验证指标。
+- 所有会影响默认能力、权限、工具、事件、session、remote、plugin effect 或 release 形态的迁移，都有行为等价保护、依赖边界检查、产品形态验证和必要的性能/构建影响说明。
 
 外部产品和技术调研不写入本文主线；相关证据沉淀到 [`../sdlc-harness/research/`](../sdlc-harness/research/)。

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -1,154 +1,232 @@
 # BitFun Core 拆解与运行时迁移计划
 
 本文只维护后续执行计划。稳定目标以
-[`product-architecture.md`](../architecture/product-architecture.md)、
-[`agent-runtime-services-design.md`](../architecture/agent-runtime-services-design.md) 和
-[`plugin-runtime-host-design.md`](../architecture/plugin-runtime-host-design.md)
-为准；已完成事实归档在 [`core-decomposition-completed.md`](core-decomposition-completed.md)。
-设计文档默认保持稳定，只有目标架构本身需要修正时才修改。
+[`product-architecture.md`](../architecture/product-architecture.md) 为准；
+[`agent-runtime-services-design.md`](../architecture/agent-runtime-services-design.md) 补充接口与 crate 约束；
+[`plugin-runtime-host-design.md`](../architecture/plugin-runtime-host-design.md) 是插件运行时和生态兼容的当前主线详细设计。
+已完成事实归档在 [`core-decomposition-completed.md`](core-decomposition-completed.md)。
+
 本计划文件名继续保留 `core-decomposition`，因为它记录的是 `bitfun-core` 收敛和 owner 迁移的执行路径。
 
 ## 1. 执行原则
 
+- 当前第一优先级是插件生态和扩展能力支撑：Extension Contract、Plugin Runtime Host、candidate effect、安全校验和真实生态适配消费路径必须优先闭环。P0 固定首条体验是 OpenCode-compatible plugin 最小垂直切片，必须覆盖 source 注册/启用、Desktop command/settings、permission 确认、effect materialize 和 CLI diagnostics；ACP 外部 agent/tool bridge 只能作为 P0+ 互操作路径，不能替代该验收。
+- 同时保护关键产品路径：ProductFull、Desktop、CLI、ACP，以及 Web / Mobile Web / Server / Remote / SDK 的显式降级或投影。
 - `bitfun-core` 最终收敛为 compatibility facade、`product-full` 组装边界和少量迁移期 adapter。
-- 迁移按概念 owner 判断：Product Surface、Product Assembly、Product Feature、Agent Kernel、Execution、Extension、Cross-platform Adapter、Stable Contracts。
-- 外部系统不是 owner 层级；OS、Git、MCP server、AI provider、remote host、browser runtime 和 plugin package 只在
-  adapter I/O 边界出现。除 Product Assembly 外，调用方应依赖 port、descriptor 或 stable contract，而不是 concrete provider。
-- 新抽象必须同步删除、迁移或显著简化旧 core 主体路径；纯 facade、纯 guard、纯文档或空接口不算完成。
-- Product Assembly 是 composition root；除它以外，普通层级只能依赖稳定 contract、port、descriptor 或被注入的 typed part。
+- Product Assembly 是 composition root；除它以外，普通层级只能依赖 stable contract、port、descriptor 或被注入的 typed part。
+- 新抽象必须同步删除、迁移或显著简化旧 core 主体路径；纯 facade、纯 guard、纯文档、纯 descriptor、纯 registry 或空接口不算完成。
+- 禁止新增没有语义的链式透传。若 A 的真实需求是 C 的稳定接口，且 B 没有策略、校验、多实现选择、反腐或兼容责任，应让 A 直接依赖 C 的 contract/port。
 - 产品特性和内核能力分开：长程任务、调度、权限、上下文、session/workspace、memory、DFX、hook/event 属于 Agent Kernel；
   `/goal`、UI、settings、命令和默认策略属于 Product Feature。
-- 主体进程插件 API 分阶段开放：当前只落地 `PluginRuntimeClient`、binding、availability 和 dispatch/response envelope；effect candidate、trust policy、descriptor 与 lifecycle 语义必须在后续 Host / UI Extension 阶段成组落地。任何阶段都不得让主体进程感知具体生态 adapter。
-- 任何会改变权限、工具 schema、事件语义、session 生命周期、remote 行为、MiniApp 行为、UI extension contract 或交付形态的变更必须暂停并单独评审。
+- 暂缓的是全量生态兼容、全入口 UI Extension 矩阵、任意可写 transform 和无约束插件 runtime；不是插件生态主线本身。
+- 默认保持权限、工具 schema、事件语义、session 生命周期、remote 行为、MiniApp 行为和交付形态等价；若 P0 插件体验需要主动改变，必须有产品决策记录、用户影响、迁移/回滚、指标和验证。
 
-## 2. 当前基线
+## 2. 执行输入假设
 
-- workspace 已按六层物理目录展开：`interfaces -> assembly -> adapters -> services -> execution -> contracts`。
-- Runtime Services、Agent Runtime、Tool Contracts、Tool Execution、Harness、Product Domains、Services Core、Services Integrations 等 owner crate 已建立。
-- `bitfun-core --no-default-features` 已裁掉多批 concrete provider 和 direct provider 依赖；Desktop、CLI、ACP 仍通过 `bitfun-core/product-full` 获取完整产品能力。
-- Computer Use 系统动作错误码、memory workspace Git baseline / diff / render、MCP OAuth credential store、generic JSON persistence、storage cleanup、front-matter markdown、workspace instruction file IO/order、token usage persistence/query、本地/远端 workspace runtime provider 已继续收口到 services owner；core 只保留既有工具 envelope、产品路径注入、授权入口、workspace binding/re-export 和 deprecated 兼容 wrapper。
-- Agentic frontend event projection 和 AgenticEvent projection manifest 已进入 `bitfun-events`；Tauri/WebSocket transport 不再内联事件字段映射或 legacy event allowlist。
-- Tool ABI 基础合同已进入 `tool-contracts`：materialized snapshot、provider identity、default permission/effect filter、cancellation contract 和 stale-call guard 由 owner crate 提供，core 只投射现有产品 Tool 元数据。
-- Terminal / ExecCommand、remote SSH concrete execution、workspace search、debug-log file append/redaction/dispatch、AI provider adapter runtime、browser CDP、WebFetch/WebSearch、review platform provider service 等多批 owner 已迁出或收口到 port/provider。
-- Boundary scripts 已覆盖核心 owner 防回流、six-layer path 解析、facade-only 文件、custom agent owner / custom subagent wrapper 保护和重点 feature gate。
+已完成事实以 [`core-decomposition-completed.md`](core-decomposition-completed.md) 为准，本文只记录后续执行需要依赖的输入假设：
 
-## 3. 目标差距
+- workspace 已按 `interfaces -> assembly -> adapters -> services -> execution -> contracts` 物理目录展开，但概念 owner 仍需通过当前迁移继续收敛。
+- Desktop、CLI、ACP 当前仍通过 `bitfun-core/product-full` 获取完整产品能力；P0 插件体验不能继续把这个状态固化为新入口依赖。
+- Tool ABI、runtime services、agent runtime、product capabilities 和 plugin disabled / projection-only 基础边界已存在；真实 Plugin Runtime Host、OpenCode-compatible plugin 消费路径和 candidate effect 闭环仍未完成。
+- Boundary scripts 可用于 owner 防回流、six-layer path、facade-only 文件和重点 feature gate，但插件 P0 需要补充更具体的 host / extension / adapter checks。
 
-| 差距 | 影响 | 收敛要求 |
+## 3. 当前目标差距
+
+| 差距 | 影响 | 当前收敛要求 |
 |---|---|---|
-| 部分 concrete owner 仍在 core 或产品命令路径 | 层级依赖和平台差异仍可能回流 | 继续迁移剩余 process/session host adapter、SDK-facing concrete provider 选择、DeepReview / prompt-cache / product command host adapter 等仍由 core 持有的产品耦合 I/O owner |
-| SDK readiness 仍未闭环 | 独立 Agent Runtime SDK 可能牵引 product-full 或 concrete provider | fake-provider smoke、minimal feature、cargo tree/metadata 对比和 API version 保护 |
-| UI Extension Contract 与产品形态矩阵仍需实现 | Desktop/Web/CLI/SDK/ACP 的插件 UI 行为可能不一致 | 建立 descriptor round-trip、fallback、unsupported/unavailable 和只读 state view |
-| Plugin Runtime Host 仍缺少真实执行 Host 和生态 adapter | 插件能力只能表达 disabled / projection-only，不能加载或执行外部插件 | 在 UI Extension Contract 后落地受控 Host facade、effect / trust / diagnostics / deadline / epoch；生态 adapter 在 Host 边界稳定后接入 |
-| OpenCode compatibility adapter 仍缺少真实消费路径 | OpenCode 插件能力无法受控进入 BitFun | 插件 Host 边界稳定后再接入；具体生态 adapter、JS/TS runtime 和可写插件能力后置 |
+| Extension Contract 还没有形成最小闭环 | 插件、插件贡献的 tool provider、ACP 外部 agent、hook、UI contribution 容易各走各的入口 | 围绕 OpenCode-compatible plugin 第一条体验定义 extension point、descriptor、availability、trust/source、candidate effect 和 fallback 的最小稳定合同 |
+| Plugin Runtime Host 缺少可执行边界 | 插件能力只能表达 disabled / projection-only，不能受控加载或执行外部贡献 | 建立 host lifecycle、dispatch envelope、deadline、diagnostics、failure quarantine 和 dispose 语义 |
+| 真实生态适配缺少消费路径 | OpenCode-compatible plugin 能力无法验证合同是否可用 | 先落 OpenCode-compatible plugin 最小适配链路；ACP 外部 agent/tool bridge 可复用合同但不替代 P0 验收 |
+| 部分 concrete owner 仍在 core 或产品命令路径 | 层级依赖和平台差异仍可能回流 | 只迁移与插件主线或关键产品路径直接相关的 owner，并同步删除或显著简化旧路径 |
+| 部分调用存在薄 facade / 多层透传 | A 模块依赖 B 再依赖 C，真实责任不清 | 建立直接 contract/port 依赖，保留的 facade 必须说明兼容、反腐、多实现选择或 host 边界责任 |
+| SDK minimal readiness 未闭环 | 独立 Agent Runtime 可能牵引 product-full 或 concrete provider | 只做内部 fake-provider smoke、minimal feature、cargo tree/metadata 对比和 API version 保护 |
 
-## 4. 后续大型阶段
+暂缓但不删除的目标：
 
-### Stage D：剩余 Concrete Owner 与 SDK Readiness
+- 所有生态的一次性完整兼容。
+- 所有入口的一次性完整 UI Extension 矩阵。
+- 插件直接覆写 first-party 能力。
+- 任意可写 transform、无限制 JS/TS runtime 和无约束 localhost API。
+- 对外稳定 SDK 发布。
 
-目标：继续把 concrete owner 从 `bitfun-core` / 产品命令路径收口到对应 owner crate，并验证独立 Agent Runtime SDK 边界不会牵引完整产品实现。
+这些目标重新进入执行范围前，必须同时满足：有明确产品场景、已有真实消费路径、能删除或简化旧路径、完成安全评审，并补充 focused verification。
 
-范围：
+P0-A、P0-B、P0-C 不是三个可独立交付的抽象阶段。它们必须围绕同一个 OpenCode-compatible plugin 垂直切片推进：
 
-- 继续迁移剩余 process/session host adapter、SDK-facing concrete provider 选择、DeepReview / prompt-cache / product command host adapter 等仍由 core 持有的产品耦合 I/O owner。
-- Product Assembly 负责选择 provider；Kernel、Execution、Extension、Product Feature 不直接依赖 platform concrete。
-- 建立 SDK minimal fake-provider smoke，确认 minimal feature 不牵引 Desktop、Tauri、Git provider、MCP client、AI HTTP client、remote SSH 或产品 UI。
+- 任何新增 public descriptor、envelope、host facade 或 availability API，必须绑定这条真实消费路径。
+- 如果为了分 PR 降低风险，需要先落内部实现，该实现不得作为稳定 public API 暴露，也不得要求其他模块先适配空 registry。
+- P0 的验收以同一条 canonical scenario trace 为准，而不是以单独 crate 编译、descriptor 存在、host facade 可构建或任一单点消费路径为准。
 
-准出：
+## 4. 后续执行阶段
 
-- 至少完成 2-3 个 concrete owner 的实际迁移，并同步删除或简化 core 旧主体路径。
-- `cargo check --workspace`、`cargo check -p bitfun-core --no-default-features`、SDK minimal smoke、cargo metadata/tree 对比和必要 product checks 通过。
+### Stage P0-A：Extension Contract 最小闭环
 
-### Stage E：UI Extension Contract 与产品形态矩阵
-
-目标：为插件 UI contribution 提供声明式 descriptor，并明确不同交付形态的支持、禁用和降级行为。
-
-准入：本阶段不得只新增 descriptor、registry 或 matrix。任何 UI Extension Contract 代码都必须绑定至少一条既有
-实际消费方或旧路径迁移，例如输入框命令、settings entry、状态投影或插件候选 UI 的实际接入，并同步删除或显著简化旧
-实现；否则只允许保留在设计文档中。
+目标：先让 OpenCode-compatible plugin、插件贡献的 tool/hook/command、UI contribution 和 candidate effect 共享同一套最小合同；原生 MCP 继续走 Execution + Platform Adapter。
 
 范围：
 
-- 定义 slot、route、command/keymap、prompt augmentation、dialog/toast、settings entry、state view descriptor。
-- UI state view 只读；descriptor 不包含 React component、Tauri window、DOM node、renderer handle 或可执行代码。
-- Product Assembly 维护 UI contribution registry、capability matrix 和 unsupported/unavailable fallback。
-- 建立 Desktop、Web、CLI、Server、Remote、ACP、SDK、Mobile Web 的插件能力矩阵。
-
-Stage E 目标 UI Extension 形态矩阵：
-
-| 形态 | UI Extension 状态 | 降级要求 |
-|---|---|---|
-| ProductFull / Desktop / Web / Mobile Web | disabled: NotBuilt | 可声明 UI 扩展能力缺口，但不能执行、渲染或加载外部 UI |
-| CLI / Server / Remote / ACP / SDK | disabled: UnsupportedProfile | 必须返回 typed unsupported，不得隐式复用桌面或 Web UI 实现 |
+- 定义 `ExtensionPoint`、capability/effect descriptor、trust/source、data category、execution domain、availability、fallback 和 typed unsupported/unavailable。
+- 定义 `PluginEffectCandidate` 的权限、副作用、审计、回滚和 owner 裁决语义。
+- 定义最小 `UiContributionDescriptor`，只覆盖当前消费方需要的 slot / command / settings entry / readonly state view。
+- 将已有 disabled / projection-only plugin binding 与 extension availability 对齐。
+- 定义 Plugin Runtime availability 到产品状态的映射，避免 runtime binding、surface state 和 capability availability 各自新增 enum。
 
 准出：
 
-- UI descriptor round-trip、host fallback、unsupported/unavailable 和 product-shape focused tests 通过。
-- Web、Desktop、CLI 不因 UI Extension Contract 引入互相依赖。
+- 必须绑定同一条 OpenCode-compatible plugin canonical scenario trace：manifest/source、descriptor、provider candidate、candidate effect、permission/effect gate 和产品可见状态都服务该端到端体验；不允许只新增 registry 或用单点消费路径宣布 P0-A 完成。
+- 不暴露 React component、Tauri handle、runtime service manager、具体生态对象或 untyped `Any`。
+- 新增或更新具体测试目标，并在 PR 中列出路径；测试至少覆盖 descriptor round-trip、unsupported/unavailable、candidate effect 拒绝路径和 availability 映射。
 
-### Stage F：Plugin Runtime Host 执行边界
+### Stage P0-B：Plugin Runtime Host 可执行边界
 
-目标：在 disabled/projection-only 边界和 UI Extension Contract 之后，建立真实插件 Host 的受控执行边界，但仍不直接绑定 OpenCode、Claude Code 或 Codex 等具体生态实现。
+目标：建立受控插件 Host，让插件可以执行，但不能成为 kernel、permission、audit、tool result 或 UI implementation 的权威源。
 
 范围：
 
-- 定义插件 lifecycle、deadline、epoch、idempotency、failure quarantine、diagnostics 和 dispose 语义。
-- 定义 effect candidate、trust policy、permission/audit 只读投射和拒绝路径；插件 Host 不直接写 kernel 权威状态、permission decision、audit event 或 UI implementation。
-- Product Assembly 只注册 Host facade 和 typed capability；具体 runtime、worker、subprocess、package discovery 由上层组装器选择并注入。
-- 建立 Desktop、CLI、Server、Remote、ACP、Web、Mobile Web、SDK 的 Host availability / unavailable / unsupported 行为矩阵。
+- 定义 host lifecycle、manifest validation、dispatch envelope、deadline、epoch、idempotency、diagnostics、dispose 和 failure quarantine。
+- Product Assembly 只注入 host facade、trust policy、adapter set 和 typed availability；具体 runtime、worker、subprocess、source discovery、activation 和 package discovery 由 host 边界拥有。
+- Host 只返回 descriptor、provider candidate 或 `PluginEffectCandidate`；所有可写效果必须重新进入 Tool ABI、permission/effect gate、安全控制面和能力 owner。
+- Desktop 和 CLI 至少有明确 host availability；ACP 在 P0 只允许 status-only、projection-only 或 typed unsupported，不接入 command/effect host 闭环；Web / Mobile Web / Server / Remote / SDK 必须返回 typed unsupported、unavailable 或 projection-only。
 
 准出：
 
-- Host facade 不暴露具体生态 adapter 类型、UI implementation handle、Tauri handle、full `RuntimeServices` bundle 或 `bitfun-core/product-full`。
-- disabled、projection-only、unavailable、host failure、dispose 和 permission/effect focused tests 通过。
-- 默认不开放可写 transform 或外部 JS/TS plugin runtime；这些能力需要单独安全评审。
+- Host facade 不暴露具体生态 adapter 类型、UI implementation handle、Tauri handle、full `RuntimeServices` bundle、`bitfun-core/product-full` 或 raw `serde_json::Value` 稳定 ABI。
+- 必须在同一 PR 或同一 feature-gated integration 中绑定真实 OpenCode-compatible plugin consumption；未绑定 consumer 的 Host 只能存在于私有模块或明确禁用的 feature 下，不得接入生产路径、不得暴露 public API、不得计入阶段完成。
+- disabled、projection-only、host unavailable、host failure、dispose、deadline 和 permission/effect 具体测试通过，PR 中列出测试路径。
+- 默认不开放无约束可写 transform、无约束 localhost API 或插件直接调用内部 service manager。
 
-### Stage G：OpenCode Compatibility Adapter
+### Stage P0-C：OpenCode-compatible plugin 首条消费路径
 
-目标：在 Plugin Runtime Host、Tool ABI、Event Manifest 和 UI Extension Contract 可用后，实现受控 OpenCode 兼容适配。
+目标：接入 OpenCode-compatible plugin 最小路径，证明插件生态合同能支撑实际能力。ACP 外部 agent/tool bridge 属于 P0+，可复用合同但不是本阶段替代方案。
 
 范围：
 
-- 建立 OpenCode server plugin hook support matrix：event、tool、permission.ask、tool.execute.before/after、tool.definition、config/provider/model/skill/MCP transform。
-- 建立 OpenCode TUI plugin support matrix：slot、route、command/keymap、prompt、toast/dialog、theme、只读 state view。
-- 将 OpenCode tool、event、permission、workspace/worktree、remote path、artifact ref 映射为 BitFun canonical contract。
-- 不支持能力返回 typed unsupported；可写 transform 和外部 JS/TS plugin runtime 单独安全评审后再开放。
+- 建立 OpenCode-compatible adapter manifest 和 support matrix，只声明当前支持能力，不支持能力返回 typed unsupported。
+- 支持从 OpenCode 兼容来源或本地路径读取 manifest，完成 source/trust 校验、启用、禁用和配置错误诊断。
+- 将外部 tool、event、permission、workspace/worktree、remote path、artifact ref 映射为 BitFun canonical contract。
+- 绑定 canonical P0 消费方：Desktop settings entry + command contribution，command 调用 plugin-provided tool，并进入 permission/effect gate；用户确认后由 owner materialize effect 并产出可见结果。
+- CLI 至少提供同一插件的 manifest/status/diagnostics；hook、readonly state view 和额外 UI slot 属于可选扩展，未实现时返回 typed unsupported。
 
 准出：
 
-- OpenCode adapter 不依赖 `bitfun-core/product-full`、full `RuntimeServices` bundle、UI implementation 或 concrete provider handle。
-- adapter、permission/effect、event manifest、UI contribution 和 Desktop/CLI/Server/Remote/ACP/Web/Mobile Web/SDK product shape checks 通过。
+- adapter 不依赖 `bitfun-core/product-full`、full `RuntimeServices` bundle、UI implementation 或 concrete provider handle。
+- adapter、permission/effect、event manifest、UI contribution 和产品形态具体测试通过，PR 中列出测试路径。
+- PR 说明支持矩阵、未支持能力、降级方式和安全影响。
 
-## 5. 固定执行流程
+P0 产品验收指标：
 
-1. 同步最新 `main`，检查主干新增的 CLI、tool、terminal、session、scheduler、remote、MiniApp、ACP、OpenCode、plugin、UI 或 product interface 变更。
-2. 对照设计文档和 Issue #970 明确本次 owner 边界，不从旧计划标签继承完成判断。
-3. 先补等价保护和 boundary guard，再迁移实现主体。
-4. 删除、迁移或显著简化 core 中对应旧路径。
-5. 运行 focused verification、boundary check 和必要的 feature / dependency / product-shape 对比。
-6. 从独立第三方角度审查功能漂移、性能劣化、依赖回流、产品形态遗漏、安全绕过和文档一致性。
-7. 合入后只更新 completed 摘要和 issue 状态；设计文档只有目标架构变更时才修改。
+- 插件 manifest 可从 OpenCode 兼容来源或本地路径注册，并在 Desktop settings / command entry 和 CLI diagnostics 中被发现；启用、禁用、trust 确认、配置校验、manifest 校验失败、host unavailable、deadline、failure quarantine 都有可诊断状态。
+- 最小 diagnostics 字段包括 plugin id/source、trust/config validation result、manifest validation error、host availability reason、deadline/quarantine reason，并稳定输出至少一个可与 Desktop artifact/status 对齐的 correlation id 或 event id。
+- 必须提供一个 canonical OpenCode-compatible fixture plugin：本地 manifest/source、settings 插件卡片、command entry、plugin-provided tool、一个无害可见 effect/artifact、confirm happy path、deny/no-side-effect path 和 CLI diagnostics/audit 输出。
+- command contribution 可被用户发现并触发 plugin-provided tool，且必须走同一 OpenCode-compatible plugin 垂直切片。
+- canonical happy path 必须闭环：OpenCode-compatible plugin command -> plugin-provided tool -> permission confirm -> owner materialize effect -> Desktop 可见结果/artifact/status -> CLI diagnostics/audit 可追踪。
+- permission ask 支持确认和拒绝；确认面板必须展示 plugin id/source/hash、requested capability/effect、target/artifact、risk level、owner、可回滚性、deny 后状态和 audit/event id；拒绝、超时、policy-denied 和 host failure 都不会写 kernel state、audit success 或 tool result。
+- `PluginEffectCandidate` 有审计记录、owner 裁决、回滚语义和 diagnostics；被拒绝时不产生最终副作用，被确认并 materialize 后必须能追踪 owner、artifact/status 和 audit/event id。
+- failure quarantine 必须定义 scope、清除条件和用户可执行恢复动作；Desktop settings 插件卡片必须显示 scope、原因、日志入口和合法动作，CLI diagnostics 必须输出对应 action hint、correlation/event id，例如 retry、disable、retrust、open log 或 clear quarantine。
+- P0 必选面只含 Desktop settings/command 和 CLI diagnostics。ACP 在 P0 只允许 canonical availability/diagnostics projection、status-only 或 typed unsupported，不参与 command/effect 闭环；Web / Mobile Web / Server / Remote / SDK 返回 typed unsupported、unavailable 或 projection-only。
+- 原生 MCP 能力不因 P0 插件路径被迁移或重复实现；只有插件贡献的 MCP/tool provider 进入 Plugin Runtime Host。
 
-## 6. 验证矩阵
+## 5. 后端复杂度整改清单
+
+以下清单来自当前代码审视，用于约束后续实现，不表示本次文档变更已经完成代码整改。
+
+| 优先级 | 问题 | 证据 | 整改方向 |
+|---|---|---|---|
+| P0 | ACP 入口仍直接绑定 `bitfun-core/product-full`，协议入口会被完整产品运行时牵引 | `src/crates/interfaces/acp/Cargo.toml`、`src/crates/interfaces/acp/src/runtime.rs`、`src/crates/interfaces/acp/src/client/manager.rs` | 定义或复用 agent/session/tool/config/process stable ports，由 Product Assembly 注入实现；目标是让 ACP 从 `ProductFullCompatibility` 收敛到 `NoDirectCoreDependency` |
+| P0 | Plugin Runtime Contract 过薄，`PluginDispatchEnvelope` / `PluginResponseEnvelope` 仍像长期 JSON ABI | `src/crates/contracts/runtime-ports/src/lib.rs` | 在真实 Host 前补 typed contract：extension point、source、capability、deadline、epoch、data category、side effects、idempotency、diagnostics、effect candidate |
+| P1 | `bitfun-core` facade 仍是事实上的大入口 | `src/crates/assembly/core/src/lib.rs`、`src/crates/assembly/core/Cargo.toml` | 建立 facade export allowlist；新调用方禁止依赖 `bitfun_core::agentic::*` / `service::*`；每个 re-export 写明 owner、迁移目标和删除条件 |
+| P1 | LSP/Git/service facade 是典型 A -> B -> C 薄透传 | `src/crates/assembly/core/src/service/lsp/**`、`src/crates/assembly/core/src/service/git/**` | 旧 import 可兼容保留，新代码直接依赖 `bitfun_core_types::lsp`、`bitfun_services_core::lsp`、`bitfun_services_integrations::git` 或更窄 port |
+| P1 | `runtime-ports` 单文件合同过宽 | `src/crates/contracts/runtime-ports/src/lib.rs` | 先拆模块而非必拆 crate：plugin、agent_session、remote、tool_provider、events、session_store、service_capability；新增插件合同不得继续堆到单文件 |
+| P1 | Product capability 与 tool pack feature group 双重建模 | `src/crates/assembly/product-capabilities/src/lib.rs`、`src/crates/execution/tool-provider-groups/src/lib.rs` | 短期保留 provider group id 作为 assembly 选择边界；长期提升唯一 stable capability fact，避免 product/tool/extension 三套 taxonomy |
+| P2 | API adapter 层仍直接做文件 IO | `src/crates/adapters/api-layer/src/handlers.rs` | handler 只接收 FileSystem/Workspace port 或 service adapter；文件副作用下沉到 services owner |
+
+## 6. 后续收敛阶段
+
+### Stage D1：关键路径 Concrete Owner 收敛
+
+目标：继续把插件主线和关键产品路径上的 concrete owner 从 `bitfun-core` / 产品命令路径收口到对应 owner crate。
+
+范围：
+
+- process/session host adapter、SDK-facing concrete provider 选择、DeepReview / prompt-cache / product command host adapter、extension host adapter 等仍由 core 持有的产品耦合 I/O owner。
+- Product Assembly 负责选择 provider；Kernel、Execution、Product Feature 和 Extension Contract 不直接依赖 platform concrete。
+- 每次迁移必须有旧路径删除、兼容 facade 收窄或调用链缩短的证据。
+
+准出：
+
+- 至少完成一个可证明的 owner 迁移或薄 facade 删除。
+- `cargo check --workspace`、`cargo check -p bitfun-core --no-default-features` 或更小的 focused Rust check 按影响范围通过。
+- 边界脚本没有新增 core 回流。
+
+### Stage D2：链式依赖与 facade 瘦身
+
+目标：针对 A -> B -> C 的纯透传路径做专项整改，让调用方依赖真实稳定接口而不是层层转发。
+
+范围：
+
+- 盘点 core facade、product command facade、runtime service facade、adapter facade、extension facade 和 frontend API wrapper。
+- 对没有策略、校验、缓存、多实现选择、反腐、host 边界或兼容责任的薄层，删除或让调用方直接依赖 contract/port。
+- 保留的 facade 必须写明责任：兼容门面、协议反腐、多实现选择、Product Assembly、Plugin Runtime Host 或迁移期临时层。
+
+准出：
+
+- 每个改动都能说明减少了哪条依赖链或删除了哪条旧路径。
+- 不引入新的全局 mutable registry、untyped service locator 或无消费方 descriptor。
+
+### Stage D3：内部 SDK minimal 与产品形态保护
+
+目标：验证 Agent Runtime 的最小嵌入边界不会牵引完整产品实现，同时不扩大为公开 SDK 发布项目。
+
+范围：
+
+- fake-provider smoke、minimal feature、cargo metadata/tree 对比和 API version 保护。
+- ProductFull、Desktop、CLI、ACP 保持完整能力；Web / Mobile Web / Server / Remote / SDK 显式 unavailable / unsupported / projection。
+- 插件 runtime binding 覆盖 disabled / projection-only / host availability 的形态保护。
+
+准出：
+
+- minimal smoke 不依赖 `bitfun-core/product-full`、Desktop、Tauri、Git provider、MCP client、AI HTTP client、remote SSH 或产品 UI。
+- 产品形态检查能证明非完整入口不会默默继承完整桌面或插件能力。
+
+## 7. 固定执行流程
+
+1. 同步最新 `main`，检查主干新增的 CLI、tool、terminal、session、scheduler、remote、MiniApp、ACP、plugin 或 product interface 变更。
+2. 对照 `product-architecture.md` 明确本次 owner 边界，不从旧计划标签继承完成判断。
+3. 插件主线变更先明确 extension point、host boundary、candidate effect、安全裁决和真实消费路径。
+4. 先补等价保护和 boundary guard，再迁移实现主体。
+5. 删除、迁移或显著简化 core 中对应旧路径。
+6. 运行 focused verification、boundary check 和必要的 feature / dependency / product-shape 对比。
+7. 从独立第三方角度审查功能漂移、性能劣化、依赖回流、产品形态遗漏、安全绕过和文档一致性。
+8. 合入后只更新 completed 摘要和 issue 状态；设计文档只有目标架构变更时才修改。
+
+## 8. 验证矩阵
 
 | 触达范围 | 最小验证 |
 |---|---|
 | docs / boundary / layout | `pnpm run check:repo-hygiene`，`node --test scripts/check-core-boundaries.test.mjs`，`node scripts/check-core-boundaries.mjs` |
 | Workspace layout / Cargo path | `cargo metadata --no-deps --format-version 1` |
-| Product Feature / capability matrix | `cargo test -p bitfun-product-capabilities`，feature pack focused tests，UI descriptor focused tests |
+| Extension Contract / descriptor / availability | `cargo test -p bitfun-runtime-ports --test plugin_runtime_contracts`；同时更新 crate-local public API budget/allowlist 或 `scripts/core-boundaries/rules/**`，并让 `scripts/check-core-boundaries.mjs` 阻止 raw JSON ABI、无 consumer public descriptor/envelope 和 product-full 回流；最低覆盖 descriptor round-trip、availability 映射、candidate effect 拒绝路径 |
+| Plugin Runtime Host | 固定目标为 `cargo test -p bitfun-runtime-ports --test plugin_runtime_contracts`；若 host 代码进入本阶段，必须新增并运行 `cargo test -p bitfun-runtime-ports --test plugin_runtime_host_contracts` 或 host owner crate 的同名 contract test，并在本矩阵落定命令；最低覆盖 lifecycle、dispatch envelope、deadline、dispose、failure quarantine、permission prompt/diagnostic serialization、permission/effect gate；缺失固定目标本身就是准出阻断 |
+| OpenCode-compatible adapter path | 固定 P0 目标为 `cargo test -p bitfun-opencode-adapter --test opencode_plugin_fixture_contracts`；若 adapter owner crate 使用不同名称，同一 PR 必须先更新本矩阵并提供确定命令；最低覆盖 source/manifest/support matrix、trust/config validation、event/effect mapping、UI contribution fallback、confirm happy path 和 deny/no-side-effect path；临时测试或 PR 文案不能替代该目标 |
+| Product Feature / capability availability | `cargo test -p bitfun-product-capabilities`；若能力集合或 availability 变化，补对应 product capability 测试 |
 | Agent Kernel / permission / event | `cargo test -p bitfun-agent-runtime`，`cargo check -p bitfun-core --no-default-features` |
-| Runtime Services / backend events | `cargo test -p bitfun-runtime-services`，backend event delivery focused tests |
-| Tool / MCP / terminal / sandbox | `cargo test -p bitfun-agent-tools`，`cargo test -p tool-runtime`，terminal / exec-command / MCP focused tests |
-| Harness / Product Domains | `cargo test -p bitfun-harness`，`cargo test -p bitfun-product-domains`，DeepReview / MiniApp focused tests |
-| Extension / OpenCode / ACP | plugin runtime host focused tests，UI contribution descriptor tests，OpenCode adapter focused tests，ACP permission / external tool focused tests |
-| Product shape / SDK | SDK fake-provider smoke，Desktop / CLI / Web / Server / Remote / ACP / SDK / Mobile Web capability matrix checks，cargo tree / metadata 对比 |
+| Runtime Services / backend events | `cargo test -p bitfun-runtime-services`；事件投递变化时补具体测试路径 |
+| Tool / MCP / terminal / sandbox | `cargo test -p bitfun-agent-tools`，`cargo test -p tool-runtime`；terminal / exec-command / MCP 变化时补具体测试路径 |
+| Harness / Product Domains | `cargo test -p bitfun-harness`，`cargo test -p bitfun-product-domains`；DeepReview / MiniApp 变化时补具体测试路径 |
+| Product shape / internal SDK minimal | 固定目标为 `cargo test -p bitfun-product-capabilities --test plugin_product_shape`、`cargo test -p bitfun-product-capabilities --test product_sdk_assembly`、`cargo metadata --no-deps --format-version 1`；覆盖 Desktop / CLI / ACP / Web / Server / Remote / SDK / Mobile Web capability availability 和 SDK fake-provider smoke，证明非 P0 入口不是 full plugin runtime 且 SDK minimal 不牵引 `product-full` / concrete provider；若 `plugin_product_shape` 尚不存在，同一 PR 必须新增该路径并在本矩阵落定命令 |
 | 大范围 owner 迁移 | `cargo check --workspace`，必要时补 `cargo test --workspace` |
 
-## 7. 暂停条件
+## 9. 暂停条件
 
 - 新 owner crate 必须依赖回 `bitfun-core` 才能编译或测试。
-- Agent Kernel 吸收 product feature、UI state、Tauri、产品命令、AI provider、MCP client、process execution、Git provider 等 concrete dependency。
+- Agent Kernel 吸收 product feature、UI state、Tauri、产品命令、AI provider、MCP client、process execution、Git provider、具体 plugin adapter 等 concrete dependency。
 - Product Assembly 变成无类型 service locator 或全局 mutable app state。
 - Plugin Runtime Host 直接写 permission、audit、kernel state、tool result 或 UI implementation。
-- PR 只新增抽象，没有迁移、删除或显著简化旧 core 主体路径。
+- Compatibility Adapter 直接依赖 `bitfun-core/product-full`、full `RuntimeServices`、Tauri handle、React component 或 concrete provider handle。
+- PR 只新增抽象，没有迁移、删除、真实消费路径或显著简化旧 core 主体路径。
+- 新增 public plugin descriptor、envelope、host API 或 availability API，但没有绑定 OpenCode-compatible plugin 第一条体验。
+- 新增 public plugin descriptor、envelope、host API 或 availability API，只在 PR 正文说明 owner/consumer/P0 trace/wire impact/retirement condition，没有落入 crate-local budget/allowlist 或边界脚本可检查规则。
+- Plugin Runtime Contract 把 raw `serde_json::Value` 作为长期稳定 ABI，或没有携带 source、capability、deadline、epoch、side effects、diagnostics 等安全事实。
+- ACP 外部 agent/tool bridge 被当作 P0 插件体验替代方案，而不是 P0+ 互操作路径。
 - SDK facade 必须暴露 `bitfun-core`、`product-full`、concrete service manager 或产品命令 registry 才能完成基本 agent 执行。
+- 全量 UI Extension 矩阵、全量生态兼容或无约束可写 transform 在没有产品场景、安全评审和 focused verification 前进入当前 PR。


### PR DESCRIPTION
## Summary
- Clarifies `docs/architecture/product-architecture.md` as the primary architecture source for plugin ecosystem P0.
- Narrows P0 to one OpenCode-compatible plugin vertical slice: Desktop settings/command + CLI diagnostics.
- Moves ACP / Server / Remote / Web / Mobile / SDK full plugin runtime to P0+ or explicit degradation.
- Tightens Plugin Runtime Host contracts for permission prompts, diagnostics, quarantine recovery, public API budget, and fixed verification targets.

## Review
- Completed adversarial review from independent architecture and product perspectives.
- Addressed follow-up findings around P0 escape paths, ACP scope, fixed verification targets, prompt source uniqueness, and structured diagnostics.

## Validation
- `git diff --check -- docs/architecture/product-architecture.md docs/plans/core-decomposition-plan.md docs/architecture/plugin-runtime-host-design.md`
- `pnpm run check:repo-hygiene`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `cargo test -p bitfun-runtime-ports --test plugin_runtime_contracts --no-run`
- `cargo test -p bitfun-product-capabilities --test product_sdk_assembly --no-run`