### PR TITLE
fix(agentic): anchor context compression to provider token usage

### DIFF
--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -72,7 +72,6 @@ pub struct SessionConfigDTO {
     pub safe_mode: Option<bool>,
     pub max_turns: Option<usize>,
     pub enable_context_compression: Option<bool>,
-    pub compression_threshold: Option<f32>,
     pub model_name: Option<String>,
     #[serde(default)]
     pub remote_connection_id: Option<String>,
@@ -689,7 +688,6 @@ pub async fn create_session(
             safe_mode: c.safe_mode.unwrap_or(true),
             max_turns: c.max_turns.unwrap_or(200),
             enable_context_compression: c.enable_context_compression.unwrap_or(true),
-            compression_threshold: c.compression_threshold.unwrap_or(0.8),
             workspace_path: Some(request.workspace_path.clone()),
             workspace_id: request.workspace_id.clone(),
             remote_connection_id: remote_conn.clone(),

--- a/src/apps/desktop/src/api/miniapp_agent_api.rs
+++ b/src/apps/desktop/src/api/miniapp_agent_api.rs
@@ -228,7 +228,6 @@ pub async fn miniapp_agent_run(
             safe_mode: true,
             auto_compact: true,
             enable_context_compression: true,
-            compression_threshold: 0.65,
             ..Default::default()
         };
         // Cowork supplies the office skill group and research/file tools when

--- a/src/crates/adapters/ai-adapters/src/stream/stream_handler/stream_stats.rs
+++ b/src/crates/adapters/ai-adapters/src/stream/stream_handler/stream_stats.rs
@@ -1,4 +1,4 @@
-use crate::stream::types::unified::UnifiedResponse;
+use crate::stream::types::unified::{UnifiedResponse, UnifiedTokenUsage};
 use chrono::{DateTime, Local};
 use log::debug;
 use std::collections::BTreeMap;
@@ -15,6 +15,7 @@ pub(super) struct StreamStats {
     last_event_at_wall: Option<DateTime<Local>>,
     total_sse_events: usize,
     total_unified_responses: usize,
+    last_usage: Option<UnifiedTokenUsage>,
     counters: BTreeMap<String, usize>,
 }
 
@@ -30,6 +31,7 @@ impl StreamStats {
             last_event_at_wall: None,
             total_sse_events: 0,
             total_unified_responses: 0,
+            last_usage: None,
             counters: BTreeMap::new(),
         }
     }
@@ -68,7 +70,8 @@ impl StreamStats {
             self.increment("out:tool_call");
             classified = true;
         }
-        if response.usage.is_some() {
+        if let Some(usage) = response.usage.as_ref() {
+            self.last_usage = Some(usage.clone());
             self.increment("out:usage");
             classified = true;
         }
@@ -127,6 +130,20 @@ impl StreamStats {
                 .collect::<Vec<_>>()
                 .join("\n")
         };
+
+        if let Some(usage) = self.last_usage.as_ref() {
+            debug!(
+                target: "ai::stream_usage",
+                "{} final token usage: input={}, output={}, total={}, reasoning={:?}, cache_read={:?}, cache_write={:?}",
+                self.provider,
+                usage.prompt_token_count,
+                usage.candidates_token_count,
+                usage.total_token_count,
+                usage.reasoning_token_count,
+                usage.cached_content_token_count,
+                usage.cache_creation_token_count
+            );
+        }
 
         debug!(
             target: "ai::stream_stats",

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -966,11 +966,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         )
     }
 
-    fn estimate_context_tokens(messages: &[Message]) -> usize {
-        let mut cloned = messages.to_vec();
-        cloned.iter_mut().map(|message| message.get_tokens()).sum()
-    }
-
     fn manual_compaction_metadata() -> serde_json::Value {
         serde_json::json!({
             "kind": "manual_compaction",
@@ -982,7 +977,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         turn_id: &str,
         outcome: &ContextCompactionOutcome,
         context_window: usize,
-        threshold: f32,
     ) -> crate::service::session::ModelRoundData {
         use crate::service::session::{ModelRoundData, ToolCallData, ToolItemData, ToolResultData};
 
@@ -1007,7 +1001,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         "trigger": "manual",
                         "tokens_before": outcome.tokens_before,
                         "context_window": context_window,
-                        "threshold": threshold,
                     }),
                     id: outcome.compression_id.clone(),
                 },
@@ -1069,7 +1062,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         compression_id: String,
         error: &str,
         context_window: usize,
-        threshold: f32,
     ) -> crate::service::session::ModelRoundData {
         use crate::service::session::{ModelRoundData, ToolCallData, ToolItemData, ToolResultData};
 
@@ -1092,7 +1084,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     input: serde_json::json!({
                         "trigger": "manual",
                         "context_window": context_window,
-                        "threshold": threshold,
                         "summary_source": "none",
                     }),
                     id: compression_id,
@@ -2887,7 +2878,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         })
         .await;
 
-        let current_tokens = Self::estimate_context_tokens(&context_messages);
         let manual_workspace = Self::build_workspace_binding(&session.config).await;
         let manual_workspace_services = Self::build_workspace_services(&manual_workspace).await;
         let manual_execution_context = ExecutionContext {
@@ -2926,8 +2916,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             Some(mcw) => mcw.min(session_max_tokens),
             None => session_max_tokens,
         };
-        let compression_threshold = session.config.compression_threshold;
-
         match self
             .execution_engine
             .compact_session_context(
@@ -2935,7 +2923,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 turn_id.clone(),
                 manual_execution_context,
                 context_messages,
-                current_tokens,
                 "manual",
             )
             .await
@@ -2945,7 +2932,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     &turn_id,
                     &outcome,
                     context_window,
-                    compression_threshold,
                 );
                 self.session_manager
                     .complete_maintenance_turn(
@@ -2982,7 +2968,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     compression_id,
                     &error_text,
                     context_window,
-                    compression_threshold,
                 );
                 let _ = self
                     .session_manager

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -24,7 +24,8 @@ use crate::agentic::image_analysis::{
 };
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{
-    CompressionMode, ContextCompressor, SessionManager, UserContextCacheIdentity,
+    CompressionMode, ContextCompressor, SessionManager, TokenAnchor, TokenAnchorInput,
+    UserContextCacheIdentity,
 };
 use crate::agentic::skill_agent_snapshot::build_skill_agent_tool_listing_sections_from_snapshot;
 use crate::agentic::tools::implementations::{SkillTool, TaskTool};
@@ -249,6 +250,45 @@ impl ContextHealthSnapshot {
     }
 }
 
+#[derive(Debug, Clone)]
+struct TokenAnchorPressureDetails {
+    anchor_id: String,
+    prefix_message_count: usize,
+    input_tokens: usize,
+    adjusted_anchor_tokens: usize,
+    system_tokens_at_anchor: usize,
+    current_system_tokens: usize,
+    system_delta: isize,
+    tool_tokens_at_anchor: usize,
+    current_tool_tokens: usize,
+    tool_delta: isize,
+    prepended_reminder_tokens_at_anchor: usize,
+    current_prepended_reminder_tokens: usize,
+    prepended_reminder_delta: isize,
+    tail_tokens: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TokenPressureSnapshot {
+    total_tokens: usize,
+    system_tokens: usize,
+    tool_tokens: usize,
+    prepended_reminder_tokens: usize,
+    conversation_tokens: usize,
+    context_window: usize,
+    input_limit: usize,
+    output_reserve_tokens: usize,
+    safety_reserve_tokens: usize,
+    usage_ratio: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CompressionTriggerBudget {
+    input_limit: usize,
+    output_reserve_tokens: usize,
+    safety_reserve_tokens: usize,
+}
+
 /// Execution engine
 pub struct ExecutionEngine {
     round_executor: Arc<RoundExecutor>,
@@ -259,7 +299,8 @@ pub struct ExecutionEngine {
 }
 
 impl ExecutionEngine {
-    const COMPRESSION_MAX_TOKENS: u32 = 8192;
+    const AUTO_COMPRESSION_DEFAULT_OUTPUT_RESERVE_TOKENS: usize = 16_000;
+    const AUTO_COMPRESSION_SAFETY_RESERVE_TOKENS: usize = 10_000;
     const FINALIZE_AFTER_REPEATED_TOOL_FAILURES_REMINDER: &'static str = "This turn must end now because repeated tool failures have prevented further progress. Ignore any unfinished work. Your task now is to give the user a final answer. Do not call any more tools; any tool call will fail. Respond in plain text only. Summarize what was completed, what failed, the evidence available from the tool results, and the single best next step for the user.";
     const FINALIZE_AFTER_MAX_ROUNDS_REMINDER: &'static str = "This turn must end now because it has reached the round limit. Ignore any unfinished work. Your task now is to give the user a final answer. Do not call any more tools; any tool call will fail. Respond in plain text only. Summarize the most useful completed work and evidence collected so far, and clearly distinguish resolved items from anything still unresolved.";
     const FINALIZE_TOOL_DENIED_MESSAGE: &'static str =
@@ -294,18 +335,111 @@ impl ExecutionEngine {
         )
     }
 
-    /// Estimate how full the mutable conversation portion is for compression decisions.
+    /// Estimate request pressure for compression decisions.
     ///
-    /// System prompt and tool definitions are fixed per dialog turn and should not
-    /// count against the auto-compression threshold the same way tool results do.
-    /// Keeping them fixed also preserves provider-side prefix/KV cache reuse;
-    /// changing tool definitions mid-turn turns every later round into a cache miss.
+    /// `total_tokens` tracks the whole provider request input. The snapshot also
+    /// keeps the mutable conversation portion and fixed scaffold overhead
+    /// available for diagnostics, while the trigger decision reserves output and
+    /// safety budget from the full context window.
     fn estimate_auto_compression_pressure(
         messages: &[Message],
         tools: Option<&[ToolDefinition]>,
         context_window: usize,
-    ) -> (usize, usize, f32) {
-        let total_tokens = Self::estimate_request_tokens_internal(messages, tools);
+        trigger_budget: CompressionTriggerBudget,
+        prepended_reminder_tokens: usize,
+    ) -> TokenPressureSnapshot {
+        let total_tokens = Self::estimate_request_tokens_internal(messages, tools)
+            .saturating_add(prepended_reminder_tokens);
+        Self::token_pressure_snapshot_from_total(
+            total_tokens,
+            messages,
+            tools,
+            context_window,
+            trigger_budget,
+            prepended_reminder_tokens,
+        )
+    }
+
+    fn estimate_auto_compression_pressure_with_anchor(
+        messages: &[Message],
+        tools: Option<&[ToolDefinition]>,
+        context_window: usize,
+        trigger_budget: CompressionTriggerBudget,
+        anchor: Option<&TokenAnchor>,
+        prepended_reminder_tokens: usize,
+    ) -> (TokenPressureSnapshot, Option<TokenAnchorPressureDetails>) {
+        let Some(anchor) = anchor else {
+            let snapshot = Self::estimate_auto_compression_pressure(
+                messages,
+                tools,
+                context_window,
+                trigger_budget,
+                prepended_reminder_tokens,
+            );
+            return (snapshot, None);
+        };
+
+        let current_system_tokens = Self::system_tokens_for_pressure(messages);
+        let current_tool_tokens = tools
+            .map(TokenCounter::estimate_tool_definitions_tokens)
+            .unwrap_or(0);
+        let adjusted_anchor_tokens = Self::apply_token_delta(
+            anchor.input_tokens,
+            anchor.system_tokens_at_anchor,
+            current_system_tokens,
+        );
+        let adjusted_anchor_tokens = Self::apply_token_delta(
+            adjusted_anchor_tokens,
+            anchor.tool_tokens_at_anchor,
+            current_tool_tokens,
+        );
+        let adjusted_anchor_tokens = Self::apply_token_delta(
+            adjusted_anchor_tokens,
+            anchor.prepended_reminder_tokens_at_anchor,
+            prepended_reminder_tokens,
+        );
+        let tail_tokens = Self::estimate_tail_tokens(&messages[anchor.prefix_message_count..]);
+        let total_tokens = adjusted_anchor_tokens.saturating_add(tail_tokens);
+
+        let snapshot = Self::token_pressure_snapshot_from_total(
+            total_tokens,
+            messages,
+            tools,
+            context_window,
+            trigger_budget,
+            prepended_reminder_tokens,
+        );
+        (
+            snapshot,
+            Some(TokenAnchorPressureDetails {
+                anchor_id: anchor.anchor_id.clone(),
+                prefix_message_count: anchor.prefix_message_count,
+                input_tokens: anchor.input_tokens,
+                adjusted_anchor_tokens,
+                system_tokens_at_anchor: anchor.system_tokens_at_anchor,
+                current_system_tokens,
+                system_delta: current_system_tokens as isize
+                    - anchor.system_tokens_at_anchor as isize,
+                tool_tokens_at_anchor: anchor.tool_tokens_at_anchor,
+                current_tool_tokens,
+                tool_delta: current_tool_tokens as isize - anchor.tool_tokens_at_anchor as isize,
+                prepended_reminder_tokens_at_anchor: anchor.prepended_reminder_tokens_at_anchor,
+                current_prepended_reminder_tokens: prepended_reminder_tokens,
+                prepended_reminder_delta: prepended_reminder_tokens as isize
+                    - anchor.prepended_reminder_tokens_at_anchor as isize,
+                tail_tokens,
+            }),
+        )
+    }
+
+    fn token_pressure_snapshot_from_total(
+        total_tokens: usize,
+        messages: &[Message],
+        tools: Option<&[ToolDefinition]>,
+        context_window: usize,
+        trigger_budget: CompressionTriggerBudget,
+        prepended_reminder_tokens: usize,
+    ) -> TokenPressureSnapshot {
         let system_tokens = messages
             .first()
             .filter(|message| message.role == MessageRole::System)
@@ -314,11 +448,76 @@ impl ExecutionEngine {
         let tool_tokens = tools
             .map(TokenCounter::estimate_tool_definitions_tokens)
             .unwrap_or(0);
-        let reserved_overhead = system_tokens.saturating_add(tool_tokens);
+        let reserved_overhead = system_tokens
+            .saturating_add(tool_tokens)
+            .saturating_add(prepended_reminder_tokens);
         let conversation_tokens = total_tokens.saturating_sub(reserved_overhead);
-        let conversation_budget = context_window.saturating_sub(reserved_overhead).max(1);
-        let usage_ratio = conversation_tokens as f32 / conversation_budget as f32;
-        (total_tokens, conversation_tokens, usage_ratio)
+        let usage_ratio = ContextHealthSnapshot::token_usage_ratio(total_tokens, context_window);
+        TokenPressureSnapshot {
+            total_tokens,
+            system_tokens,
+            tool_tokens,
+            prepended_reminder_tokens,
+            conversation_tokens,
+            context_window,
+            input_limit: trigger_budget.input_limit,
+            output_reserve_tokens: trigger_budget.output_reserve_tokens,
+            safety_reserve_tokens: trigger_budget.safety_reserve_tokens,
+            usage_ratio,
+        }
+    }
+
+    fn compression_trigger_budget(
+        context_window: usize,
+        configured_max_tokens: Option<u32>,
+    ) -> CompressionTriggerBudget {
+        let output_reserve_tokens = configured_max_tokens
+            .map(|value| value as usize)
+            .unwrap_or(Self::AUTO_COMPRESSION_DEFAULT_OUTPUT_RESERVE_TOKENS);
+        let safety_reserve_tokens = Self::AUTO_COMPRESSION_SAFETY_RESERVE_TOKENS;
+        let input_limit =
+            context_window.saturating_sub(output_reserve_tokens + safety_reserve_tokens);
+
+        CompressionTriggerBudget {
+            input_limit,
+            output_reserve_tokens,
+            safety_reserve_tokens,
+        }
+    }
+
+    fn prepended_reminder_tokens_for_pressure(prepended_reminders: &[&str]) -> usize {
+        prepended_reminders
+            .iter()
+            .map(|reminder| reminder.trim())
+            .filter(|reminder| !reminder.is_empty())
+            .map(|reminder| {
+                Message::user(render_system_reminder(reminder))
+                    .estimate_tokens_with_reasoning(false)
+            })
+            .sum()
+    }
+
+    fn system_tokens_for_pressure(messages: &[Message]) -> usize {
+        messages
+            .first()
+            .filter(|message| message.role == MessageRole::System)
+            .map(|message| message.estimate_tokens_with_reasoning(false))
+            .unwrap_or(0)
+    }
+
+    fn estimate_tail_tokens(messages: &[Message]) -> usize {
+        messages
+            .iter()
+            .map(|message| message.estimate_tokens_with_reasoning(true))
+            .sum()
+    }
+
+    fn apply_token_delta(base: usize, old: usize, new: usize) -> usize {
+        if new >= old {
+            base.saturating_add(new - old)
+        } else {
+            base.saturating_sub(old - new)
+        }
     }
 
     fn tool_signature_args_summary(args_str: &str) -> String {
@@ -381,19 +580,6 @@ impl ExecutionEngine {
     fn should_continue_after_partial_response(reason: &str) -> bool {
         let lower = reason.to_ascii_lowercase();
         !lower.contains("cancelled")
-    }
-
-    fn compression_request_max_tokens(configured_max_tokens: Option<u32>, cap: u32) -> Option<u32> {
-        Some(configured_max_tokens.unwrap_or(cap).min(cap))
-    }
-
-    fn build_compression_ai_client(
-        ai_client: &crate::infrastructure::ai::AIClient,
-    ) -> crate::infrastructure::ai::AIClient {
-        ai_client.with_max_tokens(Self::compression_request_max_tokens(
-            ai_client.config.max_tokens,
-            Self::COMPRESSION_MAX_TOKENS,
-        ))
     }
 
     /// Detect periodic tool-signature loops in the trailing window.
@@ -499,6 +685,7 @@ impl ExecutionEngine {
         messages: Vec<Message>,
         context_window: usize,
         tools: Option<&[ToolDefinition]>,
+        prepended_reminder_tokens: usize,
     ) -> Vec<Message> {
         use crate::agentic::core::MessageRole;
 
@@ -554,6 +741,7 @@ impl ExecutionEngine {
             .map(|m| m.estimate_tokens_with_reasoning(true))
             .sum::<usize>()
             + tool_tokens
+            + prepended_reminder_tokens
             + 3;
 
         let mut kept_start = 0;
@@ -1430,10 +1618,9 @@ impl ExecutionEngine {
     ) -> BitFunResult<String> {
         let mut last_error = None;
         let base_wait_time_ms = 500;
-        let compression_ai_client = Arc::new(Self::build_compression_ai_client(ai_client.as_ref()));
 
         for attempt in 0..max_tries {
-            let result = compression_ai_client
+            let result = ai_client
                 .send_message_with_trace(
                     request_messages.clone(),
                     tool_definitions.clone(),
@@ -1686,12 +1873,12 @@ impl ExecutionEngine {
 
     /// Compress context, will emit compression events (Started, Completed, and Failed)
     #[allow(clippy::too_many_arguments)]
-    pub async fn compress_messages(
+    async fn compress_messages(
         &self,
         session_id: &str,
         dialog_turn_id: &str,
         runtime_messages: Vec<Message>,
-        current_tokens: usize,
+        before_pressure: TokenPressureSnapshot,
         context_window: usize,
         ai_client: Arc<crate::infrastructure::ai::AIClient>,
         tool_definitions: &Option<Vec<ToolDefinition>>,
@@ -1727,9 +1914,8 @@ impl ExecutionEngine {
                 turn_id: dialog_turn_id.to_string(),
                 compression_id: compression_id.clone(),
                 trigger: "auto".to_string(),
-                tokens_before: current_tokens,
+                tokens_before: before_pressure.total_tokens,
                 context_window,
-                threshold: session.config.compression_threshold,
             },
             EventPriority::Normal,
         )
@@ -1817,10 +2003,21 @@ impl ExecutionEngine {
                 let duration_ms = elapsed_ms_u64(start_time);
 
                 // Recalculate tokens after compression
-                let compressed_tokens = Self::estimate_request_tokens_internal(
-                    &mut new_messages,
+                let prepended_reminders = prepended_prompt_reminders.ordered_reminders();
+                let prepended_reminder_tokens =
+                    Self::prepended_reminder_tokens_for_pressure(&prepended_reminders);
+                let after_pressure = Self::estimate_auto_compression_pressure(
+                    &new_messages,
                     tool_definitions.as_deref(),
+                    context_window,
+                    CompressionTriggerBudget {
+                        input_limit: before_pressure.input_limit,
+                        output_reserve_tokens: before_pressure.output_reserve_tokens,
+                        safety_reserve_tokens: before_pressure.safety_reserve_tokens,
+                    },
+                    prepended_reminder_tokens,
                 );
+                let compressed_tokens = after_pressure.total_tokens;
                 let summary_source = if compression_result.has_model_summary {
                     "model"
                 } else {
@@ -1828,13 +2025,27 @@ impl ExecutionEngine {
                 };
 
                 info!(
-                    "Compression completed: session_id={}, turn_id={}, messages {} -> {}, tokens {} -> {}, compression_count={}, duration_ms={}, summary_source={}",
+                    "Compression completed: session_id={}, turn_id={}, messages {} -> {}, total_tokens {} -> {}, system_tokens {} -> {}, tool_tokens {} -> {}, prepended_reminder_tokens {} -> {}, conversation_tokens {} -> {}, context_window={}, input_limit={}, output_reserve={}, safety_reserve={}, usage {:.3} -> {:.3}, compression_count={}, duration_ms={}, summary_source={}",
                     session_id,
                     dialog_turn_id,
                     old_messages_len,
                     new_messages.len(),
-                    current_tokens,
-                    compressed_tokens,
+                    before_pressure.total_tokens,
+                    after_pressure.total_tokens,
+                    before_pressure.system_tokens,
+                    after_pressure.system_tokens,
+                    before_pressure.tool_tokens,
+                    after_pressure.tool_tokens,
+                    before_pressure.prepended_reminder_tokens,
+                    after_pressure.prepended_reminder_tokens,
+                    before_pressure.conversation_tokens,
+                    after_pressure.conversation_tokens,
+                    before_pressure.context_window,
+                    before_pressure.input_limit,
+                    before_pressure.output_reserve_tokens,
+                    before_pressure.safety_reserve_tokens,
+                    before_pressure.usage_ratio,
+                    after_pressure.usage_ratio,
                     session.compression_state.compression_count,
                     duration_ms,
                     summary_source
@@ -1847,9 +2058,13 @@ impl ExecutionEngine {
                         turn_id: dialog_turn_id.to_string(),
                         compression_id: compression_id.clone(),
                         compression_count: session.compression_state.compression_count,
-                        tokens_before: current_tokens,
+                        tokens_before: before_pressure.total_tokens,
                         tokens_after: compressed_tokens,
-                        compression_ratio: (compressed_tokens as f64) / (current_tokens as f64),
+                        compression_ratio: if before_pressure.total_tokens == 0 {
+                            1.0
+                        } else {
+                            (compressed_tokens as f64) / (before_pressure.total_tokens as f64)
+                        },
                         duration_ms,
                         has_summary: compression_result.has_model_summary,
                         summary_source: summary_source.to_string(),
@@ -1887,7 +2102,6 @@ impl ExecutionEngine {
         dialog_turn_id: String,
         context: ExecutionContext,
         messages: Vec<Message>,
-        current_tokens: usize,
         trigger: &str,
     ) -> BitFunResult<ContextCompactionOutcome> {
         let mut session = self
@@ -1901,6 +2115,20 @@ impl ExecutionEngine {
             .await?;
         let context_window = (scaffold.ai_client.config.context_window as usize)
             .min(session.config.max_context_tokens);
+        let prepended_reminders = scaffold.prepended_prompt_reminders.ordered_reminders();
+        let prepended_reminder_tokens =
+            Self::prepended_reminder_tokens_for_pressure(&prepended_reminders);
+        let compression_trigger_budget =
+            Self::compression_trigger_budget(context_window, scaffold.ai_client.config.max_tokens);
+        let mut runtime_messages = vec![scaffold.system_prompt_message.clone()];
+        runtime_messages.extend(messages.clone());
+        let before_pressure = Self::estimate_auto_compression_pressure(
+            &runtime_messages,
+            scaffold.tool_definitions.as_deref(),
+            context_window,
+            compression_trigger_budget,
+            prepended_reminder_tokens,
+        );
 
         self.emit_event(
             AgenticEvent::ContextCompressionStarted {
@@ -1908,9 +2136,8 @@ impl ExecutionEngine {
                 turn_id: dialog_turn_id.to_string(),
                 compression_id: compression_id.clone(),
                 trigger: trigger.to_string(),
-                tokens_before: current_tokens,
+                tokens_before: before_pressure.total_tokens,
                 context_window,
-                threshold: session.config.compression_threshold,
             },
             EventPriority::Normal,
         )
@@ -1922,12 +2149,28 @@ impl ExecutionEngine {
 
         if turns.is_empty() {
             let duration_ms = elapsed_ms_u64(start_time);
-            let tokens_after = current_tokens;
-            let compression_ratio = if current_tokens == 0 {
+            let tokens_after = before_pressure.total_tokens;
+            let compression_ratio = if before_pressure.total_tokens == 0 {
                 1.0
             } else {
-                (tokens_after as f64) / (current_tokens as f64)
+                (tokens_after as f64) / (before_pressure.total_tokens as f64)
             };
+            info!(
+                "Manual compression skipped: session_id={}, turn_id={}, reason=no_eligible_turns, total_tokens={}, system_tokens={}, tool_tokens={}, prepended_reminder_tokens={}, conversation_tokens={}, context_window={}, input_limit={}, output_reserve={}, safety_reserve={}, usage={:.3}, duration_ms={}",
+                session_id,
+                dialog_turn_id,
+                before_pressure.total_tokens,
+                before_pressure.system_tokens,
+                before_pressure.tool_tokens,
+                before_pressure.prepended_reminder_tokens,
+                before_pressure.conversation_tokens,
+                before_pressure.context_window,
+                before_pressure.input_limit,
+                before_pressure.output_reserve_tokens,
+                before_pressure.safety_reserve_tokens,
+                before_pressure.usage_ratio,
+                duration_ms
+            );
 
             self.emit_event(
                 AgenticEvent::ContextCompressionCompleted {
@@ -1935,7 +2178,7 @@ impl ExecutionEngine {
                     turn_id: dialog_turn_id.to_string(),
                     compression_id: compression_id.clone(),
                     compression_count: session.compression_state.compression_count,
-                    tokens_before: current_tokens,
+                    tokens_before: before_pressure.total_tokens,
                     tokens_after,
                     compression_ratio,
                     duration_ms,
@@ -1949,7 +2192,7 @@ impl ExecutionEngine {
             return Ok(ContextCompactionOutcome {
                 compression_id,
                 compression_count: session.compression_state.compression_count,
-                tokens_before: current_tokens,
+                tokens_before: before_pressure.total_tokens,
                 tokens_after,
                 compression_ratio,
                 duration_ms,
@@ -1959,8 +2202,6 @@ impl ExecutionEngine {
             });
         }
 
-        let mut runtime_messages = vec![scaffold.system_prompt_message.clone()];
-        runtime_messages.extend(messages);
         let compression_contract = self
             .session_manager
             .compression_contract_for_session(&session_id, scaffold.compression_contract_limit);
@@ -2007,7 +2248,7 @@ impl ExecutionEngine {
             model_summary,
         ) {
             Ok(compression_result) => {
-                let mut compressed_messages = compression_result.messages;
+                let compressed_messages = compression_result.messages;
                 self.session_manager
                     .replace_context_messages(&session_id, compressed_messages.clone())
                     .await;
@@ -2037,15 +2278,49 @@ impl ExecutionEngine {
                     .await;
 
                 let duration_ms = elapsed_ms_u64(start_time);
-                let tokens_after = compressed_messages
-                    .iter_mut()
-                    .map(|message| message.get_tokens())
-                    .sum::<usize>();
-                let compression_ratio = if current_tokens == 0 {
+                let mut compressed_runtime_messages = vec![scaffold.system_prompt_message.clone()];
+                compressed_runtime_messages.extend(compressed_messages.clone());
+                let after_pressure = Self::estimate_auto_compression_pressure(
+                    &compressed_runtime_messages,
+                    scaffold.tool_definitions.as_deref(),
+                    context_window,
+                    compression_trigger_budget,
+                    prepended_reminder_tokens,
+                );
+                let tokens_after = after_pressure.total_tokens;
+                let compression_ratio = if before_pressure.total_tokens == 0 {
                     1.0
                 } else {
-                    (tokens_after as f64) / (current_tokens as f64)
+                    (tokens_after as f64) / (before_pressure.total_tokens as f64)
                 };
+                info!(
+                    "Manual compression completed: session_id={}, turn_id={}, total_tokens {} -> {}, system_tokens {} -> {}, tool_tokens {} -> {}, prepended_reminder_tokens {} -> {}, conversation_tokens {} -> {}, context_window={}, input_limit={}, output_reserve={}, safety_reserve={}, usage {:.3} -> {:.3}, compression_count={}, duration_ms={}, summary_source={}",
+                    session_id,
+                    dialog_turn_id,
+                    before_pressure.total_tokens,
+                    after_pressure.total_tokens,
+                    before_pressure.system_tokens,
+                    after_pressure.system_tokens,
+                    before_pressure.tool_tokens,
+                    after_pressure.tool_tokens,
+                    before_pressure.prepended_reminder_tokens,
+                    after_pressure.prepended_reminder_tokens,
+                    before_pressure.conversation_tokens,
+                    after_pressure.conversation_tokens,
+                    before_pressure.context_window,
+                    before_pressure.input_limit,
+                    before_pressure.output_reserve_tokens,
+                    before_pressure.safety_reserve_tokens,
+                    before_pressure.usage_ratio,
+                    after_pressure.usage_ratio,
+                    compression_count,
+                    duration_ms,
+                    if compression_result.has_model_summary {
+                        "model"
+                    } else {
+                        "local_fallback"
+                    }
+                );
 
                 self.emit_event(
                     AgenticEvent::ContextCompressionCompleted {
@@ -2053,7 +2328,7 @@ impl ExecutionEngine {
                         turn_id: dialog_turn_id.to_string(),
                         compression_id: compression_id.clone(),
                         compression_count,
-                        tokens_before: current_tokens,
+                        tokens_before: before_pressure.total_tokens,
                         tokens_after,
                         compression_ratio,
                         duration_ms,
@@ -2071,7 +2346,7 @@ impl ExecutionEngine {
                 Ok(ContextCompactionOutcome {
                     compression_id,
                     compression_count,
-                    tokens_before: current_tokens,
+                    tokens_before: before_pressure.total_tokens,
                     tokens_after,
                     compression_ratio,
                     duration_ms,
@@ -2423,7 +2698,8 @@ impl ExecutionEngine {
         );
 
         let enable_context_compression = session.config.enable_context_compression;
-        let compression_threshold = session.config.compression_threshold;
+        let compression_trigger_budget =
+            Self::compression_trigger_budget(context_window, ai_client.config.max_tokens);
 
         let mut execution_context_vars = context.context.clone();
         execution_context_vars.insert("turn_index".to_string(), context.turn_index.to_string());
@@ -2472,24 +2748,100 @@ impl ExecutionEngine {
             //   - L1: AI-summary based full compression (preserves semantics).
             //   - L2: Emergency truncation (only if tokens still exceed the
             //         provider context window after L1).
-            let (current_tokens, conversation_tokens, token_usage_ratio) =
-                Self::estimate_auto_compression_pressure(
+            let pressure_prepended_reminders = turn_prompt_scaffold
+                .prepended_prompt_reminders
+                .ordered_reminders();
+            let pressure_prepended_reminder_tokens =
+                Self::prepended_reminder_tokens_for_pressure(&pressure_prepended_reminders);
+            let token_anchor_selection = self
+                .session_manager
+                .select_latest_matching_token_anchor(&context.session_id, &messages)
+                .await;
+            let (token_pressure, anchor_details) =
+                Self::estimate_auto_compression_pressure_with_anchor(
                     &messages,
                     tool_definitions.as_deref(),
                     context_window,
+                    compression_trigger_budget,
+                    token_anchor_selection.selected.as_ref(),
+                    pressure_prepended_reminder_tokens,
                 );
+            if let Some(details) = anchor_details.as_ref() {
+                debug!(
+                    "Token pressure estimate: session_id={}, turn_id={}, round_index={}, source=provider_anchor, anchor_id={}, prefix_messages={}, input_tokens={}, adjusted_anchor_tokens={}, tail_tokens={}, system_tokens_at_anchor={}, current_system_tokens={}, system_delta={}, tool_tokens_at_anchor={}, current_tool_tokens={}, tool_delta={}, prepended_reminder_tokens_at_anchor={}, current_prepended_reminder_tokens={}, prepended_reminder_delta={}, total_tokens={}, system_tokens={}, tool_tokens={}, prepended_reminder_tokens={}, conversation_tokens={}, context_window={}, input_limit={}, output_reserve={}, safety_reserve={}, usage={:.3}",
+                    context.session_id,
+                    context.dialog_turn_id,
+                    round_index,
+                    details.anchor_id,
+                    details.prefix_message_count,
+                    details.input_tokens,
+                    details.adjusted_anchor_tokens,
+                    details.tail_tokens,
+                    details.system_tokens_at_anchor,
+                    details.current_system_tokens,
+                    details.system_delta,
+                    details.tool_tokens_at_anchor,
+                    details.current_tool_tokens,
+                    details.tool_delta,
+                    details.prepended_reminder_tokens_at_anchor,
+                    details.current_prepended_reminder_tokens,
+                    details.prepended_reminder_delta,
+                    token_pressure.total_tokens,
+                    token_pressure.system_tokens,
+                    token_pressure.tool_tokens,
+                    token_pressure.prepended_reminder_tokens,
+                    token_pressure.conversation_tokens,
+                    token_pressure.context_window,
+                    token_pressure.input_limit,
+                    token_pressure.output_reserve_tokens,
+                    token_pressure.safety_reserve_tokens,
+                    token_pressure.usage_ratio
+                );
+                if !token_anchor_selection.skipped.is_empty() {
+                    trace!(
+                        "Token anchor selection skipped newer anchors before match: session_id={}, turn_id={}, round_index={}, selected_anchor_id={}, skipped={:?}",
+                        context.session_id,
+                        context.dialog_turn_id,
+                        round_index,
+                        details.anchor_id,
+                        token_anchor_selection.skipped
+                    );
+                }
+            } else {
+                debug!(
+                    "Token pressure estimate: session_id={}, turn_id={}, round_index={}, source=full_estimate, total_tokens={}, system_tokens={}, tool_tokens={}, prepended_reminder_tokens={}, conversation_tokens={}, context_window={}, input_limit={}, output_reserve={}, safety_reserve={}, usage={:.3}, fallback_reasons={:?}",
+                    context.session_id,
+                    context.dialog_turn_id,
+                    round_index,
+                    token_pressure.total_tokens,
+                    token_pressure.system_tokens,
+                    token_pressure.tool_tokens,
+                    token_pressure.prepended_reminder_tokens,
+                    token_pressure.conversation_tokens,
+                    token_pressure.context_window,
+                    token_pressure.input_limit,
+                    token_pressure.output_reserve_tokens,
+                    token_pressure.safety_reserve_tokens,
+                    token_pressure.usage_ratio,
+                    token_anchor_selection.skipped
+                );
+            }
             debug!(
-                "Round {} token usage before send: total={} / {}, conversation={} / {}, usage={:.1}%",
+                "Round {} token usage before send: total={} / {}, conversation={} / {}, usage={:.1}%, input_limit={}, output_reserve={}, safety_reserve={}",
                 round_index,
-                current_tokens,
-                context_window,
-                conversation_tokens,
-                context_window,
-                token_usage_ratio * 100.0
+                token_pressure.total_tokens,
+                token_pressure.context_window,
+                token_pressure.conversation_tokens,
+                token_pressure.context_window,
+                token_pressure.usage_ratio * 100.0,
+                token_pressure.input_limit,
+                token_pressure.output_reserve_tokens,
+                token_pressure.safety_reserve_tokens
             );
 
-            let should_compress =
-                enable_context_compression && token_usage_ratio >= compression_threshold;
+            let should_compress = enable_context_compression
+                && token_pressure.total_tokens >= token_pressure.input_limit;
+            let mut send_pressure_reusable = true;
 
             // Circuit breaker: skip full compression if it has failed too many
             // consecutive times.  Microcompact and emergency truncation still run.
@@ -2498,10 +2850,14 @@ impl ExecutionEngine {
 
             if !should_compress {
                 debug!(
-                    "No compression needed: session={}, token_usage={:.1}%, threshold={:.1}%",
+                    "No compression needed: session={}, total_tokens={}, input_limit={}, context_window={}, output_reserve={}, safety_reserve={}, usage={:.1}%",
                     context.session_id,
-                    token_usage_ratio * 100.0,
-                    compression_threshold * 100.0
+                    token_pressure.total_tokens,
+                    token_pressure.input_limit,
+                    token_pressure.context_window,
+                    token_pressure.output_reserve_tokens,
+                    token_pressure.safety_reserve_tokens,
+                    token_pressure.usage_ratio * 100.0
                 );
             } else if circuit_breaker_open {
                 warn!(
@@ -2510,10 +2866,14 @@ impl ExecutionEngine {
                 );
             } else {
                 info!(
-                    "Triggering context compression: session={}, token_usage={:.1}%, threshold={:.1}%",
+                    "Triggering context compression: session={}, total_tokens={}, input_limit={}, context_window={}, output_reserve={}, safety_reserve={}, usage={:.1}%",
                     context.session_id,
-                    token_usage_ratio * 100.0,
-                    compression_threshold * 100.0
+                    token_pressure.total_tokens,
+                    token_pressure.input_limit,
+                    token_pressure.context_window,
+                    token_pressure.output_reserve_tokens,
+                    token_pressure.safety_reserve_tokens,
+                    token_pressure.usage_ratio * 100.0
                 );
 
                 match self
@@ -2521,7 +2881,7 @@ impl ExecutionEngine {
                         &context.session_id,
                         &context.dialog_turn_id,
                         messages.clone(),
-                        current_tokens,
+                        token_pressure,
                         context_window,
                         ai_client.clone(),
                         &tool_definitions,
@@ -2539,7 +2899,7 @@ impl ExecutionEngine {
                             round_index,
                             messages.len(),
                             compressed_messages.len(),
-                            current_tokens,
+                            token_pressure.total_tokens,
                             compressed_tokens,
                         );
 
@@ -2561,6 +2921,7 @@ impl ExecutionEngine {
                         );
                         full_compression_count += 1;
                         consecutive_compression_failures = 0;
+                        send_pressure_reusable = false;
                     }
                     Ok(None) => {
                         debug!("No eligible multi-turn context available for compression");
@@ -2582,30 +2943,54 @@ impl ExecutionEngine {
 
             // L2: Emergency truncation — if tokens still exceed context_window
             // after all compression layers, drop oldest API rounds until we fit.
-            let post_compress_tokens =
-                Self::estimate_request_tokens_internal(&messages, tool_definitions.as_deref());
-            if post_compress_tokens > context_window {
+            let send_prepended_reminders = turn_prompt_scaffold
+                .prepended_prompt_reminders
+                .ordered_reminders();
+            let send_prepended_reminder_tokens =
+                Self::prepended_reminder_tokens_for_pressure(&send_prepended_reminders);
+            let mut send_pressure = if send_pressure_reusable
+                && token_pressure.prepended_reminder_tokens == send_prepended_reminder_tokens
+            {
+                token_pressure
+            } else {
+                Self::estimate_auto_compression_pressure(
+                    &messages,
+                    tool_definitions.as_deref(),
+                    context_window,
+                    compression_trigger_budget,
+                    send_prepended_reminder_tokens,
+                )
+            };
+            if send_pressure.total_tokens > context_window {
                 warn!(
                     "Round {} tokens ({}) still exceed context_window ({}) after compression, performing emergency truncation",
-                    round_index, post_compress_tokens, context_window
+                    round_index, send_pressure.total_tokens, context_window
                 );
+                let before_truncate_tokens = send_pressure.total_tokens;
                 messages = Self::emergency_truncate_messages(
                     messages,
                     context_window,
                     tool_definitions.as_deref(),
+                    send_prepended_reminder_tokens,
                 );
-                let after_truncate =
-                    Self::estimate_request_tokens_internal(&messages, tool_definitions.as_deref());
+                self.session_manager
+                    .prune_token_anchors_to_messages(&context.session_id, &messages)
+                    .await;
+                send_pressure = Self::estimate_auto_compression_pressure(
+                    &messages,
+                    tool_definitions.as_deref(),
+                    context_window,
+                    compression_trigger_budget,
+                    send_prepended_reminder_tokens,
+                );
                 info!(
                     "Emergency truncation complete: tokens {} -> {}",
-                    post_compress_tokens, after_truncate
+                    before_truncate_tokens, send_pressure.total_tokens
                 );
             }
 
-            let before_send_tokens =
-                Self::estimate_request_tokens_internal(&messages, tool_definitions.as_deref());
             ContextHealthSnapshot::from_runtime_observations(
-                ContextHealthSnapshot::token_usage_ratio(before_send_tokens, context_window),
+                send_pressure.usage_ratio,
                 full_compression_count,
                 compression_failure_count,
                 &recent_tool_signatures,
@@ -2664,9 +3049,6 @@ impl ExecutionEngine {
                 messages.len()
             );
 
-            let prepended_reminders = turn_prompt_scaffold
-                .prepended_prompt_reminders
-                .ordered_reminders();
             let ai_messages = Self::build_ai_messages_for_send(
                 &messages,
                 &ai_client.config.format,
@@ -2676,7 +3058,7 @@ impl ExecutionEngine {
                     .map(|workspace| workspace.root_path()),
                 &context.dialog_turn_id,
                 primary_supports_image_understanding,
-                &prepended_reminders,
+                &send_prepended_reminders,
             )
             .await?;
 
@@ -2702,6 +3084,31 @@ impl ExecutionEngine {
             // Save the last token usage statistics (update each time, keep the last one)
             if let Some(ref usage) = round_result.usage {
                 last_usage = Some(usage.clone());
+                let round_id = round_result
+                    .assistant_message
+                    .metadata
+                    .round_id
+                    .clone()
+                    .unwrap_or_else(|| format!("round_{}", round_index));
+                let system_tokens_at_anchor = Self::system_tokens_for_pressure(&messages);
+                let tool_tokens_at_anchor = tool_definitions
+                    .as_deref()
+                    .map(TokenCounter::estimate_tool_definitions_tokens)
+                    .unwrap_or(0);
+                let anchor = TokenAnchor::from_request_prefix(
+                    TokenAnchorInput {
+                        session_id: context.session_id.clone(),
+                        turn_id: context.dialog_turn_id.clone(),
+                        round_id,
+                        model_id: ai_client.config.model.clone(),
+                        input_tokens: usage.prompt_token_count as usize,
+                        system_tokens_at_anchor,
+                        tool_tokens_at_anchor,
+                        prepended_reminder_tokens_at_anchor: send_prepended_reminder_tokens,
+                    },
+                    &messages,
+                );
+                self.session_manager.remember_token_anchor(anchor).await;
             }
 
             // Add assistant message to history
@@ -2762,10 +3169,15 @@ impl ExecutionEngine {
                 failed_tool_recovery_attempts = 0;
             }
 
-            let after_round_tokens =
-                Self::estimate_request_tokens_internal(&messages, tool_definitions.as_deref());
+            let after_round_pressure = Self::estimate_auto_compression_pressure(
+                &messages,
+                tool_definitions.as_deref(),
+                context_window,
+                compression_trigger_budget,
+                send_prepended_reminder_tokens,
+            );
             let after_round_health = ContextHealthSnapshot::from_runtime_observations(
-                ContextHealthSnapshot::token_usage_ratio(after_round_tokens, context_window),
+                after_round_pressure.usage_ratio,
                 full_compression_count,
                 compression_failure_count,
                 &recent_tool_signatures,
@@ -3385,10 +3797,10 @@ mod tests {
     use super::{ContextHealthSnapshot, ExecutionEngine, TurnPromptScaffold};
     use crate::agentic::agents::PrependedPromptReminders;
     use crate::agentic::core::{InternalReminderKind, Message, MessageRole, ToolCall, ToolResult};
+    use crate::agentic::session::{TokenAnchor, TokenAnchorInput};
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::service::config::types::AIConfig;
     use crate::service::config::types::AIModelConfig;
-    use crate::util::types::config as ai_config_types;
     use crate::util::types::ToolDefinition;
     use serde_json::json;
     use sha2::{Digest, Sha256};
@@ -3426,7 +3838,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_compression_pressure_excludes_system_and_tool_overhead() {
+    fn auto_compression_pressure_tracks_total_and_conversation_tokens() {
         let messages = vec![
             Message::system("system prompt".repeat(10_000)),
             Message::user("hello".to_string()),
@@ -3436,13 +3848,199 @@ mod tests {
             description: "Read files".repeat(5_000),
             parameters: json!({"type": "object"}),
         }];
+        let prepended_reminders = vec!["prepended reminder".repeat(5_000)];
+        let prepended_reminder_refs = prepended_reminders
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        let prepended_reminder_tokens =
+            ExecutionEngine::prepended_reminder_tokens_for_pressure(&prepended_reminder_refs);
 
-        let (total_tokens, conversation_tokens, usage_ratio) =
-            ExecutionEngine::estimate_auto_compression_pressure(&messages, Some(&tools), 128_000);
+        let snapshot = ExecutionEngine::estimate_auto_compression_pressure(
+            &messages,
+            Some(&tools),
+            128_000,
+            ExecutionEngine::compression_trigger_budget(128_000, None),
+            prepended_reminder_tokens,
+        );
 
-        assert!(total_tokens > conversation_tokens);
-        assert!(usage_ratio < total_tokens as f32 / 128_000_f32);
+        assert!(snapshot.total_tokens > snapshot.conversation_tokens);
+        assert!(snapshot.system_tokens > 0);
+        assert!(snapshot.tool_tokens > 0);
+        assert_eq!(
+            snapshot.prepended_reminder_tokens,
+            prepended_reminder_tokens
+        );
+        assert!(
+            (snapshot.usage_ratio - snapshot.total_tokens as f32 / 128_000_f32).abs()
+                < f32::EPSILON
+        );
         assert_eq!(messages[1].role, MessageRole::User);
+    }
+
+    #[test]
+    fn compression_trigger_budget_reserves_output_and_safety_tokens() {
+        let budget = ExecutionEngine::compression_trigger_budget(128_000, Some(32_000));
+
+        assert_eq!(budget.output_reserve_tokens, 32_000);
+        assert_eq!(budget.safety_reserve_tokens, 10_000);
+        assert_eq!(budget.input_limit, 86_000);
+    }
+
+    #[test]
+    fn compression_trigger_budget_uses_16k_output_reserve_when_max_tokens_is_unset() {
+        let budget = ExecutionEngine::compression_trigger_budget(128_000, None);
+
+        assert_eq!(budget.output_reserve_tokens, 16_000);
+        assert_eq!(budget.safety_reserve_tokens, 10_000);
+        assert_eq!(budget.input_limit, 102_000);
+    }
+
+    #[test]
+    fn auto_compression_pressure_uses_provider_input_anchor_plus_tail_estimate() {
+        let prefix = vec![
+            Message::system("system prompt".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let system_tokens = ExecutionEngine::system_tokens_for_pressure(&prefix);
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: system_tokens,
+                tool_tokens_at_anchor: 0,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &prefix,
+        );
+        let mut messages = prefix;
+        messages.push(Message::assistant("assistant tail".repeat(10)));
+        let tail_tokens =
+            ExecutionEngine::estimate_tail_tokens(&messages[anchor.prefix_message_count..]);
+
+        let (snapshot, details) = ExecutionEngine::estimate_auto_compression_pressure_with_anchor(
+            &messages,
+            None,
+            1_000,
+            ExecutionEngine::compression_trigger_budget(1_000, None),
+            Some(&anchor),
+            0,
+        );
+
+        assert_eq!(snapshot.total_tokens, 100 + tail_tokens);
+        assert_eq!(details.expect("anchor details").tail_tokens, tail_tokens);
+    }
+
+    #[test]
+    fn auto_compression_pressure_applies_tool_definition_delta_to_anchor() {
+        let messages = vec![
+            Message::system("system prompt".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let old_tools = vec![ToolDefinition {
+            name: "Read".to_string(),
+            description: "read files".to_string(),
+            parameters: json!({"type": "object"}),
+        }];
+        let new_tools = vec![ToolDefinition {
+            name: "Read".to_string(),
+            description: "read files with a longer provider-visible description".repeat(10),
+            parameters: json!({"type": "object"}),
+        }];
+        let old_tool_tokens =
+            crate::util::TokenCounter::estimate_tool_definitions_tokens(&old_tools);
+        let new_tool_tokens =
+            crate::util::TokenCounter::estimate_tool_definitions_tokens(&new_tools);
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: ExecutionEngine::system_tokens_for_pressure(&messages),
+                tool_tokens_at_anchor: old_tool_tokens,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &messages,
+        );
+
+        let (snapshot, details) = ExecutionEngine::estimate_auto_compression_pressure_with_anchor(
+            &messages,
+            Some(&new_tools),
+            1_000,
+            ExecutionEngine::compression_trigger_budget(1_000, None),
+            Some(&anchor),
+            0,
+        );
+
+        assert_eq!(
+            snapshot.total_tokens,
+            100 + (new_tool_tokens - old_tool_tokens)
+        );
+        assert_eq!(snapshot.tool_tokens, new_tool_tokens);
+        assert_eq!(
+            details.expect("anchor details").tool_delta,
+            (new_tool_tokens - old_tool_tokens) as isize
+        );
+    }
+
+    #[test]
+    fn auto_compression_pressure_applies_prepended_reminder_delta_to_anchor() {
+        let messages = vec![
+            Message::system("system prompt".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let old_reminders = vec!["short reminder".to_string()];
+        let new_reminders = vec!["longer reminder ".repeat(20)];
+        let old_reminder_refs = old_reminders.iter().map(String::as_str).collect::<Vec<_>>();
+        let new_reminder_refs = new_reminders.iter().map(String::as_str).collect::<Vec<_>>();
+        let old_reminder_tokens =
+            ExecutionEngine::prepended_reminder_tokens_for_pressure(&old_reminder_refs);
+        let new_reminder_tokens =
+            ExecutionEngine::prepended_reminder_tokens_for_pressure(&new_reminder_refs);
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: ExecutionEngine::system_tokens_for_pressure(&messages),
+                tool_tokens_at_anchor: 0,
+                prepended_reminder_tokens_at_anchor: old_reminder_tokens,
+            },
+            &messages,
+        );
+
+        let (snapshot, details) = ExecutionEngine::estimate_auto_compression_pressure_with_anchor(
+            &messages,
+            None,
+            1_000,
+            ExecutionEngine::compression_trigger_budget(1_000, None),
+            Some(&anchor),
+            new_reminder_tokens,
+        );
+        let details = details.expect("anchor details");
+
+        assert_eq!(
+            snapshot.total_tokens,
+            100 + (new_reminder_tokens - old_reminder_tokens)
+        );
+        assert_eq!(
+            snapshot.conversation_tokens,
+            snapshot.total_tokens
+                - ExecutionEngine::system_tokens_for_pressure(&messages)
+                - new_reminder_tokens
+        );
+        assert_eq!(snapshot.prepended_reminder_tokens, new_reminder_tokens);
+        assert_eq!(
+            details.prepended_reminder_delta,
+            (new_reminder_tokens - old_reminder_tokens) as isize
+        );
     }
 
     #[test]
@@ -3500,60 +4098,6 @@ mod tests {
         let summary = ExecutionEngine::tool_signature_args_summary(args);
 
         assert_eq!(summary, args);
-    }
-
-    #[test]
-    fn compression_request_max_tokens_clamps_to_global_cap() {
-        assert_eq!(
-            ExecutionEngine::compression_request_max_tokens(Some(16_000), 8192),
-            Some(8192)
-        );
-        assert_eq!(
-            ExecutionEngine::compression_request_max_tokens(Some(4096), 8192),
-            Some(4096)
-        );
-        assert_eq!(
-            ExecutionEngine::compression_request_max_tokens(None, 8192),
-            Some(8192)
-        );
-    }
-
-    #[test]
-    fn build_compression_ai_client_overrides_only_max_tokens() {
-        let client = crate::infrastructure::ai::AIClient::new(ai_config_types::AIConfig {
-            name: "test".to_string(),
-            base_url: "https://example.com/v1".to_string(),
-            request_url: "https://example.com/v1/responses".to_string(),
-            api_key: "key".to_string(),
-            model: "test-model".to_string(),
-            format: "responses".to_string(),
-            context_window: 128_000,
-            max_tokens: None,
-            temperature: None,
-            top_p: None,
-            reasoning_mode: Default::default(),
-            inline_think_in_text: true,
-            custom_headers: None,
-            custom_headers_mode: None,
-            skip_ssl_verify: false,
-            reasoning_effort: None,
-            thinking_budget_tokens: None,
-            custom_request_body: None,
-            custom_request_body_mode: None,
-        });
-
-        let compression_client = ExecutionEngine::build_compression_ai_client(&client);
-
-        assert_eq!(client.config.max_tokens, None);
-        assert_eq!(
-            compression_client.config.max_tokens,
-            Some(ExecutionEngine::COMPRESSION_MAX_TOKENS)
-        );
-        assert_eq!(compression_client.config.model, client.config.model);
-        assert_eq!(
-            compression_client.config.request_url,
-            client.config.request_url
-        );
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -14,7 +14,7 @@ use crate::agentic::session::transcript_render::{
     transcript_text_lines, transcript_thinking_blocks, transcript_tool_blocks,
     TranscriptRoundBlock, TranscriptRoundData, TranscriptTextBlock, TranscriptToolBlock,
 };
-use crate::agentic::session::{SessionPromptCache, PROMPT_CACHE_SCHEMA_VERSION};
+use crate::agentic::session::{SessionPromptCache, TokenAnchor, PROMPT_CACHE_SCHEMA_VERSION};
 use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
 use crate::infrastructure::PathManager;
 use crate::service::config::get_global_config_service;
@@ -54,6 +54,7 @@ use tokio::sync::Mutex;
 pub use bitfun_services_core::session::SessionMetadataPage;
 
 const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+const TOKEN_ANCHOR_SCHEMA_VERSION: u32 = 1;
 const SESSION_TRANSCRIPT_PREVIEW_CHAR_LIMIT: usize = 120;
 const SESSION_TURN_READ_CONCURRENCY: usize = 4;
 
@@ -118,6 +119,13 @@ struct StoredSessionPromptCacheFile {
     schema_version: u32,
     #[serde(flatten)]
     cache: SessionPromptCache,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredTokenAnchorsFile {
+    schema_version: u32,
+    session_id: String,
+    anchors: Vec<TokenAnchor>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -348,6 +356,12 @@ impl PersistenceManager {
     fn prompt_cache_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
         self.session_layout(workspace_path)
             .prompt_cache_path(session_id)
+    }
+
+    fn token_anchors_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
+        self.session_layout(workspace_path)
+            .session_dir(session_id)
+            .join("token-anchors.json")
     }
 
     fn turns_dir(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
@@ -1223,6 +1237,54 @@ impl PersistenceManager {
             Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
             Err(error) => Err(BitFunError::io(format!(
                 "Failed to delete prompt cache for session {}: {}",
+                session_id, error
+            ))),
+        }
+    }
+
+    pub async fn load_token_anchors(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<Option<Vec<TokenAnchor>>> {
+        Ok(self
+            .read_json_optional::<StoredTokenAnchorsFile>(
+                &self.token_anchors_path(workspace_path, session_id),
+            )
+            .await?
+            .map(|file| file.anchors))
+    }
+
+    pub async fn save_token_anchors(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        anchors: &[TokenAnchor],
+    ) -> BitFunResult<()> {
+        self.ensure_runtime_for_write(workspace_path).await?;
+        self.ensure_session_dir(workspace_path, session_id).await?;
+
+        self.write_json_atomic(
+            &self.token_anchors_path(workspace_path, session_id),
+            &StoredTokenAnchorsFile {
+                schema_version: TOKEN_ANCHOR_SCHEMA_VERSION,
+                session_id: session_id.to_string(),
+                anchors: anchors.to_vec(),
+            },
+        )
+        .await
+    }
+
+    pub async fn delete_token_anchors(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<()> {
+        match fs::remove_file(self.token_anchors_path(workspace_path, session_id)).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(BitFunError::io(format!(
+                "Failed to delete token anchors for session {}: {}",
                 session_id, error
             ))),
         }
@@ -2586,6 +2648,7 @@ mod tests {
     };
     use crate::agentic::core::{Message, Session, SessionConfig, SessionKind, ToolResult};
     use crate::agentic::memories::db::{MemoryDatabase, MemoryRow, MEMORY_PHASE2_GLOBAL_JOB_KEY};
+    use crate::agentic::session::{TokenAnchor, TokenAnchorInput};
     use crate::agentic::skill_agent_snapshot::{
         AgentSnapshotEntry, SkillSnapshotEntry, TurnSkillAgentSnapshot,
     };
@@ -2627,6 +2690,54 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[tokio::test]
+    async fn token_anchors_save_load_and_delete_roundtrip() {
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+        let session_id = format!("session-{}", Uuid::new_v4());
+        let messages = vec![
+            Message::system("system".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: session_id.clone(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &messages,
+        );
+
+        manager
+            .save_token_anchors(workspace.path(), &session_id, std::slice::from_ref(&anchor))
+            .await
+            .expect("token anchors should save");
+        let loaded = manager
+            .load_token_anchors(workspace.path(), &session_id)
+            .await
+            .expect("token anchors should load")
+            .expect("token anchor file should exist");
+
+        assert_eq!(loaded, vec![anchor]);
+
+        manager
+            .delete_token_anchors(workspace.path(), &session_id)
+            .await
+            .expect("token anchors should delete");
+        let loaded_after_delete = manager
+            .load_token_anchors(workspace.path(), &session_id)
+            .await
+            .expect("deleted token anchor load should succeed");
+
+        assert!(loaded_after_delete.is_none());
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/session/mod.rs
+++ b/src/crates/assembly/core/src/agentic/session/mod.rs
@@ -9,6 +9,7 @@ pub mod file_read_state;
 pub mod prompt_cache;
 pub mod session_manager;
 pub mod session_store_port;
+pub mod token_anchor;
 pub(crate) mod transcript_render;
 pub mod turn_skill_agent_snapshot_store;
 
@@ -19,6 +20,7 @@ pub use file_read_state::*;
 pub use prompt_cache::*;
 pub use session_manager::*;
 pub use session_store_port::*;
+pub use token_anchor::*;
 pub use turn_skill_agent_snapshot_store::*;
 
 pub use bitfun_runtime_ports::{

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -17,8 +17,8 @@ use crate::agentic::session::{
     EvidenceLedgerSummary, EvidenceLedgerTargetKind, FileReadState, FileReadStateStore,
     PromptCacheLookup, PromptCachePersistenceWriteAction, PromptCachePolicy,
     PromptCacheRestoreDecision, PromptCacheScope, SessionContextStore, SessionEvidenceLedger,
-    SessionPromptCache, SessionPromptCacheStore, SystemPromptCacheIdentity,
-    TurnSkillAgentSnapshotStore, UserContextCacheIdentity,
+    SessionPromptCache, SessionPromptCacheStore, SystemPromptCacheIdentity, TokenAnchor,
+    TokenAnchorSelection, TokenAnchorStore, TurnSkillAgentSnapshotStore, UserContextCacheIdentity,
 };
 use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
 use crate::agentic::workspace::WorkspaceBinding;
@@ -127,6 +127,7 @@ pub struct SessionManager {
     /// Sub-components
     context_store: Arc<SessionContextStore>,
     prompt_cache_store: Arc<SessionPromptCacheStore>,
+    token_anchor_store: Arc<TokenAnchorStore>,
     turn_skill_agent_snapshot_store: Arc<TurnSkillAgentSnapshotStore>,
     skill_agent_baseline_override_snapshot_store: Arc<DashMap<String, TurnSkillAgentSnapshot>>,
     file_read_state_store: Arc<FileReadStateStore>,
@@ -1021,6 +1022,132 @@ impl SessionManager {
         }
     }
 
+    async fn ensure_token_anchors_loaded(&self, session_id: &str) {
+        if self.token_anchor_store.has_session(session_id) {
+            return;
+        }
+
+        let anchors = if self.should_persist_session_id(session_id) {
+            match self.effective_session_storage_path(session_id).await {
+                Some(workspace_path) => match self
+                    .persistence_manager
+                    .load_token_anchors(&workspace_path, session_id)
+                    .await
+                {
+                    Ok(Some(anchors)) => anchors,
+                    Ok(None) => Vec::new(),
+                    Err(error) => {
+                        warn!(
+                            "Failed to load token anchors: session_id={}, workspace_path={}, error={}",
+                            session_id,
+                            workspace_path.display(),
+                            error
+                        );
+                        Vec::new()
+                    }
+                },
+                None => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
+
+        if let Some(stats) = self.token_anchor_store.replace_session(session_id, anchors) {
+            debug!(
+                "Token anchor retention pruned loaded anchors: session_id={}, before={}, after={}, removed={}, recent_limit={}, retained_recent={}, retained_turn_boundaries={}",
+                session_id,
+                stats.before,
+                stats.after,
+                stats.removed,
+                stats.recent_limit,
+                stats.retained_recent,
+                stats.retained_turn_boundaries
+            );
+        }
+    }
+
+    async fn persist_token_anchors_best_effort(&self, session_id: &str, reason: &str) {
+        if !self.should_persist_session_id(session_id) {
+            return;
+        }
+
+        let Some(workspace_path) = self.effective_session_storage_path(session_id).await else {
+            debug!(
+                "Skipping token anchor persistence because workspace path is unavailable: session_id={}, reason={}",
+                session_id, reason
+            );
+            return;
+        };
+
+        let anchors = self.token_anchor_store.anchors(session_id);
+        let persist_result = if anchors.is_empty() {
+            self.persistence_manager
+                .delete_token_anchors(&workspace_path, session_id)
+                .await
+        } else {
+            self.persistence_manager
+                .save_token_anchors(&workspace_path, session_id, &anchors)
+                .await
+        };
+
+        if let Err(error) = persist_result {
+            warn!(
+                "Failed to persist token anchors: session_id={}, workspace_path={}, reason={}, error={}",
+                session_id,
+                workspace_path.display(),
+                reason,
+                error
+            );
+        }
+    }
+
+    pub async fn remember_token_anchor(&self, anchor: TokenAnchor) {
+        let session_id = anchor.session_id.clone();
+        self.ensure_token_anchors_loaded(&session_id).await;
+        if let Some(stats) = self.token_anchor_store.append(anchor) {
+            debug!(
+                "Token anchor retention pruned anchors: session_id={}, before={}, after={}, removed={}, recent_limit={}, retained_recent={}, retained_turn_boundaries={}",
+                session_id,
+                stats.before,
+                stats.after,
+                stats.removed,
+                stats.recent_limit,
+                stats.retained_recent,
+                stats.retained_turn_boundaries
+            );
+        }
+        self.persist_token_anchors_best_effort(&session_id, "token_anchor_recorded")
+            .await;
+    }
+
+    pub async fn latest_matching_token_anchor(
+        &self,
+        session_id: &str,
+        messages: &[Message],
+    ) -> Option<TokenAnchor> {
+        self.select_latest_matching_token_anchor(session_id, messages)
+            .await
+            .selected
+    }
+
+    pub async fn select_latest_matching_token_anchor(
+        &self,
+        session_id: &str,
+        messages: &[Message],
+    ) -> TokenAnchorSelection {
+        self.ensure_token_anchors_loaded(session_id).await;
+        self.token_anchor_store
+            .select_latest_matching(session_id, messages)
+    }
+
+    pub async fn prune_token_anchors_to_messages(&self, session_id: &str, messages: &[Message]) {
+        self.ensure_token_anchors_loaded(session_id).await;
+        self.token_anchor_store
+            .remove_non_matching(session_id, messages);
+        self.persist_token_anchors_best_effort(session_id, "token_anchor_pruned")
+            .await;
+    }
+
     pub fn new(
         context_store: Arc<SessionContextStore>,
         persistence_manager: Arc<PersistenceManager>,
@@ -1036,6 +1163,7 @@ impl SessionManager {
             session_storage_path_index: Arc::new(DashMap::new()),
             context_store,
             prompt_cache_store: Arc::new(SessionPromptCacheStore::new()),
+            token_anchor_store: Arc::new(TokenAnchorStore::new()),
             turn_skill_agent_snapshot_store: Arc::new(TurnSkillAgentSnapshotStore::new()),
             skill_agent_baseline_override_snapshot_store: Arc::new(DashMap::new()),
             file_read_state_store: Arc::new(FileReadStateStore::new()),
@@ -1226,6 +1354,7 @@ impl SessionManager {
         let session_storage_path_index = self.session_storage_path_index.clone();
         let context_store = self.context_store.clone();
         let prompt_cache_store = self.prompt_cache_store.clone();
+        let token_anchor_store = self.token_anchor_store.clone();
         let turn_skill_agent_snapshot_store = self.turn_skill_agent_snapshot_store.clone();
         let skill_agent_baseline_override_snapshot_store =
             self.skill_agent_baseline_override_snapshot_store.clone();
@@ -1251,6 +1380,7 @@ impl SessionManager {
                 session_storage_path_index,
                 context_store,
                 prompt_cache_store,
+                token_anchor_store,
                 turn_skill_agent_snapshot_store,
                 skill_agent_baseline_override_snapshot_store,
                 file_read_state_store,
@@ -1394,6 +1524,7 @@ impl SessionManager {
 
         // 2. Initialize the in-memory context cache.
         self.context_store.create_session(&session_id);
+        self.token_anchor_store.create_session(&session_id);
         self.turn_skill_agent_snapshot_store
             .create_session(&session_id);
         self.file_read_state_store.create_session(&session_id);
@@ -2526,6 +2657,7 @@ impl SessionManager {
         );
         self.context_store.delete_session(session_id);
         self.prompt_cache_store.delete_session(session_id);
+        self.token_anchor_store.delete_session(session_id);
         self.turn_skill_agent_snapshot_store
             .delete_session(session_id);
         self.skill_agent_baseline_override_snapshot_store
@@ -3338,6 +3470,7 @@ impl SessionManager {
         if session_already_in_memory {
             self.context_store.delete_session(session_id);
             self.prompt_cache_store.delete_session(session_id);
+            self.token_anchor_store.delete_session(session_id);
             self.turn_skill_agent_snapshot_store
                 .delete_session(session_id);
             self.skill_agent_baseline_override_snapshot_store
@@ -3479,7 +3612,10 @@ impl SessionManager {
         };
 
         // 2) Restore the in-memory context cache.
-        self.context_store.replace_context(session_id, messages);
+        self.context_store
+            .replace_context(session_id, messages.clone());
+        self.prune_token_anchors_to_messages(session_id, &messages)
+            .await;
 
         let last_user_dialog_agent_type = if target_turn == 0 {
             None
@@ -4796,8 +4932,11 @@ impl SessionManager {
     /// Replace the runtime context cache for a session and immediately refresh the current turn
     /// snapshot. This is primarily used after compression rewrites the model-visible context.
     pub async fn replace_context_messages(&self, session_id: &str, messages: Vec<Message>) {
-        self.context_store.replace_context(session_id, messages);
+        self.context_store
+            .replace_context(session_id, messages.clone());
         self.file_read_state_store.clear_session(session_id);
+        self.prune_token_anchors_to_messages(session_id, &messages)
+            .await;
         self.persist_current_turn_context_snapshot_best_effort(session_id, "context_replaced")
             .await;
     }
@@ -5054,6 +5193,7 @@ impl SessionManager {
         let enable_persistence = self.config.enable_persistence;
         let context_store = self.context_store.clone();
         let prompt_cache_store = self.prompt_cache_store.clone();
+        let token_anchor_store = self.token_anchor_store.clone();
         let turn_skill_agent_snapshot_store = self.turn_skill_agent_snapshot_store.clone();
         let skill_agent_baseline_override_snapshot_store =
             self.skill_agent_baseline_override_snapshot_store.clone();
@@ -5119,6 +5259,7 @@ impl SessionManager {
                     {
                         context_store.delete_session(&candidate.session_id);
                         prompt_cache_store.delete_session(&candidate.session_id);
+                        token_anchor_store.delete_session(&candidate.session_id);
                         turn_skill_agent_snapshot_store.delete_session(&candidate.session_id);
                         skill_agent_baseline_override_snapshot_store.remove(&candidate.session_id);
                         file_read_state_store.delete_session(&candidate.session_id);

--- a/src/crates/assembly/core/src/agentic/session/token_anchor.rs
+++ b/src/crates/assembly/core/src/agentic/session/token_anchor.rs
@@ -1,0 +1,550 @@
+use crate::agentic::core::{Message, MessageRole, MessageSemanticKind};
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+pub const TOKEN_ANCHOR_RECENT_RETAIN_COUNT: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenAnchor {
+    pub anchor_id: String,
+    pub session_id: String,
+    pub turn_id: String,
+    pub round_id: String,
+    pub prefix_message_count: usize,
+    pub prefix_last_message_id: Option<String>,
+    pub prefix_digest: String,
+    pub model_id: String,
+    pub input_tokens: usize,
+    pub system_tokens_at_anchor: usize,
+    pub tool_tokens_at_anchor: usize,
+    pub prepended_reminder_tokens_at_anchor: usize,
+    pub created_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenAnchorSkip {
+    pub anchor_id: String,
+    pub prefix_message_count: usize,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenAnchorSelection {
+    pub selected: Option<TokenAnchor>,
+    pub skipped: Vec<TokenAnchorSkip>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenAnchorRetentionStats {
+    pub before: usize,
+    pub after: usize,
+    pub removed: usize,
+    pub recent_limit: usize,
+    pub retained_recent: usize,
+    pub retained_turn_boundaries: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenAnchorInput {
+    pub session_id: String,
+    pub turn_id: String,
+    pub round_id: String,
+    pub model_id: String,
+    pub input_tokens: usize,
+    pub system_tokens_at_anchor: usize,
+    pub tool_tokens_at_anchor: usize,
+    pub prepended_reminder_tokens_at_anchor: usize,
+}
+
+impl TokenAnchor {
+    pub fn from_request_prefix(input: TokenAnchorInput, messages: &[Message]) -> Self {
+        Self {
+            anchor_id: format!("token_anchor_{}", Uuid::new_v4()),
+            session_id: input.session_id,
+            turn_id: input.turn_id,
+            round_id: input.round_id,
+            prefix_message_count: messages.len(),
+            prefix_last_message_id: messages.last().map(|message| message.id.clone()),
+            prefix_digest: digest_message_prefix(messages),
+            model_id: input.model_id,
+            input_tokens: input.input_tokens,
+            system_tokens_at_anchor: input.system_tokens_at_anchor,
+            tool_tokens_at_anchor: input.tool_tokens_at_anchor,
+            prepended_reminder_tokens_at_anchor: input.prepended_reminder_tokens_at_anchor,
+            created_at_unix_ms: current_unix_ms(),
+        }
+    }
+
+    pub fn matches_prefix(&self, messages: &[Message]) -> bool {
+        self.prefix_mismatch_reason(messages).is_none()
+    }
+
+    pub fn prefix_mismatch_reason(&self, messages: &[Message]) -> Option<String> {
+        if self.prefix_message_count > messages.len() {
+            return Some(format!(
+                "anchor_prefix_longer_than_messages(anchor_prefix={}, messages={})",
+                self.prefix_message_count,
+                messages.len()
+            ));
+        }
+
+        match (
+            self.prefix_message_count,
+            self.prefix_last_message_id.as_deref(),
+        ) {
+            (0, None) => {}
+            (0, Some(_)) => {
+                return Some("empty_prefix_has_last_message_id".to_string());
+            }
+            (count, Some(last_id)) => {
+                let current_last_id = messages.get(count - 1).map(|message| message.id.as_str());
+                if current_last_id != Some(last_id) {
+                    return Some(format!(
+                        "prefix_last_message_id_mismatch(expected={}, actual={})",
+                        last_id,
+                        current_last_id.unwrap_or("<missing>")
+                    ));
+                }
+            }
+            (_, None) => {
+                return Some("non_empty_prefix_missing_last_message_id".to_string());
+            }
+        }
+
+        let current_digest = digest_message_prefix(&messages[..self.prefix_message_count]);
+        if current_digest != self.prefix_digest {
+            return Some(format!(
+                "prefix_digest_mismatch(expected={}, actual={})",
+                self.prefix_digest, current_digest
+            ));
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TokenAnchorStore {
+    anchors_by_session: DashMap<String, Vec<TokenAnchor>>,
+}
+
+impl TokenAnchorStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn has_session(&self, session_id: &str) -> bool {
+        self.anchors_by_session.contains_key(session_id)
+    }
+
+    pub fn create_session(&self, session_id: &str) {
+        self.anchors_by_session
+            .entry(session_id.to_string())
+            .or_default();
+    }
+
+    pub fn replace_session(
+        &self,
+        session_id: &str,
+        mut anchors: Vec<TokenAnchor>,
+    ) -> Option<TokenAnchorRetentionStats> {
+        let retention = apply_anchor_retention(&mut anchors, TOKEN_ANCHOR_RECENT_RETAIN_COUNT);
+        self.anchors_by_session
+            .insert(session_id.to_string(), anchors);
+        retention
+    }
+
+    pub fn append(&self, anchor: TokenAnchor) -> Option<TokenAnchorRetentionStats> {
+        let mut anchors = self
+            .anchors_by_session
+            .entry(anchor.session_id.clone())
+            .or_default();
+        anchors.push(anchor);
+        apply_anchor_retention(&mut anchors, TOKEN_ANCHOR_RECENT_RETAIN_COUNT)
+    }
+
+    pub fn anchors(&self, session_id: &str) -> Vec<TokenAnchor> {
+        self.anchors_by_session
+            .get(session_id)
+            .map(|anchors| anchors.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn latest_matching(&self, session_id: &str, messages: &[Message]) -> Option<TokenAnchor> {
+        self.select_latest_matching(session_id, messages).selected
+    }
+
+    pub fn select_latest_matching(
+        &self,
+        session_id: &str,
+        messages: &[Message],
+    ) -> TokenAnchorSelection {
+        let Some(anchors) = self.anchors_by_session.get(session_id) else {
+            return TokenAnchorSelection {
+                selected: None,
+                skipped: vec![TokenAnchorSkip {
+                    anchor_id: "<none>".to_string(),
+                    prefix_message_count: 0,
+                    reason: "no_anchor_store_for_session".to_string(),
+                }],
+            };
+        };
+
+        let mut skipped = Vec::new();
+        for anchor in anchors.iter().rev() {
+            if let Some(reason) = anchor.prefix_mismatch_reason(messages) {
+                skipped.push(TokenAnchorSkip {
+                    anchor_id: anchor.anchor_id.clone(),
+                    prefix_message_count: anchor.prefix_message_count,
+                    reason,
+                });
+                continue;
+            }
+
+            return TokenAnchorSelection {
+                selected: Some(anchor.clone()),
+                skipped,
+            };
+        }
+
+        if skipped.is_empty() {
+            skipped.push(TokenAnchorSkip {
+                anchor_id: "<none>".to_string(),
+                prefix_message_count: 0,
+                reason: "no_anchors_recorded".to_string(),
+            });
+        }
+
+        TokenAnchorSelection {
+            selected: None,
+            skipped,
+        }
+    }
+
+    pub fn remove_non_matching(&self, session_id: &str, messages: &[Message]) {
+        if let Some(mut anchors) = self.anchors_by_session.get_mut(session_id) {
+            anchors.retain(|anchor| anchor.matches_prefix(messages));
+        }
+    }
+
+    pub fn delete_session(&self, session_id: &str) {
+        self.anchors_by_session.remove(session_id);
+    }
+}
+
+fn apply_anchor_retention(
+    anchors: &mut Vec<TokenAnchor>,
+    recent_limit: usize,
+) -> Option<TokenAnchorRetentionStats> {
+    let before = anchors.len();
+    if before <= recent_limit {
+        return None;
+    }
+
+    let recent_start = before.saturating_sub(recent_limit);
+    let retained_recent = before - recent_start;
+    let mut retain_indices: HashSet<usize> = (recent_start..before).collect();
+    let mut turn_boundaries: HashMap<String, (usize, usize)> = HashMap::new();
+
+    for (index, anchor) in anchors.iter().enumerate() {
+        turn_boundaries
+            .entry(anchor.turn_id.clone())
+            .and_modify(|(_, last)| *last = index)
+            .or_insert((index, index));
+    }
+
+    let mut boundary_indices = HashSet::new();
+    for (first, last) in turn_boundaries.values() {
+        boundary_indices.insert(*first);
+        boundary_indices.insert(*last);
+    }
+    retain_indices.extend(boundary_indices.iter().copied());
+
+    if retain_indices.len() == before {
+        return None;
+    }
+
+    let mut retained = Vec::with_capacity(retain_indices.len());
+    for (index, anchor) in anchors.drain(..).enumerate() {
+        if retain_indices.contains(&index) {
+            retained.push(anchor);
+        }
+    }
+
+    let after = retained.len();
+    *anchors = retained;
+
+    Some(TokenAnchorRetentionStats {
+        before,
+        after,
+        removed: before - after,
+        recent_limit,
+        retained_recent,
+        retained_turn_boundaries: boundary_indices.len(),
+    })
+}
+
+pub fn digest_message_prefix(messages: &[Message]) -> String {
+    let mut hasher = Sha256::new();
+    for message in messages {
+        if message.role != MessageRole::System {
+            hasher.update(message.id.as_bytes());
+            hasher.update([0]);
+        }
+        hasher.update(format!("{:?}", message.role).as_bytes());
+        hasher.update([0]);
+        if let Some(kind) = message.metadata.semantic_kind.as_ref() {
+            hasher.update(semantic_kind_tag(kind).as_bytes());
+        }
+        hasher.update([0xff]);
+    }
+    hex_digest(hasher)
+}
+
+fn semantic_kind_tag(kind: &MessageSemanticKind) -> &'static str {
+    match kind {
+        MessageSemanticKind::ActualUserInput => "actual_user_input",
+        MessageSemanticKind::InternalReminder => "internal_reminder",
+        MessageSemanticKind::CompressionBoundaryMarker => "compression_boundary_marker",
+        MessageSemanticKind::CompressionSummary => "compression_summary",
+        MessageSemanticKind::ComputerUseVerificationScreenshot => {
+            "computer_use_verification_screenshot"
+        }
+        MessageSemanticKind::ComputerUsePostActionSnapshot => "computer_use_post_action_snapshot",
+    }
+}
+
+fn hex_digest(hasher: Sha256) -> String {
+    format!("{:x}", hasher.finalize())
+}
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agentic::core::Message;
+    use std::collections::HashSet;
+
+    fn test_anchor(turn_index: usize, round_index: usize, global_index: usize) -> TokenAnchor {
+        let messages = vec![
+            Message::system("sys".to_string()),
+            Message::user(format!("message-{global_index}")),
+        ];
+        TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: format!("turn-{turn_index}"),
+                round_id: format!("round-{round_index}"),
+                model_id: "model".to_string(),
+                input_tokens: global_index,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &messages,
+        )
+    }
+
+    #[test]
+    fn matching_anchor_survives_suffix_append() {
+        let prefix = vec![
+            Message::system("sys".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &prefix,
+        );
+
+        let mut current = prefix;
+        current.push(Message::assistant("answer".to_string()));
+
+        assert!(anchor.matches_prefix(&current));
+    }
+
+    #[test]
+    fn matching_anchor_rejects_truncated_prefix() {
+        let prefix = vec![
+            Message::system("sys".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &prefix,
+        );
+
+        assert!(!anchor.matches_prefix(&prefix[..1]));
+    }
+
+    #[test]
+    fn matching_anchor_allows_system_message_replacement() {
+        let prefix = vec![
+            Message::system("old sys".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &prefix,
+        );
+        let current = vec![
+            Message::system("new sys".to_string()),
+            prefix[1].clone(),
+            Message::assistant("answer".to_string()),
+        ];
+
+        assert!(anchor.matches_prefix(&current));
+    }
+
+    #[test]
+    fn store_selects_older_anchor_after_suffix_rollback() {
+        let first_prefix = vec![
+            Message::system("sys".to_string()),
+            Message::user("hello".to_string()),
+        ];
+        let mut second_prefix = first_prefix.clone();
+        second_prefix.push(Message::assistant("answer".to_string()));
+        let first_anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round-1".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 100,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &first_prefix,
+        );
+        let second_anchor = TokenAnchor::from_request_prefix(
+            TokenAnchorInput {
+                session_id: "session".to_string(),
+                turn_id: "turn".to_string(),
+                round_id: "round-2".to_string(),
+                model_id: "model".to_string(),
+                input_tokens: 150,
+                system_tokens_at_anchor: 10,
+                tool_tokens_at_anchor: 20,
+                prepended_reminder_tokens_at_anchor: 0,
+            },
+            &second_prefix,
+        );
+        let store = TokenAnchorStore::new();
+        store.append(first_anchor.clone());
+        store.append(second_anchor);
+
+        let selected = store
+            .latest_matching("session", &first_prefix)
+            .expect("older anchor should remain usable after rollback");
+
+        assert_eq!(selected.anchor_id, first_anchor.anchor_id);
+    }
+
+    #[test]
+    fn store_retains_recent_anchors_and_turn_boundaries() {
+        let store = TokenAnchorStore::new();
+        let mut turn_boundaries = Vec::new();
+        let mut global_index = 0;
+
+        for turn_index in 0..3 {
+            let first = global_index;
+            for round_index in 0..80 {
+                store.append(test_anchor(turn_index, round_index, global_index));
+                global_index += 1;
+            }
+            turn_boundaries.push((first, global_index - 1));
+        }
+
+        let anchors = store.anchors("session");
+        let retained_tokens = anchors
+            .iter()
+            .map(|anchor| anchor.input_tokens)
+            .collect::<HashSet<_>>();
+        let recent_start = global_index - TOKEN_ANCHOR_RECENT_RETAIN_COUNT;
+
+        for token in recent_start..global_index {
+            assert!(
+                retained_tokens.contains(&token),
+                "missing recent anchor {}",
+                token
+            );
+        }
+
+        for (first, last) in turn_boundaries {
+            assert!(
+                retained_tokens.contains(&first),
+                "missing first turn anchor {}",
+                first
+            );
+            assert!(
+                retained_tokens.contains(&last),
+                "missing last turn anchor {}",
+                last
+            );
+        }
+
+        assert!(!retained_tokens.contains(&1));
+        assert!(!retained_tokens.contains(&81));
+        assert!(anchors.len() <= TOKEN_ANCHOR_RECENT_RETAIN_COUNT + 6);
+    }
+
+    #[test]
+    fn store_applies_retention_to_replaced_session() {
+        let store = TokenAnchorStore::new();
+        let anchors = (0..80)
+            .map(|round_index| test_anchor(0, round_index, round_index))
+            .collect::<Vec<_>>();
+
+        let stats = store
+            .replace_session("session", anchors)
+            .expect("loaded anchors should be pruned");
+        let retained_tokens = store
+            .anchors("session")
+            .iter()
+            .map(|anchor| anchor.input_tokens)
+            .collect::<HashSet<_>>();
+
+        assert_eq!(stats.recent_limit, TOKEN_ANCHOR_RECENT_RETAIN_COUNT);
+        assert!(retained_tokens.contains(&0));
+        assert!(retained_tokens.contains(&79));
+        assert!(retained_tokens.contains(&16));
+        assert!(!retained_tokens.contains(&1));
+    }
+}

--- a/src/crates/contracts/events/src/agentic.rs
+++ b/src/crates/contracts/events/src/agentic.rs
@@ -192,7 +192,6 @@ pub enum AgenticEvent {
         trigger: String,
         tokens_before: usize,
         context_window: usize,
-        threshold: f32,
     },
 
     ContextCompressionCompleted {

--- a/src/crates/contracts/events/src/frontend_projection.rs
+++ b/src/crates/contracts/events/src/frontend_projection.rs
@@ -334,7 +334,6 @@ pub fn project_agentic_frontend_event(event: AgenticEvent) -> Option<AgenticFron
             trigger,
             tokens_before,
             context_window,
-            threshold,
         } => Some(AgenticFrontendEvent::new(
             "agentic://context-compression-started",
             "context-compression-started",
@@ -345,7 +344,6 @@ pub fn project_agentic_frontend_event(event: AgenticEvent) -> Option<AgenticFron
                 "trigger": trigger,
                 "tokensBefore": tokens_before,
                 "contextWindow": context_window,
-                "threshold": threshold,
             }),
         )),
         AgenticEvent::ContextCompressionCompleted {

--- a/src/crates/execution/agent-runtime/src/session.rs
+++ b/src/crates/execution/agent-runtime/src/session.rs
@@ -141,8 +141,6 @@ pub struct SessionConfig {
     pub safe_mode: bool,
     pub max_turns: usize,
     pub enable_context_compression: bool,
-    /// Compression threshold (token usage rate), compression triggered when exceeded
-    pub compression_threshold: f32,
     /// Workspace path bound to this session. Used to run AI in the correct workspace
     /// without changing the desktop's foreground workspace.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -173,7 +171,6 @@ impl Default for SessionConfig {
             safe_mode: true,
             max_turns: 200,
             enable_context_compression: true,
-            compression_threshold: 0.8, // 80%
             workspace_path: None,
             workspace_id: None,
             remote_connection_id: None,
@@ -259,7 +256,6 @@ mod tests {
         assert!(config.safe_mode);
         assert_eq!(config.max_turns, 200);
         assert!(config.enable_context_compression);
-        assert_eq!(config.compression_threshold, 0.8);
         assert!(config.workspace_path.is_none());
         assert!(config.workspace_id.is_none());
         assert!(config.remote_connection_id.is_none());
@@ -336,7 +332,6 @@ mod tests {
                     "safe_mode": true,
                     "max_turns": 200,
                     "enable_context_compression": true,
-                    "compression_threshold": 0.800000011920929,
                     "workspace_path": "/workspace",
                     "model_id": "model-a"
                 },

--- a/src/web-ui/src/component-library/components/FlowChatCards/ContextCompressionCard/ContextCompressionCard.tsx
+++ b/src/web-ui/src/component-library/components/FlowChatCards/ContextCompressionCard/ContextCompressionCard.tsx
@@ -41,13 +41,15 @@ export const ContextCompressionCard: React.FC<ContextCompressionCardProps> = ({
 }) => {
   const { t, formatNumber } = useI18n('components');
 
-  const resolvedCompressionCount = compressionCount || result?.compression_count || 1;
-  const resolvedTokensBefore = tokensBefore || result?.tokens_before || input?.tokens_before;
-  const resolvedTokensAfter = tokensAfter || result?.tokens_after || input?.tokens_after;
-  const resolvedCompressionRatio = compressionRatio || result?.compression_ratio || 
-    (resolvedTokensBefore && resolvedTokensAfter ? (resolvedTokensAfter / resolvedTokensBefore) : undefined);
-  const resolvedDuration = duration || result?.duration;
-  const resolvedTrigger = trigger || result?.trigger || input?.trigger || 'manual';
+  const resolvedCompressionCount = compressionCount ?? result?.compression_count ?? 1;
+  const resolvedTokensBefore = tokensBefore ?? result?.tokens_before ?? input?.tokens_before;
+  const resolvedTokensAfter = tokensAfter ?? result?.tokens_after ?? input?.tokens_after;
+  const resolvedCompressionRatio = compressionRatio ?? result?.compression_ratio ??
+    (typeof resolvedTokensBefore === 'number' && resolvedTokensBefore > 0 && typeof resolvedTokensAfter === 'number'
+      ? (resolvedTokensAfter / resolvedTokensBefore)
+      : undefined);
+  const resolvedDuration = duration ?? result?.duration;
+  const resolvedTrigger = trigger ?? result?.trigger ?? input?.trigger ?? 'manual';
 
   const getTriggerText = (triggerType: string) => {
     switch (triggerType) {
@@ -64,8 +66,14 @@ export const ContextCompressionCard: React.FC<ContextCompressionCardProps> = ({
     }
   };
 
-  const savedTokens = resolvedTokensBefore && resolvedTokensAfter ? 
-    resolvedTokensBefore - resolvedTokensAfter : undefined;
+  const savedTokens =
+    typeof resolvedTokensBefore === 'number' && typeof resolvedTokensAfter === 'number'
+      ? resolvedTokensBefore - resolvedTokensAfter
+      : undefined;
+  const savedRatio =
+    typeof resolvedCompressionRatio === 'number'
+      ? 1 - resolvedCompressionRatio
+      : undefined;
 
   const getStatusIcon = (size: number = 14) => {
     switch (status) {
@@ -96,9 +104,9 @@ export const ContextCompressionCard: React.FC<ContextCompressionCardProps> = ({
           </span>
         )}
         
-        {status === 'completed' && savedTokens !== undefined && resolvedCompressionRatio !== undefined && (
+        {status === 'completed' && savedTokens !== undefined && savedRatio !== undefined && (
           <span className="context-compression-card__result">
-            {t('flowChatCards.contextCompressionCard.savedTokens', { count: formatNumber(savedTokens), ratio: (resolvedCompressionRatio * 100).toFixed(0) })}
+            {t('flowChatCards.contextCompressionCard.savedTokens', { count: formatNumber(savedTokens), ratio: (savedRatio * 100).toFixed(0) })}
           </span>
         )}
       </div>
@@ -144,9 +152,9 @@ export const ContextCompressionCard: React.FC<ContextCompressionCardProps> = ({
               <span className="context-compression-card__simple-tokens">
                 {formatNumber(resolvedTokensBefore)} → {formatNumber(resolvedTokensAfter)} tokens
               </span>
-              {savedTokens !== undefined && resolvedCompressionRatio !== undefined && (
+              {savedTokens !== undefined && savedRatio !== undefined && (
                 <span className="context-compression-card__simple-savings">
-                  {t('flowChatCards.contextCompressionCard.savedTokens', { count: formatNumber(savedTokens), ratio: (resolvedCompressionRatio * 100).toFixed(1) })}
+                  {t('flowChatCards.contextCompressionCard.savedTokens', { count: formatNumber(savedTokens), ratio: (savedRatio * 100).toFixed(1) })}
                 </span>
               )}
             </div>

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -2058,10 +2058,10 @@ function handleAcpContextUsageUpdate(event: AcpContextUsageUpdatedEvent): void {
  * Handle context compression started event
  */
 function handleCompressionStarted(_context: FlowChatContext, event: any): void {
-  const { sessionId, turnId, compressionId, trigger, tokensBefore, contextWindow, threshold } = event;
+  const { sessionId, turnId, compressionId, trigger, tokensBefore, contextWindow } = event;
   
   log.info('Context compression started', {
-    sessionId, turnId, compressionId, trigger, tokensBefore, contextWindow, threshold
+    sessionId, turnId, compressionId, trigger, tokensBefore, contextWindow
   });
   
   const store = FlowChatStore.getInstance();
@@ -2096,7 +2096,6 @@ function handleCompressionStarted(_context: FlowChatContext, event: any): void {
         trigger,
         tokens_before: tokensBefore,
         context_window: contextWindow,
-        threshold,
       },
       id: compressionId
     },

--- a/src/web-ui/src/flow_chat/tool-cards/ContextCompressionDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ContextCompressionDisplay.tsx
@@ -38,14 +38,14 @@ export const ContextCompressionDisplay: React.FC<ContextCompressionDisplayProps>
 }) => {
   const { t } = useTranslation('flow-chat');
   const data = toolItem ? {
-    compressionCount: toolItem.toolResult?.result?.compression_count || compressionData?.compression_count,
-    tokensBefore: toolItem.toolResult?.result?.tokens_before || toolItem.toolCall?.input?.tokens_before || compressionData?.tokens_before,
-    tokensAfter: toolItem.toolResult?.result?.tokens_after || compressionData?.tokens_after,
-    compressionRatio: toolItem.toolResult?.result?.compression_ratio || compressionData?.compression_ratio,
-    duration: toolItem.toolResult?.duration_ms || compressionData?.duration,
+    compressionCount: toolItem.toolResult?.result?.compression_count ?? compressionData?.compression_count,
+    tokensBefore: toolItem.toolResult?.result?.tokens_before ?? toolItem.toolCall?.input?.tokens_before ?? compressionData?.tokens_before,
+    tokensAfter: toolItem.toolResult?.result?.tokens_after ?? compressionData?.tokens_after,
+    compressionRatio: toolItem.toolResult?.result?.compression_ratio ?? compressionData?.compression_ratio,
+    duration: toolItem.toolResult?.duration_ms ?? compressionData?.duration,
     hasSummary: toolItem.toolResult?.result?.has_summary ?? compressionData?.has_summary,
-    summarySource: toolItem.toolResult?.result?.summary_source || compressionData?.summary_source,
-    trigger: toolItem.toolCall?.input?.trigger || compressionData?.trigger,
+    summarySource: toolItem.toolResult?.result?.summary_source ?? compressionData?.summary_source,
+    trigger: toolItem.toolCall?.input?.trigger ?? compressionData?.trigger,
     status: (toolItem.status === 'cancelled' || toolItem.status === 'analyzing') ? 'completed' : toolItem.status,
     error: toolItem.toolResult?.error
   } : {
@@ -75,8 +75,14 @@ export const ContextCompressionDisplay: React.FC<ContextCompressionDisplayProps>
     }
   };
 
-  const savedTokens = data.tokensBefore && data.tokensAfter ? 
-    data.tokensBefore - data.tokensAfter : undefined;
+  const savedTokens =
+    typeof data.tokensBefore === 'number' && typeof data.tokensAfter === 'number'
+      ? data.tokensBefore - data.tokensAfter
+      : undefined;
+  const savedRatio =
+    typeof data.compressionRatio === 'number'
+      ? 1 - data.compressionRatio
+      : undefined;
   const formatNumber = (value: number): string => i18nService.formatNumber(value);
 
   const isLoading = data.status === 'preparing' || data.status === 'streaming' || data.status === 'running';
@@ -118,11 +124,11 @@ export const ContextCompressionDisplay: React.FC<ContextCompressionDisplayProps>
                   after: formatNumber(data.tokensAfter),
                 })}
               </span>
-              {savedTokens !== undefined && data.compressionRatio !== undefined && (
+              {savedTokens !== undefined && savedRatio !== undefined && (
                 <span className="savings-tag">
                   {t('toolCards.contextCompression.savingsTag', {
                     saved: formatNumber(savedTokens),
-                    ratio: (data.compressionRatio * 100).toFixed(0),
+                    ratio: (savedRatio * 100).toFixed(0),
                   })}
                 </span>
               )}

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -32,7 +32,6 @@ export interface SessionConfig {
   safeMode?: boolean;
   maxTurns?: number;
   enableContextCompression?: boolean;
-  compressionThreshold?: number;
   remoteConnectionId?: string;
   remoteSshHost?: string;
 }
@@ -434,7 +433,6 @@ export interface CompressionEvent extends AgenticEvent {
   trigger?: string;                // "auto" | "manual" | "user_message"
   tokensBefore?: number;           
   contextWindow?: number;          
-  threshold?: number;              
   
   compressionCount?: number;       
   tokensAfter?: number;            


### PR DESCRIPTION
## Summary

- Replace configurable compression thresholds with an input-limit budget derived from context window minus output and safety reserves.
- Add persisted token anchors so compression pressure can reuse provider-reported prompt usage, then estimate only the unmatched tail.
- Remove the old `compressionThreshold` / compression-start `threshold` contract from Rust DTOs, frontend API types, event projection, and UI handlers.
- Improve compression diagnostics, final stream usage logging, and compression card saved-token percentage rendering.

Fixes #

## Type and Areas

Type:

bug fix / refactor

Areas:

Rust core, agentic session/execution/persistence, desktop/Tauri APIs, event contracts, AI adapters, web UI

## Motivation / Impact

The compression trigger now tracks provider-visible request pressure more accurately and reserves response headroom before sending another round. This reduces the chance that local token estimates or stale ratio thresholds delay compression until the request is too close to the model context limit.

The change also removes the old threshold field from internal session/config/event surfaces and keeps the frontend compression UI aligned with the new contract. Compression cards now display saved percentage as the amount reduced, not the remaining compression ratio.

## Verification

- `pnpm run type-check:web` passed.
- `cargo test -p bitfun-core token_anchor --lib` passed: 7 passed.
- `cargo test -p bitfun-core compression_trigger_budget --lib` passed: 2 passed.
- `cargo test -p bitfun-core auto_compression_pressure --lib` passed: 4 passed.
- `cargo check --workspace` passed.

## Reviewer Notes

- Token anchors are stored per session in `token-anchors.json` and are pruned when context is rewritten, restored, or emergency-truncated.
- Auto compression now triggers when `total_tokens >= input_limit`, where `input_limit = context_window - output_reserve - safety_reserve`.
- Default output reserve is 16k tokens when provider `max_tokens` is unset; safety reserve is 10k tokens.
- This intentionally removes the old `compressionThreshold` session config and `threshold` compression-start event payload.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.