### PR TITLE
fix(desktop): restore existing window on taskbar relaunch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ tauri-plugin-autostart = "2.5"
 tauri-plugin-notification = "2.3"
 tauri-plugin-updater = "2.10"
 tauri-plugin-global-shortcut = "2.3"
+tauri-plugin-single-instance = "2.4"
 tauri-build = { version = "2.6", features = [] }
 
 # Desktop support

--- a/src/apps/desktop/Cargo.toml
+++ b/src/apps/desktop/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-autostart = { workspace = true }
 tauri-plugin-notification = { workspace = true }
 tauri-plugin-updater = { workspace = true }
 tauri-plugin-global-shortcut = { workspace = true }
+tauri-plugin-single-instance = { workspace = true }
 # Keep Tauri's transitive time resolution on the known-good release in CI,
 # where the root Cargo.lock is intentionally ignored.
 time = { workspace = true }

--- a/src/apps/desktop/src/api/computer_use_api.rs
+++ b/src/apps/desktop/src/api/computer_use_api.rs
@@ -4,6 +4,7 @@ use crate::api::app_state::AppState;
 use crate::computer_use::DesktopComputerUseHost;
 use bitfun_core::agentic::tools::computer_use_host::ComputerUseHost;
 use bitfun_core::service::config::types::AIConfig;
+use bitfun_core::util::process_manager;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
@@ -82,7 +83,7 @@ pub async fn computer_use_open_system_settings(
             "screen_capture" => "ms-settings:privacy",
             _ => return Err(format!("Unknown settings pane: {}", request.pane)),
         };
-        std::process::Command::new("cmd")
+        process_manager::create_command("cmd")
             .args(["/C", "start", "", uri])
             .status()
             .map_err(|e| e.to_string())?;

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -193,6 +193,59 @@ async fn hide_main_window_after_close_request(app: tauri::AppHandle) -> Result<(
     Ok(())
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+fn show_main_window_for_secondary_launch(
+    app: &tauri::AppHandle,
+    attempt: &str,
+) -> Result<(), String> {
+    let Some(main_window) = app.get_webview_window("main") else {
+        return Err("main window not found".to_string());
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        cancel_main_window_close_request_on_macos();
+        mark_main_window_hidden_on_macos(false);
+    }
+
+    main_window
+        .unminimize()
+        .map_err(|error| format!("failed to unminimize main window: {}", error))?;
+    main_window
+        .show()
+        .map_err(|error| format!("failed to show main window: {}", error))?;
+    main_window
+        .set_focus()
+        .map_err(|error| format!("failed to focus main window: {}", error))?;
+
+    log::info!(
+        "Main window shown from secondary launch: attempt={}",
+        attempt
+    );
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+fn handle_secondary_launch(app: &tauri::AppHandle) {
+    if let Err(error) = show_main_window_for_secondary_launch(app, "immediate") {
+        log::warn!(
+            "Failed to show main window from secondary launch immediately: {}",
+            error
+        );
+
+        let app_handle = app.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            if let Err(error) = show_main_window_for_secondary_launch(&app_handle, "retry") {
+                log::warn!(
+                    "Failed to show main window from secondary launch retry: {}",
+                    error
+                );
+            }
+        });
+    }
+}
+
 #[tauri::command]
 async fn webdriver_bridge_result(request: WebdriverBridgeResultRequest) -> Result<(), String> {
     log::debug!("webdriver_bridge_result command invoked");
@@ -342,7 +395,21 @@ pub async fn run() {
 
     let path_manager = get_path_manager_arc();
 
-    let app = tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+            log::info!(
+                "Existing BitFun Desktop instance received launch request: args_count={}, cwd={}",
+                args.len(),
+                cwd
+            );
+            handle_secondary_launch(app);
+        }));
+    }
+
+    let app = builder
         .plugin(logging::build_log_plugin(log_targets))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src/apps/desktop/src/main.rs
+++ b/src/apps/desktop/src/main.rs
@@ -1,8 +1,6 @@
-// Hide console window in Windows release builds
-#![cfg_attr(
-    all(not(debug_assertions), target_os = "windows"),
-    windows_subsystem = "windows"
-)]
+// Keep secondary launches from flashing a console window before the single-instance
+// plugin redirects them back to the existing desktop process.
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() {


### PR DESCRIPTION
## Summary
- Prevent Windows taskbar relaunch from creating a second desktop instance/tray icon by registering the Tauri single-instance plugin first.
- Restore and focus the existing main window when a secondary launch is received.
- Suppress transient Windows console windows for relaunches and the system-settings command path.

Fixes #1450.

## Verification
- pnpm run fmt:rs
- cargo check -p bitfun-desktop
- cargo test -p bitfun-desktop
- cargo build -p bitfun-desktop