### PR TITLE
fix(web-ui): render preview iframes via document write

### DIFF
--- a/src/web-ui/src/tools/bitfun-canvas/BitfunCanvasPanel.test.tsx
+++ b/src/web-ui/src/tools/bitfun-canvas/BitfunCanvasPanel.test.tsx
@@ -70,16 +70,11 @@ vi.mock('@/tools/editor/components/CodeEditor', () => ({
   default: () => null,
 }));
 
-const originalCreateObjectUrl = URL.createObjectURL;
-const originalRevokeObjectUrl = URL.revokeObjectURL;
-
 describe('BitfunCanvasPanel message boundary', () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
-    URL.createObjectURL = vi.fn(() => 'blob:bitfun-canvas-test');
-    URL.revokeObjectURL = vi.fn();
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -90,9 +85,28 @@ describe('BitfunCanvasPanel message boundary', () => {
       root.unmount();
     });
     container.remove();
-    URL.createObjectURL = originalCreateObjectUrl;
-    URL.revokeObjectURL = originalRevokeObjectUrl;
     vi.clearAllMocks();
+  });
+
+  it('renders Canvas HTML through document write instead of a blob URL', async () => {
+    await act(async () => {
+      root.render(
+        <BitfunCanvasPanel
+          artifactReference="bitfun-canvas://session/session_1/canvas/canvas_1"
+          html="<!doctype html><html><body>Canvas</body></html>"
+        />,
+      );
+    });
+
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
+    expect(iframe.getAttribute('src')).toBe('about:blank');
+    expect(iframe.getAttribute('srcdoc')).toBeNull();
+    expect(iframe.contentDocument?.documentElement.outerHTML).toContain('Canvas');
   });
 
   it('ignores Canvas host actions from non-iframe message sources', async () => {

--- a/src/web-ui/src/tools/bitfun-canvas/BitfunCanvasPanel.tsx
+++ b/src/web-ui/src/tools/bitfun-canvas/BitfunCanvasPanel.tsx
@@ -251,11 +251,12 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
   const reportedRuntimeErrorsRef = useRef(new Set<string>());
   const autoRepairRuntimeErrorsRef = useRef(new Set<string>());
   const loadedCanvasSignatureRef = useRef<string | null>(null);
+  const injectedFrameKeyRef = useRef<string | null>(null);
   const [sourceVisible, setSourceVisible] = useState(false);
   const [designMode, setDesignMode] = useState(false);
   const [exportingHtml, setExportingHtml] = useState(false);
   const [loadedCanvas, setLoadedCanvas] = useState<CanvasSnapshotValue | null>(null);
-  const [frameSrc, setFrameSrc] = useState<string | undefined>();
+  const [frameReadyKey, setFrameReadyKey] = useState<string | null>(null);
   const resolvedHtml = loadedCanvas?.compiledPayload?.html || html;
   const resolvedSource = loadedCanvas?.source?.source || source;
   const resolvedStatus = loadedCanvas?.artifact?.status || status;
@@ -268,6 +269,8 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
   const renderedHtml = renderedCanvas.html;
   const hasHtml = typeof renderedHtml === 'string' && renderedHtml.trim().length > 0;
   const renderedHtmlKey = `${renderedCanvas.runtime}:${renderedCanvas.revision ?? ''}:${renderedHtml?.length ?? 0}`;
+  const frameDocumentKey = `${artifactReference ?? 'inline'}:${renderedHtmlKey}`;
+  const isFrameReady = frameReadyKey === frameDocumentKey;
   const sourcePreview = useMemo(() => {
     if (!resolvedSource) return '';
     return resolvedSource.length > 5000 ? `${resolvedSource.slice(0, 5000)}\n...` : resolvedSource;
@@ -306,19 +309,6 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
     resolvedHtml,
     resolvedStatus,
   ]);
-
-  useEffect(() => {
-    if (!hasHtml || !renderedHtml) {
-      setFrameSrc(undefined);
-      return undefined;
-    }
-
-    const url = URL.createObjectURL(new Blob([renderedHtml], { type: 'text/html;charset=utf-8' }));
-    setFrameSrc(url);
-    return () => {
-      URL.revokeObjectURL(url);
-    };
-  }, [hasHtml, renderedHtml, renderedHtmlKey]);
 
   const postToIframe = useCallback((message: Record<string, unknown>) => {
     const win = iframeRef.current?.contentWindow;
@@ -690,7 +680,11 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
   ]);
 
   useLayoutEffect(() => {
-    if (!hasHtml || !artifactReference || !frameSrc) return;
+    if (!hasHtml || !artifactReference) {
+      setFrameReadyKey(null);
+      injectedFrameKeyRef.current = null;
+      return;
+    }
     iframeStatusRef.current = {
       bootStarted: false,
       moduleStarted: false,
@@ -866,6 +860,7 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
     };
 
     window.addEventListener('message', handleMessage);
+    setFrameReadyKey(frameDocumentKey);
     const timer = window.setTimeout(() => {
       const status = iframeStatusRef.current;
       if (renderedCanvas.runtime === 'react' && !status.moduleStarted && !status.ready && !status.runtimeError) {
@@ -874,7 +869,7 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
           runtime: renderedCanvas.runtime,
           revision: renderedCanvas.revision,
           renderedHtmlLength: renderedHtml?.length ?? 0,
-          frameTransport: 'blob',
+          frameTransport: 'document-write',
           bootStarted: status.bootStarted,
         });
       }
@@ -886,9 +881,9 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
   }, [
     artifactReference,
     designMode,
+    frameDocumentKey,
     handleCanvasAction,
     hasHtml,
-    frameSrc,
     initializeIframe,
     loadState,
     postDesignModeToIframe,
@@ -903,6 +898,53 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
     resolvedTitle,
     remoteSshHost,
     workspacePath,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!isFrameReady || !renderedHtml) return;
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const doc = iframe.contentDocument;
+    if (!doc) {
+      log.warn('Canvas iframe document is unavailable for HTML injection', {
+        artifactReference,
+        runtime: renderedCanvas.runtime,
+        revision: renderedCanvas.revision,
+        frameTransport: 'document-write',
+      });
+      return;
+    }
+
+    try {
+      injectedFrameKeyRef.current = frameDocumentKey;
+      doc.open();
+      doc.write(renderedHtml);
+      doc.close();
+      log.info('Canvas iframe HTML written', {
+        artifactReference,
+        runtime: renderedCanvas.runtime,
+        revision: renderedCanvas.revision,
+        renderedHtmlLength: renderedHtml.length,
+        frameTransport: 'document-write',
+      });
+    } catch (error) {
+      injectedFrameKeyRef.current = null;
+      log.error('Failed to write Canvas iframe HTML', {
+        artifactReference,
+        runtime: renderedCanvas.runtime,
+        revision: renderedCanvas.revision,
+        frameTransport: 'document-write',
+        error,
+      });
+    }
+  }, [
+    artifactReference,
+    frameDocumentKey,
+    isFrameReady,
+    renderedCanvas.revision,
+    renderedCanvas.runtime,
+    renderedHtml,
   ]);
 
   useEffect(() => {
@@ -986,23 +1028,27 @@ export const BitfunCanvasPanel: React.FC<BitfunCanvasPanelProps> = ({
           {exportingHtml ? <Loader2 size={15} className="bitfun-canvas-panel__toolbar-icon--spin" /> : <Download size={15} />}
         </button>
       </div>
-      <iframe
-        ref={iframeRef}
-        className="bitfun-canvas-panel__frame"
-        title={resolvedTitle}
-        src={frameSrc}
-        sandbox="allow-scripts"
-        data-artifact-reference={artifactReference}
-        onLoad={() => {
-          log.info('Canvas iframe loaded', {
-            artifactReference,
-            runtime: renderedCanvas.runtime,
-            revision: renderedCanvas.revision,
-            frameTransport: 'blob',
-          });
-          void initializeIframe('load');
-        }}
-      />
+      {isFrameReady && (
+        <iframe
+          key={frameDocumentKey}
+          ref={iframeRef}
+          className="bitfun-canvas-panel__frame"
+          title={resolvedTitle}
+          src="about:blank"
+          sandbox="allow-scripts allow-same-origin"
+          data-artifact-reference={artifactReference}
+          onLoad={() => {
+            if (injectedFrameKeyRef.current !== frameDocumentKey) return;
+            log.info('Canvas iframe loaded', {
+              artifactReference,
+              runtime: renderedCanvas.runtime,
+              revision: renderedCanvas.revision,
+              frameTransport: 'document-write',
+            });
+            void initializeIframe('load');
+          }}
+        />
+      )}
       {sourceVisible && (
         <div className="bitfun-canvas-panel__source-overlay" role="dialog" aria-modal="true">
           <div className="bitfun-canvas-panel__source-dialog">

--- a/src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.test.tsx
+++ b/src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.test.tsx
@@ -1,13 +1,66 @@
-import { describe, expect, it } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
 
-import { GENERATIVE_WIDGET_SHELL_HTML } from './GenerativeWidgetFrame';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import GenerativeWidgetFrame, { GENERATIVE_WIDGET_SHELL_HTML } from './GenerativeWidgetFrame';
+
+vi.mock('@/infrastructure/theme', () => ({
+  themeService: {
+    on: vi.fn(() => vi.fn()),
+  },
+}));
 
 describe('GenerativeWidgetFrame shell', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
   it('keeps iframe-local small text aligned with the host default token', () => {
     const values = [...GENERATIVE_WIDGET_SHELL_HTML.matchAll(/--font-size-sm:\s*([^;]+);/g)].map(
       (match) => match[1]?.trim()
     );
 
     expect(values).toEqual(['13px']);
+  });
+
+  it('writes the widget shell into about:blank instead of relying on srcdoc', async () => {
+    await act(async () => {
+      root.render(
+        <GenerativeWidgetFrame
+          widgetId="widget_1"
+          title="Widget"
+          widgetCode="<svg viewBox='0 0 10 10'><circle cx='5' cy='5' r='4' /></svg>"
+        />,
+      );
+    });
+
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0));
+    });
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
+    expect(iframe.getAttribute('src')).toBe('about:blank');
+    expect(iframe.getAttribute('srcdoc')).toBeNull();
+    expect(iframe.getAttribute('sandbox')).toContain('allow-same-origin');
+    expect(iframe.contentDocument?.documentElement.outerHTML).toContain('bitfun-widget');
   });
 });

--- a/src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.tsx
+++ b/src/web-ui/src/tools/generative-widget/GenerativeWidgetFrame.tsx
@@ -950,6 +950,44 @@ export const GenerativeWidgetFrame: React.FC<GenerativeWidgetFrameProps> = ({
   }, [onHeightChange, onWidgetEvent, widgetId]);
 
   useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return undefined;
+
+    let cancelled = false;
+    setIsLoaded(false);
+
+    const writeShellHtml = () => {
+      const doc = iframe.contentDocument;
+      if (!doc) return false;
+      doc.open();
+      doc.write(GENERATIVE_WIDGET_SHELL_HTML);
+      doc.close();
+      if (!cancelled) {
+        setIsLoaded(true);
+      }
+      return true;
+    };
+
+    if (writeShellHtml()) {
+      return undefined;
+    }
+
+    const handleLoad = () => {
+      writeShellHtml();
+    };
+
+    iframe.addEventListener('load', handleLoad);
+    if (iframe.src !== 'about:blank') {
+      iframe.src = 'about:blank';
+    }
+
+    return () => {
+      cancelled = true;
+      iframe.removeEventListener('load', handleLoad);
+    };
+  }, []);
+
+  useEffect(() => {
     const updateTheme = () => {
       setThemePayload(readWidgetThemePayload());
     };
@@ -1008,9 +1046,8 @@ export const GenerativeWidgetFrame: React.FC<GenerativeWidgetFrameProps> = ({
         title={title || 'Generative widget'}
         className="bitfun-generative-widget-frame__iframe"
         style={{ width: '100%', minWidth: '100%' }}
-        sandbox="allow-scripts allow-forms allow-modals allow-popups"
-        srcDoc={GENERATIVE_WIDGET_SHELL_HTML}
-        onLoad={() => setIsLoaded(true)}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+        src="about:blank"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- replace Canvas preview blob/srcDoc iframe loading with about:blank + document.write
- replace Generative UI shell srcDoc loading with about:blank + document.write
- add focused tests covering document-write iframe rendering paths

## Why
Tauri WebKit does not reliably start sandboxed preview iframes loaded via blob/srcDoc. MiniApp fixed the same class of issue by moving to about:blank + document.write; this applies the same transport to Canvas and Generative UI previews.

## Verification
- pnpm --dir src/web-ui run test:run src/tools/generative-widget/GenerativeWidgetFrame.test.tsx src/tools/bitfun-canvas/BitfunCanvasPanel.test.tsx
- pnpm run type-check:web