### PR TITLE
feat(web-ui): 为 view_image 工具增加对话内图片预览卡片

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/ViewImageToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ViewImageToolCard.scss
@@ -1,0 +1,87 @@
+.view-image-tool-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+
+  .view-image-tool-card__inline-preview-row {
+    width: 100%;
+    padding: 0 2px 2px;
+  }
+
+  .view-image-tool-card__inline-preview {
+    position: relative;
+    width: 100%;
+    min-height: 120px;
+    max-height: 180px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--border-base);
+    background: var(--element-bg-soft);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      display: block;
+      width: 100%;
+      max-height: 180px;
+      object-fit: contain;
+    }
+  }
+
+  .view-image-tool-card__open-overlay {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: 1px solid var(--border-base);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--color-bg-primary) 88%, transparent);
+    color: var(--color-text-primary);
+    font-size: 12px;
+    line-height: 1.2;
+    cursor: pointer;
+    backdrop-filter: blur(6px);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+
+    &:hover {
+      background: var(--color-bg-primary);
+      border-color: var(--color-accent-500);
+      color: var(--color-accent-600);
+    }
+  }
+
+  .view-image-tool-card__inline-preview--loading,
+  .view-image-tool-card__inline-preview--placeholder,
+  .view-image-tool-card__inline-preview--error {
+    flex-direction: column;
+    gap: 8px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    padding: 16px;
+    text-align: center;
+  }
+
+  .view-image-tool-card__inline-preview--error {
+    color: var(--color-error);
+  }
+
+  .view-image-tool-card__spinner {
+    animation: view-image-tool-card-spin 1s linear infinite;
+  }
+}
+
+@keyframes view-image-tool-card-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/web-ui/src/flow_chat/tool-cards/ViewImageToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ViewImageToolCard.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { ViewImageToolCard } from './ViewImageToolCard';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const messages: Record<string, string> = {
+  'toolCards.viewImage.loading': 'Loading image...',
+  'toolCards.viewImage.loadFailed': 'Failed to load image',
+  'toolCards.viewImage.runtimeUriUnsupported': 'Preview is not available for this runtime artifact path',
+  'copyOutput.openInEditor': 'Open in editor',
+};
+
+const { readFileContent } = vi.hoisted(() => ({
+  readFileContent: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  workspaceAPI: {
+    readFileContent,
+  },
+}));
+
+vi.mock('./DefaultToolCard', () => ({
+  DefaultToolCard: () => <div data-testid="default-tool-card">default-card</div>,
+}));
+
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => messages[key] ?? key,
+    }),
+  };
+});
+
+vi.mock('../../component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const config: ToolCardConfig = {
+  toolName: 'view_image',
+  displayName: 'View Image',
+  icon: 'IMG',
+  requiresConfirmation: false,
+  resultDisplayType: 'detailed',
+  description: 'Attach an image file for model vision',
+  displayMode: 'standard',
+  primaryColor: 'var(--color-accent-600)',
+};
+
+function buildToolItem(overrides: Partial<FlowToolItem> = {}): FlowToolItem {
+  return {
+    id: 'tool-1',
+    type: 'tool',
+    toolName: 'view_image',
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'tool-1',
+      input: { path: '/workspace/screenshots/pixel.png' },
+    },
+    toolResult: {
+      success: true,
+      result: {
+        path: '/workspace/screenshots/pixel.png',
+        mime_type: 'image/png',
+        width: 1,
+        height: 1,
+        size: 128,
+        summary: 'Attached image: /workspace/screenshots/pixel.png',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('ViewImageToolCard', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    readFileContent.mockReset();
+    readFileContent.mockResolvedValue('aGVsbG8=');
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the default tool card header and requests image bytes', () => {
+    act(() => {
+      root.render(
+        <ViewImageToolCard
+          toolItem={buildToolItem()}
+          config={config}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="default-tool-card"]')).not.toBeNull();
+    expect(readFileContent).toHaveBeenCalledWith('/workspace/screenshots/pixel.png');
+    expect(container.querySelector('.view-image-tool-card__inline-preview-row')).not.toBeNull();
+  });
+
+  it('shows an open-in-editor overlay when a handler is provided', () => {
+    const onOpenInEditor = vi.fn();
+
+    act(() => {
+      root.render(
+        <ViewImageToolCard
+          toolItem={buildToolItem()}
+          config={config}
+          onOpenInEditor={onOpenInEditor}
+        />,
+      );
+    });
+
+    const overlay = container.querySelector('.view-image-tool-card__open-overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay?.textContent).toContain('Open in editor');
+
+    act(() => {
+      overlay?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onOpenInEditor).toHaveBeenCalledWith('/workspace/screenshots/pixel.png');
+  });
+
+  it('shows a runtime-uri error without calling readFileContent', async () => {
+    act(() => {
+      root.render(
+        <ViewImageToolCard
+          toolItem={buildToolItem({
+            toolResult: {
+              success: true,
+              result: {
+                path: 'bitfun://runtime/workspace-1/sessions/session-1/tool-previews/tool-1.webp',
+                mime_type: 'image/webp',
+                width: 10,
+                height: 10,
+                size: 100,
+                summary: 'Attached image',
+              },
+            },
+          })}
+          config={config}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(readFileContent).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('Preview is not available for this runtime artifact path');
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/ViewImageToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ViewImageToolCard.tsx
@@ -1,0 +1,199 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ExternalLink, ImageIcon, Loader } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Tooltip } from '@/component-library';
+import { workspaceAPI } from '@/infrastructure/api';
+import { basenamePath, isBitFunRuntimeUri } from '@/shared/utils/pathUtils';
+import type { ToolCardProps } from '../types/flow-chat';
+import { DefaultToolCard } from './DefaultToolCard';
+import './ViewImageToolCard.scss';
+
+function mimeTypeFromPath(path: string): string {
+  const ext = path.toLowerCase().split('.').pop();
+  const mimeTypes: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    bmp: 'image/bmp',
+    webp: 'image/webp',
+    svg: 'image/svg+xml',
+    ico: 'image/x-icon',
+    avif: 'image/avif',
+  };
+  return mimeTypes[ext || ''] || 'image/jpeg';
+}
+
+function resolveImagePath(toolItem: ToolCardProps['toolItem']): string {
+  const inputPath = typeof toolItem.toolCall?.input?.path === 'string'
+    ? toolItem.toolCall.input.path.trim()
+    : '';
+
+  const rawResult = toolItem.toolResult?.result;
+  let result: Record<string, unknown> | null = null;
+  if (typeof rawResult === 'string' && rawResult.trim().length > 0) {
+    try {
+      result = JSON.parse(rawResult) as Record<string, unknown>;
+    } catch {
+      result = null;
+    }
+  } else if (rawResult && typeof rawResult === 'object') {
+    result = rawResult as Record<string, unknown>;
+  }
+
+  if (typeof result?.path === 'string' && result.path.trim().length > 0) {
+    return result.path.trim();
+  }
+
+  return inputPath;
+}
+
+export const ViewImageToolCard: React.FC<ToolCardProps> = ({
+  toolItem,
+  config,
+  onOpenInEditor,
+  onExpand,
+  onOpenInPanel,
+  sessionId,
+  displayContext,
+  interruptionNote,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const { status } = toolItem;
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [loadState, setLoadState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const imagePath = useMemo(() => resolveImagePath(toolItem), [toolItem]);
+  const fileName = useMemo(() => basenamePath(imagePath) || imagePath, [imagePath]);
+  const mimeType = imagePath ? mimeTypeFromPath(imagePath) : 'image/jpeg';
+  const showInlinePreview = status === 'completed' && Boolean(imagePath);
+  const canOpenInEditor = showInlinePreview && Boolean(onOpenInEditor) && !isBitFunRuntimeUri(imagePath);
+
+  useEffect(() => {
+    if (status !== 'completed' || !imagePath) {
+      setImageUrl(null);
+      setLoadState('idle');
+      setLoadError(null);
+      return;
+    }
+
+    if (isBitFunRuntimeUri(imagePath)) {
+      setImageUrl(null);
+      setLoadState('error');
+      setLoadError(t('toolCards.viewImage.runtimeUriUnsupported'));
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadImage = async () => {
+      setLoadState('loading');
+      setLoadError(null);
+      setImageUrl(null);
+
+      try {
+        const base64Content = await workspaceAPI.readFileContent(imagePath);
+        if (cancelled) return;
+
+        setImageUrl(`data:${mimeType};base64,${base64Content}`);
+        setLoadState('loaded');
+      } catch (error) {
+        if (cancelled) return;
+        setLoadState('error');
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : t('toolCards.viewImage.loadFailed'),
+        );
+      }
+    };
+
+    void loadImage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imagePath, mimeType, status, t]);
+
+  const handleOpenInEditor = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (imagePath && onOpenInEditor) {
+      onOpenInEditor(imagePath);
+    }
+  }, [imagePath, onOpenInEditor]);
+
+  const renderInlinePreview = () => {
+    const openOverlay = canOpenInEditor && loadState !== 'error' ? (
+      <Tooltip content={t('copyOutput.openInEditor')}>
+        <button
+          type="button"
+          className="view-image-tool-card__open-overlay"
+          onClick={handleOpenInEditor}
+          aria-label={t('copyOutput.openInEditor')}
+        >
+          <ExternalLink size={14} />
+          <span>{t('copyOutput.openInEditor')}</span>
+        </button>
+      </Tooltip>
+    ) : null;
+
+    if (loadState === 'loading') {
+      return (
+        <div className="view-image-tool-card__inline-preview view-image-tool-card__inline-preview--loading">
+          {openOverlay}
+          <Loader size={22} className="view-image-tool-card__spinner" />
+          <span>{t('toolCards.viewImage.loading')}</span>
+        </div>
+      );
+    }
+
+    if (loadState === 'error') {
+      return (
+        <div className="view-image-tool-card__inline-preview view-image-tool-card__inline-preview--error">
+          {loadError || t('toolCards.viewImage.loadFailed')}
+        </div>
+      );
+    }
+
+    if (imageUrl) {
+      return (
+        <div className="view-image-tool-card__inline-preview">
+          {openOverlay}
+          <img src={imageUrl} alt={fileName} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="view-image-tool-card__inline-preview view-image-tool-card__inline-preview--placeholder">
+        {openOverlay}
+        <ImageIcon size={28} />
+      </div>
+    );
+  };
+
+  return (
+    <div data-testid="view-image-tool-card" className="view-image-tool-card">
+      <DefaultToolCard
+        toolItem={toolItem}
+        config={config}
+        onExpand={onExpand}
+        onOpenInEditor={onOpenInEditor}
+        onOpenInPanel={onOpenInPanel}
+        sessionId={sessionId}
+        displayContext={displayContext}
+        interruptionNote={interruptionNote}
+      />
+
+      {showInlinePreview && (
+        <div className="view-image-tool-card__inline-preview-row">
+          {renderInlinePreview()}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ViewImageToolCard;

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -52,6 +52,7 @@ import { ReviewSessionSummaryCard } from './ReviewSessionSummaryCard';
 import { SessionControlToolCard } from './SessionControlToolCard';
 import { SessionMessageToolCard } from './SessionMessageToolCard';
 import { ComputerUseToolCard } from './ComputerUseToolCard';
+import { ViewImageToolCard } from './ViewImageToolCard';
 
 // Tool card component map - uses backend tool names
 export const TOOL_CARD_COMPONENTS = {
@@ -120,6 +121,9 @@ export const TOOL_CARD_COMPONENTS = {
 
   // Computer use (desktop automation)
   'ComputerUse': ComputerUseToolCard,
+
+  // Multimodal image viewing
+  'view_image': ViewImageToolCard,
 
   // BitFun Canvas tools
   'CreateCanvas': CanvasToolCard,

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1642,6 +1642,11 @@
       "readingFile": "Reading",
       "preparingRead": "Preparing to read"
     },
+    "viewImage": {
+      "loading": "Loading image...",
+      "loadFailed": "Failed to load image",
+      "runtimeUriUnsupported": "Preview is not available for this runtime artifact path"
+    },
     "terminalControl": {
       "terminatingSession": "Terminating terminal",
       "sessionKilled": "Terminal killed",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1642,6 +1642,11 @@
       "readingFile": "正在读取",
       "preparingRead": "准备读取"
     },
+    "viewImage": {
+      "loading": "正在加载图片...",
+      "loadFailed": "图片加载失败",
+      "runtimeUriUnsupported": "暂不支持预览此运行时产物路径"
+    },
     "terminalControl": {
       "terminatingSession": "正在终止终端",
       "sessionKilled": "终端已终止",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1642,6 +1642,11 @@
       "readingFile": "正在讀取",
       "preparingRead": "準備讀取"
     },
+    "viewImage": {
+      "loading": "正在載入圖片...",
+      "loadFailed": "圖片載入失敗",
+      "runtimeUriUnsupported": "暫不支援預覽此執行階段產物路徑"
+    },
     "terminalControl": {
       "terminatingSession": "正在終止終端",
       "sessionKilled": "終端已終止",


### PR DESCRIPTION
让 view_image 的执行结果在 Flow Chat 中可见：复用默认工具卡片展示头部，
并在下方懒加载图片预览，支持右上角在编辑器中打开。

<img width="2660" height="990" alt="image" src="https://github.com/user-attachments/assets/9160c6c3-4a56-4b9c-9c86-0996307235ef" />


## Summary

<!-- Briefly describe what changed. -->

Fixes #1490

## Type and Areas

Type: Feature

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas: web UI

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

