### PR TITLE
feat(updater): add openbitfun.com fallback endpoint for auto-update

### DIFF
--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -83,9 +83,15 @@ function prepareTauriConfig(baseConfigPath, { desktopDir, flashgrepBinary }) {
       process.exit(1);
     }
 
-    const endpoint =
+    const primaryEndpoint =
       process.env.TAURI_UPDATER_ENDPOINT ||
       'https://github.com/GCWing/BitFun/releases/latest/download/latest.json';
+    // Fallback endpoint used when GitHub is unreachable (not when no update is found).
+    // Tauri updater iterates endpoints and only falls through on network/HTTP errors;
+    // a 204 (no update) or a successfully parsed manifest stops the loop.
+    const fallbackEndpoint =
+      process.env.TAURI_UPDATER_FALLBACK_ENDPOINT ||
+      'https://openbitfun.com/release/latest.json';
 
     config.bundle = {
       ...(config.bundle || {}),
@@ -94,14 +100,16 @@ function prepareTauriConfig(baseConfigPath, { desktopDir, flashgrepBinary }) {
     config.plugins = {
       ...(config.plugins || {}),
       updater: {
-        endpoints: [endpoint],
+        endpoints: [primaryEndpoint, fallbackEndpoint],
         pubkey,
         windows: {
           installMode: 'passive',
         },
       },
     };
-    console.log(`[tauri-build] Updater artifacts enabled: ${endpoint}`);
+    console.log(
+      `[tauri-build] Updater artifacts enabled: ${primaryEndpoint} (fallback: ${fallbackEndpoint})`
+    );
   }
 
   const generatedDir = join(desktopDir, 'gen');

--- a/scripts/openbitfun-release-sync.sh
+++ b/scripts/openbitfun-release-sync.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# sync-release.sh — Mirror BitFun release assets from GitHub to openbitfun.com.
+#
+# Flow:
+#   1. Fetch latest.json from GitHub (follows /releases/latest/download/ redirect)
+#   2. Download every platform installer package into release/{version}/
+#   3. Rewrite download URLs in latest.json to point at openbitfun.com
+#   4. Publish release/{version}/latest.json and release/latest.json
+#   5. Remove old version dirs, keeping only the two most recent
+#
+# The published release/latest.json is the Tauri updater fallback endpoint.
+# When GitHub is unreachable, the desktop client automatically falls through
+# to https://openbitfun.com/release/latest.json and downloads from this mirror.
+#
+# Cron (every 12 hours):
+#   0 */12 * * * /root/lwb/repo/BitFun-AutoUpdate/sync-release.sh \
+#       >> /root/lwb/repo/BitFun-AutoUpdate/sync.log 2>&1
+#
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────
+GITHUB_LATEST_JSON_URL="https://github.com/GCWing/BitFun/releases/latest/download/latest.json"
+OPENBITFUN_BASE_URL="https://openbitfun.com/release"
+WEBSITE_RELEASE_DIR="/root/lwb/repo/BitFun-Website/dist/release"
+KEEP_VERSIONS=2
+CONNECT_TIMEOUT=30
+MAX_TIME=1800          # per-request ceiling (30 min; installer packages can be large)
+MAX_RETRIES=3
+RETRY_DELAY=5
+PYTHON="${PYTHON:-python3}"
+
+# ── Helpers ────────────────────────────────────────────────────
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+
+# ── Main ───────────────────────────────────────────────────────
+main() {
+  log "=== BitFun release sync started ==="
+
+  mkdir -p "$WEBSITE_RELEASE_DIR"
+
+  # 1. Fetch latest.json from GitHub
+  log "Fetching latest.json from GitHub..."
+  LATEST_JSON=$(curl -fsSL \
+    --connect-timeout "$CONNECT_TIMEOUT" \
+    --max-time "$MAX_TIME" \
+    "$GITHUB_LATEST_JSON_URL") || {
+    log "ERROR: Failed to fetch latest.json from GitHub"
+    exit 1
+  }
+
+  # 2. Extract version
+  VERSION=$(printf '%s' "$LATEST_JSON" | "$PYTHON" -c \
+    "import sys,json;print(json.load(sys.stdin)['version'])") || {
+    log "ERROR: Failed to parse version from latest.json"
+    exit 1
+  }
+  log "Latest version: $VERSION"
+
+  # 3. Create version directory
+  VERSION_DIR="${WEBSITE_RELEASE_DIR}/${VERSION}"
+  mkdir -p "$VERSION_DIR"
+
+  # 4. Download all platform installer packages
+  #    Extract "<url>\t<filename>" pairs, then curl each one.
+  ASSET_LIST=$(printf '%s' "$LATEST_JSON" | "$PYTHON" -c "
+import sys, json
+data = json.load(sys.stdin)
+for p, info in data.get('platforms', {}).items():
+    url = info['url']
+    fname = url.split('/')[-1]
+    print(f'{url}\t{fname}')
+") || {
+    log "ERROR: Failed to extract asset list from latest.json"
+    exit 1
+  }
+
+  while IFS=$'\t' read -r url filename; do
+    [ -z "$url" ] && continue
+    dest="${VERSION_DIR}/${filename}"
+
+    if [ -f "$dest" ]; then
+      log "  Already exists: $filename"
+      continue
+    fi
+
+    log "  Downloading: $filename"
+    ok=0
+    for attempt in $(seq 1 "$MAX_RETRIES"); do
+      if curl -fsSL \
+          --connect-timeout "$CONNECT_TIMEOUT" \
+          --max-time "$MAX_TIME" \
+          -o "$dest" "$url"; then
+        ok=1
+        break
+      fi
+      log "  Retry $attempt/$MAX_RETRIES for $filename"
+      sleep "$RETRY_DELAY"
+    done
+
+    if [ "$ok" -ne 1 ]; then
+      log "ERROR: Failed to download $filename after $MAX_RETRIES attempts"
+      rm -f "$dest"
+      exit 1
+    fi
+  done <<< "$ASSET_LIST"
+
+  # 5. Rewrite URLs in latest.json to point at openbitfun.com
+  printf '%s' "$LATEST_JSON" | "$PYTHON" -c "
+import sys, json
+data = json.load(sys.stdin)
+version = data['version']
+base = '${OPENBITFUN_BASE_URL}/' + version
+for p, info in data.get('platforms', {}).items():
+    fname = info['url'].split('/')[-1]
+    info['url'] = base + '/' + fname
+print(json.dumps(data, indent=2))
+" > "${VERSION_DIR}/latest.json"
+  log "Saved ${VERSION_DIR}/latest.json"
+
+  # 6. Publish root latest.json (Tauri fallback endpoint)
+  cp "${VERSION_DIR}/latest.json" "${WEBSITE_RELEASE_DIR}/latest.json"
+  log "Updated ${WEBSITE_RELEASE_DIR}/latest.json"
+
+  # 7. Clean up old versions — keep only the latest KEEP_VERSIONS dirs
+  ALL_DIRS=()
+  while IFS= read -r d; do
+    ALL_DIRS+=("$d")
+  done < <(find "$WEBSITE_RELEASE_DIR" -mindepth 1 -maxdepth 1 -type d | sort -V)
+  TOTAL=${#ALL_DIRS[@]}
+  if [ "$TOTAL" -gt "$KEEP_VERSIONS" ]; then
+    REMOVE_COUNT=$((TOTAL - KEEP_VERSIONS))
+    for ((i = 0; i < REMOVE_COUNT; i++)); do
+      log "Removing old version: $(basename "${ALL_DIRS[$i]}")"
+      rm -rf "${ALL_DIRS[$i]}"
+    done
+  fi
+
+  log "=== Sync complete: version $VERSION ==="
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a secondary updater endpoint so the desktop client can fall back to `openbitfun.com` when GitHub is unreachable — a common issue in regions with unstable GitHub connectivity (e.g. mainland China).

## How it works

Tauri's updater plugin (`tauri-plugin-updater` v2.10) natively iterates the `endpoints` array. The fallback behavior matches the requirement precisely:

| GitHub response | Tauri behavior | Falls through? |
|---|---|---|
| Network timeout / connection failure | sets `last_error`, continues to next endpoint | **Yes** |
| HTTP 5xx / 4xx | continues to next endpoint | **Yes** |
| 204 No Content (no update) | returns `Ok(None)` immediately | No |
| 200 + manifest, version not newer | returns `Ok(None)` | No |

This means the fallback activates **only on connection failure**, not when no newer version exists.

## Changes

### 1. `scripts/desktop-tauri-build.mjs`
- Added `openbitfun.com/release/latest.json` as a fallback endpoint alongside the primary GitHub endpoint
- Supports `TAURI_UPDATER_FALLBACK_ENDPOINT` env var for CI configurability

### 2. `scripts/openbitfun-release-sync.sh` (new)
Server-side script that mirrors release assets from GitHub to openbitfun.com:
- Fetches `latest.json` from GitHub
- Downloads all platform installer packages (with retry)
- Rewrites download URLs to point at `openbitfun.com`
- Publishes `release/{version}/` and `release/latest.json`
- Retains only the two most recent version directories
- Designed to run via cron every 12 hours

## Verification
- [x] Build script syntax: `node --check` passed
- [x] Shell script syntax: `bash -n` passed
- [x] JSON extraction and URL rewrite logic verified with mock data
- [x] Version cleanup logic verified (correct `sort -V` ordering, keeps latest 2)
- [x] Server-side script deployed and first sync completed (v0.2.12, all 5 platforms)
- [x] `https://openbitfun.com/release/latest.json` returns valid manifest with rewritten URLs