### PR TITLE
feat(web-ui): add account login dialog entry in nav footer menu

### DIFF
--- a/BitFun-Installer/src/i18n/generatedLocaleContract.ts
+++ b/BitFun-Installer/src/i18n/generatedLocaleContract.ts
@@ -61,7 +61,8 @@ export const SHARED_TERMS_BY_APP_LANGUAGE = {
       "codeAgent": "Code Agent",
       "deepReview": "Deep Review",
       "settings": "Settings",
-      "workspace": "Workspace"
+      "workspace": "Workspace",
+      "accountLogin": "Account Login"
     },
     "modes": {
       "agentic": "Agentic Mode",
@@ -111,7 +112,8 @@ export const SHARED_TERMS_BY_APP_LANGUAGE = {
       "codeAgent": "代码助手",
       "deepReview": "深度代码评审",
       "settings": "设置",
-      "workspace": "工作区"
+      "workspace": "工作区",
+      "accountLogin": "账户登录"
     },
     "modes": {
       "agentic": "代理模式",
@@ -161,7 +163,8 @@ export const SHARED_TERMS_BY_APP_LANGUAGE = {
       "codeAgent": "程式碼助手",
       "deepReview": "深度程式碼審查",
       "settings": "設定",
-      "workspace": "工作區"
+      "workspace": "工作區",
+      "accountLogin": "帳號登入"
     },
     "modes": {
       "agentic": "代理模式",

--- a/src/crates/assembly/core/src/service/i18n/generated_locale_contract.rs
+++ b/src/crates/assembly/core/src/service/i18n/generated_locale_contract.rs
@@ -124,6 +124,11 @@ pub const GENERATED_SHARED_TERMS: &[GeneratedSharedTermEntry] = &[
     },
     GeneratedSharedTermEntry {
         locale: LocaleId::ZhCN,
+        key: "features.accountLogin",
+        value: "账户登录",
+    },
+    GeneratedSharedTermEntry {
+        locale: LocaleId::ZhCN,
         key: "features.codeAgent",
         value: "代码助手",
     },
@@ -294,6 +299,11 @@ pub const GENERATED_SHARED_TERMS: &[GeneratedSharedTermEntry] = &[
     },
     GeneratedSharedTermEntry {
         locale: LocaleId::ZhTW,
+        key: "features.accountLogin",
+        value: "帳號登入",
+    },
+    GeneratedSharedTermEntry {
+        locale: LocaleId::ZhTW,
         key: "features.codeAgent",
         value: "程式碼助手",
     },
@@ -461,6 +471,11 @@ pub const GENERATED_SHARED_TERMS: &[GeneratedSharedTermEntry] = &[
         locale: LocaleId::EnUS,
         key: "connectionMethods.ngrok",
         value: "Ngrok",
+    },
+    GeneratedSharedTermEntry {
+        locale: LocaleId::EnUS,
+        key: "features.accountLogin",
+        value: "Account Login",
     },
     GeneratedSharedTermEntry {
         locale: LocaleId::EnUS,

--- a/src/mobile-web/src/i18n/generatedLocaleContract.ts
+++ b/src/mobile-web/src/i18n/generatedLocaleContract.ts
@@ -45,7 +45,8 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "代码助手",
       "deepReview": "深度代码评审",
       "settings": "设置",
-      "workspace": "工作区"
+      "workspace": "工作区",
+      "accountLogin": "账户登录"
     },
     "modes": {
       "agentic": "代理模式",
@@ -95,7 +96,8 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "程式碼助手",
       "deepReview": "深度程式碼審查",
       "settings": "設定",
-      "workspace": "工作區"
+      "workspace": "工作區",
+      "accountLogin": "帳號登入"
     },
     "modes": {
       "agentic": "代理模式",
@@ -145,7 +147,8 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "Code Agent",
       "deepReview": "Deep Review",
       "settings": "Settings",
-      "workspace": "Workspace"
+      "workspace": "Workspace",
+      "accountLogin": "Account Login"
     },
     "modes": {
       "agentic": "Agentic Mode",

--- a/src/shared/i18n/resources/shared/en-US/terms.json
+++ b/src/shared/i18n/resources/shared/en-US/terms.json
@@ -8,7 +8,8 @@
     "codeAgent": "Code Agent",
     "deepReview": "Deep Review",
     "settings": "Settings",
-    "workspace": "Workspace"
+    "workspace": "Workspace",
+    "accountLogin": "Account Login"
   },
   "modes": {
     "agentic": "Agentic Mode",

--- a/src/shared/i18n/resources/shared/zh-CN/terms.json
+++ b/src/shared/i18n/resources/shared/zh-CN/terms.json
@@ -8,7 +8,8 @@
     "codeAgent": "代码助手",
     "deepReview": "深度代码评审",
     "settings": "设置",
-    "workspace": "工作区"
+    "workspace": "工作区",
+    "accountLogin": "账户登录"
   },
   "modes": {
     "agentic": "代理模式",

--- a/src/shared/i18n/resources/shared/zh-TW/terms.json
+++ b/src/shared/i18n/resources/shared/zh-TW/terms.json
@@ -8,7 +8,8 @@
     "codeAgent": "程式碼助手",
     "deepReview": "深度程式碼審查",
     "settings": "設定",
-    "workspace": "工作區"
+    "workspace": "工作區",
+    "accountLogin": "帳號登入"
   },
   "modes": {
     "agentic": "代理模式",

--- a/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.scss
+++ b/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.scss
@@ -1,0 +1,61 @@
+/**
+ * Account Login Dialog Styles
+ * Mirrors the SSH connection dialog visual style.
+ */
+
+.account-login-dialog {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  font-family: inherit;
+
+  &__error-banner {
+    flex-shrink: 0;
+    padding: 8px 16px 10px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--color-bg-primary);
+  }
+
+  &__error-alert.alert {
+    padding: 8px 10px;
+    align-items: center;
+  }
+
+  &__scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 10px 0 6px;
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0 16px;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    flex-shrink: 0;
+    margin-top: 0;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border-subtle);
+    background: var(--color-bg-primary);
+
+    .btn.btn-sm {
+      height: 28px;
+      min-height: 28px;
+      padding: 0 10px;
+      font-size: 11px;
+    }
+  }
+}

--- a/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.tsx
+++ b/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.tsx
@@ -1,0 +1,129 @@
+/**
+ * Account login dialog with three fields: username, password, auth server.
+ * Visual style mirrors the SSH new-connection dialog.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useI18n } from '@/infrastructure/i18n';
+import { Modal, Button, Input, Alert } from '@/component-library';
+import { User, Lock, Server, LogIn } from 'lucide-react';
+import './AccountLoginDialog.scss';
+
+interface AccountLoginDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const { t } = useI18n('common');
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [authServer, setAuthServer] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setUsername('');
+      setPassword('');
+      setAuthServer('');
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleLogin = useCallback(() => {
+    if (!username.trim() || !password.trim() || !authServer.trim()) {
+      setError(t('accountLogin.emptyFields'));
+      return;
+    }
+    setError(null);
+    onClose();
+  }, [username, password, authServer, t, onClose]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('shared:features.accountLogin')}
+      size="medium"
+      showCloseButton
+      closeOnOverlayClick={false}
+      contentClassName="modal__content--fill-flex"
+    >
+      <div className="account-login-dialog">
+        {error && (
+          <div className="account-login-dialog__error-banner">
+            <Alert
+              type="error"
+              message={error}
+              closable
+              onClose={() => setError(null)}
+              className="account-login-dialog__error-alert"
+            />
+          </div>
+        )}
+
+        <div className="account-login-dialog__scroll">
+          <div className="account-login-dialog__form">
+            <div className="account-login-dialog__field">
+              <Input
+                label={t('accountLogin.username')}
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder=""
+                prefix={<User size={16} />}
+                size="medium"
+              />
+            </div>
+            <div className="account-login-dialog__field">
+              <Input
+                label={t('accountLogin.password')}
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder=""
+                prefix={<Lock size={16} />}
+                size="medium"
+              />
+            </div>
+            <div className="account-login-dialog__field">
+              <Input
+                label={t('accountLogin.authServer')}
+                type="url"
+                value={authServer}
+                onChange={(e) => setAuthServer(e.target.value)}
+                placeholder={t('accountLogin.authServerPlaceholder')}
+                prefix={<Server size={16} />}
+                size="medium"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="account-login-dialog__actions">
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={onClose}
+          >
+            {t('accountLogin.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            onClick={handleLogin}
+          >
+            <LogIn size={14} />
+            {t('accountLogin.login')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default AccountLoginDialog;

--- a/src/web-ui/src/app/components/AccountLoginDialog/index.ts
+++ b/src/web-ui/src/app/components/AccountLoginDialog/index.ts
@@ -1,0 +1,2 @@
+export { AccountLoginDialog } from './AccountLoginDialog';
+export { AccountLoginDialog as default } from './AccountLoginDialog';

--- a/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLink,
   BarChart3,
   ChevronUp,
+  LogIn,
 } from 'lucide-react';
 import { Tooltip, Modal } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
@@ -31,6 +32,7 @@ import {
 } from '../../RemoteConnectDialog/remoteConnectDisclaimerStorage';
 
 const RemoteConnectDialog = lazy(() => import('../../RemoteConnectDialog'));
+const AccountLoginDialog = lazy(() => import('../../AccountLoginDialog'));
 const AboutDialog = lazy(() =>
   import('../../AboutDialog').then(module => ({ default: module.AboutDialog }))
 );
@@ -56,6 +58,7 @@ const PersistentFooterActions: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuClosing, setMenuClosing] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
+  const [showAccountLogin, setShowAccountLogin] = useState(false);
   const [showRemoteConnect, setShowRemoteConnect] = useState(false);
   const [showRemoteDisclaimer, setShowRemoteDisclaimer] = useState(false);
   const [hasAgreedRemoteDisclaimer, setHasAgreedRemoteDisclaimer] = useState<boolean>(() => getRemoteConnectDisclaimerAgreed());
@@ -121,6 +124,11 @@ const PersistentFooterActions: React.FC = () => {
     enableToolbarMode();
   };
 
+  const handleAccountLogin = () => {
+    closeMenu();
+    setShowAccountLogin(true);
+  };
+
   const handleRemoteConnect = useCallback(async () => {
     if (!hasWorkspace) {
       warning(t('header.remoteConnectRequiresWorkspace'));
@@ -184,6 +192,17 @@ const PersistentFooterActions: React.FC = () => {
                   role="menu"
                   data-testid="nav-footer-menu"
                 >
+                  <button
+                    type="button"
+                    className="bitfun-nav-panel__footer-menu-item"
+                    role="menuitem"
+                    onClick={handleAccountLogin}
+                    data-testid="nav-footer-account-login-item"
+                  >
+                    <LogIn size={14} />
+                    <span>{t('shared:features.accountLogin')}</span>
+                  </button>
+                  <div className="bitfun-nav-panel__footer-menu-divider" />
                   <Tooltip
                     content={t('header.remoteConnectRequiresWorkspace')}
                     placement="right"
@@ -284,6 +303,11 @@ const PersistentFooterActions: React.FC = () => {
       {showAbout && (
         <Suspense fallback={null}>
           <AboutDialog isOpen={showAbout} onClose={() => setShowAbout(false)} />
+        </Suspense>
+      )}
+      {showAccountLogin && (
+        <Suspense fallback={null}>
+          <AccountLoginDialog isOpen={showAccountLogin} onClose={() => setShowAccountLogin(false)} />
         </Suspense>
       )}
       {showRemoteConnect && (

--- a/src/web-ui/src/infrastructure/i18n/presets/generatedLocaleContract.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/generatedLocaleContract.ts
@@ -39,7 +39,8 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "代码助手",
       "deepReview": "深度代码评审",
       "settings": "设置",
-      "workspace": "工作区"
+      "workspace": "工作区",
+      "accountLogin": "账户登录"
     },
     "modes": {
       "agentic": "代理模式",
@@ -89,7 +90,8 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "Code Agent",
       "deepReview": "Deep Review",
       "settings": "Settings",
-      "workspace": "Workspace"
+      "workspace": "Workspace",
+      "accountLogin": "Account Login"
     },
     "modes": {
       "agentic": "Agentic Mode",
@@ -139,7 +141,8 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "程式碼助手",
       "deepReview": "深度程式碼審查",
       "settings": "設定",
-      "workspace": "工作區"
+      "workspace": "工作區",
+      "accountLogin": "帳號登入"
     },
     "modes": {
       "agentic": "代理模式",

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -463,6 +463,17 @@
     "errorEnterName": "Please enter a project name",
     "errorCreateFailed": "Failed to create project"
   },
+  "accountLogin": {
+    "username": "Username",
+    "password": "Password",
+    "authServer": "Auth Server",
+    "usernamePlaceholder": "Enter username",
+    "passwordPlaceholder": "Enter password",
+    "authServerPlaceholder": "https://auth.example.com",
+    "login": "Log In",
+    "cancel": "Cancel",
+    "emptyFields": "Please fill in all fields"
+  },
   "remoteConnect": {
     "tabNgrok": "NAT Traversal",
     "tabCustomServer": "Self-Hosted",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -463,6 +463,17 @@
     "errorEnterName": "请输入工作区名称",
     "errorCreateFailed": "创建工作区失败"
   },
+  "accountLogin": {
+    "username": "用户名",
+    "password": "密码",
+    "authServer": "认证服务器",
+    "usernamePlaceholder": "请输入用户名",
+    "passwordPlaceholder": "请输入密码",
+    "authServerPlaceholder": "https://auth.example.com",
+    "login": "登录",
+    "cancel": "取消",
+    "emptyFields": "请填写所有字段"
+  },
   "remoteConnect": {
     "tabNgrok": "内网穿透",
     "tabCustomServer": "自建服务器",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -463,6 +463,17 @@
     "errorEnterName": "請輸入工作區名稱",
     "errorCreateFailed": "建立工作區失敗"
   },
+  "accountLogin": {
+    "username": "帳號",
+    "password": "密碼",
+    "authServer": "認證伺服器",
+    "usernamePlaceholder": "請輸入帳號",
+    "passwordPlaceholder": "請輸入密碼",
+    "authServerPlaceholder": "https://auth.example.com",
+    "login": "登入",
+    "cancel": "取消",
+    "emptyFields": "請填寫所有欄位"
+  },
   "remoteConnect": {
     "tabNgrok": "內網穿透",
     "tabCustomServer": "自建伺服器",


### PR DESCRIPTION
## Summary

- Add an **Account Login** dialog with username, password, and auth server fields, styled consistently with the SSH connection dialog.
- Wire the dialog from the persistent nav footer menu via lazy-loaded `AccountLoginDialog`.
- Add shared i18n term `features.accountLogin` and Web UI `accountLogin` locale strings for en-US, zh-CN, and zh-TW.

## Test plan

- [x] `pnpm run i18n:contract:test`
- [x] `pnpm run i18n:audit`
- [x] `pnpm run type-check:web`
- [ ] Open nav footer menu and verify **Account Login** item appears with correct label
- [ ] Open dialog and verify three fields (username, password, auth server) render correctly
- [ ] Submit with empty fields and verify validation error message
- [ ] Cancel / close dialog and reopen to confirm form resets