### PR TITLE
fix: persist session traces and repair /btw and one-shot scheduling state

### DIFF
--- a/src/crates/adapters/ai-adapters/src/client.rs
+++ b/src/crates/adapters/ai-adapters/src/client.rs
@@ -38,12 +38,6 @@ pub struct StreamResponse {
     pub trace_handle: Option<ModelExchangeRequestTraceHandle>,
 }
 
-/// Default time to wait for the first effective streamed output after a request starts.
-pub const DEFAULT_STREAM_TTFT_TIMEOUT_SECS: u64 = 30;
-
-/// Default idle time between streamed chunks once the stream has started.
-pub const DEFAULT_STREAM_IDLE_TIMEOUT_SECS: u64 = 45;
-
 /// Runtime stream behavior shared across provider implementations.
 #[derive(Debug, Clone, Default)]
 pub struct StreamOptions {

--- a/src/crates/adapters/ai-adapters/src/lib.rs
+++ b/src/crates/adapters/ai-adapters/src/lib.rs
@@ -11,10 +11,7 @@ pub mod tool_call_accumulator;
 pub mod trace;
 pub mod types;
 
-pub use client::{
-    AIClient, StreamOptions, StreamResponse, DEFAULT_STREAM_IDLE_TIMEOUT_SECS,
-    DEFAULT_STREAM_TTFT_TIMEOUT_SECS,
-};
+pub use client::{AIClient, StreamOptions, StreamResponse};
 pub use model_selector::{
     classify_model_selector, resolve_cache_model_selector, resolve_required_model_selector,
     ModelSelectorError, ModelSelectorKind,

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -5696,7 +5696,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .filter(|name| !name.is_empty())
             .unwrap_or("Side thread")
             .to_string();
-        let child_session = self
+        let mut child_session = self
             .session_manager
             .create_session_with_id_and_details(
                 Some(child_session_id.to_string()),
@@ -5707,6 +5707,15 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 SessionKind::EphemeralChild,
             )
             .await?;
+        self.session_manager
+            .inherit_session_agent_type_state(
+                &child_session.session_id,
+                snapshot.last_user_dialog_agent_type.clone(),
+                snapshot.last_submitted_agent_type.clone(),
+            )
+            .await?;
+        child_session.last_user_dialog_agent_type = snapshot.last_user_dialog_agent_type.clone();
+        child_session.last_submitted_agent_type = snapshot.last_submitted_agent_type.clone();
 
         let copied = self
             .session_manager
@@ -8150,6 +8159,14 @@ mod tests {
             .await
             .expect("parent session should be created");
         session_manager
+            .inherit_session_agent_type_state(
+                &parent_session.session_id,
+                Some("agentic".to_string()),
+                Some("agentic".to_string()),
+            )
+            .await
+            .expect("parent agent type state should be set");
+        session_manager
             .replace_context_messages(
                 &parent_session.session_id,
                 vec![crate::agentic::core::Message::user(
@@ -8199,6 +8216,14 @@ mod tests {
         assert_eq!(
             child_session.kind,
             crate::agentic::core::SessionKind::EphemeralChild
+        );
+        assert_eq!(
+            child_session.last_user_dialog_agent_type.as_deref(),
+            Some("agentic")
+        );
+        assert_eq!(
+            child_session.last_submitted_agent_type.as_deref(),
+            Some("agentic")
         );
         assert_eq!(
             session_manager

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -1335,6 +1335,10 @@ impl ExecutionEngine {
         final_ai_messages.push(AIMessage::user(render_system_reminder(reminder_text)));
         final_ai_messages.push(AIMessage::user(Self::FINALIZE_USER_FOLLOWUP.to_string()));
 
+        let model_exchange_trace_dir = self
+            .session_manager
+            .persistent_model_exchange_trace_dir(&context.session_id)
+            .await;
         let round_context = RoundContext {
             session_id: context.session_id.clone(),
             subagent_parent_info: context.subagent_parent_info.clone(),
@@ -1343,6 +1347,7 @@ impl ExecutionEngine {
             round_number,
             round_group_id,
             workspace: context.workspace.clone(),
+            model_exchange_trace_dir,
             available_tools: finalize_tool_names,
             collapsed_tools: Vec::new(),
             unlocked_collapsed_tools: Vec::new(),
@@ -1925,10 +1930,15 @@ impl ExecutionEngine {
         let compression_contract = self
             .session_manager
             .compression_contract_for_session(session_id, compression_contract_limit);
+        let model_exchange_trace_dir = self
+            .session_manager
+            .persistent_model_exchange_trace_dir(session_id)
+            .await;
         let trace_config = prepare_model_exchange_trace_for_workspace(
             session_id,
             dialog_turn_id,
             workspace,
+            model_exchange_trace_dir.as_deref(),
             ModelExchangeTraceOperation {
                 kind: "context_compression",
                 id: &compression_id,
@@ -2205,10 +2215,15 @@ impl ExecutionEngine {
         let compression_contract = self
             .session_manager
             .compression_contract_for_session(&session_id, scaffold.compression_contract_limit);
+        let model_exchange_trace_dir = self
+            .session_manager
+            .persistent_model_exchange_trace_dir(&session_id)
+            .await;
         let trace_config = prepare_model_exchange_trace_for_workspace(
             &session_id,
             &dialog_turn_id,
             context.workspace.as_ref(),
+            model_exchange_trace_dir.as_deref(),
             ModelExchangeTraceOperation {
                 kind: "context_compression",
                 id: &compression_id,
@@ -3011,6 +3026,10 @@ impl ExecutionEngine {
             let unlocked_collapsed_tools =
                 collect_product_unlocked_collapsed_tools(&messages, &collapsed_tools);
 
+            let model_exchange_trace_dir = self
+                .session_manager
+                .persistent_model_exchange_trace_dir(&context.session_id)
+                .await;
             let round_context = RoundContext {
                 session_id: context.session_id.clone(),
                 subagent_parent_info: context.subagent_parent_info.clone(),
@@ -3019,6 +3038,7 @@ impl ExecutionEngine {
                 round_number: round_index,
                 round_group_id: None,
                 workspace: context.workspace.clone(),
+                model_exchange_trace_dir,
                 available_tools: available_tools.clone(),
                 collapsed_tools: collapsed_tools.clone(),
                 unlocked_collapsed_tools,

--- a/src/crates/assembly/core/src/agentic/execution/model_exchange_trace.rs
+++ b/src/crates/assembly/core/src/agentic/execution/model_exchange_trace.rs
@@ -4,9 +4,7 @@ use crate::infrastructure::ai::AIClient;
 use crate::service::config::{
     GlobalConfigManager, ModelExchangeTracingConfig, ModelExchangeTracingMode,
 };
-use crate::service::workspace_runtime::{
-    get_workspace_runtime_service_arc, WorkspaceRuntimeContext,
-};
+use crate::service::workspace_runtime::get_workspace_runtime_service_arc;
 use async_trait::async_trait;
 use bitfun_ai_adapters::{
     ModelExchangeRequestAttempt, ModelExchangeRequestTraceHandle, ModelExchangeResponseTrace,
@@ -99,7 +97,7 @@ impl ModelExchangeTracePolicy {
 
 #[derive(Debug)]
 struct WorkspaceModelExchangeTraceSink {
-    runtime_context: WorkspaceRuntimeContext,
+    trace_session_dir: PathBuf,
     policy: ModelExchangeTracePolicy,
     session_id: String,
     turn_id: String,
@@ -114,7 +112,7 @@ struct WorkspaceModelExchangeTraceSink {
 
 impl WorkspaceModelExchangeTraceSink {
     fn new(
-        runtime_context: WorkspaceRuntimeContext,
+        trace_session_dir: PathBuf,
         policy: ModelExchangeTracePolicy,
         session_id: String,
         turn_id: String,
@@ -126,7 +124,7 @@ impl WorkspaceModelExchangeTraceSink {
         model_id: String,
     ) -> Self {
         Self {
-            runtime_context,
+            trace_session_dir,
             policy,
             session_id,
             turn_id,
@@ -141,10 +139,7 @@ impl WorkspaceModelExchangeTraceSink {
     }
 
     async fn allocate_sequence(&self) -> Result<u64, String> {
-        let session_dir = self
-            .runtime_context
-            .request_trace_session_dir(&self.session_id);
-        let key = session_dir.to_string_lossy().to_string();
+        let key = self.trace_session_dir.to_string_lossy().to_string();
         let allocator = sequence_allocators()
             .entry(key)
             .or_insert_with(|| Arc::new(Mutex::new(None)))
@@ -153,7 +148,7 @@ impl WorkspaceModelExchangeTraceSink {
         let current = match *guard {
             Some(value) => value,
             None => {
-                let detected = detect_last_sequence(&session_dir).await?;
+                let detected = detect_last_sequence(&self.trace_session_dir).await?;
                 *guard = Some(detected);
                 detected
             }
@@ -161,6 +156,11 @@ impl WorkspaceModelExchangeTraceSink {
         let next = current.saturating_add(1);
         *guard = Some(next);
         Ok(next)
+    }
+
+    fn trace_path(&self, sequence: u64) -> PathBuf {
+        self.trace_session_dir
+            .join(format!("request-{:06}.json", sequence))
     }
 
     async fn write_record(
@@ -264,9 +264,7 @@ impl ModelExchangeTraceSink for WorkspaceModelExchangeTraceSink {
         };
 
         let trace_id = Uuid::new_v4().to_string();
-        let path = self
-            .runtime_context
-            .request_trace_path(&self.session_id, sequence);
+        let path = self.trace_path(sequence);
         let record = ModelExchangeTraceRecord {
             version: TRACE_LAYOUT_VERSION,
             trace_id: trace_id.clone(),
@@ -356,6 +354,7 @@ pub async fn prepare_model_exchange_trace(
         &context.session_id,
         &context.dialog_turn_id,
         context.workspace.as_ref(),
+        context.model_exchange_trace_dir.as_deref(),
         ModelExchangeTraceOperation {
             kind: "model_round",
             id: round_id,
@@ -370,6 +369,7 @@ pub async fn prepare_model_exchange_trace_for_workspace(
     session_id: &str,
     turn_id: &str,
     workspace: Option<&WorkspaceBinding>,
+    model_exchange_trace_dir: Option<&Path>,
     operation: ModelExchangeTraceOperation<'_>,
     ai_client: &AIClient,
 ) -> Option<ModelExchangeTraceConfig> {
@@ -385,23 +385,26 @@ pub async fn prepare_model_exchange_trace_for_workspace(
         return None;
     };
 
-    let runtime_context = match get_workspace_runtime_service_arc()
-        .ensure_runtime_for_workspace_binding(workspace)
-        .await
-    {
-        Ok(result) => result.context,
-        Err(error) => {
-            warn!(
-                "Model exchange trace skipped because runtime init failed: session_id={}, operation_kind={}, operation_id={}, error={}",
-                session_id, operation.kind, operation.id, error
-            );
-            return None;
-        }
+    let trace_session_dir = match model_exchange_trace_dir {
+        Some(path) => path.to_path_buf(),
+        None => match get_workspace_runtime_service_arc()
+            .ensure_runtime_for_workspace_binding(workspace)
+            .await
+        {
+            Ok(result) => result.context.request_trace_session_dir(session_id),
+            Err(error) => {
+                warn!(
+                    "Model exchange trace skipped because runtime init failed: session_id={}, operation_kind={}, operation_id={}, error={}",
+                    session_id, operation.kind, operation.id, error
+                );
+                return None;
+            }
+        },
     };
 
     Some(ModelExchangeTraceConfig {
         sink: Arc::new(WorkspaceModelExchangeTraceSink::new(
-            runtime_context,
+            trace_session_dir,
             policy,
             session_id.to_string(),
             turn_id.to_string(),

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -1368,6 +1368,7 @@ mod tests {
             round_number: 0,
             round_group_id: None,
             workspace: None,
+            model_exchange_trace_dir: None,
             available_tools: Vec::new(),
             collapsed_tools: Vec::new(),
             unlocked_collapsed_tools: Vec::new(),

--- a/src/crates/assembly/core/src/agentic/execution/types.rs
+++ b/src/crates/assembly/core/src/agentic/execution/types.rs
@@ -10,6 +10,7 @@ pub use bitfun_agent_runtime::events::FinishReason;
 use bitfun_runtime_ports::{DelegationPolicy, RemoteExecPort, TerminalPort};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tool_runtime::context::PrimaryModelFacts;
@@ -53,6 +54,7 @@ pub struct RoundContext {
     pub round_number: usize,
     pub round_group_id: Option<String>,
     pub workspace: Option<WorkspaceBinding>,
+    pub model_exchange_trace_dir: Option<PathBuf>,
     pub available_tools: Vec<String>,
     pub collapsed_tools: Vec<String>,
     pub unlocked_collapsed_tools: Vec<String>,

--- a/src/crates/assembly/core/src/agentic/fork_agent/mod.rs
+++ b/src/crates/assembly/core/src/agentic/fork_agent/mod.rs
@@ -17,6 +17,8 @@ pub struct ForkAgentContextSnapshot {
     pub remote_ssh_host: Option<String>,
     pub session_model_id: Option<String>,
     pub session_config: SessionConfig,
+    pub last_user_dialog_agent_type: Option<String>,
+    pub last_submitted_agent_type: Option<String>,
     pub messages: Vec<Message>,
 }
 
@@ -44,6 +46,8 @@ impl ForkAgentContextSnapshot {
             remote_ssh_host: parent_session.config.remote_ssh_host.clone(),
             session_model_id: parent_session.config.model_id.clone(),
             session_config: parent_session.config.clone(),
+            last_user_dialog_agent_type: parent_session.last_user_dialog_agent_type.clone(),
+            last_submitted_agent_type: parent_session.last_submitted_agent_type.clone(),
             messages,
         })
     }
@@ -112,5 +116,21 @@ mod tests {
         assert_eq!(child_config.remote_ssh_host.as_deref(), Some("prod-box"));
         assert_eq!(child_config.model_id.as_deref(), Some("primary"));
         assert_eq!(child_config.max_turns, 7);
+    }
+
+    #[test]
+    fn snapshot_retains_parent_agent_type_state() {
+        let mut parent = parent_session();
+        parent.last_user_dialog_agent_type = Some("agentic".to_string());
+        parent.last_submitted_agent_type = Some("Plan".to_string());
+
+        let snapshot =
+            ForkAgentContextSnapshot::from_parent_session(&parent, Vec::new()).expect("snapshot");
+
+        assert_eq!(
+            snapshot.last_user_dialog_agent_type.as_deref(),
+            Some("agentic")
+        );
+        assert_eq!(snapshot.last_submitted_agent_type.as_deref(), Some("Plan"));
     }
 }

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -2453,6 +2453,46 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Inherit parent dialog mode state when creating forked child sessions.
+    ///
+    /// `last_user_dialog_agent_type` drives first-entry mode reminders, while
+    /// `last_submitted_agent_type` preserves scheduler prompt-cache state.
+    pub async fn inherit_session_agent_type_state(
+        &self,
+        session_id: &str,
+        last_user_dialog_agent_type: Option<String>,
+        last_submitted_agent_type: Option<String>,
+    ) -> BitFunResult<()> {
+        if let Some(mut session) = self.sessions.get_mut(session_id) {
+            session.last_user_dialog_agent_type = last_user_dialog_agent_type;
+            session.last_submitted_agent_type = last_submitted_agent_type;
+            session.updated_at = SystemTime::now();
+            session.last_activity_at = SystemTime::now();
+        } else {
+            return Err(BitFunError::NotFound(format!(
+                "Session not found: {}",
+                session_id
+            )));
+        }
+
+        if self.should_persist_session_id(session_id) {
+            let effective_path = self.effective_session_storage_path(session_id).await;
+            let session_snapshot = self.sessions.get(session_id).map(|s| s.clone());
+            if let (Some(workspace_path), Some(session)) = (effective_path, session_snapshot) {
+                self.persistence_manager
+                    .save_session(&workspace_path, &session)
+                    .await?;
+            }
+        }
+
+        debug!(
+            "Session agent type state inherited: session_id={}",
+            session_id
+        );
+
+        Ok(())
+    }
+
     fn derive_last_user_dialog_agent_type_from_turns(
         turns: &[DialogTurnData],
         fallback_agent_type: Option<&str>,

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -44,7 +44,7 @@ use bitfun_runtime_ports::{SessionStoragePathRequest, SessionStorePort};
 use bitfun_services_core::session::{
     apply_session_lineage, collect_hidden_subagent_cascade as collect_hidden_subagent_cascade_ids,
     merge_session_custom_metadata as merge_session_custom_metadata_value,
-    set_deep_review_run_manifest, set_session_relationship,
+    set_deep_review_run_manifest, set_session_relationship, SessionStorageLayout,
 };
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
@@ -521,6 +521,23 @@ impl SessionManager {
     async fn effective_session_storage_path(&self, session_id: &str) -> Option<PathBuf> {
         let config = self.sessions.get(session_id)?.config.clone();
         self.effective_storage_path_for_config(&config).await
+    }
+
+    pub async fn persistent_model_exchange_trace_dir(&self, session_id: &str) -> Option<PathBuf> {
+        if !self.should_persist_session_id(session_id) {
+            return None;
+        }
+
+        let storage_path = self
+            .effective_session_storage_path(session_id)
+            .await
+            .or_else(|| {
+                self.session_storage_path_index
+                    .get(session_id)
+                    .map(|entry| entry.value().clone())
+            })?;
+
+        Some(SessionStorageLayout::new(storage_path).request_traces_dir(session_id))
     }
 
     pub async fn resolve_session_workspace_binding(
@@ -5742,6 +5759,48 @@ mod tests {
             .await
             .expect("metadata lookup should succeed")
             .is_none());
+        assert_eq!(
+            manager
+                .persistent_model_exchange_trace_dir(&session.session_id)
+                .await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn persisted_session_uses_session_local_model_exchange_trace_dir() {
+        let workspace = TestWorkspace::new();
+        let path_manager = workspace.path_manager();
+        let persistence_manager =
+            Arc::new(PersistenceManager::new(path_manager.clone()).expect("persistence manager"));
+        let manager = test_manager(persistence_manager);
+
+        let session = manager
+            .create_session_with_id_and_details(
+                Some(Uuid::new_v4().to_string()),
+                "Main thread".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+                None,
+                SessionKind::Standard,
+            )
+            .await
+            .expect("standard session should create");
+
+        assert_eq!(
+            manager
+                .persistent_model_exchange_trace_dir(&session.session_id)
+                .await,
+            Some(
+                path_manager
+                    .project_sessions_dir(workspace.path())
+                    .join(&session.session_id)
+                    .join("request-traces")
+            )
+        );
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/infrastructure/ai/mod.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/mod.rs
@@ -10,10 +10,7 @@ use std::time::Duration;
 pub use bitfun_ai_adapters::providers;
 pub use bitfun_ai_adapters::stream as ai_stream_handlers;
 
-pub use bitfun_ai_adapters::{
-    AIClient, StreamOptions, StreamResponse, DEFAULT_STREAM_IDLE_TIMEOUT_SECS,
-    DEFAULT_STREAM_TTFT_TIMEOUT_SECS,
-};
+pub use bitfun_ai_adapters::{AIClient, StreamOptions, StreamResponse};
 pub use client_factory::{
     get_global_ai_client_factory, initialize_global_ai_client_factory, AIClientFactory,
 };
@@ -42,34 +39,26 @@ mod tests {
     use crate::service::config::types::AIModelConfig;
 
     #[test]
-    fn model_reasoning_mode_does_not_override_ttft_timeout() {
+    fn model_reasoning_mode_does_not_override_stream_timeouts() {
         let config = AIConfig::default();
         let mut model = AIModelConfig::default();
         model.reasoning_mode = Some(crate::service::config::types::ReasoningMode::Enabled);
 
         let options = build_stream_options_for_model(&config, Some(&model));
 
-        assert_eq!(
-            options.ttft_timeout,
-            Some(Duration::from_secs(DEFAULT_STREAM_TTFT_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            options.idle_timeout,
-            Some(Duration::from_secs(DEFAULT_STREAM_IDLE_TIMEOUT_SECS))
-        );
+        assert_eq!(options.ttft_timeout, Some(Duration::from_secs(600)));
+        assert_eq!(options.idle_timeout, Some(Duration::from_secs(600)));
     }
 
     #[test]
-    fn explicit_none_ttft_timeout_means_wait_indefinitely() {
+    fn explicit_none_stream_timeouts_mean_wait_indefinitely() {
         let mut config = AIConfig::default();
+        config.stream_idle_timeout_secs = None;
         config.stream_ttft_timeout_secs = None;
 
         let options = build_stream_options_for_model(&config, None);
 
         assert_eq!(options.ttft_timeout, None);
-        assert_eq!(
-            options.idle_timeout,
-            Some(Duration::from_secs(DEFAULT_STREAM_IDLE_TIMEOUT_SECS))
-        );
+        assert_eq!(options.idle_timeout, None);
     }
 }

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -744,12 +744,12 @@ fn default_true() -> bool {
 
 /// Default streaming idle timeout between chunks.
 fn default_stream_idle_timeout() -> Option<u64> {
-    Some(45)
+    Some(600)
 }
 
 /// Default timeout while waiting for the first effective streamed output.
 fn default_stream_ttft_timeout() -> Option<u64> {
-    Some(30)
+    Some(600)
 }
 
 /// Default is no timeout (wait forever).
@@ -2079,11 +2079,11 @@ mod tests {
     }
 
     #[test]
-    fn default_ai_config_uses_stream_timeouts() {
+    fn default_ai_config_uses_generous_stream_timeouts() {
         let config = AIConfig::default();
 
-        assert_eq!(config.stream_idle_timeout_secs, Some(45));
-        assert_eq!(config.stream_ttft_timeout_secs, Some(30));
+        assert_eq!(config.stream_idle_timeout_secs, Some(600));
+        assert_eq!(config.stream_ttft_timeout_secs, Some(600));
         assert_eq!(config.subagent_max_concurrency, 5);
         assert_eq!(
             config.subagent_batch_execution_policy,
@@ -2179,7 +2179,7 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_missing_stream_idle_timeout_as_default() {
+    fn deserializes_missing_stream_timeouts_as_generous_defaults() {
         let config: AIConfig = serde_json::from_value(serde_json::json!({
             "models": [],
             "agent_models": {},
@@ -2193,8 +2193,8 @@ mod tests {
         }))
         .expect("config without stream_idle_timeout_secs should deserialize");
 
-        assert_eq!(config.stream_idle_timeout_secs, Some(45));
-        assert_eq!(config.stream_ttft_timeout_secs, Some(30));
+        assert_eq!(config.stream_idle_timeout_secs, Some(600));
+        assert_eq!(config.stream_ttft_timeout_secs, Some(600));
         assert_eq!(config.subagent_max_concurrency, 5);
         assert_eq!(
             config.subagent_batch_execution_policy,
@@ -2220,7 +2220,7 @@ mod tests {
         .expect("config with explicit null stream_ttft_timeout_secs should deserialize");
 
         assert_eq!(config.stream_ttft_timeout_secs, None);
-        assert_eq!(config.stream_idle_timeout_secs, Some(45));
+        assert_eq!(config.stream_idle_timeout_secs, Some(600));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/cron/service.rs
+++ b/src/crates/assembly/core/src/service/cron/service.rs
@@ -196,6 +196,8 @@ impl CronService {
         let job = jobs
             .get_mut(job_id)
             .ok_or_else(|| BitFunError::NotFound(format!("Scheduled job not found: {}", job_id)))?;
+        let previous_schedule = job.schedule.clone();
+        let was_enabled = job.enabled;
 
         if let Some(name) = request.name {
             job.name = name.trim().to_string();
@@ -212,6 +214,8 @@ impl CronService {
         if let Some(schedule) = request.schedule {
             job.schedule = materialize_schedule(schedule, current_ms);
         }
+        let schedule_changed = job.schedule != previous_schedule;
+        let reenabled = !was_enabled && job.enabled;
 
         validate_request_fields(&job.name, &job.payload, &job.target)?;
         validate_schedule(&job.schedule, job.created_at_ms)?;
@@ -222,15 +226,9 @@ impl CronService {
 
         if !job.enabled {
             job.state.next_run_at_ms = None;
-        } else if job.state.active_turn_id.is_some() {
-            if job.is_one_shot() {
-                job.state.next_run_at_ms = None;
-            } else {
-                job.state.next_run_at_ms =
-                    compute_next_run_after_ms(&job.schedule, job.created_at_ms, current_ms)?;
-            }
         } else {
-            job.state.next_run_at_ms = compute_initial_next_run_at_ms(job, current_ms)?;
+            job.state.next_run_at_ms =
+                compute_next_run_after_update(job, current_ms, schedule_changed, reenabled)?;
         }
 
         let updated = job.clone();
@@ -761,6 +759,27 @@ fn materialize_schedule(schedule: CronSchedule, anchor_ms: i64) -> CronSchedule 
     }
 }
 
+fn compute_next_run_after_update(
+    job: &CronJob,
+    current_ms: i64,
+    schedule_changed: bool,
+    reenabled: bool,
+) -> BitFunResult<Option<i64>> {
+    if schedule_changed || reenabled {
+        return compute_next_run_after_ms(&job.schedule, job.created_at_ms, current_ms);
+    }
+
+    if job.state.active_turn_id.is_some() {
+        if job.is_one_shot() {
+            Ok(None)
+        } else {
+            compute_next_run_after_ms(&job.schedule, job.created_at_ms, current_ms)
+        }
+    } else {
+        compute_initial_next_run_at_ms(job, current_ms)
+    }
+}
+
 fn materialize_target(target: CronJobTarget) -> CronJobTarget {
     match target {
         CronJobTarget::Session {
@@ -1005,6 +1024,32 @@ fn cron_enqueue_error_is_missing_session(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::cron::CronJobState;
+
+    fn sample_job(schedule: CronSchedule) -> CronJob {
+        CronJob {
+            id: "cron_test".to_string(),
+            name: "test".to_string(),
+            schedule,
+            payload: CronJobPayload {
+                text: "hello".to_string(),
+            },
+            enabled: true,
+            target: CronJobTarget::Session {
+                session_id: "session_1".to_string(),
+                workspace: CronWorkspaceRef {
+                    workspace_id: None,
+                    workspace_path: "E:/workspace".to_string(),
+                    remote_connection_id: None,
+                    remote_ssh_host: None,
+                },
+            },
+            created_at_ms: 0,
+            config_updated_at_ms: 0,
+            updated_at_ms: 0,
+            state: CronJobState::default(),
+        }
+    }
 
     #[test]
     fn generate_cron_job_id_uses_short_hex_suffix() {
@@ -1065,5 +1110,66 @@ mod tests {
             None,
             Some("ssh-1"),
         ));
+    }
+
+    #[test]
+    fn changed_at_schedule_rearms_consumed_one_shot_only_for_future_time() {
+        let mut job = sample_job(CronSchedule::At {
+            at: "1970-01-01T00:00:03Z".to_string(),
+        });
+        job.state.last_enqueued_at_ms = Some(1_500);
+
+        let future_next =
+            compute_next_run_after_update(&job, 2_000, true, false).expect("future next run");
+        assert_eq!(future_next, Some(3_000));
+
+        job.schedule = CronSchedule::At {
+            at: "1970-01-01T00:00:01Z".to_string(),
+        };
+        let past_next =
+            compute_next_run_after_update(&job, 2_000, true, false).expect("past next run");
+        assert_eq!(past_next, None);
+    }
+
+    #[test]
+    fn reenabled_at_schedule_rearms_consumed_one_shot_only_for_future_time() {
+        let mut job = sample_job(CronSchedule::At {
+            at: "1970-01-01T00:00:03Z".to_string(),
+        });
+        job.state.last_enqueued_at_ms = Some(1_500);
+
+        let future_next =
+            compute_next_run_after_update(&job, 2_000, false, true).expect("future next run");
+        assert_eq!(future_next, Some(3_000));
+
+        job.schedule = CronSchedule::At {
+            at: "1970-01-01T00:00:01Z".to_string(),
+        };
+        let past_next =
+            compute_next_run_after_update(&job, 2_000, false, true).expect("past next run");
+        assert_eq!(past_next, None);
+    }
+
+    #[test]
+    fn unchanged_at_schedule_keeps_initial_catchup_semantics() {
+        let job = sample_job(CronSchedule::At {
+            at: "1970-01-01T00:00:01Z".to_string(),
+        });
+
+        let next =
+            compute_next_run_after_update(&job, 2_000, false, false).expect("initial next run");
+        assert_eq!(next, Some(1_000));
+    }
+
+    #[test]
+    fn unchanged_consumed_at_schedule_stays_completed() {
+        let mut job = sample_job(CronSchedule::At {
+            at: "1970-01-01T00:00:03Z".to_string(),
+        });
+        job.state.last_enqueued_at_ms = Some(1_500);
+
+        let next =
+            compute_next_run_after_update(&job, 2_000, false, false).expect("completed next run");
+        assert_eq!(next, None);
     }
 }

--- a/src/crates/services/services-core/src/session/layout.rs
+++ b/src/crates/services/services-core/src/session/layout.rs
@@ -43,6 +43,15 @@ impl SessionStorageLayout {
         self.session_dir(session_id).join("prompt_cache.json")
     }
 
+    pub fn request_traces_dir(&self, session_id: &str) -> PathBuf {
+        self.session_dir(session_id).join("request-traces")
+    }
+
+    pub fn request_trace_path(&self, session_id: &str, sequence: u64) -> PathBuf {
+        self.request_traces_dir(session_id)
+            .join(format!("request-{:06}.json", sequence))
+    }
+
     pub fn turns_dir(&self, session_id: &str) -> PathBuf {
         self.session_dir(session_id).join("turns")
     }
@@ -87,6 +96,10 @@ impl SessionStorageLayout {
 
     pub async fn ensure_session_dir(&self, session_id: &str) -> io::Result<PathBuf> {
         self.ensure_dir(self.session_dir(session_id)).await
+    }
+
+    pub async fn ensure_request_traces_dir(&self, session_id: &str) -> io::Result<PathBuf> {
+        self.ensure_dir(self.request_traces_dir(session_id)).await
     }
 
     pub async fn ensure_turns_dir(&self, session_id: &str) -> io::Result<PathBuf> {

--- a/src/crates/services/services-core/tests/session_layout_contracts.rs
+++ b/src/crates/services/services-core/tests/session_layout_contracts.rs
@@ -59,6 +59,14 @@ fn session_layout_preserves_legacy_file_names() {
             .join("prompt_cache.json")
     );
     assert_eq!(
+        layout.request_trace_path("session-1", 7),
+        root.path()
+            .join("sessions")
+            .join("session-1")
+            .join("request-traces")
+            .join("request-000007.json")
+    );
+    assert_eq!(
         layout.turn_path("session-1", 7),
         root.path()
             .join("sessions")
@@ -117,6 +125,10 @@ async fn session_layout_ensures_target_directories() {
         .ensure_session_dir("session-1")
         .await
         .expect("session dir should be created");
+    let request_traces_dir = layout
+        .ensure_request_traces_dir("session-1")
+        .await
+        .expect("request traces dir should be created");
     let turns_dir = layout
         .ensure_turns_dir("session-1")
         .await
@@ -131,6 +143,7 @@ async fn session_layout_ensures_target_directories() {
         .expect("artifacts dir should be created");
 
     assert!(session_dir.exists());
+    assert!(request_traces_dir.exists());
     assert!(turns_dir.exists());
     assert!(snapshots_dir.exists());
     assert!(artifacts_dir.exists());

--- a/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.tsx
@@ -106,6 +106,11 @@ function timestampMsToLocalDateTimeInput(timestampMs: number): string {
   return toLocalDateTimeInput(new Date(timestampMs).toISOString());
 }
 
+function isFutureLocalDateTimeInput(value: string, nowMs = Date.now()): boolean {
+  const timestampMs = new Date(value).getTime();
+  return Number.isFinite(timestampMs) && timestampMs > nowMs;
+}
+
 function formatEveryMinutes(everyMs: number): string {
   const everyMinutes = everyMs / MINUTE_IN_MS;
   if (Number.isInteger(everyMinutes)) return String(everyMinutes);
@@ -956,7 +961,11 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
                 onChange={e => {
                   const at = e.currentTarget.value;
                   setValidationErrors(current => ({ ...current, at: false }));
-                  setDraft(c => ({ ...c, at }));
+                  setDraft(c => ({
+                    ...c,
+                    at,
+                    enabled: !c.enabled && isFutureLocalDateTimeInput(at) ? true : c.enabled,
+                  }));
                 }}
               />
             </div>

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -2156,9 +2156,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         parentSessionId: currentSessionId,
         workspacePath,
         question,
-        modelId: imagesForBtw.length > 0
-          ? currentSession?.config?.modelName
-          : 'fast',
         imagePayload,
       });
       imagesForBtw.forEach(image => removeContext(image.id));
@@ -2176,7 +2173,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       pendingLargePastesRef.current = originalPendingLargePastes;
       dispatchInput({ type: 'SET_VALUE', payload: originalMessage });
     }
-  }, [clearPendingLargePastes, currentSession?.config?.modelName, currentSessionId, derivedState, expandComposerSpecialTokens, imageContexts, inputState.value, isBtwSession, removeContext, setQueuedInput, t, workspacePath]);
+  }, [clearPendingLargePastes, currentSessionId, derivedState, expandComposerSpecialTokens, imageContexts, inputState.value, isBtwSession, removeContext, setQueuedInput, t, workspacePath]);
 
   const submitCompactFromInput = useCallback(async () => {
     if (!effectiveTargetSessionId || !effectiveTargetSession) {

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.test.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.test.ts
@@ -180,6 +180,7 @@ describe('BtwThreadService', () => {
         ],
       }),
     );
+    expect(mockAskStream.mock.calls[0][0]).not.toHaveProperty('modelId');
     expect(mockAddDialogTurn).toHaveBeenCalledWith(
       'btw-child',
       expect.objectContaining({
@@ -259,7 +260,7 @@ describe('BtwThreadService', () => {
     expect(mockTransition).toHaveBeenCalledWith('btw-child', 'finishing_settled');
   });
 
-  it('uses the provided parent model for image /btw sends instead of forcing fast', async () => {
+  it('uses an explicit model override for /btw sends when provided', async () => {
     sessions.set('btw-child', {
       sessionId: 'btw-child',
       title: 'Side question',

--- a/src/web-ui/src/flow_chat/services/BtwThreadService.ts
+++ b/src/web-ui/src/flow_chat/services/BtwThreadService.ts
@@ -290,6 +290,7 @@ export async function sendMessageToTransientBtwSession(params: {
     question,
     imagePayload: params.imagePayload,
   });
+  const modelId = params.modelId?.trim();
   try {
     await btwAPI.askStream({
       requestId,
@@ -297,7 +298,7 @@ export async function sendMessageToTransientBtwSession(params: {
       childSessionId: params.childSessionId,
       childSessionName: params.childSessionName || childSession.title || 'Side thread',
       question,
-      modelId: params.modelId ?? childSession.config.modelName ?? 'fast',
+      ...(modelId ? { modelId } : {}),
       imageContexts: params.imagePayload?.imageContexts,
     });
   } catch (error) {
@@ -305,8 +306,8 @@ export async function sendMessageToTransientBtwSession(params: {
     await stateMachineManager.transition(params.childSessionId, SessionExecutionEvent.FINISHING_SETTLED);
     throw error;
   }
-  if (params.modelId?.trim()) {
-    flowChatStore.updateSessionModelName(params.childSessionId, params.modelId.trim());
+  if (modelId) {
+    flowChatStore.updateSessionModelName(params.childSessionId, modelId);
   }
 
   return { requestId };


### PR DESCRIPTION
## Summary

- Persist model exchange trace files for saved sessions under the session-local `request-traces` directory, while keeping transient sessions on the workspace runtime trace path.
- Let `/btw` child sessions inherit the parent model and mode state by default, only sending `modelId` when an explicit override is provided.
- Rearm consumed one-shot scheduled jobs when they are updated or re-enabled for a future `At` time, without backfilling historical one-shot updates.

Fixes #

## Type and Areas

Type:

Bug fix / regression fix

Areas:

Rust core, services-core session layout, web UI scheduled jobs, web UI `/btw` flow chat

## Motivation / Impact

Saved-session model exchange traces now stay with persisted session data instead of being routed only through workspace runtime paths. `/btw` side threads preserve parent model/cache continuity and agent mode state, avoiding unintended fast-model/default-mode behavior. One-shot scheduled jobs can be edited or re-enabled for a future time and will run again, while past one-shot timestamps remain completed.

## Verification

- `cargo test -p bitfun-core service::cron::service::tests --lib -- --nocapture` — passed
- `cargo test -p bitfun-core persisted_session_uses_session_local_model_exchange_trace_dir --lib -- --nocapture` — passed
- `cargo test -p bitfun-core ephemeral_child_session_is_kept_in_memory_without_persisting --lib -- --nocapture` — passed
- `cargo test -p bitfun-core snapshot_retains_parent_agent_type_state --lib -- --nocapture` — passed
- `cargo test -p bitfun-core hidden_btw_session_seeds_forked_listing_baselines --lib -- --nocapture` — passed
- `cargo test -p bitfun-services-core --test session_layout_contracts -- --nocapture` — passed
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/BtwThreadService.test.ts` — passed
- `pnpm run type-check:web` — passed
- `cargo check --workspace` — passed

## Reviewer Notes

- Persisted sessions now resolve model exchange trace output through `SessionStorageLayout::request_traces_dir`; ephemeral child sessions still return no persistent trace directory.
- `/btw` defaults now rely on backend/session inheritance instead of forcing `fast` from the frontend.
- Scheduled job updates remain future-only for changed or re-enabled one-shot `At` schedules.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.