### PR TITLE
fix(ai-adapters): parse OpenAI reasoning alias chunks

### DIFF
--- a/src/crates/adapters/ai-adapters/src/stream/types/openai.rs
+++ b/src/crates/adapters/ai-adapters/src/stream/types/openai.rs
@@ -77,6 +77,8 @@ struct Delta {
     role: Option<String>,
     /// Standard OpenAI-compatible reasoning field (DeepSeek, Qwen, etc.)
     reasoning_content: Option<String>,
+    /// Some OpenAI-compatible providers stream thinking under `reasoning`.
+    reasoning: Option<String>,
     /// MiniMax-specific reasoning field; used as fallback when `reasoning_content` is absent.
     reasoning_details: Option<Vec<ReasoningDetail>>,
     content: Option<String>,
@@ -166,6 +168,7 @@ impl OpenAISSEData {
         } = first_choice;
         let Delta {
             reasoning_content,
+            reasoning,
             reasoning_details,
             content,
             tool_calls,
@@ -176,7 +179,7 @@ impl OpenAISSEData {
         // `content: ""` in reasoning-only chunks). Keep empty reasoning content so downstream
         // can replay structurally present thinking blocks when a provider requires it.
         let content = content.filter(|s| !s.is_empty());
-        let reasoning_content = reasoning_content;
+        let reasoning_content = reasoning_content.or(reasoning);
 
         // MiniMax uses `reasoning_details` instead of `reasoning_content`.
         // Collect all "reasoning.text" entries and join them as a fallback.
@@ -372,6 +375,31 @@ mod tests {
         assert_eq!(responses.len(), 1);
         assert_eq!(responses[0].reasoning_content.as_deref(), Some(""));
         assert_eq!(responses[0].finish_reason.as_deref(), Some("stop"));
+    }
+
+    #[test]
+    fn parses_reasoning_alias_chunk() {
+        let raw = r#"{
+            "id": "chatcmpl_test",
+            "created": 123,
+            "model": "compatible-test",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "reasoning": "I should check the provider-specific field."
+                },
+                "finish_reason": null
+            }]
+        }"#;
+
+        let sse_data: OpenAISSEData = serde_json::from_str(raw).expect("valid openai sse data");
+        let responses = sse_data.into_unified_responses();
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(
+            responses[0].reasoning_content.as_deref(),
+            Some("I should check the provider-specific field.")
+        );
     }
 
     #[test]

--- a/src/crates/adapters/ai-adapters/tests/fixtures/stream/openai/reasoning_alias_text.sse
+++ b/src/crates/adapters/ai-adapters/tests/fixtures/stream/openai/reasoning_alias_text.sse
@@ -1,0 +1,10 @@
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":319,"model":"compatible-test","choices":[{"index":0,"delta":{"role": "assistant", "content": ""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":320,"model":"compatible-test","choices":[{"index":0,"delta":{"reasoning":"First reason. "},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":321,"model":"compatible-test","choices":[{"index":0,"delta":{"reasoning":"Then answer."},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":322,"model":"compatible-test","choices":[{"index":0,"delta":{"content":"Final answer."},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}}
+
+data: [DONE]
+

--- a/src/crates/adapters/ai-adapters/tests/stream_processor_openai.rs
+++ b/src/crates/adapters/ai-adapters/tests/stream_processor_openai.rs
@@ -135,6 +135,46 @@ async fn openai_fixture_keeps_malformed_tool_arguments_invalid() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openai_fixture_parses_reasoning_alias_into_thinking() {
+    let output = run_stream_fixture(
+        StreamFixtureProvider::OpenAi,
+        "stream/openai/reasoning_alias_text.sse",
+        FixtureSseServerOptions::default(),
+    )
+    .await;
+
+    let result = output.result.expect("stream result");
+
+    assert_eq!(result.full_thinking, "First reason. Then answer.");
+    assert!(result.reasoning_content_present);
+    assert_eq!(result.full_text, "Final answer.");
+    assert!(result.tool_calls.is_empty());
+    assert_eq!(
+        result.usage.as_ref().map(|usage| usage.total_token_count),
+        Some(8)
+    );
+
+    let thinking_chunks: Vec<(&str, bool)> = output
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            AgenticEvent::ThinkingChunk {
+                content, is_end, ..
+            } => Some((content.as_str(), *is_end)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        thinking_chunks,
+        vec![
+            ("First reason. ", false),
+            ("Then answer.", false),
+            ("", true)
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn openai_fixture_parses_inline_think_tags_into_reasoning_content() {
     let output = run_stream_fixture_with_options(
         StreamFixtureProvider::OpenAi,


### PR DESCRIPTION
## Summary

Support OpenAI-compatible Chat Completions stream chunks that emit thinking text under `choices[0].delta.reasoning`.

Fixes #

## Type and Areas

Type:

bug fix

Areas:

AI adapters, Rust stream parsing, tests

## Motivation / Impact

Some OpenAI-compatible providers stream reasoning text as `delta.reasoning` instead of `delta.reasoning_content`. This PR maps that alias into the unified `reasoning_content` path so downstream thinking accumulation and ThinkingChunk emission work consistently.

The added SSE fixture also covers a real-style leading assistant role chunk with empty content, confirming it is harmless while subsequent reasoning alias chunks are parsed.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-ai-adapters parses_reasoning_alias_chunk`
- `cargo test -p bitfun-ai-adapters openai_fixture_parses_reasoning_alias_into_thinking`

## Reviewer Notes

`reasoning_content` remains the first-priority field. The new `reasoning` alias is only used when `reasoning_content` is absent, before falling back to MiniMax `reasoning_details`.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.