### PR TITLE
fix: relax startup crash detection

### DIFF
--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -195,6 +195,8 @@ pub struct RestartAppRequest {}
 #[allow(unreachable_code)]
 pub async fn restart_app(app: AppHandle, request: RestartAppRequest) -> Result<(), String> {
     let _ = request;
+    crate::crash_diagnostics::mark_clean_shutdown("restart_app");
+    crate::perform_process_exit_cleanup();
     app.restart();
     Ok(())
 }

--- a/src/apps/desktop/src/crash_diagnostics.rs
+++ b/src/apps/desktop/src/crash_diagnostics.rs
@@ -31,7 +31,16 @@ pub struct UnexpectedExitInfo {
     pub started_at: Option<String>,
     pub session_log_dir: Option<String>,
     pub crash_report_path: Option<String>,
+    pub category: UnexpectedExitCategory,
+    pub notify_on_startup: bool,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UnexpectedExitCategory {
+    Crash,
+    UncleanShutdown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -125,12 +134,20 @@ pub fn previous_unexpected_exit() -> Option<UnexpectedExitInfo> {
 
 pub fn log_previous_unexpected_exit_if_any() {
     if let Some(info) = previous_unexpected_exit() {
-        log::warn!(
-            "Previous desktop session ended unexpectedly: session_log_dir={:?}, crash_report_path={:?}, reason={}",
-            info.session_log_dir,
-            info.crash_report_path,
-            info.reason
-        );
+        if info.notify_on_startup {
+            log::warn!(
+                "Previous desktop session ended unexpectedly: session_log_dir={:?}, crash_report_path={:?}, reason={}",
+                info.session_log_dir,
+                info.crash_report_path,
+                info.reason
+            );
+        } else {
+            log::info!(
+                "Previous desktop session did not record a clean shutdown: session_log_dir={:?}, reason={}",
+                info.session_log_dir,
+                info.reason
+            );
+        }
     }
 }
 
@@ -269,12 +286,29 @@ fn detect_previous_unexpected_exit(run_state_path: &Path) -> Option<UnexpectedEx
         .filter(|path| path.exists())
         .map(|path| path.to_string_lossy().to_string());
 
+    let category = if crash_report_path.is_some() {
+        UnexpectedExitCategory::Crash
+    } else {
+        UnexpectedExitCategory::UncleanShutdown
+    };
+    let notify_on_startup = matches!(category, UnexpectedExitCategory::Crash);
+    let reason = match category {
+        UnexpectedExitCategory::Crash => {
+            "Previous run wrote a crash report before shutdown".to_string()
+        }
+        UnexpectedExitCategory::UncleanShutdown => {
+            "Previous run state was not marked as clean shutdown".to_string()
+        }
+    };
+
     Some(UnexpectedExitInfo {
         detected: true,
         started_at: Some(state.started_at),
         session_log_dir,
         crash_report_path,
-        reason: "Previous run state was not marked as clean shutdown".to_string(),
+        category,
+        notify_on_startup,
+        reason,
     })
 }
 
@@ -463,6 +497,8 @@ mod tests {
             Some(session_dir.to_string_lossy().as_ref())
         );
         assert!(info.crash_report_path.is_some());
+        assert_eq!(info.category, UnexpectedExitCategory::Crash);
+        assert!(info.notify_on_startup);
 
         let _ = fs::remove_dir_all(temp_dir);
     }
@@ -492,6 +528,42 @@ mod tests {
         write_json_file(&run_state_path, &run_state).expect("test run state should be written");
 
         assert!(detect_previous_unexpected_exit(&run_state_path).is_none());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn records_unclean_shutdown_without_startup_notification_when_no_crash_report() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "bitfun-crash-diagnostics-unclean-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should be after unix epoch")
+                .as_nanos()
+        ));
+        let session_dir = temp_dir.join("20260528T120000");
+        fs::create_dir_all(&session_dir).expect("test session directory should be created");
+
+        let run_state = RunState {
+            app_version: "test".to_string(),
+            pid: 123,
+            started_at: "2026-05-28T12:00:00Z".to_string(),
+            updated_at: "2026-05-28T12:00:01Z".to_string(),
+            session_log_dir: session_dir.to_string_lossy().to_string(),
+            clean_shutdown: false,
+            shutdown_at: None,
+            exit_reason: None,
+            startup_trace_id: "test-trace".to_string(),
+        };
+        let run_state_path = temp_dir.join(RUN_STATE_FILE);
+        write_json_file(&run_state_path, &run_state).expect("test run state should be written");
+
+        let info = detect_previous_unexpected_exit(&run_state_path)
+            .expect("unclean run state should still be recorded");
+        assert!(info.detected);
+        assert!(info.crash_report_path.is_none());
+        assert_eq!(info.category, UnexpectedExitCategory::UncleanShutdown);
+        assert!(!info.notify_on_startup);
 
         let _ = fs::remove_dir_all(temp_dir);
     }

--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -725,7 +725,7 @@ function App() {
       try {
         const { configAPI, workspaceAPI } = await import('@/infrastructure/api');
         const runtimeInfo = await configAPI.getRuntimeLoggingInfo();
-        if (cancelled || !runtimeInfo.previousUnexpectedExit?.detected) {
+        if (cancelled || !runtimeInfo.previousUnexpectedExit?.notifyOnStartup) {
           return;
         }
         const recoveryKey = `bitfun:unexpected-exit-notice:${runtimeInfo.previousUnexpectedExit.sessionLogDir || 'unknown'}`;

--- a/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
@@ -378,11 +378,20 @@ function BasicsLoggingSection() {
         >
           {runtimeInfo?.previousUnexpectedExit?.detected && (
             <Alert
-              type="warning"
-              message={t('logging.previousCrash.title')}
-              description={t('logging.previousCrash.description', {
-                path: runtimeInfo.previousUnexpectedExit.sessionLogDir || '-',
-              })}
+              type={runtimeInfo.previousUnexpectedExit.category === 'crash' ? 'warning' : 'info'}
+              message={t(
+                runtimeInfo.previousUnexpectedExit.category === 'crash'
+                  ? 'logging.previousCrash.title'
+                  : 'logging.previousUncleanShutdown.title'
+              )}
+              description={t(
+                runtimeInfo.previousUnexpectedExit.category === 'crash'
+                  ? 'logging.previousCrash.description'
+                  : 'logging.previousUncleanShutdown.description',
+                {
+                  path: runtimeInfo.previousUnexpectedExit.sessionLogDir || '-',
+                }
+              )}
             />
           )}
           <ConfigPageRow

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -607,6 +607,8 @@ export interface UnexpectedExitInfo {
   startedAt?: string;
   sessionLogDir?: string;
   crashReportPath?: string;
+  category?: 'crash' | 'unclean_shutdown';
+  notifyOnStartup?: boolean;
   reason: string;
 }
 

--- a/src/web-ui/src/locales/en-US/settings/basics.json
+++ b/src/web-ui/src/locales/en-US/settings/basics.json
@@ -125,9 +125,13 @@
       "title": "Previous session ended unexpectedly",
       "description": "Last session logs are available at {{path}}."
     },
+    "previousUncleanShutdown": {
+      "title": "Previous session did not record a normal shutdown",
+      "description": "Last session logs are available at {{path}}. This can happen after a restart, system shutdown, or development reload."
+    },
     "startupRecovery": {
-      "title": "Previous session did not close normally",
-      "message": "BitFun reopened after an unexpected quit. You can export diagnostics if you want to report the issue."
+      "title": "Previous session ended unexpectedly",
+      "message": "BitFun found a crash report from the previous session. You can export diagnostics if you want to report the issue."
     },
     "levels": {
       "trace": "Trace",

--- a/src/web-ui/src/locales/zh-CN/settings/basics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/basics.json
@@ -125,9 +125,13 @@
       "title": "上次会话异常结束",
       "description": "上次会话日志位于 {{path}}。"
     },
+    "previousUncleanShutdown": {
+      "title": "上次会话未记录到正常关闭",
+      "description": "上次会话日志位于 {{path}}。重启、系统关机或开发热重载后也可能出现这种记录。"
+    },
     "startupRecovery": {
-      "title": "上次没有正常关闭",
-      "message": "BitFun 已从一次异常退出后重新打开。如需反馈问题，可以导出诊断包。"
+      "title": "上次会话异常结束",
+      "message": "BitFun 发现上次会话留下了崩溃报告。如需反馈问题，可以导出诊断包。"
     },
     "levels": {
       "trace": "Trace",

--- a/src/web-ui/src/locales/zh-TW/settings/basics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/basics.json
@@ -111,9 +111,13 @@
       "title": "上次會話異常結束",
       "description": "上次會話日誌位於 {{path}}。"
     },
+    "previousUncleanShutdown": {
+      "title": "上次會話未記錄到正常關閉",
+      "description": "上次會話日誌位於 {{path}}。重新啟動、系統關機或開發熱重載後也可能出現這種記錄。"
+    },
     "startupRecovery": {
-      "title": "上次沒有正常關閉",
-      "message": "BitFun 已從一次異常退出後重新開啟。如需回報問題，可以匯出診斷包。"
+      "title": "上次會話異常結束",
+      "message": "BitFun 發現上次會話留下了崩潰報告。如需回報問題，可以匯出診斷包。"
     },
     "levels": {
       "trace": "Trace",


### PR DESCRIPTION
## Summary
- classify previous desktop exits as crash vs unclean shutdown
- only show startup recovery notifications when a crash report exists
- mark app restarts as clean shutdowns and soften settings copy for unclean shutdowns

## Verification
- pnpm run fmt:rs
- pnpm run i18n:audit
- pnpm run type-check:web
- cargo test -p bitfun-desktop crash_diagnostics
- cargo check -p bitfun-desktop