### PR TITLE
fix(gettoolspec): return assistant hints for non-collapsed tools

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
@@ -102,6 +102,19 @@ impl GetToolSpecCatalogProvider<dyn Tool, ToolUseContext> for ProductToolCatalog
             None => Ok(self.default_collapsed_tools().await),
         }
     }
+
+    async fn available_tools_for_get_tool_spec(
+        &self,
+        context: Option<&ToolUseContext>,
+    ) -> Result<Vec<ToolRef>, String> {
+        match context {
+            Some(context) => self
+                .contextual_available_tools(context)
+                .await
+                .map_err(|error| error.to_string()),
+            None => Ok(self.default_collapsed_tools().await),
+        }
+    }
 }
 
 impl ProductToolCatalogProvider {
@@ -131,6 +144,26 @@ impl ProductToolCatalogProvider {
             .visible_tools(&policy.allowed_tools, &policy.exposure_overrides, context)
             .await;
         Ok(visible_tools.collapsed_tools)
+    }
+
+    async fn contextual_available_tools(
+        &self,
+        context: &ToolUseContext,
+    ) -> BitFunResult<Vec<ToolRef>> {
+        let agent_type = context.agent_type.as_deref().ok_or_else(|| {
+            BitFunError::Validation("GetToolSpec requires agent type context".to_string())
+        })?;
+        let workspace_root = context.workspace_root();
+        let agent_registry = get_agent_registry();
+        let policy = agent_registry
+            .get_agent_tool_policy(agent_type, workspace_root)
+            .await;
+        let visible_tools = product_tool_catalog_runtime(self)
+            .visible_tools(&policy.allowed_tools, &policy.exposure_overrides, context)
+            .await;
+        let mut tools = visible_tools.expanded_tools;
+        tools.extend(visible_tools.collapsed_tools);
+        Ok(tools)
     }
 }
 
@@ -410,20 +443,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn product_get_tool_spec_rejects_expanded_webfetch_in_agentic_mode() {
-        let error = resolve_product_get_tool_spec_results(
+    async fn product_get_tool_spec_returns_assistant_hint_for_expanded_webfetch_in_agentic_mode() {
+        let results = resolve_product_get_tool_spec_results(
             &json!({ "tool_name": "WebFetch" }),
             &tool_context(Some("agentic")),
             "GetToolSpec",
         )
         .await
-        .expect_err("agentic mode expands WebFetch, so GetToolSpec should reject it");
+        .expect("agentic mode expands WebFetch, so GetToolSpec should return a direct-use hint");
 
+        assert_eq!(results.len(), 1);
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
+            panic!("expected normal tool result");
+        };
+
+        assert_eq!(data["tool_name"], "WebFetch");
+        assert_eq!(data["already_available"], true);
         assert!(
-            error
-                .to_string()
-                .contains("not an available collapsed tool"),
-            "unexpected error: {error}"
+            result_for_assistant
+                .as_deref()
+                .unwrap_or_default()
+                .contains("already fully defined in the available tool list"),
+            "unexpected assistant text: {result_for_assistant:?}"
         );
     }
 

--- a/src/crates/execution/tool-contracts/src/framework.rs
+++ b/src/crates/execution/tool-contracts/src/framework.rs
@@ -461,6 +461,39 @@ pub fn build_get_tool_spec_duplicate_load_result(tool_name: &str) -> ToolResult 
     }
 }
 
+pub fn build_get_tool_spec_already_available_hint(tool_name: &str) -> String {
+    format!(
+        "Tool '{}' is already fully defined in the available tool list. Use '{}' directly.",
+        tool_name, tool_name
+    )
+}
+
+pub fn build_get_tool_spec_already_available_result(tool_name: &str) -> ToolResult {
+    ToolResult::Result {
+        data: serde_json::json!({
+            "tool_name": tool_name,
+            "already_available": true
+        }),
+        result_for_assistant: Some(build_get_tool_spec_already_available_hint(tool_name)),
+        image_attachments: None,
+    }
+}
+
+pub fn build_get_tool_spec_unavailable_collapsed_hint(tool_name: &str) -> String {
+    format!("'{}' is not available in the current context", tool_name)
+}
+
+pub fn build_get_tool_spec_unavailable_collapsed_result(tool_name: &str) -> ToolResult {
+    ToolResult::Result {
+        data: serde_json::json!({
+            "tool_name": tool_name,
+            "available_collapsed_tool": false
+        }),
+        result_for_assistant: Some(build_get_tool_spec_unavailable_collapsed_hint(tool_name)),
+        image_attachments: None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GetToolSpecExecutionError {
     MissingToolName,
@@ -715,6 +748,13 @@ where
         &self,
         context: Option<&Context>,
     ) -> Result<Vec<ToolRef<Tool>>, String>;
+
+    async fn available_tools_for_get_tool_spec(
+        &self,
+        context: Option<&Context>,
+    ) -> Result<Vec<ToolRef<Tool>>, String> {
+        self.collapsed_tools_for_get_tool_spec(context).await
+    }
 }
 
 pub fn summarize_get_tool_spec_collapsed_tools<Tool: ToolRegistryItem + ?Sized>(
@@ -836,9 +876,7 @@ where
     let tool = collapsed_tools
         .iter()
         .find(|tool| tool.name() == tool_name)
-        .ok_or_else(|| {
-            format!("Tool '{tool_name}' is not an available collapsed tool in the current context")
-        })?;
+        .ok_or_else(|| format!("'{tool_name}' is not available in the current context"))?;
 
     if tool.name() == get_tool_spec_tool_name {
         return Err(format!("Tool '{tool_name}' cannot inspect itself"));
@@ -895,15 +933,32 @@ where
     match resolve_get_tool_spec_execution_plan(input, loaded_collapsed_tools)? {
         GetToolSpecExecutionPlan::DuplicateLoad(result) => Ok(result),
         GetToolSpecExecutionPlan::LoadDetail { tool_name } => {
-            let detail = resolve_get_tool_spec_detail_from_provider(
-                provider,
-                tool_name,
-                context,
-                get_tool_spec_tool_name,
-            )
-            .await
-            .map_err(GetToolSpecExecutionError::Detail)?;
-            Ok(build_get_tool_spec_detail_result(&detail))
+            let collapsed_tools = provider
+                .collapsed_tools_for_get_tool_spec(Some(context))
+                .await
+                .map_err(GetToolSpecExecutionError::Detail)?;
+
+            if collapsed_tools.iter().any(|tool| tool.name() == tool_name) {
+                let detail = resolve_get_tool_spec_detail(
+                    &collapsed_tools,
+                    tool_name,
+                    context,
+                    get_tool_spec_tool_name,
+                )
+                .await
+                .map_err(GetToolSpecExecutionError::Detail)?;
+                return Ok(build_get_tool_spec_detail_result(&detail));
+            }
+
+            let available_tools = provider
+                .available_tools_for_get_tool_spec(Some(context))
+                .await
+                .map_err(GetToolSpecExecutionError::Detail)?;
+            if available_tools.iter().any(|tool| tool.name() == tool_name) {
+                return Ok(build_get_tool_spec_already_available_result(tool_name));
+            }
+
+            Ok(build_get_tool_spec_unavailable_collapsed_result(tool_name))
         }
     }
 }

--- a/src/crates/execution/tool-contracts/tests/tool_contracts.rs
+++ b/src/crates/execution/tool-contracts/tests/tool_contracts.rs
@@ -2087,6 +2087,26 @@ impl GetToolSpecCatalogProvider<ContextualManifestTool, ManifestTestContext>
 
         Ok(tools)
     }
+
+    async fn available_tools_for_get_tool_spec(
+        &self,
+        context: Option<&ManifestTestContext>,
+    ) -> Result<Vec<Arc<ContextualManifestTool>>, String> {
+        let tools = match context {
+            Some(context) => {
+                let mut tools = Vec::new();
+                for tool in &self.tools {
+                    if tool.is_available_in_context(context).await {
+                        tools.push(tool.clone());
+                    }
+                }
+                tools
+            }
+            None => self.tools.clone(),
+        };
+
+        Ok(tools)
+    }
 }
 
 #[async_trait::async_trait]
@@ -2734,10 +2754,7 @@ async fn get_tool_spec_detail_resolver_preserves_contextual_detail_contract() {
         resolve_get_tool_spec_detail(&collapsed_tools, "Git", &context, GET_TOOL_SPEC_TOOL_NAME)
             .await
             .expect_err("missing tool should stay a validation-style error");
-    assert_eq!(
-        missing,
-        "Tool 'Git' is not an available collapsed tool in the current context"
-    );
+    assert_eq!(missing, "'Git' is not available in the current context");
 
     let self_inspection = resolve_get_tool_spec_detail(
         &collapsed_tools,
@@ -2847,6 +2864,47 @@ async fn get_tool_spec_provider_execution_returns_detail_result_from_provider() 
     assert!(assistant.contains("<description>\nWebFetch description for agentic"));
     assert!(assistant.contains("\"agent\""));
     assert!(assistant.contains("\"agentic\""));
+    assert_eq!(image_attachments, None);
+}
+
+#[tokio::test]
+async fn get_tool_spec_provider_execution_returns_already_available_result_for_expanded_tool() {
+    let provider = ContextualManifestSnapshotProvider {
+        tools: vec![
+            contextual_manifest_tool("WebFetch", ToolExposure::Collapsed, None),
+            contextual_manifest_tool("Read", ToolExposure::Expanded, None),
+        ],
+    };
+    let context = ManifestTestContext { agent: "agentic" };
+    let input = json!({ "tool_name": "Read" });
+
+    let result = resolve_get_tool_spec_execution_result_from_provider(
+        &provider,
+        &input,
+        &[],
+        &context,
+        GET_TOOL_SPEC_TOOL_NAME,
+    )
+    .await
+    .expect("expanded available tool should return a normal assistant hint");
+
+    let ToolResult::Result {
+        data,
+        result_for_assistant,
+        image_attachments,
+    } = result
+    else {
+        panic!("expected normal tool result");
+    };
+
+    assert_eq!(data["tool_name"], "Read");
+    assert_eq!(data["already_available"], true);
+    assert_eq!(
+        result_for_assistant.as_deref(),
+        Some(
+            "Tool 'Read' is already fully defined in the available tool list. Use 'Read' directly."
+        )
+    );
     assert_eq!(image_attachments, None);
 }
 
@@ -2980,7 +3038,7 @@ fn get_tool_spec_runtime_facade_owns_static_tool_surface() {
 }
 
 #[tokio::test]
-async fn get_tool_spec_provider_execution_classifies_detail_errors() {
+async fn get_tool_spec_provider_execution_returns_unavailable_result_for_unknown_tool() {
     let provider = ContextualManifestSnapshotProvider {
         tools: vec![contextual_manifest_tool(
             "WebFetch",
@@ -2991,7 +3049,7 @@ async fn get_tool_spec_provider_execution_classifies_detail_errors() {
     let context = ManifestTestContext { agent: "agentic" };
     let input = json!({ "tool_name": "Git" });
 
-    let err = resolve_get_tool_spec_execution_result_from_provider(
+    let result = resolve_get_tool_spec_execution_result_from_provider(
         &provider,
         &input,
         &[],
@@ -2999,18 +3057,24 @@ async fn get_tool_spec_provider_execution_classifies_detail_errors() {
         GET_TOOL_SPEC_TOOL_NAME,
     )
     .await
-    .expect_err("missing detail should be classified separately from input errors");
+    .expect("unknown tool should return a normal assistant hint");
 
+    let ToolResult::Result {
+        data,
+        result_for_assistant,
+        image_attachments,
+    } = result
+    else {
+        panic!("expected normal tool result");
+    };
+
+    assert_eq!(data["tool_name"], "Git");
+    assert_eq!(data["available_collapsed_tool"], false);
     assert_eq!(
-        err,
-        GetToolSpecExecutionError::Detail(
-            "Tool 'Git' is not an available collapsed tool in the current context".to_string()
-        )
+        result_for_assistant.as_deref(),
+        Some("'Git' is not available in the current context")
     );
-    assert_eq!(
-        err.to_string(),
-        "Tool 'Git' is not an available collapsed tool in the current context"
-    );
+    assert_eq!(image_attachments, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Update GetToolSpec so requests for tools that are already available in the
current agent tool list return a normal assistant hint instead of a validation
error. Unknown tools now also return a normal result with a concise unavailable
message.

Resolve available-tool checks from the current agent policy context rather than
the full registry, and add focused coverage for expanded and unavailable tool
requests.
