### PR TITLE
chore: clean up desktop cargo check warnings

### DIFF
--- a/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
@@ -24,7 +24,9 @@ use bitfun_core::agentic::tools::computer_use_host::{
     VisualActionResult, VisualClickParams, VisualMark, VisualMarkView, VisualMarkViewOpts,
 };
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
-use log::{debug, warn};
+#[cfg(target_os = "macos")]
+use log::debug;
+use log::warn;
 use std::time::{Duration, Instant};
 
 impl DesktopComputerUseHost {

--- a/src/apps/desktop/src/computer_use/windows_wgc_capture.rs
+++ b/src/apps/desktop/src/computer_use/windows_wgc_capture.rs
@@ -71,7 +71,7 @@ pub fn capture_window_bgra(hwnd: HWND) -> BitFunResult<(Vec<u8>, u32, u32)> {
             .map_err(|e| BitFunError::service(format!("WGC StartCapture: {e}")))?;
 
         let deadline = Instant::now() + Duration::from_secs(2);
-        let mut last_err: Option<String> = None;
+        let mut last_err: Option<String>;
         let result = loop {
             match frame_pool.TryGetNextFrame() {
                 Ok(frame) => match copy_frame_to_bgra(&frame, &d3d_device, &d3d_context) {

--- a/src/crates/assembly/core/src/agentic/tools/implementations/web/readable.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/web/readable.rs
@@ -1,8 +1,9 @@
 use crate::util::errors::{BitFunError, BitFunResult};
 
+#[cfg(test)]
+pub(crate) use tool_runtime::web_readable::{html_to_text, looks_noisy};
 pub(crate) use tool_runtime::web_readable::{
-    html_to_text, is_html, looks_noisy, ReadableWebOutput as ReadableOutput,
-    RequestedWebFetchFormat as RequestedFormat,
+    is_html, ReadableWebOutput as ReadableOutput, RequestedWebFetchFormat as RequestedFormat,
 };
 
 pub(crate) fn normalize_requested_format(format: Option<&str>) -> BitFunResult<RequestedFormat> {

--- a/src/crates/interfaces/acp/src/runtime/events.rs
+++ b/src/crates/interfaces/acp/src/runtime/events.rs
@@ -2,12 +2,12 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use agent_client_protocol::schema::{
-    ContentBlock, PermissionOption, PermissionOptionKind, RequestPermissionRequest, SessionId,
+    PermissionOption, PermissionOptionKind, RequestPermissionRequest, SessionId,
     SessionNotification, SessionUpdate, ToolCall, ToolCallContent, ToolCallLocation,
     ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
 };
 use agent_client_protocol::{Client, ConnectionTo, Result};
-use bitfun_core::service::session::{ToolCallData, ToolItemData};
+use bitfun_core::service::session::ToolItemData;
 use bitfun_events::ToolEventData;
 
 pub(super) const PERMISSION_ALLOW_ONCE: &str = "allow_once";
@@ -523,6 +523,8 @@ impl ToolEventExt for ToolEventData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::schema::ContentBlock;
+    use bitfun_core::service::session::ToolCallData;
 
     #[test]
     fn early_detected_creates_tool_call_once() {


### PR DESCRIPTION
- Move test-only Rust imports behind cfg(test)
- Scope macOS-only debug logging import to macOS builds
- Remove unused initial assignment in Windows WGC capture
