### PR TITLE
ci(theme): enforce color governance ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: pnpm run theme:color-audit:test
 
       - name: Audit theme color governance
-        run: pnpm run theme:color-audit
+        run: pnpm run theme:color-audit:all
 
       - name: Validate theme visual governance contract
         run: pnpm run theme:visual-contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,18 @@ For the full script list, see [`package.json`](package.json).
   no-growth baselines, shared-term/l10n governance baselines, non-blocking
   same-text locale inventory, and the no-hardcoded-CJK source budget.
 
+### Theme and color tokens
+
+- Theme and color-token baselines are ratchet contracts, not editable test
+  expectations. Do not make a failing theme audit pass by raising values in
+  `scripts/theme-color-governance-baseline*.json`, loosening fixture/assertion
+  counts, adding broad allowlist entries, or removing CI audit coverage.
+- Lower theme baselines when measured debt is removed. If a change truly needs a
+  new color or key, add the smallest owner contract and document why existing
+  semantic, component, or specialized-domain tokens cannot cover it.
+- For theme, CSS variable, widget payload, mobile, installer, or CLI/TUI color
+  changes, run `pnpm run theme:color-audit:all`.
+
 ### Logging
 
 Logs must be English-only, with no emojis.

--- a/docs/architecture/theme-token-optimization.md
+++ b/docs/architecture/theme-token-optimization.md
@@ -50,6 +50,23 @@
 3. 有独立语义：新增 semantic 或 component token，并说明为什么不能复用。
 4. 属于 editor、terminal、syntax、diff 等专用域：进入 exception namespace。
 
+### Theme Governance Ratchet Contract
+
+主题治理 baseline 是 no-growth / ratchet 契约，不是普通测试快照。测试中的数量、
+baseline `max`、near-pair decision 和 allowlist 都不能被当成“让 CI 通过”的可调参数。
+如果审计失败，默认修复路径是复用现有 token、合并冗余色值、删除游离 key，或补充最小 owner
+contract；不能直接上调测试期望值或 baseline。
+
+受保护指标包括：普通 app UI raw color、token-equivalent literal、fallback var、unresolved
+CSS var、non-contract key、dynamic family、compatibility alias、surface rename、static root
+contract key、generated widget payload key、mobile / installer key、CLI/TUI runtime key，以及普通组件和专用域
+near color pair。上述指标只能在实际审计值下降时下调 baseline；确需增长时，必须使用独立治理 PR
+说明用户可见语义、不能复用的原因、影响 surface、回退方案和复审结论。
+
+AI 生成或辅助修改不得通过扩大 fixture 数量、放宽断言、增加 allowlist 或关闭审计命令来绕过该契约。
+PR reviewer 应把这类修改视为主题治理回退，而不是正常测试维护。跨 root 主题变更必须执行
+`pnpm run theme:color-audit:all`，CI 也必须保持同等覆盖。
+
 第一阶段不覆盖：
 
 - 重新设计品牌视觉方向或重做主题风格。

--- a/src/web-ui/AGENTS.md
+++ b/src/web-ui/AGENTS.md
@@ -26,6 +26,13 @@ Most changes start in:
 
 - Do not call Tauri APIs directly from UI components; go through the adapter / infrastructure layer
 - Reuse existing theme, i18n, component-library, and Zustand stores before adding new frontend primitives
+- Theme and color-token changes must follow
+  `docs/architecture/theme-token-optimization.md`: failing audits should be
+  fixed by reusing tokens, merging redundant values, or adding a scoped owner
+  contract. Do not raise baseline or test expectation counts just to make a
+  theme audit pass. Use `pnpm run theme:color-audit:all` for changes that touch
+  theme tokens, CSS variables, color literals, widget payloads, mobile,
+  installer, or CLI/TUI color projection.
 - Keep locale metadata in the generated i18n contract files. Edit
   `src/shared/i18n/contract/locales.json`, run `pnpm run i18n:generate`, and
   keep Web UI strings under `src/web-ui/src/locales`.


### PR DESCRIPTION
## Summary

- Document theme/color-token baselines as ratchet contracts in the repo and Web UI agent guides.
- Add a formal theme governance ratchet contract to the theme optimization architecture doc.
- Run CI theme color governance with `theme:color-audit:all` so Web UI, mobile, installer, and CLI/TUI are covered together.

Refs #1197

## Verification

- `pnpm run check:github-config`
- `pnpm run theme:color-audit:test`
- `pnpm run theme:color-audit:all`
- `pnpm run theme:visual-contract`
- `git diff --check`

## AI assistance

AI-assisted change. Relevant governance and audit checks passed locally.