### PR TITLE
Add evaluation CLI version metadata

### DIFF
--- a/src/apps/cli/Cargo.toml
+++ b/src/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-cli"
-version.workspace = true
+version = "0.2.10-eval.1"
 authors.workspace = true
 edition.workspace = true
 description = "BitFun CLI - Terminal User Interface"

--- a/src/apps/cli/build.rs
+++ b/src/apps/cli/build.rs
@@ -2,11 +2,89 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::process::Command;
 
 fn main() {
+    emit_build_metadata();
+
     if let Err(e) = embed_cli_prompts() {
         eprintln!("Warning: Failed to embed CLI prompts: {}", e);
     }
+}
+
+fn emit_build_metadata() {
+    println!("cargo:rerun-if-env-changed=BITFUN_CLI_BUILD_COMMIT");
+    emit_git_rerun_paths();
+
+    let commit = std::env::var("BITFUN_CLI_BUILD_COMMIT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(resolve_git_commit)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=BITFUN_CLI_BUILD_COMMIT={commit}");
+}
+
+fn emit_git_rerun_paths() {
+    let Some(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR").ok() else {
+        return;
+    };
+
+    let git_dir = Command::new("git")
+        .args(["-C", &manifest_dir, "rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .and_then(|output| output.status.success().then_some(output.stdout))
+        .and_then(|stdout| String::from_utf8(stdout).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    let Some(git_dir) = git_dir else {
+        return;
+    };
+
+    let git_dir = Path::new(&manifest_dir).join(git_dir);
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        git_dir.join("packed-refs").display()
+    );
+
+    if let Some(head_ref) = current_git_head_ref(&manifest_dir) {
+        println!(
+            "cargo:rerun-if-changed={}",
+            git_dir.join(head_ref).display()
+        );
+    }
+}
+
+fn current_git_head_ref(manifest_dir: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["-C", manifest_dir, "symbolic-ref", "--quiet", "HEAD"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let head_ref = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!head_ref.is_empty()).then_some(head_ref)
+}
+
+fn resolve_git_commit() -> Option<String> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let output = Command::new("git")
+        .args(["-C", &manifest_dir, "rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let commit = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!commit.is_empty()).then_some(commit)
 }
 
 fn embed_cli_prompts() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -28,6 +28,13 @@ use config::CliConfig;
 use modes::chat::ChatMode;
 use modes::exec::ExecOutputFormat;
 
+const CLI_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (commit ",
+    env!("BITFUN_CLI_BUILD_COMMIT"),
+    ")"
+);
+
 // ======================== Global MCP Service ========================
 
 static MCP_SERVICE: OnceLock<std::sync::Arc<bitfun_core::service::mcp::MCPService>> =
@@ -61,7 +68,7 @@ pub fn get_mcp_service() -> Option<&'static std::sync::Arc<bitfun_core::service:
 #[derive(Parser)]
 #[command(name = "bitfun")]
 #[command(about = "BitFun CLI - AI agent-driven command-line programming assistant", long_about = None)]
-#[command(version)]
+#[command(version = CLI_VERSION)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -382,11 +389,7 @@ async fn initialize_core_services(
     skip_tool_confirmation: bool,
     suppress_title_generation: bool,
     disable_persistence: bool,
-) -> Result<(
-    agent::agentic_system::AgenticSystem,
-    bool,
-    bool,
-)> {
+) -> Result<(agent::agentic_system::AgenticSystem, bool, bool)> {
     use bitfun_core::infrastructure::ai::AIClientFactory;
 
     bitfun_core::service::config::initialize_global_config()
@@ -422,10 +425,7 @@ async fn initialize_core_services(
     if suppress_title_generation {
         if let Some(ref svc) = config_service {
             let _ = svc
-                .set_config(
-                    "app.ai_experience.enable_session_title_generation",
-                    false,
-                )
+                .set_config("app.ai_experience.enable_session_title_generation", false)
                 .await;
         }
     }
@@ -485,7 +485,11 @@ async fn initialize_core_services(
         }
     }
 
-    Ok((agentic_system, original_skip_confirmation, original_title_generation))
+    Ok((
+        agentic_system,
+        original_skip_confirmation,
+        original_title_generation,
+    ))
 }
 
 /// Restore original tool confirmation setting

--- a/src/apps/cli/tests/version.rs
+++ b/src/apps/cli/tests/version.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn version_flag_prints_evaluation_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_bitfun-cli"))
+        .arg("--version")
+        .output()
+        .expect("bitfun-cli --version should run");
+
+    assert!(
+        output.status.success(),
+        "bitfun-cli --version failed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        format!(
+            "bitfun {} (commit {})",
+            env!("CARGO_PKG_VERSION"),
+            env!("BITFUN_CLI_BUILD_COMMIT")
+        )
+    );
+}
+
+#[test]
+fn evaluation_version_is_not_desktop_workspace_version() {
+    let root_manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../Cargo.toml");
+    let manifest_text =
+        std::fs::read_to_string(&root_manifest).expect("workspace Cargo.toml should be readable");
+    let manifest: toml::Value =
+        toml::from_str(&manifest_text).expect("workspace Cargo.toml should parse");
+    let workspace_version = manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("version"))
+        .and_then(toml::Value::as_str)
+        .expect("workspace package version should exist");
+
+    assert_ne!(env!("CARGO_PKG_VERSION"), workspace_version);
+}


### PR DESCRIPTION
## Summary
- give bitfun-cli an evaluation-specific package version separate from desktop/workspace version
- include the build commit hash in bitfun-cli --version output
- add a focused integration test for --version output and version separation

## Verification
- cargo test -p bitfun-cli --test version