### PR TITLE
refactor(runtime-ports): type plugin runtime contracts

### DIFF
--- a/scripts/core-boundaries/checker.mjs
+++ b/scripts/core-boundaries/checker.mjs
@@ -24,6 +24,7 @@ import {
   facadeOnlyFiles,
   forbiddenContentRules,
   forbiddenContentUnderRules,
+  publicApiAllowlistRules,
   requiredContentRules,
 } from './rules/source-rules.mjs';
 import { runManifestParserSelfTest } from './self-test.mjs';
@@ -835,6 +836,132 @@ function checkRequiredContent(repoPath, patterns, reason) {
   }
 }
 
+function collectTopLevelRustPublicSymbols(text) {
+  const symbols = [];
+  let braceDepth = 0;
+  for (const line of text.split(/\r?\n/)) {
+    if (braceDepth === 0) {
+      const match = line.match(
+        /^\s*pub\s+(?:(?:async|unsafe)\s+)*(?:(?:const\s+fn)|fn|type|struct|enum|trait|mod|const|static)\s+([A-Za-z_][A-Za-z0-9_]*)\b/,
+      );
+      if (match) {
+        symbols.push(match[1]);
+      }
+    }
+    const code = line.replace(/\/\/.*$/, '');
+    braceDepth += (code.match(/\{/g) || []).length;
+    braceDepth -= (code.match(/\}/g) || []).length;
+    if (braceDepth < 0) {
+      braceDepth = 0;
+    }
+  }
+  return symbols;
+}
+
+function collectPluginRootReexports(text) {
+  const symbols = [];
+  const blockRegex = /\bpub\s+use\s+plugin::\{([\s\S]*?)\};/g;
+  for (const match of text.matchAll(blockRegex)) {
+    symbols.push(
+      ...match[1]
+        .split(',')
+        .map((symbol) => symbol.trim())
+        .filter(Boolean),
+    );
+  }
+  const singleRegex =
+    /\bpub\s+use\s+plugin::([A-Za-z_][A-Za-z0-9_]*)(?:\s+as\s+[A-Za-z_][A-Za-z0-9_]*)?\s*;/g;
+  for (const match of text.matchAll(singleRegex)) {
+    symbols.push(match[1]);
+  }
+  return symbols;
+}
+
+function allowedSymbolsForRule(rule, entriesField, symbolsField) {
+  if (rule[entriesField]) {
+    return rule[entriesField].map((entry) => entry.symbol);
+  }
+  return rule[symbolsField] || [];
+}
+
+function checkPublicApiEntryMetadata(path, entries, reason) {
+  if (!entries) {
+    return;
+  }
+  const requiredFields = ['symbol', 'owner', 'consumer', 'p0', 'rationale', 'exit'];
+  for (const entry of entries) {
+    for (const field of requiredFields) {
+      if (typeof entry[field] !== 'string' || entry[field].trim().length === 0) {
+        failures.push({
+          path,
+          line: 1,
+          message: `${reason}; public API entry ${entry.symbol || '<missing>'} is missing ${field}`,
+        });
+      }
+    }
+    if (typeof entry.wireImpact !== 'boolean') {
+      failures.push({
+        path,
+        line: 1,
+        message: `${reason}; public API entry ${entry.symbol || '<missing>'} must declare wireImpact`,
+      });
+    }
+  }
+}
+
+function compareSymbolAllowlist(path, actualSymbols, allowedSymbols, reason) {
+  const allowed = new Set(allowedSymbols);
+  const actual = new Set(actualSymbols);
+  for (const symbol of actual) {
+    if (!allowed.has(symbol)) {
+      failures.push({
+        path,
+        line: 1,
+        message: `${reason}; unexpected public symbol: ${symbol}`,
+      });
+    }
+  }
+  for (const symbol of allowed) {
+    if (!actual.has(symbol)) {
+      failures.push({
+        path,
+        line: 1,
+        message: `${reason}; missing public symbol: ${symbol}`,
+      });
+    }
+  }
+}
+
+function checkPublicApiAllowlist(rule) {
+  const path = repoPathToFsPath(rule.path);
+  const text = readText(path);
+  checkPublicApiEntryMetadata(path, rule.allowedSymbolEntries, rule.reason);
+  checkPublicApiEntryMetadata(path, rule.allowedPluginReexportEntries, rule.reason);
+  if (rule.allowedSymbols || rule.allowedSymbolEntries) {
+    compareSymbolAllowlist(
+      path,
+      collectTopLevelRustPublicSymbols(text),
+      allowedSymbolsForRule(rule, 'allowedSymbolEntries', 'allowedSymbols'),
+      rule.reason,
+    );
+  }
+  if (rule.allowedPluginReexports || rule.allowedPluginReexportEntries) {
+    compareSymbolAllowlist(
+      path,
+      collectPluginRootReexports(text),
+      allowedSymbolsForRule(rule, 'allowedPluginReexportEntries', 'allowedPluginReexports'),
+      rule.reason,
+    );
+    if (/\bpub\s+use\s+plugin::\*/.test(text)) {
+      failures.push({
+        path,
+        line: 1,
+        message: `${rule.reason}; wildcard plugin re-export is forbidden`,
+      });
+    }
+  }
+}
+
 function checkForbiddenContentUnder(repoDir, patterns, reason) {
   const dir = repoPathToFsPath(repoDir);
   walkFiles(dir, (path) => {
@@ -881,9 +1008,12 @@ export function runCoreBoundaryCheck() {
       requiredContentRules,
       forbiddenContentRules,
       forbiddenContentUnderRules,
+      publicApiAllowlistRules,
       facadeOnlyFiles,
       forbiddenRuleTextForPath,
       regexSourceContainsContract,
+      collectTopLevelRustPublicSymbols,
+      collectPluginRootReexports,
       createFacadeLineChecker,
       escapeRegex,
     });
@@ -942,6 +1072,10 @@ export function runCoreBoundaryCheck() {
 
   for (const rule of requiredContentRules) {
     checkRequiredContent(rule.path, rule.patterns, rule.reason);
+  }
+
+  for (const rule of publicApiAllowlistRules) {
+    checkPublicApiAllowlist(rule);
   }
 
   if (failures.length > 0) {

--- a/scripts/core-boundaries/rules/source-rules.mjs
+++ b/scripts/core-boundaries/rules/source-rules.mjs
@@ -5,4 +5,5 @@ export {
   forbiddenContentRules,
   forbiddenContentUnderRules,
 } from './source/forbidden-rules.mjs';
+export { publicApiAllowlistRules } from './source/public-api-rules.mjs';
 export { requiredContentRules } from './source/required-rules.mjs';

--- a/scripts/core-boundaries/rules/source/forbidden-rules.mjs
+++ b/scripts/core-boundaries/rules/source/forbidden-rules.mjs
@@ -2,6 +2,51 @@
 
 export const forbiddenContentRules = [
   {
+    path: 'src/crates/contracts/runtime-ports/src/lib.rs',
+    patterns: [
+      {
+        regex: /\bpub\s+use\s+plugin::\*/,
+        message:
+          'runtime-ports root must not wildcard re-export plugin contracts; update the explicit public API budget',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/contracts/runtime-ports/src/plugin.rs',
+    patterns: [
+      {
+        regex: /\bserde_json::Value\b|\bserde_json::Map\b|\bjson!\b/,
+        message:
+          'plugin runtime contracts must not expose raw JSON ABI; use typed refs, descriptors, candidates, diagnostics, and quarantine facts',
+      },
+      {
+        regex: /\bpub\s+(?:\w+\s+)*payload\s*:\s*serde_json::Value\b/,
+        message:
+          'PluginDispatchEnvelope must not regress to raw payload transport across the Host boundary',
+      },
+      {
+        regex: /\bpub\s+accepted\s*:\s*bool\b/,
+        message:
+          'PluginResponseEnvelope must return typed effect candidates and diagnostics instead of an accepted bool',
+      },
+      {
+        regex: /product-full/,
+        message:
+          'plugin runtime contracts must not pull product-full delivery assumptions into runtime-ports',
+      },
+      {
+        regex: /\brequires_permission\b|\bpermission_prompt\b/,
+        message:
+          'plugin effect permission state must use PluginPermissionGate to avoid invalid required-without-prompt combinations',
+      },
+      {
+        regex: /\bNotRequired\b|\bPluginMaterializeCondition\b|\bmaterialize_when\b/,
+        message:
+          'plugin effect materialization must be derived from an auditable PluginPermissionGate, not an unaudited no-op or free materialize flag',
+      },
+    ],
+  },
+  {
     path: 'src/crates/adapters/transport/src/adapters/tauri.rs',
     patterns: [
       {

--- a/scripts/core-boundaries/rules/source/public-api-rules.mjs
+++ b/scripts/core-boundaries/rules/source/public-api-rules.mjs
@@ -1,0 +1,120 @@
+// Public API allowlists for contract modules where accidental surface growth is costly.
+
+function pluginRuntimeEntry(symbol, p0, consumer, wireImpact = true) {
+  return {
+    symbol,
+    owner: 'runtime-ports plugin contract owner',
+    consumer,
+    p0,
+    wireImpact,
+    rationale: `${p0} needs a stable contract symbol instead of raw JSON or product-full leakage`,
+    exit: 'remove only after a reviewed compatibility migration and root re-export budget update',
+  };
+}
+
+export const pluginRuntimePublicApiEntries = [
+  ...[
+    'PluginSourceKind',
+    'PluginSourceRef',
+    'PluginManifestRef',
+    'PluginTrustLevel',
+    'PluginStatusKind',
+    'PluginStatusSnapshot',
+    'PluginConfigValidationIssue',
+    'PluginConfigValidationState',
+    'PluginConfigValidationStatus',
+    'PluginRuntimeReadRequest',
+    'PluginRuntimeReadResponse',
+  ].map((symbol) =>
+    pluginRuntimeEntry(
+      symbol,
+      'plugin discovery, status, and config-validation projection',
+      'desktop settings, CLI diagnostics, and runtime host read-model tests',
+    ),
+  ),
+  ...[
+    'PluginCapabilityRef',
+    'PluginTargetRef',
+    'PluginArtifactRef',
+    'PluginAuditRef',
+    'PluginOwnerKind',
+    'PluginOwnerRef',
+    'PluginDataClassification',
+    'PluginPayloadRedaction',
+    'PluginPayloadRef',
+    'PluginRiskLevel',
+    'PermissionPromptEffectKind',
+    'PermissionPromptDenyState',
+    'PermissionPromptDescriptor',
+    'PluginRollbackMode',
+    'PluginRollbackPolicy',
+    'PluginPermissionGate',
+    'PluginEffectCandidate',
+    'PluginEffectCandidatePayload',
+  ].map((symbol) =>
+    pluginRuntimeEntry(
+      symbol,
+      'plugin permission, effect-preview, and candidate materialization',
+      'runtime-ports dispatch response tests and product P0 permission projection',
+    ),
+  ),
+  ...[
+    'PluginDiagnostic',
+    'PluginDiagnosticDetail',
+    'PluginDiagnosticSeverity',
+    'PluginQuarantineScope',
+    'PluginQuarantineReason',
+    'PluginQuarantineClearCondition',
+    'PluginQuarantineState',
+    'PluginRecoveryAction',
+    'PluginRecoveryActionKind',
+    'PluginRecoveryActionRequest',
+    'PluginRecoveryActionResult',
+    'PluginRecoveryActionStatus',
+  ].map((symbol) =>
+    pluginRuntimeEntry(
+      symbol,
+      'plugin diagnostics, quarantine, and owner-mediated recovery',
+      'runtime-ports diagnostics tests and product P0 plugin settings recovery projection',
+    ),
+  ),
+  ...[
+    'ExtensionCapabilityAvailability',
+    'PluginRuntimeAvailability',
+    'PluginRuntimeUnavailableReason',
+    'PluginRuntimeEpochs',
+    'PluginDispatchEnvelope',
+    'PluginResponseEnvelope',
+    'PluginHostLifecycleEvent',
+    'PluginHostLifecyclePhase',
+    'PluginRuntimeClient',
+    'DisabledPluginRuntimeClient',
+    'ProjectionOnlyPluginRuntimeClient',
+    'PluginRuntimeBinding',
+  ].map((symbol) =>
+    pluginRuntimeEntry(
+      symbol,
+      'plugin host boundary, lifecycle, and execution availability',
+      'product assembly, agent runtime, and runtime-ports contract tests',
+    ),
+  ),
+];
+
+export const pluginRuntimePublicApiSymbols = pluginRuntimePublicApiEntries.map(
+  (entry) => entry.symbol,
+);
+
+export const publicApiAllowlistRules = [
+  {
+    path: 'src/crates/contracts/runtime-ports/src/plugin.rs',
+    reason:
+      'plugin runtime public contract symbols must stay explicitly budgeted and consumer-backed',
+    allowedSymbolEntries: pluginRuntimePublicApiEntries,
+  },
+  {
+    path: 'src/crates/contracts/runtime-ports/src/lib.rs',
+    reason:
+      'runtime-ports root must re-export only the explicitly budgeted plugin runtime contract surface',
+    allowedPluginReexportEntries: pluginRuntimePublicApiEntries,
+  },
+];

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -4709,6 +4709,87 @@ export const requiredContentRules = [
     ],
   },
   {
+    path: 'src/crates/contracts/runtime-ports/src/plugin.rs',
+    reason:
+      'runtime-ports plugin module must own typed Plugin Runtime Contract DTOs and host boundary client traits',
+    patterns: [
+      {
+        regex: /\bpub trait PluginRuntimeClient\b/,
+        message: 'missing plugin runtime client boundary contract',
+      },
+      {
+        regex: /\bread_plugins\b/,
+        message: 'missing plugin discovery/status read boundary contract',
+      },
+      {
+        regex: /\bexecute_recovery_action\b/,
+        message: 'missing plugin recovery action execution boundary contract',
+      },
+      {
+        regex: /\bpub enum PluginRuntimeBinding\b/,
+        message: 'missing plugin runtime binding boundary contract',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/contracts/runtime-ports/tests/plugin_runtime_contracts.rs',
+    reason:
+      'runtime-ports plugin contract tests must cover typed envelopes, candidate effects, and disabled/projection-only behavior',
+    patterns: [
+      {
+        regex: /\bdispatch_envelope_serializes_typed_host_boundary_without_raw_payload\b/,
+        message: 'missing typed dispatch envelope regression',
+      },
+      {
+        regex: /\bresponse_envelope_carries_effect_candidates_and_observed_epochs\b/,
+        message: 'missing typed response envelope regression',
+      },
+      {
+        regex: /\bpolicy_allowed_effects_keep_auditable_permission_facts\b/,
+        message: 'missing auditable policy-allowed permission gate regression',
+      },
+      {
+        regex: /\bread_plugins_contract_supports_discovery_status_and_config_projection\b/,
+        message: 'missing plugin read-model contract regression',
+      },
+      {
+        regex: /\bPluginStatusSnapshot\b/,
+        message: 'missing plugin status snapshot regression coverage',
+      },
+      {
+        regex: /\bdisabled_plugin_runtime_binding_reports_not_available\b/,
+        message: 'missing disabled runtime binding regression',
+      },
+      {
+        regex: /\bprojection_only_plugin_runtime_rejects_dispatch_without_host\b/,
+        message: 'missing projection-only runtime binding regression',
+      },
+    ],
+  },
+  {
+    path: 'src/crates/contracts/runtime-ports/tests/plugin_runtime_host_contracts.rs',
+    reason:
+      'runtime-ports plugin host contract tests must cover permission prompts, diagnostics, quarantine, and lifecycle facts',
+    patterns: [
+      {
+        regex: /\bpermission_prompt_descriptor_contains_minimum_user_decision_facts\b/,
+        message: 'missing permission prompt descriptor regression',
+      },
+      {
+        regex: /\bdiagnostic_and_quarantine_state_are_auditable_and_recoverable\b/,
+        message: 'missing diagnostic and quarantine regression',
+      },
+      {
+        regex: /\brecovery_action_request_and_result_are_typed_execution_contracts\b/,
+        message: 'missing recovery action request/result regression',
+      },
+      {
+        regex: /\bhost_lifecycle_event_tracks_phase_source_and_epoch\b/,
+        message: 'missing plugin host lifecycle regression',
+      },
+    ],
+  },
+  {
     path: 'src/crates/contracts/runtime-ports/src/lib.rs',
     reason:
       'runtime-ports must keep remote and subagent runtime boundary contracts DTO/trait-only',
@@ -4724,18 +4805,6 @@ export const requiredContentRules = [
       {
         regex: /\bpub trait RuntimeEventSink\b/,
         message: 'missing runtime event sink contract',
-      },
-      {
-        regex: /\bpub trait PluginRuntimeClient\b/,
-        message: 'missing plugin runtime client boundary contract',
-      },
-      {
-        regex: /\bpub enum PluginRuntimeBinding\b/,
-        message: 'missing plugin runtime binding boundary contract',
-      },
-      {
-        regex: /\bpub struct DisabledPluginRuntimeClient\b/,
-        message: 'missing disabled plugin runtime client contract',
       },
       {
         regex: /\bpub struct AgentSessionCreateResult\b[\s\S]*\bpub session_name: String\b/,

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -17,9 +17,12 @@ export function runManifestParserSelfTest({
   requiredContentRules,
   forbiddenContentRules,
   forbiddenContentUnderRules,
+  publicApiAllowlistRules,
   facadeOnlyFiles,
   forbiddenRuleTextForPath,
   regexSourceContainsContract,
+  collectTopLevelRustPublicSymbols,
+  collectPluginRootReexports,
   createFacadeLineChecker,
   escapeRegex,
 }) {
@@ -741,6 +744,106 @@ export function runManifestParserSelfTest({
   );
   if (!runtimePortsProfile?.forbiddenNonOptionalDeps.includes('bitfun-services-core')) {
     throw new Error('runtime-ports dependency profile must forbid service implementations');
+  }
+  const pluginRuntimeContractRule = requiredContentRules.find(
+    (rule) => rule.path === 'src/crates/contracts/runtime-ports/src/plugin.rs',
+  );
+  if (!pluginRuntimeContractRule) {
+    throw new Error('plugin runtime contracts must have a module-local owner rule');
+  }
+  const pluginRuntimeContractRuleText = pluginRuntimeContractRule.patterns
+    .map((pattern) => pattern.regex.source)
+    .join('\n');
+  for (const contract of [
+    'PluginRuntimeClient',
+    'PluginRuntimeBinding',
+    'read_plugins',
+    'execute_recovery_action',
+  ]) {
+    if (!pluginRuntimeContractRuleText.includes(contract)) {
+      throw new Error(`plugin runtime contract owner rule must require: ${contract}`);
+    }
+  }
+  const pluginRuntimeForbiddenRuleText = forbiddenRuleTextForPath(
+    'src/crates/contracts/runtime-ports/src/plugin.rs',
+  );
+  for (const forbiddenContract of [
+    'serde_json::Value',
+    'accepted',
+    'product-full',
+    'requires_permission',
+    'permission_prompt',
+    'PluginMaterializeCondition',
+  ]) {
+    if (!pluginRuntimeForbiddenRuleText.includes(forbiddenContract)) {
+      throw new Error(`plugin runtime boundary rule must forbid: ${forbiddenContract}`);
+    }
+  }
+  const pluginPublicApiRule = publicApiAllowlistRules.find(
+    (rule) => rule.path === 'src/crates/contracts/runtime-ports/src/plugin.rs',
+  );
+  const pluginRootReexportRule = publicApiAllowlistRules.find(
+    (rule) => rule.path === 'src/crates/contracts/runtime-ports/src/lib.rs',
+  );
+  const parsedPluginReexports = collectPluginRootReexports(`
+    pub use plugin::{PluginDispatchEnvelope, PluginResponseEnvelope};
+    pub use plugin::{
+      PluginRuntimeReadRequest,
+      PluginRuntimeReadResponse,
+    };
+    pub use plugin::PluginRuntimeClient;
+  `);
+  if (
+    parsedPluginReexports.join(',') !==
+    'PluginDispatchEnvelope,PluginResponseEnvelope,PluginRuntimeReadRequest,PluginRuntimeReadResponse,PluginRuntimeClient'
+  ) {
+    throw new Error('plugin root re-export parser must collect all block and single re-exports');
+  }
+  const parsedPluginSymbols = collectTopLevelRustPublicSymbols(`
+    pub enum TopLevelEnum { Value }
+    impl TopLevelEnum { pub fn hidden_method(&self) {} }
+    pub mod host;
+    pub const CONTRACT_VERSION: u16 = 1;
+  `);
+  if (parsedPluginSymbols.join(',') !== 'TopLevelEnum,host,CONTRACT_VERSION') {
+    throw new Error('public API parser must collect top-level items without impl methods');
+  }
+  const pluginPublicApiSymbols = (pluginPublicApiRule?.allowedSymbolEntries || []).map(
+    (entry) => entry.symbol,
+  );
+  const pluginRootReexportSymbols = (pluginRootReexportRule?.allowedPluginReexportEntries || []).map(
+    (entry) => entry.symbol,
+  );
+  if (!pluginPublicApiSymbols.includes('PluginDispatchEnvelope')) {
+    throw new Error('plugin runtime public API allowlist must include dispatch envelope');
+  }
+  if (!pluginPublicApiSymbols.includes('PluginPermissionGate')) {
+    throw new Error('plugin runtime public API allowlist must include permission gate');
+  }
+  if (!pluginPublicApiSymbols.includes('PluginRecoveryActionRequest')) {
+    throw new Error('plugin runtime public API allowlist must include recovery action request');
+  }
+  if (!pluginPublicApiSymbols.includes('PluginRuntimeReadRequest')) {
+    throw new Error('plugin runtime public API allowlist must include read request');
+  }
+  if (!pluginPublicApiSymbols.includes('PluginStatusSnapshot')) {
+    throw new Error('plugin runtime public API allowlist must include plugin status snapshot');
+  }
+  for (const entry of pluginPublicApiRule.allowedSymbolEntries) {
+    for (const field of ['owner', 'consumer', 'p0', 'rationale', 'exit']) {
+      if (!entry[field]) {
+        throw new Error(`plugin runtime public API entry must declare ${field}: ${entry.symbol}`);
+      }
+    }
+    if (typeof entry.wireImpact !== 'boolean') {
+      throw new Error(`plugin runtime public API entry must declare wireImpact: ${entry.symbol}`);
+    }
+  }
+  if (!pluginRootReexportSymbols.includes('PluginDispatchEnvelope')) {
+    throw new Error('runtime-ports root re-export allowlist must include dispatch envelope');
+  }
+  if (pluginRootReexportSymbols.length !== pluginPublicApiSymbols.length) {
+    throw new Error('plugin root re-export allowlist must match plugin module public budget');
   }
   const runtimeServicesRule = lightweightBoundaryRules.find(
     (rule) => rule.crateName === 'runtime-services',

--- a/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
+++ b/src/crates/assembly/product-capabilities/tests/product_capabilities.rs
@@ -32,8 +32,17 @@ impl PluginRuntimeClient for AvailablePluginRuntimeClient {
         envelope: PluginDispatchEnvelope,
     ) -> PortResult<PluginResponseEnvelope> {
         Ok(PluginResponseEnvelope {
-            envelope_id: envelope.envelope_id,
-            accepted: true,
+            envelope_version: envelope.envelope_version,
+            request_event_id: envelope.event_id,
+            project_domain_id: envelope.project_domain_id,
+            adapter_id: "test-plugin-runtime".to_string(),
+            plugin_id: Some(envelope.source.plugin_id),
+            completed_at_ms: 0,
+            effects: Vec::new(),
+            diagnostics: Vec::new(),
+            quarantine: None,
+            plugin_statuses: Vec::new(),
+            observed_epochs: envelope.epochs,
         })
     }
 }
@@ -53,8 +62,17 @@ impl PluginRuntimeClient for MisreportedPluginRuntimeClient {
         envelope: PluginDispatchEnvelope,
     ) -> PortResult<PluginResponseEnvelope> {
         Ok(PluginResponseEnvelope {
-            envelope_id: envelope.envelope_id,
-            accepted: true,
+            envelope_version: envelope.envelope_version,
+            request_event_id: envelope.event_id,
+            project_domain_id: envelope.project_domain_id,
+            adapter_id: "test-plugin-runtime".to_string(),
+            plugin_id: Some(envelope.source.plugin_id),
+            completed_at_ms: 0,
+            effects: Vec::new(),
+            diagnostics: Vec::new(),
+            quarantine: None,
+            plugin_statuses: Vec::new(),
+            observed_epochs: envelope.epochs,
         })
     }
 }

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -11,6 +11,25 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+mod plugin;
+pub use plugin::{
+    DisabledPluginRuntimeClient, ExtensionCapabilityAvailability, PermissionPromptDenyState,
+    PermissionPromptDescriptor, PermissionPromptEffectKind, PluginArtifactRef, PluginAuditRef,
+    PluginCapabilityRef, PluginConfigValidationIssue, PluginConfigValidationState,
+    PluginConfigValidationStatus, PluginDataClassification, PluginDiagnostic,
+    PluginDiagnosticDetail, PluginDiagnosticSeverity, PluginDispatchEnvelope,
+    PluginEffectCandidate, PluginEffectCandidatePayload, PluginHostLifecycleEvent,
+    PluginHostLifecyclePhase, PluginManifestRef, PluginOwnerKind, PluginOwnerRef,
+    PluginPayloadRedaction, PluginPayloadRef, PluginPermissionGate, PluginQuarantineClearCondition,
+    PluginQuarantineReason, PluginQuarantineScope, PluginQuarantineState, PluginRecoveryAction,
+    PluginRecoveryActionKind, PluginRecoveryActionRequest, PluginRecoveryActionResult,
+    PluginRecoveryActionStatus, PluginResponseEnvelope, PluginRiskLevel, PluginRollbackMode,
+    PluginRollbackPolicy, PluginRuntimeAvailability, PluginRuntimeBinding, PluginRuntimeClient,
+    PluginRuntimeEpochs, PluginRuntimeReadRequest, PluginRuntimeReadResponse,
+    PluginRuntimeUnavailableReason, PluginSourceKind, PluginSourceRef, PluginStatusKind,
+    PluginStatusSnapshot, PluginTargetRef, PluginTrustLevel, ProjectionOnlyPluginRuntimeClient,
+};
+
 pub type PortResult<T> = Result<T, PortError>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -99,214 +118,6 @@ impl std::fmt::Display for RuntimeServiceCapability {
 
 pub trait RuntimeServicePort: Send + Sync {
     fn capability(&self) -> RuntimeServiceCapability;
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PluginRuntimeUnavailableReason {
-    NotBuilt,
-    UnsupportedProfile,
-    DisabledByPolicy,
-    HostUnavailable,
-}
-
-impl PluginRuntimeUnavailableReason {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::NotBuilt => "not_built",
-            Self::UnsupportedProfile => "unsupported_profile",
-            Self::DisabledByPolicy => "disabled_by_policy",
-            Self::HostUnavailable => "host_unavailable",
-        }
-    }
-}
-
-impl std::fmt::Display for PluginRuntimeUnavailableReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", tag = "status")]
-pub enum ExtensionCapabilityAvailability {
-    Disabled {
-        reason: PluginRuntimeUnavailableReason,
-    },
-    ProjectionOnly {
-        reason: PluginRuntimeUnavailableReason,
-    },
-    Available,
-    Unavailable {
-        reason: PluginRuntimeUnavailableReason,
-    },
-}
-
-impl ExtensionCapabilityAvailability {
-    pub const fn disabled(reason: PluginRuntimeUnavailableReason) -> Self {
-        Self::Disabled { reason }
-    }
-
-    pub const fn projection_only(reason: PluginRuntimeUnavailableReason) -> Self {
-        Self::ProjectionOnly { reason }
-    }
-
-    pub const fn is_executable(self) -> bool {
-        matches!(self, Self::Available)
-    }
-}
-
-pub type PluginRuntimeAvailability = ExtensionCapabilityAvailability;
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PluginDispatchEnvelope {
-    pub envelope_id: String,
-    pub event_name: String,
-    #[serde(default)]
-    pub payload: serde_json::Value,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PluginResponseEnvelope {
-    pub envelope_id: String,
-    pub accepted: bool,
-}
-
-#[async_trait::async_trait]
-pub trait PluginRuntimeClient: Send + Sync {
-    fn availability(&self) -> PluginRuntimeAvailability;
-
-    async fn dispatch(
-        &self,
-        envelope: PluginDispatchEnvelope,
-    ) -> PortResult<PluginResponseEnvelope>;
-}
-
-#[derive(Debug, Clone)]
-pub struct DisabledPluginRuntimeClient {
-    reason: PluginRuntimeUnavailableReason,
-}
-
-impl DisabledPluginRuntimeClient {
-    pub const fn new(reason: PluginRuntimeUnavailableReason) -> Self {
-        Self { reason }
-    }
-
-    fn not_available(&self) -> PortError {
-        PortError::new(
-            PortErrorKind::NotAvailable,
-            format!("plugin runtime is disabled: {}", self.reason),
-        )
-    }
-}
-
-impl Default for DisabledPluginRuntimeClient {
-    fn default() -> Self {
-        Self::new(PluginRuntimeUnavailableReason::NotBuilt)
-    }
-}
-
-#[async_trait::async_trait]
-impl PluginRuntimeClient for DisabledPluginRuntimeClient {
-    fn availability(&self) -> PluginRuntimeAvailability {
-        PluginRuntimeAvailability::Disabled {
-            reason: self.reason,
-        }
-    }
-
-    async fn dispatch(
-        &self,
-        _envelope: PluginDispatchEnvelope,
-    ) -> PortResult<PluginResponseEnvelope> {
-        Err(self.not_available())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ProjectionOnlyPluginRuntimeClient {
-    reason: PluginRuntimeUnavailableReason,
-}
-
-impl ProjectionOnlyPluginRuntimeClient {
-    pub const fn new(reason: PluginRuntimeUnavailableReason) -> Self {
-        Self { reason }
-    }
-
-    fn not_available(&self) -> PortError {
-        PortError::new(
-            PortErrorKind::NotAvailable,
-            format!("plugin runtime is projection-only: {}", self.reason),
-        )
-    }
-}
-
-#[async_trait::async_trait]
-impl PluginRuntimeClient for ProjectionOnlyPluginRuntimeClient {
-    fn availability(&self) -> PluginRuntimeAvailability {
-        PluginRuntimeAvailability::ProjectionOnly {
-            reason: self.reason,
-        }
-    }
-
-    async fn dispatch(
-        &self,
-        _envelope: PluginDispatchEnvelope,
-    ) -> PortResult<PluginResponseEnvelope> {
-        Err(self.not_available())
-    }
-}
-
-#[derive(Clone)]
-pub enum PluginRuntimeBinding {
-    Disabled(DisabledPluginRuntimeClient),
-    ProjectionOnly(ProjectionOnlyPluginRuntimeClient),
-    Client(Arc<dyn PluginRuntimeClient>),
-}
-
-impl PluginRuntimeBinding {
-    pub const fn disabled(reason: PluginRuntimeUnavailableReason) -> Self {
-        Self::Disabled(DisabledPluginRuntimeClient::new(reason))
-    }
-
-    pub const fn projection_only(reason: PluginRuntimeUnavailableReason) -> Self {
-        Self::ProjectionOnly(ProjectionOnlyPluginRuntimeClient::new(reason))
-    }
-
-    pub fn client(client: Arc<dyn PluginRuntimeClient>) -> Self {
-        Self::Client(client)
-    }
-
-    pub fn availability(&self) -> PluginRuntimeAvailability {
-        match self {
-            Self::Disabled(client) => client.availability(),
-            Self::ProjectionOnly(client) => client.availability(),
-            Self::Client(client) => client.availability(),
-        }
-    }
-
-    pub fn as_client(&self) -> Arc<dyn PluginRuntimeClient> {
-        match self {
-            Self::Disabled(client) => Arc::new(client.clone()),
-            Self::ProjectionOnly(client) => Arc::new(client.clone()),
-            Self::Client(client) => Arc::clone(client),
-        }
-    }
-}
-
-impl Default for PluginRuntimeBinding {
-    fn default() -> Self {
-        Self::disabled(PluginRuntimeUnavailableReason::NotBuilt)
-    }
-}
-
-impl std::fmt::Debug for PluginRuntimeBinding {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PluginRuntimeBinding")
-            .field("availability", &self.availability())
-            .finish()
-    }
 }
 
 pub trait FileSystemPort: RuntimeServicePort {}

--- a/src/crates/contracts/runtime-ports/src/plugin.rs
+++ b/src/crates/contracts/runtime-ports/src/plugin.rs
@@ -1,0 +1,819 @@
+use crate::{PortError, PortErrorKind, PortResult};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginRuntimeUnavailableReason {
+    NotBuilt,
+    UnsupportedProfile,
+    DisabledByPolicy,
+    HostUnavailable,
+}
+
+impl PluginRuntimeUnavailableReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotBuilt => "not_built",
+            Self::UnsupportedProfile => "unsupported_profile",
+            Self::DisabledByPolicy => "disabled_by_policy",
+            Self::HostUnavailable => "host_unavailable",
+        }
+    }
+}
+
+impl std::fmt::Display for PluginRuntimeUnavailableReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+#[non_exhaustive]
+pub enum ExtensionCapabilityAvailability {
+    Disabled {
+        reason: PluginRuntimeUnavailableReason,
+    },
+    ProjectionOnly {
+        reason: PluginRuntimeUnavailableReason,
+    },
+    Available,
+    Unavailable {
+        reason: PluginRuntimeUnavailableReason,
+    },
+}
+
+impl ExtensionCapabilityAvailability {
+    pub const fn disabled(reason: PluginRuntimeUnavailableReason) -> Self {
+        Self::Disabled { reason }
+    }
+
+    pub const fn projection_only(reason: PluginRuntimeUnavailableReason) -> Self {
+        Self::ProjectionOnly { reason }
+    }
+
+    pub const fn is_executable(self) -> bool {
+        matches!(self, Self::Available)
+    }
+}
+
+pub type PluginRuntimeAvailability = ExtensionCapabilityAvailability;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginSourceKind {
+    LocalPath,
+    OpenCodeCompatible,
+    RemoteRegistry,
+    BitFunNative,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginTrustLevel {
+    Unknown,
+    Trusted,
+    Denied,
+    Revoked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginSourceRef {
+    pub plugin_id: String,
+    pub source_kind: PluginSourceKind,
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub content_hash: String,
+    pub trust_level: PluginTrustLevel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<PluginManifestRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginManifestRef {
+    pub manifest_id: String,
+    pub schema_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginConfigValidationStatus {
+    Valid,
+    Warning,
+    Invalid,
+    NotValidated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginConfigValidationIssue {
+    pub field: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginConfigValidationState {
+    pub status: PluginConfigValidationStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<PluginConfigValidationIssue>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginStatusKind {
+    Enabled,
+    ProjectionOnly,
+    Disabled,
+    InvalidConfig,
+    TrustRequired,
+    Quarantined,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginStatusSnapshot {
+    pub source: PluginSourceRef,
+    pub status: PluginStatusKind,
+    pub availability: PluginRuntimeAvailability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_validation: Option<PluginConfigValidationState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quarantine: Option<PluginQuarantineState>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostic_ids: Vec<String>,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginOwnerKind {
+    ProductFeature,
+    ExtensionContract,
+    AssemblyPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginOwnerRef {
+    pub kind: PluginOwnerKind,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginCapabilityRef {
+    pub capability_id: String,
+    pub owner: PluginOwnerRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginTargetRef {
+    pub target_kind: String,
+    pub target_id: String,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<PluginArtifactRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginAuditRef {
+    pub correlation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginArtifactRef {
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginDataClassification {
+    Public,
+    Workspace,
+    Sensitive,
+    Secret,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginPayloadRedaction {
+    None,
+    Partial,
+    Full,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginPayloadRef {
+    pub payload_id: String,
+    pub schema_version: String,
+    pub data_classification: PluginDataClassification,
+    pub redaction: PluginPayloadRedaction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginRiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PermissionPromptEffectKind {
+    Unsupported,
+    ProviderCandidate,
+    Descriptor,
+    EvidenceCandidate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginRollbackMode {
+    RemoveContribution,
+    RestorePrevious,
+    DisablePlugin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRollbackPolicy {
+    pub mode: PluginRollbackMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PermissionPromptDenyState {
+    NoStateChange,
+    CandidateDiscarded,
+    TemporarilyUnavailable,
+    PolicyDenied,
+    Quarantined,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionPromptDescriptor {
+    pub descriptor_version: u16,
+    pub prompt_id: String,
+    pub plugin: PluginSourceRef,
+    pub requested_capability: PluginCapabilityRef,
+    pub requested_effect: PermissionPromptEffectKind,
+    pub target: PluginTargetRef,
+    pub risk_level: PluginRiskLevel,
+    pub owner: PluginOwnerRef,
+    pub rollback: PluginRollbackPolicy,
+    pub deny_state: PermissionPromptDenyState,
+    pub audit: PluginAuditRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    tag = "status"
+)]
+#[non_exhaustive]
+pub enum PluginPermissionGate {
+    PolicyAllowed {
+        audit: PluginAuditRef,
+    },
+    PermissionRequired {
+        prompt: PermissionPromptDescriptor,
+    },
+    PolicyDenied {
+        deny_state: PermissionPromptDenyState,
+        audit: PluginAuditRef,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
+#[non_exhaustive]
+pub enum PluginEffectCandidatePayload {
+    Unsupported {
+        capability: String,
+        reason: String,
+    },
+    ProviderCandidate {
+        provider_id: String,
+        tool_contract_id: String,
+    },
+    Descriptor {
+        descriptor_id: String,
+        descriptor_version: u16,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        payload_ref: Option<PluginPayloadRef>,
+    },
+    EvidenceCandidate {
+        payload_ref: PluginPayloadRef,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginEffectCandidate {
+    pub effect_id: String,
+    pub schema_version: String,
+    pub declared_capability: PluginCapabilityRef,
+    pub target_ref: PluginTargetRef,
+    pub data_classification: PluginDataClassification,
+    pub risk_level: PluginRiskLevel,
+    pub permission: PluginPermissionGate,
+    pub source_ref: PluginSourceRef,
+    pub payload: PluginEffectCandidatePayload,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginDiagnosticSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
+#[non_exhaustive]
+pub enum PluginDiagnosticDetail {
+    Manifest {
+        manifest: PluginManifestRef,
+    },
+    ConfigValidation {
+        manifest: PluginManifestRef,
+        validation: PluginConfigValidationState,
+    },
+    Trust {
+        trust_level: PluginTrustLevel,
+    },
+    Deadline {
+        deadline_ms: u64,
+        elapsed_ms: u64,
+    },
+    Quarantine {
+        scope: PluginQuarantineScope,
+        reason: PluginQuarantineReason,
+    },
+    HostLifecycle {
+        phase: PluginHostLifecyclePhase,
+    },
+    Adapter {
+        adapter_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginDiagnostic {
+    pub diagnostic_id: String,
+    pub severity: PluginDiagnosticSeverity,
+    pub source: PluginSourceRef,
+    pub code: String,
+    pub message: String,
+    pub detail: PluginDiagnosticDetail,
+    pub audit: PluginAuditRef,
+    pub retryable: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recovery_actions: Vec<PluginRecoveryAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
+#[non_exhaustive]
+pub enum PluginQuarantineScope {
+    Plugin {
+        plugin_id: String,
+    },
+    Capability {
+        plugin_id: String,
+        capability_id: String,
+    },
+    Target {
+        plugin_id: String,
+        target_kind: String,
+        target_id: String,
+    },
+    ProjectPlugin {
+        project_domain_id: String,
+        plugin_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginQuarantineReason {
+    HostFailure,
+    PolicyViolation,
+    TrustChanged,
+    DeadlineExceeded,
+    AdapterFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginQuarantineClearCondition {
+    UserAction,
+    TrustEpochAdvanced,
+    PluginUpdated,
+    HostRestarted,
+    PolicyUpdated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginRecoveryActionKind {
+    Retry,
+    Disable,
+    Retrust,
+    OpenLog,
+    ClearQuarantine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRecoveryAction {
+    pub action_id: String,
+    pub kind: PluginRecoveryActionKind,
+    pub target: PluginTargetRef,
+    pub audit: PluginAuditRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<PluginArtifactRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRecoveryActionRequest {
+    pub request_id: String,
+    pub source: PluginSourceRef,
+    pub action_id: String,
+    pub quarantine_id: String,
+    pub scope: PluginQuarantineScope,
+    pub requested_by: PluginOwnerRef,
+    pub authorization: PluginAuditRef,
+    pub epochs: PluginRuntimeEpochs,
+    pub idempotency_key: String,
+    pub requested_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginRecoveryActionStatus {
+    Accepted,
+    Completed,
+    Rejected,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRecoveryActionResult {
+    pub request_id: String,
+    pub action_id: String,
+    pub status: PluginRecoveryActionStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<PluginDiagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quarantine: Option<PluginQuarantineState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginQuarantineState {
+    pub schema_version: u16,
+    pub quarantine_id: String,
+    pub scope: PluginQuarantineScope,
+    pub reason: PluginQuarantineReason,
+    pub source: PluginSourceRef,
+    pub audit: PluginAuditRef,
+    pub created_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_ref: Option<PluginArtifactRef>,
+    pub clears_when: Vec<PluginQuarantineClearCondition>,
+    pub recovery_actions: Vec<PluginRecoveryAction>,
+    pub diagnostic_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PluginHostLifecyclePhase {
+    Init,
+    Manifest,
+    Dispatch,
+    Deadline,
+    Dispose,
+    FailureQuarantine,
+    Diagnostics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginHostLifecycleEvent {
+    pub event_id: String,
+    pub phase: PluginHostLifecyclePhase,
+    pub project_domain_id: String,
+    pub source: PluginSourceRef,
+    pub observed_at_ms: u64,
+    pub project_epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRuntimeEpochs {
+    pub project_epoch: u64,
+    pub trust_epoch: u64,
+    pub policy_epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_registry_epoch: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRuntimeReadRequest {
+    pub request_id: String,
+    pub project_domain_id: String,
+    pub workspace_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugin_ids: Vec<String>,
+    pub include_config_validation: bool,
+    pub epochs: PluginRuntimeEpochs,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginRuntimeReadResponse {
+    pub request_id: String,
+    pub project_domain_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<PluginSourceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugin_statuses: Vec<PluginStatusSnapshot>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<PluginDiagnostic>,
+    pub observed_epochs: PluginRuntimeEpochs,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginDispatchEnvelope {
+    pub envelope_version: u16,
+    pub event_id: String,
+    pub event_type: String,
+    pub event_version: String,
+    pub project_domain_id: String,
+    pub workspace_id: String,
+    pub extension_point_id: String,
+    pub source: PluginSourceRef,
+    pub declared_capability: PluginCapabilityRef,
+    pub correlation_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    pub idempotency_key: String,
+    pub deadline_ms: u64,
+    pub epochs: PluginRuntimeEpochs,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_ref: Option<PluginPayloadRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginResponseEnvelope {
+    pub envelope_version: u16,
+    pub request_event_id: String,
+    pub project_domain_id: String,
+    pub adapter_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_id: Option<String>,
+    pub completed_at_ms: u64,
+    pub effects: Vec<PluginEffectCandidate>,
+    pub diagnostics: Vec<PluginDiagnostic>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quarantine: Option<PluginQuarantineState>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugin_statuses: Vec<PluginStatusSnapshot>,
+    pub observed_epochs: PluginRuntimeEpochs,
+}
+
+#[async_trait::async_trait]
+pub trait PluginRuntimeClient: Send + Sync {
+    fn availability(&self) -> PluginRuntimeAvailability;
+
+    async fn read_plugins(
+        &self,
+        _request: PluginRuntimeReadRequest,
+    ) -> PortResult<PluginRuntimeReadResponse> {
+        Err(PortError::new(
+            PortErrorKind::NotAvailable,
+            "plugin runtime read model is not available",
+        ))
+    }
+
+    async fn dispatch(
+        &self,
+        envelope: PluginDispatchEnvelope,
+    ) -> PortResult<PluginResponseEnvelope>;
+
+    async fn execute_recovery_action(
+        &self,
+        _request: PluginRecoveryActionRequest,
+    ) -> PortResult<PluginRecoveryActionResult> {
+        Err(PortError::new(
+            PortErrorKind::NotAvailable,
+            "plugin runtime recovery actions are not available",
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DisabledPluginRuntimeClient {
+    reason: PluginRuntimeUnavailableReason,
+}
+
+impl DisabledPluginRuntimeClient {
+    pub const fn new(reason: PluginRuntimeUnavailableReason) -> Self {
+        Self { reason }
+    }
+
+    fn not_available(&self) -> PortError {
+        PortError::new(
+            PortErrorKind::NotAvailable,
+            format!("plugin runtime is disabled: {}", self.reason),
+        )
+    }
+}
+
+impl Default for DisabledPluginRuntimeClient {
+    fn default() -> Self {
+        Self::new(PluginRuntimeUnavailableReason::NotBuilt)
+    }
+}
+
+#[async_trait::async_trait]
+impl PluginRuntimeClient for DisabledPluginRuntimeClient {
+    fn availability(&self) -> PluginRuntimeAvailability {
+        PluginRuntimeAvailability::Disabled {
+            reason: self.reason,
+        }
+    }
+
+    async fn read_plugins(
+        &self,
+        _request: PluginRuntimeReadRequest,
+    ) -> PortResult<PluginRuntimeReadResponse> {
+        Err(self.not_available())
+    }
+
+    async fn dispatch(
+        &self,
+        _envelope: PluginDispatchEnvelope,
+    ) -> PortResult<PluginResponseEnvelope> {
+        Err(self.not_available())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectionOnlyPluginRuntimeClient {
+    reason: PluginRuntimeUnavailableReason,
+}
+
+impl ProjectionOnlyPluginRuntimeClient {
+    pub const fn new(reason: PluginRuntimeUnavailableReason) -> Self {
+        Self { reason }
+    }
+
+    fn not_available(&self) -> PortError {
+        PortError::new(
+            PortErrorKind::NotAvailable,
+            format!("plugin runtime is projection-only: {}", self.reason),
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl PluginRuntimeClient for ProjectionOnlyPluginRuntimeClient {
+    fn availability(&self) -> PluginRuntimeAvailability {
+        PluginRuntimeAvailability::ProjectionOnly {
+            reason: self.reason,
+        }
+    }
+
+    async fn read_plugins(
+        &self,
+        _request: PluginRuntimeReadRequest,
+    ) -> PortResult<PluginRuntimeReadResponse> {
+        Err(self.not_available())
+    }
+
+    async fn dispatch(
+        &self,
+        _envelope: PluginDispatchEnvelope,
+    ) -> PortResult<PluginResponseEnvelope> {
+        Err(self.not_available())
+    }
+}
+
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum PluginRuntimeBinding {
+    Disabled(DisabledPluginRuntimeClient),
+    ProjectionOnly(ProjectionOnlyPluginRuntimeClient),
+    Client(Arc<dyn PluginRuntimeClient>),
+}
+
+impl PluginRuntimeBinding {
+    pub const fn disabled(reason: PluginRuntimeUnavailableReason) -> Self {
+        Self::Disabled(DisabledPluginRuntimeClient::new(reason))
+    }
+
+    pub const fn projection_only(reason: PluginRuntimeUnavailableReason) -> Self {
+        Self::ProjectionOnly(ProjectionOnlyPluginRuntimeClient::new(reason))
+    }
+
+    pub fn client(client: Arc<dyn PluginRuntimeClient>) -> Self {
+        Self::Client(client)
+    }
+
+    pub fn availability(&self) -> PluginRuntimeAvailability {
+        match self {
+            Self::Disabled(client) => client.availability(),
+            Self::ProjectionOnly(client) => client.availability(),
+            Self::Client(client) => client.availability(),
+        }
+    }
+
+    pub fn as_client(&self) -> Arc<dyn PluginRuntimeClient> {
+        match self {
+            Self::Disabled(client) => Arc::new(client.clone()),
+            Self::ProjectionOnly(client) => Arc::new(client.clone()),
+            Self::Client(client) => Arc::clone(client),
+        }
+    }
+}
+
+impl Default for PluginRuntimeBinding {
+    fn default() -> Self {
+        Self::disabled(PluginRuntimeUnavailableReason::NotBuilt)
+    }
+}
+
+impl std::fmt::Debug for PluginRuntimeBinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginRuntimeBinding")
+            .field("availability", &self.availability())
+            .finish()
+    }
+}

--- a/src/crates/contracts/runtime-ports/tests/plugin_runtime_contracts.rs
+++ b/src/crates/contracts/runtime-ports/tests/plugin_runtime_contracts.rs
@@ -1,14 +1,316 @@
 use bitfun_runtime_ports::{
-    PluginDispatchEnvelope, PluginRuntimeAvailability, PluginRuntimeBinding,
-    PluginRuntimeUnavailableReason, PortErrorKind,
+    PermissionPromptDenyState, PermissionPromptDescriptor, PermissionPromptEffectKind,
+    PluginArtifactRef, PluginAuditRef, PluginCapabilityRef, PluginDataClassification,
+    PluginDispatchEnvelope, PluginEffectCandidate, PluginEffectCandidatePayload, PluginManifestRef,
+    PluginOwnerKind, PluginOwnerRef, PluginPayloadRedaction, PluginPayloadRef,
+    PluginPermissionGate, PluginResponseEnvelope, PluginRiskLevel, PluginRollbackMode,
+    PluginRollbackPolicy, PluginRuntimeAvailability, PluginRuntimeBinding, PluginRuntimeEpochs,
+    PluginRuntimeReadRequest, PluginRuntimeReadResponse, PluginRuntimeUnavailableReason,
+    PluginSourceKind, PluginSourceRef, PluginStatusKind, PluginStatusSnapshot, PluginTargetRef,
+    PluginTrustLevel, PortErrorKind,
 };
+
+fn manifest_ref() -> PluginManifestRef {
+    PluginManifestRef {
+        manifest_id: "manifest-1".to_string(),
+        schema_version: "opencode.plugin.v1".to_string(),
+        path: Some("opencode.json".to_string()),
+    }
+}
+
+fn source_ref() -> PluginSourceRef {
+    PluginSourceRef {
+        plugin_id: "opencode.example".to_string(),
+        source_kind: PluginSourceKind::OpenCodeCompatible,
+        source: "file:///plugins/opencode-example".to_string(),
+        version: Some("1.2.3".to_string()),
+        content_hash: "sha256:abc123".to_string(),
+        trust_level: PluginTrustLevel::Trusted,
+        manifest: Some(manifest_ref()),
+    }
+}
+
+fn capability_ref() -> PluginCapabilityRef {
+    PluginCapabilityRef {
+        capability_id: "tools.provider".to_string(),
+        owner: PluginOwnerRef {
+            kind: PluginOwnerKind::ExtensionContract,
+            id: "extension.tool-provider".to_string(),
+        },
+    }
+}
+
+fn artifact_ref() -> PluginArtifactRef {
+    PluginArtifactRef {
+        artifact_id: "artifact-provider-1".to_string(),
+        artifact_kind: "tool_provider_manifest".to_string(),
+        display_name: "OpenCode provider manifest".to_string(),
+        uri: Some("bitfun://artifacts/provider-manifest".to_string()),
+    }
+}
+
+fn target_ref() -> PluginTargetRef {
+    PluginTargetRef {
+        target_kind: "tool_provider".to_string(),
+        target_id: "opencode.example.provider".to_string(),
+        display_name: "OpenCode example provider".to_string(),
+        artifact: Some(artifact_ref()),
+    }
+}
+
+fn audit_ref() -> PluginAuditRef {
+    PluginAuditRef {
+        correlation_id: "corr-1".to_string(),
+        event_id: Some("event-1".to_string()),
+    }
+}
+
+fn epochs() -> PluginRuntimeEpochs {
+    PluginRuntimeEpochs {
+        project_epoch: 7,
+        trust_epoch: 3,
+        policy_epoch: 5,
+        tool_registry_epoch: Some(11),
+    }
+}
 
 fn envelope(id: &str) -> PluginDispatchEnvelope {
     PluginDispatchEnvelope {
-        envelope_id: id.to_string(),
-        event_name: "agent.turn.completed".to_string(),
-        payload: serde_json::json!({ "turnId": "turn-1" }),
+        envelope_version: 1,
+        event_id: id.to_string(),
+        event_type: "agent.turn.completed".to_string(),
+        event_version: "2026-07-07".to_string(),
+        project_domain_id: "project-1".to_string(),
+        workspace_id: "workspace-1".to_string(),
+        extension_point_id: "command.palette".to_string(),
+        source: source_ref(),
+        declared_capability: capability_ref(),
+        correlation_id: "corr-1".to_string(),
+        causation_id: None,
+        idempotency_key: format!("{id}:command.palette"),
+        deadline_ms: 30_000,
+        epochs: epochs(),
+        payload_ref: Some(PluginPayloadRef {
+            payload_id: "payload-1".to_string(),
+            schema_version: "agent.turn.completed.v1".to_string(),
+            data_classification: PluginDataClassification::Workspace,
+            redaction: PluginPayloadRedaction::Partial,
+            uri: Some("bitfun://payloads/payload-1".to_string()),
+        }),
     }
+}
+
+fn permission_prompt() -> PermissionPromptDescriptor {
+    PermissionPromptDescriptor {
+        descriptor_version: 1,
+        prompt_id: "prompt-1".to_string(),
+        plugin: source_ref(),
+        requested_capability: capability_ref(),
+        requested_effect: PermissionPromptEffectKind::ProviderCandidate,
+        target: target_ref(),
+        risk_level: PluginRiskLevel::Medium,
+        owner: PluginOwnerRef {
+            kind: PluginOwnerKind::ProductFeature,
+            id: "tools".to_string(),
+        },
+        rollback: PluginRollbackPolicy {
+            mode: PluginRollbackMode::DisablePlugin,
+            reason_ref: Some("audit:event-1".to_string()),
+        },
+        deny_state: PermissionPromptDenyState::CandidateDiscarded,
+        audit: audit_ref(),
+    }
+}
+
+#[test]
+fn dispatch_envelope_serializes_typed_host_boundary_without_raw_payload() {
+    let json = serde_json::to_value(envelope("event-1")).expect("serialize dispatch envelope");
+
+    assert_eq!(json["envelopeVersion"], 1);
+    assert_eq!(json["eventId"], "event-1");
+    assert_eq!(json["extensionPointId"], "command.palette");
+    assert_eq!(json["source"]["sourceKind"], "open_code_compatible");
+    assert_eq!(
+        json["source"]["manifest"]["schemaVersion"],
+        "opencode.plugin.v1"
+    );
+    assert_eq!(json["declaredCapability"]["capabilityId"], "tools.provider");
+    assert_eq!(json["epochs"]["policyEpoch"], 5);
+    assert!(
+        json.get("payload").is_none(),
+        "raw payload must not be a stable host ABI"
+    );
+    assert_eq!(
+        json["payloadRef"]["dataClassification"], "workspace",
+        "payloads crossing the host boundary must carry classification"
+    );
+
+    let roundtrip: PluginDispatchEnvelope =
+        serde_json::from_value(json).expect("dispatch envelope should round-trip");
+    assert_eq!(roundtrip.source.plugin_id, "opencode.example");
+    assert_eq!(
+        roundtrip.payload_ref.expect("payload ref").payload_id,
+        "payload-1"
+    );
+}
+
+#[test]
+fn response_envelope_carries_effect_candidates_and_observed_epochs() {
+    let response = PluginResponseEnvelope {
+        envelope_version: 1,
+        request_event_id: "event-1".to_string(),
+        project_domain_id: "project-1".to_string(),
+        adapter_id: "opencode-compatible".to_string(),
+        plugin_id: Some("opencode.example".to_string()),
+        completed_at_ms: 1_720_000_001,
+        effects: vec![PluginEffectCandidate {
+            effect_id: "effect-1".to_string(),
+            schema_version: "plugin.effect.v1".to_string(),
+            declared_capability: capability_ref(),
+            target_ref: target_ref(),
+            data_classification: PluginDataClassification::Workspace,
+            risk_level: PluginRiskLevel::Medium,
+            permission: PluginPermissionGate::PermissionRequired {
+                prompt: permission_prompt(),
+            },
+            source_ref: source_ref(),
+            payload: PluginEffectCandidatePayload::ProviderCandidate {
+                provider_id: "opencode.example.provider".to_string(),
+                tool_contract_id: "tool-provider.v1".to_string(),
+            },
+        }],
+        diagnostics: Vec::new(),
+        quarantine: None,
+        plugin_statuses: vec![PluginStatusSnapshot {
+            source: source_ref(),
+            status: PluginStatusKind::Enabled,
+            availability: PluginRuntimeAvailability::Available,
+            config_validation: None,
+            quarantine: None,
+            diagnostic_ids: Vec::new(),
+            updated_at_ms: 1_720_000_001,
+        }],
+        observed_epochs: epochs(),
+    };
+
+    let json = serde_json::to_value(response).expect("serialize response envelope");
+
+    assert_eq!(json["requestEventId"], "event-1");
+    assert_eq!(json["effects"][0]["payload"]["kind"], "provider_candidate");
+    assert_eq!(
+        json["effects"][0]["permission"]["prompt"]["requestedEffect"],
+        "provider_candidate"
+    );
+    assert_eq!(
+        json["effects"][0]["permission"]["status"],
+        "permission_required"
+    );
+    assert_eq!(
+        json["effects"][0]["targetRef"]["artifact"]["displayName"],
+        "OpenCode provider manifest"
+    );
+    assert_eq!(json["pluginStatuses"][0]["status"], "enabled");
+    assert_eq!(
+        json["pluginStatuses"][0]["availability"]["status"],
+        "available"
+    );
+    assert_eq!(json["observedEpochs"]["toolRegistryEpoch"], 11);
+    assert!(
+        json.get("accepted").is_none(),
+        "host responses must return typed candidates"
+    );
+
+    let roundtrip: PluginResponseEnvelope =
+        serde_json::from_value(json).expect("response envelope should round-trip");
+    assert_eq!(roundtrip.effects.len(), 1);
+}
+
+#[test]
+fn policy_allowed_effects_keep_auditable_permission_facts() {
+    let response = PluginResponseEnvelope {
+        envelope_version: 1,
+        request_event_id: "event-2".to_string(),
+        project_domain_id: "project-1".to_string(),
+        adapter_id: "opencode-compatible".to_string(),
+        plugin_id: Some("opencode.example".to_string()),
+        completed_at_ms: 1_720_000_002,
+        effects: vec![PluginEffectCandidate {
+            effect_id: "effect-2".to_string(),
+            schema_version: "plugin.effect.v1".to_string(),
+            declared_capability: capability_ref(),
+            target_ref: target_ref(),
+            data_classification: PluginDataClassification::Workspace,
+            risk_level: PluginRiskLevel::Low,
+            permission: PluginPermissionGate::PolicyAllowed { audit: audit_ref() },
+            source_ref: source_ref(),
+            payload: PluginEffectCandidatePayload::ProviderCandidate {
+                provider_id: "opencode.example.provider".to_string(),
+                tool_contract_id: "tool-provider.v1".to_string(),
+            },
+        }],
+        diagnostics: Vec::new(),
+        quarantine: None,
+        plugin_statuses: Vec::new(),
+        observed_epochs: epochs(),
+    };
+
+    let json = serde_json::to_value(response).expect("serialize policy-allowed effect");
+
+    assert_eq!(json["effects"][0]["permission"]["status"], "policy_allowed");
+    assert_eq!(
+        json["effects"][0]["permission"]["audit"]["correlationId"],
+        "corr-1"
+    );
+    assert!(
+        json["effects"][0]["payload"]
+            .get("materializeWhen")
+            .is_none(),
+        "materialization is derived from the permission gate instead of a free payload flag"
+    );
+    assert!(
+        serde_json::from_value::<PluginPermissionGate>(serde_json::json!({
+            "status": "not_required"
+        }))
+        .is_err(),
+        "permission gates must not accept unaudited no-op states"
+    );
+}
+
+#[test]
+fn read_plugins_contract_supports_discovery_status_and_config_projection() {
+    let request = PluginRuntimeReadRequest {
+        request_id: "read-1".to_string(),
+        project_domain_id: "project-1".to_string(),
+        workspace_id: "workspace-1".to_string(),
+        plugin_ids: vec!["opencode.example".to_string()],
+        include_config_validation: true,
+        epochs: epochs(),
+    };
+    let response = PluginRuntimeReadResponse {
+        request_id: "read-1".to_string(),
+        project_domain_id: "project-1".to_string(),
+        sources: vec![source_ref()],
+        plugin_statuses: vec![PluginStatusSnapshot {
+            source: source_ref(),
+            status: PluginStatusKind::Enabled,
+            availability: PluginRuntimeAvailability::Available,
+            config_validation: None,
+            quarantine: None,
+            diagnostic_ids: Vec::new(),
+            updated_at_ms: 1_720_000_002,
+        }],
+        diagnostics: Vec::new(),
+        observed_epochs: epochs(),
+    };
+
+    let request_json = serde_json::to_value(request).expect("serialize read request");
+    let response_json = serde_json::to_value(response).expect("serialize read response");
+
+    assert_eq!(request_json["includeConfigValidation"], true);
+    assert_eq!(request_json["pluginIds"][0], "opencode.example");
+    assert_eq!(response_json["sources"][0]["pluginId"], "opencode.example");
+    assert_eq!(response_json["pluginStatuses"][0]["status"], "enabled");
+    assert_eq!(response_json["observedEpochs"]["trustEpoch"], 3);
 }
 
 #[tokio::test]
@@ -30,6 +332,21 @@ async fn disabled_plugin_runtime_binding_reports_not_available() {
 
     assert_eq!(error.kind, PortErrorKind::NotAvailable);
     assert!(error.message.contains("plugin runtime is disabled"));
+
+    let read_error = binding
+        .as_client()
+        .read_plugins(PluginRuntimeReadRequest {
+            request_id: "read-disabled".to_string(),
+            project_domain_id: "project-1".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            plugin_ids: Vec::new(),
+            include_config_validation: true,
+            epochs: epochs(),
+        })
+        .await
+        .expect_err("disabled binding must not expose plugin discovery/status reads");
+
+    assert_eq!(read_error.kind, PortErrorKind::NotAvailable);
 }
 
 #[tokio::test]

--- a/src/crates/contracts/runtime-ports/tests/plugin_runtime_host_contracts.rs
+++ b/src/crates/contracts/runtime-ports/tests/plugin_runtime_host_contracts.rs
@@ -1,0 +1,259 @@
+use bitfun_runtime_ports::{
+    PermissionPromptDenyState, PermissionPromptDescriptor, PermissionPromptEffectKind,
+    PluginArtifactRef, PluginAuditRef, PluginCapabilityRef, PluginConfigValidationIssue,
+    PluginConfigValidationState, PluginConfigValidationStatus, PluginDiagnostic,
+    PluginDiagnosticDetail, PluginDiagnosticSeverity, PluginHostLifecycleEvent,
+    PluginHostLifecyclePhase, PluginManifestRef, PluginOwnerKind, PluginOwnerRef,
+    PluginQuarantineClearCondition, PluginQuarantineReason, PluginQuarantineScope,
+    PluginQuarantineState, PluginRecoveryAction, PluginRecoveryActionKind,
+    PluginRecoveryActionRequest, PluginRecoveryActionResult, PluginRecoveryActionStatus,
+    PluginRiskLevel, PluginRollbackMode, PluginRollbackPolicy, PluginSourceKind, PluginSourceRef,
+    PluginTargetRef, PluginTrustLevel,
+};
+
+fn manifest_ref() -> PluginManifestRef {
+    PluginManifestRef {
+        manifest_id: "manifest-1".to_string(),
+        schema_version: "opencode.plugin.v1".to_string(),
+        path: Some("opencode.json".to_string()),
+    }
+}
+
+fn source_ref() -> PluginSourceRef {
+    PluginSourceRef {
+        plugin_id: "opencode.example".to_string(),
+        source_kind: PluginSourceKind::OpenCodeCompatible,
+        source: "file:///plugins/opencode-example".to_string(),
+        version: Some("1.2.3".to_string()),
+        content_hash: "sha256:abc123".to_string(),
+        trust_level: PluginTrustLevel::Trusted,
+        manifest: Some(manifest_ref()),
+    }
+}
+
+fn owner_ref() -> PluginOwnerRef {
+    PluginOwnerRef {
+        kind: PluginOwnerKind::ExtensionContract,
+        id: "extension.tool-provider".to_string(),
+    }
+}
+
+fn capability_ref() -> PluginCapabilityRef {
+    PluginCapabilityRef {
+        capability_id: "tools.provider".to_string(),
+        owner: owner_ref(),
+    }
+}
+
+fn log_ref() -> PluginArtifactRef {
+    PluginArtifactRef {
+        artifact_id: "log-1".to_string(),
+        artifact_kind: "host_log".to_string(),
+        display_name: "Plugin host dispatch log".to_string(),
+        uri: Some("bitfun://logs/plugin-host/diag-1".to_string()),
+    }
+}
+
+fn target_ref() -> PluginTargetRef {
+    PluginTargetRef {
+        target_kind: "tool_provider".to_string(),
+        target_id: "opencode.example.provider".to_string(),
+        display_name: "OpenCode example provider".to_string(),
+        artifact: Some(log_ref()),
+    }
+}
+
+fn audit_ref() -> PluginAuditRef {
+    PluginAuditRef {
+        correlation_id: "corr-1".to_string(),
+        event_id: Some("event-1".to_string()),
+    }
+}
+
+fn retry_action() -> PluginRecoveryAction {
+    PluginRecoveryAction {
+        action_id: "retry-1".to_string(),
+        kind: PluginRecoveryActionKind::Retry,
+        target: target_ref(),
+        audit: audit_ref(),
+        artifact: None,
+    }
+}
+
+fn quarantine_state() -> PluginQuarantineState {
+    PluginQuarantineState {
+        schema_version: 1,
+        quarantine_id: "quarantine-1".to_string(),
+        scope: PluginQuarantineScope::Plugin {
+            plugin_id: "opencode.example".to_string(),
+        },
+        reason: PluginQuarantineReason::DeadlineExceeded,
+        source: source_ref(),
+        audit: audit_ref(),
+        created_at_ms: 1_720_000_001,
+        log_ref: Some(log_ref()),
+        clears_when: vec![PluginQuarantineClearCondition::HostRestarted],
+        recovery_actions: vec![retry_action()],
+        diagnostic_ids: vec!["diag-1".to_string()],
+    }
+}
+
+#[test]
+fn permission_prompt_descriptor_contains_minimum_user_decision_facts() {
+    let prompt = PermissionPromptDescriptor {
+        descriptor_version: 1,
+        prompt_id: "prompt-1".to_string(),
+        plugin: source_ref(),
+        requested_capability: capability_ref(),
+        requested_effect: PermissionPromptEffectKind::ProviderCandidate,
+        target: target_ref(),
+        risk_level: PluginRiskLevel::Medium,
+        owner: PluginOwnerRef {
+            kind: PluginOwnerKind::ProductFeature,
+            id: "tools".to_string(),
+        },
+        rollback: PluginRollbackPolicy {
+            mode: PluginRollbackMode::DisablePlugin,
+            reason_ref: Some("audit:event-1".to_string()),
+        },
+        deny_state: PermissionPromptDenyState::CandidateDiscarded,
+        audit: audit_ref(),
+    };
+
+    let json = serde_json::to_value(prompt).expect("serialize prompt");
+
+    assert_eq!(json["descriptorVersion"], 1);
+    assert_eq!(json["plugin"]["pluginId"], "opencode.example");
+    assert_eq!(json["plugin"]["contentHash"], "sha256:abc123");
+    assert_eq!(json["plugin"]["manifest"]["path"], "opencode.json");
+    assert_eq!(
+        json["requestedCapability"]["capabilityId"],
+        "tools.provider"
+    );
+    assert_eq!(json["requestedEffect"], "provider_candidate");
+    assert_eq!(json["target"]["targetId"], "opencode.example.provider");
+    assert_eq!(json["target"]["displayName"], "OpenCode example provider");
+    assert_eq!(json["riskLevel"], "medium");
+    assert_eq!(json["owner"]["kind"], "product_feature");
+    assert_eq!(json["rollback"]["mode"], "disable_plugin");
+    assert_eq!(json["denyState"], "candidate_discarded");
+    assert_eq!(json["audit"]["correlationId"], "corr-1");
+}
+
+#[test]
+fn diagnostic_and_quarantine_state_are_auditable_and_recoverable() {
+    let diagnostic = PluginDiagnostic {
+        diagnostic_id: "diag-1".to_string(),
+        severity: PluginDiagnosticSeverity::Error,
+        source: source_ref(),
+        code: "config.missing_permission_gate".to_string(),
+        message: "Command contribution must declare a permission gate".to_string(),
+        detail: PluginDiagnosticDetail::ConfigValidation {
+            manifest: manifest_ref(),
+            validation: PluginConfigValidationState {
+                status: PluginConfigValidationStatus::Invalid,
+                issues: vec![PluginConfigValidationIssue {
+                    field: "commands[0].permission".to_string(),
+                    code: "missing_permission_gate".to_string(),
+                    message: "Command contribution must declare a permission gate".to_string(),
+                }],
+            },
+        },
+        audit: audit_ref(),
+        retryable: true,
+        recovery_actions: vec![retry_action()],
+    };
+    let quarantine = quarantine_state();
+
+    let diagnostic_json = serde_json::to_value(diagnostic).expect("serialize diagnostic");
+    let quarantine_json = serde_json::to_value(quarantine).expect("serialize quarantine");
+
+    assert_eq!(diagnostic_json["source"]["pluginId"], "opencode.example");
+    assert_eq!(diagnostic_json["severity"], "error");
+    assert_eq!(diagnostic_json["detail"]["kind"], "config_validation");
+    assert_eq!(diagnostic_json["detail"]["validation"]["status"], "invalid");
+    assert_eq!(
+        diagnostic_json["recoveryActions"][0]["target"]["targetId"],
+        "opencode.example.provider"
+    );
+    assert_eq!(diagnostic_json["audit"]["eventId"], "event-1");
+    assert_eq!(quarantine_json["schemaVersion"], 1);
+    assert_eq!(quarantine_json["source"]["contentHash"], "sha256:abc123");
+    assert_eq!(quarantine_json["audit"]["correlationId"], "corr-1");
+    assert_eq!(quarantine_json["scope"]["kind"], "plugin");
+    assert_eq!(quarantine_json["reason"], "deadline_exceeded");
+    assert_eq!(quarantine_json["logRef"]["artifactKind"], "host_log");
+    assert_eq!(quarantine_json["recoveryActions"][0]["kind"], "retry");
+    assert_eq!(quarantine_json["diagnosticIds"][0], "diag-1");
+}
+
+#[test]
+fn recovery_action_request_and_result_are_typed_execution_contracts() {
+    let request = PluginRecoveryActionRequest {
+        request_id: "recovery-request-1".to_string(),
+        source: source_ref(),
+        action_id: "retry-1".to_string(),
+        quarantine_id: "quarantine-1".to_string(),
+        scope: PluginQuarantineScope::Plugin {
+            plugin_id: "opencode.example".to_string(),
+        },
+        requested_by: PluginOwnerRef {
+            kind: PluginOwnerKind::ProductFeature,
+            id: "plugin-settings".to_string(),
+        },
+        authorization: audit_ref(),
+        epochs: bitfun_runtime_ports::PluginRuntimeEpochs {
+            project_epoch: 7,
+            trust_epoch: 3,
+            policy_epoch: 5,
+            tool_registry_epoch: Some(11),
+        },
+        idempotency_key: "quarantine-1:retry".to_string(),
+        requested_at_ms: 1_720_000_003,
+    };
+    let result = PluginRecoveryActionResult {
+        request_id: "recovery-request-1".to_string(),
+        action_id: "retry-1".to_string(),
+        status: PluginRecoveryActionStatus::Accepted,
+        diagnostic: None,
+        quarantine: Some(quarantine_state()),
+    };
+
+    let request_json = serde_json::to_value(request).expect("serialize recovery request");
+    let result_json = serde_json::to_value(result).expect("serialize recovery result");
+
+    assert_eq!(request_json["source"]["pluginId"], "opencode.example");
+    assert_eq!(request_json["actionId"], "retry-1");
+    assert_eq!(request_json["quarantineId"], "quarantine-1");
+    assert_eq!(request_json["scope"]["kind"], "plugin");
+    assert_eq!(request_json["requestedBy"]["kind"], "product_feature");
+    assert_eq!(request_json["authorization"]["correlationId"], "corr-1");
+    assert_eq!(request_json["epochs"]["projectEpoch"], 7);
+    assert_eq!(request_json["idempotencyKey"], "quarantine-1:retry");
+    assert_eq!(result_json["status"], "accepted");
+    assert_eq!(result_json["quarantine"]["quarantineId"], "quarantine-1");
+}
+
+#[test]
+fn host_lifecycle_event_tracks_phase_source_and_epoch() {
+    let event = PluginHostLifecycleEvent {
+        event_id: "lifecycle-1".to_string(),
+        phase: PluginHostLifecyclePhase::Dispatch,
+        project_domain_id: "project-1".to_string(),
+        source: source_ref(),
+        observed_at_ms: 1_720_000_002,
+        project_epoch: 7,
+        diagnostic_id: Some("diag-1".to_string()),
+    };
+
+    let json = serde_json::to_value(event).expect("serialize lifecycle event");
+
+    assert_eq!(json["phase"], "dispatch");
+    assert_eq!(json["source"]["sourceKind"], "open_code_compatible");
+    assert_eq!(
+        json["source"]["manifest"]["schemaVersion"],
+        "opencode.plugin.v1"
+    );
+    assert_eq!(json["projectEpoch"], 7);
+    assert_eq!(json["diagnosticId"], "diag-1");
+}

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -746,8 +746,17 @@ mod tests {
             envelope: PluginDispatchEnvelope,
         ) -> PortResult<PluginResponseEnvelope> {
             Ok(PluginResponseEnvelope {
-                envelope_id: envelope.envelope_id,
-                accepted: true,
+                envelope_version: envelope.envelope_version,
+                request_event_id: envelope.event_id,
+                project_domain_id: envelope.project_domain_id,
+                adapter_id: "test-plugin-runtime".to_string(),
+                plugin_id: Some(envelope.source.plugin_id),
+                completed_at_ms: 0,
+                effects: Vec::new(),
+                diagnostics: Vec::new(),
+                quarantine: None,
+                plugin_statuses: Vec::new(),
+                observed_epochs: envelope.epochs,
             })
         }
     }


### PR DESCRIPTION
## Summary

- Move Plugin Runtime contracts into a dedicated `runtime-ports` plugin module while keeping an explicit root export surface.
- Replace the old raw JSON/`accepted` envelope shape with typed dispatch/read/response contracts for source, manifest, config validation, status snapshots, capability, payload refs, permission gates, diagnostics, quarantine, recovery actions, lifecycle events, and observed epochs.
- Add core-boundary guards for plugin public API budgeting, wildcard export prevention, raw JSON ABI regressions, old accepted-bool responses, invalid permission materialization states, and product-full leakage.

## Scope

This is a contract and boundary-guard PR. It does not enable an executable Plugin Runtime Host or claim completion of the P0 OpenCode-compatible Desktop command/settings + CLI diagnostics loop. Product assembly and agent runtime still reject executable plugin host bindings until the host implementation lands.

## Review notes

Independent adversarial subagent review was run from backend architecture and product/plugin-ecosystem perspectives after rebasing onto `gcwing/main` (`44b3f5138`). Findings were fixed in this PR update:

- Added a minimal `read_plugins` contract so discovery/status/config-validation projection is not only reachable through dispatch responses.
- Removed unaudited `NotRequired` permission state and the free `PluginMaterializeCondition` flag; effect materialization is now derived from an auditable `PluginPermissionGate`.
- Changed recovery execution requests to carry `action_id`, quarantine/scope, requester, authorization, epochs, and idempotency facts instead of letting callers resubmit a mutable action descriptor.
- Narrowed prompt effect kinds to the typed payload set, added product-facing deny states, expanded quarantine scope granularity, and marked extensible public enums `#[non_exhaustive]`.
- Upgraded public API budget rules from a flat symbol list to owner/consumer/P0/rationale/exit metadata, and expanded the checker to cover top-level `pub mod`/`pub fn`/`pub const`/`pub static` plus all plugin re-export forms.

Remaining non-blocking follow-up: future host/CLI implementation should validate status/availability consistency and enforce owner-mediated recovery authorization at execution time.

## Validation

Passed:

- `cargo test -p bitfun-runtime-ports`
- `cargo test -p bitfun-product-capabilities --test product_capabilities`
- `cargo test -p bitfun-agent-runtime builder_rejects_plugin_runtime_client_until_host_boundary_exists`
- `cargo check -p bitfun-runtime-ports`
- `cargo check -p bitfun-product-capabilities`
- `cargo check -p bitfun-agent-runtime`
- `node --test scripts/check-core-boundaries.test.mjs`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check gcwing/main...HEAD`

Attempted but blocked outside this PR:

- `cargo check --workspace` fails in third-party `oxc_transformer 0.138.0` because its source uses experimental `if let` guards under the current local `rustc 1.94.1` toolchain.