### PR TITLE
fix(web-ui): resolve relative markdown images in chat

### DIFF
--- a/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
@@ -9,6 +9,7 @@ import { Markdown } from './Markdown';
 const mocks = vi.hoisted(() => ({
   getCurrentWorkspacePath: vi.fn(),
   revealInExplorer: vi.fn(),
+  readFileContent: vi.fn(),
   openExternal: vi.fn(),
   renderMath: vi.fn(),
 }));
@@ -19,7 +20,7 @@ vi.mock('../../../infrastructure/api', () => ({
   },
   workspaceAPI: {
     revealInExplorer: (...args: unknown[]) => mocks.revealInExplorer(...args),
-    readFileContent: vi.fn(),
+    readFileContent: (...args: unknown[]) => mocks.readFileContent(...args),
   },
   systemAPI: {
     openExternal: (...args: unknown[]) => mocks.openExternal(...args),
@@ -98,9 +99,11 @@ describe('Markdown file links', () => {
     onFileViewRequest = vi.fn();
     mocks.getCurrentWorkspacePath.mockReset();
     mocks.revealInExplorer.mockReset();
+    mocks.readFileContent.mockReset();
     mocks.openExternal.mockReset();
     mocks.renderMath.mockReset();
     mocks.getCurrentWorkspacePath.mockResolvedValue(EXAMPLE_WORKSPACE);
+    mocks.readFileContent.mockResolvedValue('cmVsdS1wbmc=');
   });
 
   afterEach(() => {
@@ -227,5 +230,25 @@ describe('Markdown file links', () => {
 
     expect(container.querySelector('[data-testid="markdown-math-renderer"]')).not.toBeNull();
     expect(mocks.renderMath).toHaveBeenCalledWith('Formula: $x + y$');
+  });
+
+  it('loads relative markdown images from the provided base path', async () => {
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={'![ReLU 图像](relu.png)'}
+          basePath={EXAMPLE_WORKSPACE}
+          onFileViewRequest={onFileViewRequest}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const image = container.querySelector<HTMLImageElement>('img[alt="ReLU 图像"]');
+    expect(image).not.toBeNull();
+    expect(mocks.readFileContent).toHaveBeenCalledWith(`${EXAMPLE_WORKSPACE}/relu.png`);
+    expect(image?.src).toBe('data:image/png;base64,cmVsdS1wbmc=');
+    expect(mocks.getCurrentWorkspacePath).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -811,7 +811,7 @@ export const Markdown = React.memo<MarkdownProps>(({
   );
 
   useEffect(() => {
-    if (!needsWorkspacePathForLinks || currentWorkspacePath) {
+    if (!needsWorkspacePathForLinks || currentWorkspacePath || basePath) {
       return;
     }
 
@@ -830,7 +830,7 @@ export const Markdown = React.memo<MarkdownProps>(({
     return () => {
       cancelled = true;
     };
-  }, [currentWorkspacePath, needsWorkspacePathForLinks]);
+  }, [basePath, currentWorkspacePath, needsWorkspacePathForLinks]);
 
   const markdownFeatureProfile = useMemo(() => ({
     contentLength: markdownContent.length,
@@ -1319,7 +1319,7 @@ export const Markdown = React.memo<MarkdownProps>(({
     },
 
     img({ node: _node, ...props }: any) {
-      return <MarkdownImage {...props} basePath={basePath} />;
+      return <MarkdownImage {...props} basePath={basePath || currentWorkspacePath} />;
     },
     
     blockquote({ children }: any) {

--- a/src/web-ui/src/flow_chat/components/FlowTextBlock.tsx
+++ b/src/web-ui/src/flow_chat/components/FlowTextBlock.tsx
@@ -73,7 +73,10 @@ export const FlowTextBlock = React.memo<FlowTextBlockProps>(({
     onTabOpen,
     onHttpLinkClick,
     onOpenVisualization,
+    activeSessionOverride,
   } = useFlowChatContext();
+  const markdownBasePath = activeSessionOverride?.workspacePath
+    || activeSessionOverride?.config?.workspacePath;
 
   // Normalize content to a string.
   const content = typeof textItem.content === 'string'
@@ -147,6 +150,7 @@ export const FlowTextBlock = React.memo<FlowTextBlockProps>(({
       {textItem.isMarkdown ? (
         <MarkdownRenderer
           content={displayContent}
+          basePath={markdownBasePath}
           // Pass the raw streaming flag (not the idle-gated
           // `isActivelyStreaming`) so the code-block render path inside
           // Markdown stays stable across bursty AI output. Otherwise


### PR DESCRIPTION
## Summary

Resolve relative Markdown image paths in assistant chat messages against the active session workspace, so model output such as `![ReLU 图像](relu.png)` can render the generated image inline.

Fixes #1473

## Type and Areas

Type: bug fix

Areas: web UI, flow chat, Markdown rendering

## Motivation / Impact

Agents can generate images into the workspace and reference them from assistant Markdown output. Before this change, relative Markdown image paths in chat messages were not reliably anchored to the active session workspace, so inline image previews could fail.

This change passes the active session workspace path into the chat Markdown renderer and uses that path when resolving relative Markdown image links. The existing workspace file-reading path is reused for loading image content.

## Verification

- `pnpm --dir src/web-ui run test:run src/component-library/components/Markdown/Markdown.test.tsx`
  - Passed after the clean history rewrite: 1 test file, 5 tests.
- `pnpm run type-check:web`
  - Not completed after the clean history rewrite because the command was interrupted locally.
  - The same equivalent code change passed this check before the branch history cleanup.
<img width="3312" height="2350" alt="预览relu图片_07-08-18-29" src="https://github.com/user-attachments/assets/f5284fb1-6b63-40b9-b38c-4bec0e375ff8" />