### PR TITLE
refactor: simplify low-risk Rust lint findings

### DIFF
--- a/scripts/generate-i18n-contract.mjs
+++ b/scripts/generate-i18n-contract.mjs
@@ -492,13 +492,12 @@ pub fn generated_locale_entry_from_code(
             for entry in GENERATED_LOCALE_CONTRACT {
                 for alias in entry.aliases {
                     let alias = alias.to_ascii_lowercase();
-                    if normalized == alias || normalized.starts_with(&format!("{alias}-")) {
-                        if best_match
+                    if (normalized == alias || normalized.starts_with(&format!("{alias}-")))
+                        && best_match
                             .map(|(_, current_len)| alias.len() > current_len)
                             .unwrap_or(true)
-                        {
-                            best_match = Some((entry, alias.len()));
-                        }
+                    {
+                        best_match = Some((entry, alias.len()));
                     }
                 }
             }

--- a/src/apps/cli/src/chat_state.rs
+++ b/src/apps/cli/src/chat_state.rs
@@ -756,17 +756,15 @@ impl ChatState {
                 }
                 _ => {}
             },
-            AgenticEvent::ModelRoundStarted { round_index, .. } => {
-                if *round_index > 0 {
-                    self.update_tool(parent_tool_id, |tool| {
-                        let progress = tool
-                            .subagent_progress
-                            .get_or_insert_with(SubagentProgress::default);
-                        progress.current_tool_name = None;
-                        progress.current_tool_title = Some(format!("Round {}", round_index + 1));
-                    });
-                    self.rebuild_streaming_message();
-                }
+            AgenticEvent::ModelRoundStarted { round_index, .. } if *round_index > 0 => {
+                self.update_tool(parent_tool_id, |tool| {
+                    let progress = tool
+                        .subagent_progress
+                        .get_or_insert_with(SubagentProgress::default);
+                    progress.current_tool_name = None;
+                    progress.current_tool_title = Some(format!("Round {}", round_index + 1));
+                });
+                self.rebuild_streaming_message();
             }
             _ => {}
         }

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -507,15 +507,12 @@ async fn run_interactive(
     );
     let startup_result = startup_page.run(&mut terminal)?;
 
-    match startup_result {
-        StartupResult::Exit => {
-            shutdown_mcp_servers().await;
-            restore_tool_confirmation(original_skip_confirmation).await;
-            ui::restore_terminal(terminal)?;
-            println!("Goodbye!");
-            return Ok(());
-        }
-        _ => {}
+    if let StartupResult::Exit = startup_result {
+        shutdown_mcp_servers().await;
+        restore_tool_confirmation(original_skip_confirmation).await;
+        ui::restore_terminal(terminal)?;
+        println!("Goodbye!");
+        return Ok(());
     }
 
     // 5. Parse startup result and enter chat

--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -332,7 +332,7 @@ impl ChatMode {
 
                     let state = ChatState::from_core_messages(
                         rid.clone(),
-                        format!("Restored Session"),
+                        "Restored Session".to_string(),
                         agent_type,
                         effective_workspace,
                         &messages,
@@ -356,7 +356,7 @@ impl ChatMode {
 
             let state = ChatState::new(
                 session_id.clone(),
-                format!("CLI Session"),
+                "CLI Session".to_string(),
                 self.agent_type.clone(),
                 self.workspace.clone(),
             );
@@ -1354,10 +1354,10 @@ impl ChatMode {
                 }
             }
 
-            (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
-                if !c.is_control() && c != '\u{0}' {
-                    chat_view.handle_char(c);
-                }
+            (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT)
+                if !c.is_control() && c != '\u{0}' =>
+            {
+                chat_view.handle_char(c);
             }
 
             _ => {}
@@ -1492,10 +1492,10 @@ impl ChatMode {
                                 MouseGestureOutcome::None => {}
                             }
                         }
-                        MouseEventKind::Moved => {
-                            if !chat_view.update_mouse_selection(mouse.column, mouse.row) {
-                                chat_view.handle_mouse_move(mouse.column, mouse.row);
-                            }
+                        MouseEventKind::Moved
+                            if !chat_view.update_mouse_selection(mouse.column, mouse.row) =>
+                        {
+                            chat_view.handle_mouse_move(mouse.column, mouse.row);
                         }
                         _ => {}
                     }
@@ -2410,9 +2410,7 @@ impl ChatMode {
             changed = true;
             match task {
                 PendingMcpTask::Toggle { server_id, handle } => {
-                    let join_result = tokio::task::block_in_place(|| {
-                        rt_handle.block_on(async move { handle.await })
-                    });
+                    let join_result = tokio::task::block_in_place(|| rt_handle.block_on(handle));
 
                     match join_result {
                         Ok(Ok(())) => {}
@@ -2437,9 +2435,7 @@ impl ChatMode {
                     chat_view.mcp_selector_update_items(updated_items);
                 }
                 PendingMcpTask::Add { name, handle } => {
-                    let join_result = tokio::task::block_in_place(|| {
-                        rt_handle.block_on(async move { handle.await })
-                    });
+                    let join_result = tokio::task::block_in_place(|| rt_handle.block_on(handle));
 
                     match join_result {
                         Ok(Ok(())) => {
@@ -2463,9 +2459,7 @@ impl ChatMode {
                     chat_view.set_status(None);
                 }
                 PendingMcpTask::Delete { server_id, handle } => {
-                    let join_result = tokio::task::block_in_place(|| {
-                        rt_handle.block_on(async move { handle.await })
-                    });
+                    let join_result = tokio::task::block_in_place(|| rt_handle.block_on(handle));
 
                     match join_result {
                         Ok(Ok(())) => {

--- a/src/apps/cli/src/modes/exec.rs
+++ b/src/apps/cli/src/modes/exec.rs
@@ -180,13 +180,12 @@ impl ExecMode {
             "Executing command"
         );
 
-        let session_id = self.prepare_session().await.map_err(|error| {
+        let session_id = self.prepare_session().await.inspect_err(|error| {
             emit_exit_diagnostic(
                 ExitKind::SessionCreateFailed,
                 &error.to_string(),
                 &self.exit_context(None, None),
             );
-            error
         })?;
         tracing::info!(session_id = %session_id, "Session ready");
         let event_queue = self.agent.event_queue().clone();
@@ -207,13 +206,12 @@ impl ExecMode {
             .agent
             .send_message(self.message.clone(), &self.agent_type)
             .await
-            .map_err(|error| {
+            .inspect_err(|error| {
                 emit_exit_diagnostic(
                     ExitKind::SendMessageFailed,
                     &error.to_string(),
                     &self.exit_context(Some(&session_id), None),
                 );
-                error
             })?;
         tracing::info!(session_id = %session_id, turn_id = %turn_id, "Message sent");
 

--- a/src/apps/cli/src/root_handlers.rs
+++ b/src/apps/cli/src/root_handlers.rs
@@ -50,7 +50,7 @@ pub(crate) async fn handle_exec_command(config: CliConfig, args: ExecCommandArgs
     let (agentic_system, original_skip_confirmation) =
         crate::initialize_core_services(skip_confirmation)
             .await
-            .map_err(|error| {
+            .inspect_err(|error| {
                 emit_exit_diagnostic(
                     ExitKind::ExecError,
                     &error.to_string(),
@@ -60,7 +60,6 @@ pub(crate) async fn handle_exec_command(config: CliConfig, args: ExecCommandArgs
                         ..Default::default()
                     },
                 );
-                error
             })?;
 
     let mut exec_mode = ExecMode::new(

--- a/src/apps/cli/src/ui/agent_selector.rs
+++ b/src/apps/cli/src/ui/agent_selector.rs
@@ -135,7 +135,7 @@ impl AgentSelectorState {
                 let is_current = self
                     .current_agent_id
                     .as_ref()
-                    .map_or(false, |id| id == &agent.id);
+                    .is_some_and(|id| id == &agent.id);
 
                 let marker = if is_current { "● " } else { "  " };
                 let marker_style = if is_current {

--- a/src/apps/cli/src/ui/chat.rs
+++ b/src/apps/cli/src/ui/chat.rs
@@ -3,9 +3,9 @@
 //! This module is split across multiple files under `ui/chat/` to keep individual files manageable.
 
 include!("chat/state.rs");
-include!("chat/render.rs");
 include!("chat/tools.rs");
 include!("chat/input.rs");
 include!("chat/popups.rs");
 include!("chat/scroll.rs");
 include!("chat/mouse.rs");
+include!("chat/render.rs");

--- a/src/apps/cli/src/ui/chat/render.rs
+++ b/src/apps/cli/src/ui/chat/render.rs
@@ -45,7 +45,8 @@ impl ChatView {
         let input_height = content_lines + 2; // +2 for top/bottom borders
 
         // Calculate shortcuts area height based on content
-        let shortcuts_height = Self::calculate_shortcuts_height(size.width, chat_state, self.browse_mode);
+        let shortcuts_height =
+            Self::calculate_shortcuts_height(size.width, chat_state, self.browse_mode);
         // Status area can grow for long status messages to avoid horizontal truncation.
         let raw_status_height =
             Self::calculate_status_height(size.width, chat_state, self.status.as_deref());
@@ -60,10 +61,10 @@ impl ChatView {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3),            // header
-                Constraint::Min(10),              // messages area
-                Constraint::Length(status_height), // status bar (dynamic)
-                Constraint::Length(input_height), // input area (dynamic)
+                Constraint::Length(3),                // header
+                Constraint::Min(10),                  // messages area
+                Constraint::Length(status_height),    // status bar (dynamic)
+                Constraint::Length(input_height),     // input area (dynamic)
                 Constraint::Length(shortcuts_height), // shortcuts hint (dynamic)
             ])
             .split(size);
@@ -145,7 +146,7 @@ impl ChatView {
 
     fn render_messages(&mut self, frame: &mut Frame, area: Rect, chat_state: &ChatState) {
         let title = if self.browse_mode {
-            format!(" Conversation [Browse Mode \u{2195}] ")
+            " Conversation [Browse Mode \u{2195}] ".to_string()
         } else {
             " Conversation ".to_string()
         };
@@ -281,7 +282,8 @@ impl ChatView {
                 total_lines.saturating_sub(visible_lines)
             };
 
-            let view_end_line = (view_start_line + visible_lines + visible_lines / 2).min(total_lines); // buffer: render half a screen extra
+            let view_end_line =
+                (view_start_line + visible_lines + visible_lines / 2).min(total_lines); // buffer: render half a screen extra
 
             // ── Step 4: Binary search for visible message range ──
             // Find first message that overlaps [view_start_line, view_end_line)
@@ -323,8 +325,8 @@ impl ChatView {
                             y_cursor.saturating_add(*y_end),
                         ));
                     }
-                    y_cursor = y_cursor
-                        .saturating_add(entry.items.len().min(u16::MAX as usize) as u16);
+                    y_cursor =
+                        y_cursor.saturating_add(entry.items.len().min(u16::MAX as usize) as u16);
                 }
             }
 
@@ -355,7 +357,8 @@ impl ChatView {
                     selected_in_subset.min(messages.len().saturating_sub(1)),
                 ));
             } else if self.auto_scroll {
-                self.list_state.select(Some(messages.len().saturating_sub(1)));
+                self.list_state
+                    .select(Some(messages.len().saturating_sub(1)));
                 self.scroll_offset = 0;
             }
 
@@ -394,7 +397,11 @@ impl ChatView {
 
     /// Render a single message into a list of owned ListItems.
     /// Returns owned items plus message-local clickable regions so results can be cached across frames.
-    fn render_message(&mut self, message: &ChatMessage, available_width: u16) -> MessageRenderResult {
+    fn render_message(
+        &mut self,
+        message: &ChatMessage,
+        available_width: u16,
+    ) -> MessageRenderResult {
         let mut items: Vec<ListItem<'static>> = Vec::new();
         let mut plain_lines: Vec<String> = Vec::new();
         let mut tool_regions: Vec<(String, u16, u16)> = Vec::new();
@@ -487,7 +494,10 @@ impl ChatView {
         if !message.flow_items.is_empty() {
             for flow_item in &message.flow_items {
                 match flow_item {
-                    FlowItem::Text { content, is_streaming } => {
+                    FlowItem::Text {
+                        content,
+                        is_streaming,
+                    } => {
                         if message.role == MessageRole::Assistant
                             && MarkdownRenderer::has_markdown_syntax(content)
                         {
@@ -529,8 +539,7 @@ impl ChatView {
                             }
                             for line in content.lines() {
                                 if message.role == MessageRole::User {
-                                    let max_text_width =
-                                        available_width.saturating_sub(3) as usize;
+                                    let max_text_width = available_width.saturating_sub(3) as usize;
                                     let wrapped = wrap_hard_display_width(line, max_text_width);
                                     if !user_bubble_open {
                                         items.push(user_padding_line(
@@ -557,8 +566,7 @@ impl ChatView {
                                         plain_lines.push(plain);
                                     }
                                 } else {
-                                    let max_text_width =
-                                        available_width.saturating_sub(2) as usize;
+                                    let max_text_width = available_width.saturating_sub(2) as usize;
                                     for wrapped_line in
                                         wrap_hard_display_width(line, max_text_width)
                                     {
@@ -576,20 +584,14 @@ impl ChatView {
                         if *is_streaming {
                             if message.role == MessageRole::User {
                                 if !user_bubble_open {
-                                    items.push(user_padding_line(
-                                        user_bg_style,
-                                        user_border_style,
-                                    ));
+                                    items.push(user_padding_line(user_bg_style, user_border_style));
                                     plain_lines.push(" | ".to_string());
                                     user_bubble_open = true;
                                 }
                                 items.push(
                                     ListItem::new(Line::from(vec![
                                         Span::raw(" ".to_string()),
-                                        Span::styled(
-                                            "\u{258f}".to_string(),
-                                            user_border_style,
-                                        ), // ▏
+                                        Span::styled("\u{258f}".to_string(), user_border_style), // ▏
                                         Span::raw(" ".to_string()),
                                         Span::styled(
                                             "\u{2588}".to_string(),
@@ -636,7 +638,8 @@ impl ChatView {
                             && !self.thinking_auto_collapsed.contains(&thinking_block_id)
                         {
                             self.collapsed_thinking.insert(thinking_block_id.clone());
-                            self.thinking_auto_collapsed.insert(thinking_block_id.clone());
+                            self.thinking_auto_collapsed
+                                .insert(thinking_block_id.clone());
                         }
 
                         let collapsed = self.collapsed_thinking.contains(&thinking_block_id);
@@ -693,19 +696,14 @@ impl ChatView {
                             ])));
                             plain_lines.push("    (empty)".to_string());
                         } else {
-                            let thinking_max_width =
-                                available_width.saturating_sub(4) as usize; // 4 = indent "    "
+                            let thinking_max_width = available_width.saturating_sub(4) as usize; // 4 = indent "    "
                             for line in content_lines {
-                                let wrapped =
-                                    wrap_hard_display_width(line, thinking_max_width);
+                                let wrapped = wrap_hard_display_width(line, thinking_max_width);
                                 for wl in wrapped {
                                     let plain = format!("    {}", wl);
                                     items.push(ListItem::new(Line::from(vec![
                                         Span::raw("    ".to_string()),
-                                        Span::styled(
-                                            wl,
-                                            self.theme.style(StyleKind::Muted),
-                                        ),
+                                        Span::styled(wl, self.theme.style(StyleKind::Muted)),
                                     ])));
                                     plain_lines.push(plain);
                                 }
@@ -738,10 +736,7 @@ impl ChatView {
                         let y_start = items.len().min(u16::MAX as usize) as u16;
                         items.extend(tool_render.items);
                         plain_lines.extend(tool_render.plain_lines);
-                        let y_end = items
-                            .len()
-                            .saturating_sub(1)
-                            .min(u16::MAX as usize) as u16;
+                        let y_end = items.len().saturating_sub(1).min(u16::MAX as usize) as u16;
                         tool_regions.push((tool_state.tool_id.clone(), y_start, y_end));
                     }
                 }
@@ -783,8 +778,8 @@ impl ChatView {
             let loading_text = format!(" {} Thinking...", self.spinner.current());
             let stats_text = format!("Tokens: {} ", chat_state.metadata.total_tokens);
 
-            let padding_len = (area.width as usize)
-                .saturating_sub(loading_text.len() + stats_text.len());
+            let padding_len =
+                (area.width as usize).saturating_sub(loading_text.len() + stats_text.len());
 
             let loading_span = Span::styled(loading_text, self.theme.style(StyleKind::Primary));
             let stats_span = Span::styled(stats_text, self.theme.style(StyleKind::Muted));
@@ -839,7 +834,8 @@ impl ChatView {
             placeholder_style: self.theme.style(StyleKind::Muted),
         };
 
-        self.text_input.render(frame, inner, &style, !chat_state.is_processing);
+        self.text_input
+            .render(frame, inner, &style, !chat_state.is_processing);
     }
 
     fn render_command_menu(&mut self, frame: &mut Frame, area: Rect) {
@@ -935,7 +931,11 @@ impl ChatView {
     }
 
     /// Calculate the required height for the shortcuts area
-    fn calculate_shortcuts_height(available_width: u16, chat_state: &ChatState, browse_mode: bool) -> u16 {
+    fn calculate_shortcuts_height(
+        available_width: u16,
+        chat_state: &ChatState,
+        browse_mode: bool,
+    ) -> u16 {
         let mode_text = if browse_mode { " Browse " } else { " Chat " };
         let left_text = format!("{} | Model: {}", mode_text, chat_state.current_model_name);
 

--- a/src/apps/cli/src/ui/command_menu.rs
+++ b/src/apps/cli/src/ui/command_menu.rs
@@ -216,11 +216,10 @@ impl CommandMenuState {
         let Some(area) = self.last_area else {
             return false;
         };
-        let in_menu = mouse.column >= area.x
+        mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)
             && mouse.row >= area.y
-            && mouse.row < area.y.saturating_add(area.height);
-        in_menu
+            && mouse.row < area.y.saturating_add(area.height)
     }
 
     fn selected_item(&self) -> Option<&CommandSpec> {

--- a/src/apps/cli/src/ui/diff_render.rs
+++ b/src/apps/cli/src/ui/diff_render.rs
@@ -152,8 +152,8 @@ fn render_unified<'a>(
     for &idx in &changed_indices {
         let start = idx.saturating_sub(context_size);
         let end = (idx + context_size + 1).min(entries.len());
-        for i in start..end {
-            visible[i] = true;
+        for is_visible in &mut visible[start..end] {
+            *is_visible = true;
         }
     }
 
@@ -389,8 +389,8 @@ fn render_split<'a>(
     for &idx in &changed_indices {
         let start = idx.saturating_sub(context_size);
         let end = (idx + context_size + 1).min(entries.len());
-        for i in start..end {
-            visible[i] = true;
+        for is_visible in &mut visible[start..end] {
+            *is_visible = true;
         }
     }
 

--- a/src/apps/cli/src/ui/markdown.rs
+++ b/src/apps/cli/src/ui/markdown.rs
@@ -332,7 +332,7 @@ impl MarkdownRenderer {
         }
 
         // Remove trailing empty lines
-        while lines.last().map_or(false, |line| {
+        while lines.last().is_some_and(|line| {
             line.spans.is_empty() || (line.spans.len() == 1 && line.spans[0].content.is_empty())
         }) {
             lines.pop();

--- a/src/apps/cli/src/ui/mcp_selector.rs
+++ b/src/apps/cli/src/ui/mcp_selector.rs
@@ -185,10 +185,8 @@ impl McpSelectorState {
             .items
             .iter()
             .map(|item| {
-                let is_loading = loading_id.as_ref().map_or(false, |id| id == &item.id);
-                let is_confirm_delete = confirm_delete_id
-                    .as_ref()
-                    .map_or(false, |id| id == &item.id);
+                let is_loading = loading_id.as_ref().is_some_and(|id| id == &item.id);
+                let is_confirm_delete = confirm_delete_id.as_ref().is_some_and(|id| id == &item.id);
 
                 // If this item is pending delete confirmation, show special style
                 if is_confirm_delete {

--- a/src/apps/cli/src/ui/model_config_form.rs
+++ b/src/apps/cli/src/ui/model_config_form.rs
@@ -440,15 +440,15 @@ impl ModelConfigFormState {
             return Some("Max tokens must be a number".into());
         }
         // Validate JSON fields if non-empty
-        if !self.custom_headers.trim().is_empty() {
-            if serde_json::from_str::<serde_json::Value>(self.custom_headers.trim()).is_err() {
-                return Some("Custom headers must be valid JSON".into());
-            }
+        if !self.custom_headers.trim().is_empty()
+            && serde_json::from_str::<serde_json::Value>(self.custom_headers.trim()).is_err()
+        {
+            return Some("Custom headers must be valid JSON".into());
         }
-        if !self.custom_request_body.trim().is_empty() {
-            if serde_json::from_str::<serde_json::Value>(self.custom_request_body.trim()).is_err() {
-                return Some("Custom request body must be valid JSON".into());
-            }
+        if !self.custom_request_body.trim().is_empty()
+            && serde_json::from_str::<serde_json::Value>(self.custom_request_body.trim()).is_err()
+        {
+            return Some("Custom request body must be valid JSON".into());
         }
         None
     }

--- a/src/apps/cli/src/ui/model_selector.rs
+++ b/src/apps/cli/src/ui/model_selector.rs
@@ -141,7 +141,7 @@ impl ModelSelectorState {
                 let is_current = self
                     .current_model_id
                     .as_ref()
-                    .map_or(false, |id| id == &model.id);
+                    .is_some_and(|id| id == &model.id);
 
                 let marker = if is_current { "● " } else { "  " };
                 let marker_style = if is_current {

--- a/src/apps/cli/src/ui/provider_selector.rs
+++ b/src/apps/cli/src/ui/provider_selector.rs
@@ -433,7 +433,7 @@ impl ProviderSelectorState {
                     let is_selected = self
                         .selectable_row_indices
                         .get(self.selected)
-                        .map_or(false, |&ri| ri == row_idx);
+                        .is_some_and(|&ri| ri == row_idx);
 
                     self.render_item_row(
                         frame,
@@ -448,7 +448,7 @@ impl ProviderSelectorState {
                     let is_selected = self
                         .selectable_row_indices
                         .get(self.selected)
-                        .map_or(false, |&ri| ri == row_idx);
+                        .is_some_and(|&ri| ri == row_idx);
 
                     self.render_item_row(
                         frame,

--- a/src/apps/cli/src/ui/session_selector.rs
+++ b/src/apps/cli/src/ui/session_selector.rs
@@ -266,7 +266,7 @@ impl SessionSelectorState {
                 let is_current = self
                     .current_session_id
                     .as_ref()
-                    .map_or(false, |id| id == &session.session_id);
+                    .is_some_and(|id| id == &session.session_id);
 
                 let marker = if is_current { "● " } else { "  " };
                 let marker_style = if is_current {

--- a/src/apps/cli/src/ui/startup.rs
+++ b/src/apps/cli/src/ui/startup.rs
@@ -738,12 +738,9 @@ impl StartupPage {
 
         // ── Global popup navigation: Ctrl+W closes all popups ──
         if self.any_popup_visible() {
-            match (key.code, key.modifiers) {
-                (KeyCode::Char('w'), KeyModifiers::CONTROL) => {
-                    self.close_all_popups();
-                    return None;
-                }
-                _ => {}
+            if let (KeyCode::Char('w'), KeyModifiers::CONTROL) = (key.code, key.modifiers) {
+                self.close_all_popups();
+                return None;
             }
         }
 

--- a/src/apps/cli/src/ui/theme.rs
+++ b/src/apps/cli/src/ui/theme.rs
@@ -78,7 +78,7 @@ pub(crate) fn resolve_effective_color_scheme(preference: &str) -> EffectiveColor
         "mono" | "monochrome" | "nocolor" | "no_color" => EffectiveColorScheme::Monochrome,
         "ansi" | "ansi16" => EffectiveColorScheme::Ansi16,
         "truecolor" | "24bit" => EffectiveColorScheme::Truecolor,
-        "" | "default" | "auto" | _ => {
+        _ => {
             if terminal_supports_truecolor() {
                 EffectiveColorScheme::Truecolor
             } else {

--- a/src/apps/cli/src/ui/theme_selector.rs
+++ b/src/apps/cli/src/ui/theme_selector.rs
@@ -128,10 +128,7 @@ impl ThemeSelectorState {
             .items
             .iter()
             .map(|t| {
-                let is_current = self
-                    .current_theme_id
-                    .as_ref()
-                    .map_or(false, |id| id == &t.id);
+                let is_current = self.current_theme_id.as_ref().is_some_and(|id| id == &t.id);
 
                 let marker = if is_current { "● " } else { "  " };
                 let marker_style = if is_current {
@@ -176,11 +173,10 @@ impl ThemeSelectorState {
         let Some(area) = self.last_area else {
             return false;
         };
-        let in_popup = mouse.column >= area.x
+        mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)
             && mouse.row >= area.y
-            && mouse.row < area.y.saturating_add(area.height);
-        in_popup
+            && mouse.row < area.y.saturating_add(area.height)
     }
 
     pub(super) fn handle_mouse_event(&mut self, mouse: &MouseEvent) -> Option<ThemeItem> {

--- a/src/apps/cli/src/ui/tool_cards.rs
+++ b/src/apps/cli/src/ui/tool_cards.rs
@@ -1167,7 +1167,7 @@ fn render_edit_block(
         let total_changes = additions + deletions;
         if total_changes > max && !expanded {
             content_lines.push(Line::from(Span::styled(
-                format!("\u{2026} (more changes, Ctrl+O to expand)"),
+                "\u{2026} (more changes, Ctrl+O to expand)".to_string(),
                 theme.style(StyleKind::Muted),
             )));
         } else if expanded && total_changes > 8 {

--- a/src/apps/desktop/src/api/browser_control_api.rs
+++ b/src/apps/desktop/src/api/browser_control_api.rs
@@ -112,7 +112,7 @@ pub async fn browser_control_get_status(
         // Identify the actual browser from CDP version response.
         let kind = ver
             .as_deref()
-            .and_then(|v| BrowserLauncher::browser_kind_from_cdp_version(v))
+            .and_then(BrowserLauncher::browser_kind_from_cdp_version)
             .unwrap_or_else(|| configured_kind.clone());
         // Only count targets of type "page" (real browser tabs),
         // not service workers, browser targets, etc.

--- a/src/apps/desktop/src/api/canvas_api.rs
+++ b/src/apps/desktop/src/api/canvas_api.rs
@@ -159,7 +159,7 @@ pub async fn report_canvas_runtime_error(
             .push_str(&format!(" (source revision: {})", source_revision));
     }
     if let Some(stack) = request.stack.as_deref().filter(|value| !value.is_empty()) {
-        diagnostic.message.push_str("\n");
+        diagnostic.message.push('\n');
         diagnostic.message.push_str(stack);
     }
     let snapshot = service

--- a/src/apps/desktop/src/api/clipboard_file_api.rs
+++ b/src/apps/desktop/src/api/clipboard_file_api.rs
@@ -97,7 +97,7 @@ fn parse_uri_list(content: &str) -> Vec<String> {
 #[cfg(any(target_os = "macos", test))]
 fn parse_clipboard_path_segments(content: &str) -> Vec<String> {
     content
-        .split(|c| c == '\n' || c == '\r')
+        .split(['\n', '\r'])
         .flat_map(|segment| segment.split(','))
         .map(str::trim)
         .filter(|segment| !segment.is_empty())

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -969,7 +969,7 @@ async fn apply_active_workspace_context(
     }
 
     let step_started = Instant::now();
-    spawn_workspace_background_warmup(&*state, workspace_info.clone());
+    spawn_workspace_background_warmup(state, workspace_info.clone());
     if let Some(trace) = startup_trace {
         trace.record_elapsed_step(
             "tauri_command",
@@ -1045,7 +1045,7 @@ async fn initialize_global_state_impl(
 
     if let Some(workspace_info) = current_workspace {
         let step_started = Instant::now();
-        apply_active_workspace_context(&state, &app, &workspace_info, Some(trace)).await;
+        apply_active_workspace_context(state, app, &workspace_info, Some(trace)).await;
         trace.record_elapsed_step(
             "tauri_command",
             "initialize_global_state.apply_active_workspace_context",
@@ -1059,7 +1059,7 @@ async fn initialize_global_state_impl(
         );
     } else {
         let step_started = Instant::now();
-        clear_active_workspace_context(&state, &app, Some(trace)).await;
+        clear_active_workspace_context(state, app, Some(trace)).await;
         trace.record_elapsed_step(
             "tauri_command",
             "initialize_global_state.clear_active_workspace_context",
@@ -2081,12 +2081,12 @@ async fn initialize_workspace_startup_state_impl(
 ) -> Result<WorkspaceStartupStateSnapshotDto, String> {
     let trace = startup_trace.inner();
 
-    initialize_global_state_impl(&state, &app, trace).await;
+    initialize_global_state_impl(state, app, trace).await;
 
     let cleanup_removed_count = match cleanup_invalid_workspaces_impl(
-        &state,
-        &app,
-        &startup_trace,
+        state,
+        app,
+        startup_trace,
         "initialize_workspace_startup_state.cleanup_invalid_workspaces",
         None,
         command_started,
@@ -2100,7 +2100,7 @@ async fn initialize_workspace_startup_state_impl(
     };
 
     let snapshot_started = Instant::now();
-    let snapshot = collect_workspace_state_snapshot(&state).await;
+    let snapshot = collect_workspace_state_snapshot(state).await;
     startup_trace.record_elapsed_step(
         "tauri_command",
         "initialize_workspace_startup_state.collect_workspace_state_snapshot",
@@ -2143,9 +2143,9 @@ async fn cleanup_invalid_workspaces_impl(
 
             let apply_context_started = Instant::now();
             if let Some(workspace_info) = state.workspace_service.get_current_workspace().await {
-                apply_active_workspace_context(&state, &app, &workspace_info, None).await;
+                apply_active_workspace_context(state, app, &workspace_info, None).await;
             } else {
-                clear_active_workspace_context(&state, &app, None).await;
+                clear_active_workspace_context(state, app, None).await;
             }
             startup_trace.record_elapsed_step(
                 "tauri_command",

--- a/src/apps/desktop/src/api/remote_connect_api.rs
+++ b/src/apps/desktop/src/api/remote_connect_api.rs
@@ -375,11 +375,14 @@ fn detect_interface_gateways() -> HashMap<String, String> {
                 // Column 3 = gateway, column 4 = interface IP
                 for line in stdout.lines() {
                     let parts: Vec<&str> = line.split_whitespace().collect();
-                    if parts.len() >= 4 && parts[0] == "0.0.0.0" && parts[1] == "0.0.0.0" {
-                        if is_ipv4(parts[2]) && is_ipv4(parts[3]) {
-                            // Key by interface IP so it can be matched later
-                            map.insert(parts[3].to_string(), parts[2].to_string());
-                        }
+                    if parts.len() >= 4
+                        && parts[0] == "0.0.0.0"
+                        && parts[1] == "0.0.0.0"
+                        && is_ipv4(parts[2])
+                        && is_ipv4(parts[3])
+                    {
+                        // Key by interface IP so it can be matched later
+                        map.insert(parts[3].to_string(), parts[2].to_string());
                     }
                 }
             }

--- a/src/apps/desktop/src/api/skill_api.rs
+++ b/src/apps/desktop/src/api/skill_api.rs
@@ -1246,10 +1246,8 @@ async fn fill_market_descriptions(client: &Client, base_url: &str, items: &mut [
         });
 
         if join_set.len() >= MARKET_DESC_FETCH_CONCURRENCY {
-            if let Some(result) = join_set.join_next().await {
-                if let Ok((skill_id, Some(desc))) = result {
-                    fetched.insert(skill_id, desc);
-                }
+            if let Some(Ok((skill_id, Some(desc)))) = join_set.join_next().await {
+                fetched.insert(skill_id, desc);
             }
         }
     }

--- a/src/apps/desktop/src/computer_use/interactive_filter.rs
+++ b/src/apps/desktop/src/computer_use/interactive_filter.rs
@@ -93,7 +93,7 @@ pub(crate) fn build_interactive_elements(
                     "AXPress" | "AXConfirm" | "AXOpen" | "AXShowMenu" | "AXPick"
                 )
             }),
-            area: (gw * gh) as f64,
+            area: gw * gh,
         });
     }
 
@@ -286,12 +286,13 @@ fn is_interactive(n: &AxNode) -> bool {
 }
 
 fn best_label(n: &AxNode) -> Option<String> {
-    for cand in [&n.title, &n.description, &n.help, &n.value, &n.identifier] {
-        if let Some(s) = cand {
-            let trimmed = s.trim();
-            if !trimmed.is_empty() {
-                return Some(clip(trimmed, 80));
-            }
+    for s in [&n.title, &n.description, &n.help, &n.value, &n.identifier]
+        .into_iter()
+        .flatten()
+    {
+        let trimmed = s.trim();
+        if !trimmed.is_empty() {
+            return Some(clip(trimmed, 80));
         }
     }
     None

--- a/src/apps/desktop/src/computer_use/ui_locate_common.rs
+++ b/src/apps/desktop/src/computer_use/ui_locate_common.rs
@@ -392,6 +392,17 @@ pub(super) fn ok_result_with_context_full(
     Ok(r)
 }
 
+/// Whether an element's global bounds fall within any visible display.
+#[allow(dead_code)]
+pub(super) fn is_element_on_screen(gx: f64, gy: f64, width: f64, height: f64) -> bool {
+    // Element must have reasonable size (not a giant container)
+    if width > 3000.0 || height > 2000.0 {
+        return false;
+    }
+    // Center must be resolvable to a display
+    DisplayInfo::from_point(gx.round() as i32, gy.round() as i32).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -538,15 +549,4 @@ mod tests {
         let (nx, ny) = global_xy_to_native_with_display(&d, 100.0, 200.0).unwrap();
         assert_eq!((nx, ny), (100, 200));
     }
-}
-
-/// Whether an element's global bounds fall within any visible display.
-#[allow(dead_code)]
-pub(super) fn is_element_on_screen(gx: f64, gy: f64, width: f64, height: f64) -> bool {
-    // Element must have reasonable size (not a giant container)
-    if width > 3000.0 || height > 2000.0 {
-        return false;
-    }
-    // Center must be resolvable to a display
-    DisplayInfo::from_point(gx.round() as i32, gy.round() as i32).is_ok()
 }

--- a/src/apps/desktop/src/computer_use/windows_bg_input.rs
+++ b/src/apps/desktop/src/computer_use/windows_bg_input.rs
@@ -793,7 +793,7 @@ fn owning_exe_basename(hwnd: HWND) -> Option<String> {
     }
     let path = String::from_utf16_lossy(&buf[..len as usize]);
     let name = path
-        .rsplit(|c: char| c == '\\' || c == '/')
+        .rsplit(['\\', '/'])
         .next()
         .unwrap_or(&path)
         .to_ascii_lowercase();

--- a/src/apps/desktop/src/computer_use/windows_list_apps.rs
+++ b/src/apps/desktop/src/computer_use/windows_list_apps.rs
@@ -180,11 +180,7 @@ fn exe_basename_for_pid(pid: u32) -> Option<String> {
         return None;
     }
     let path = String::from_utf16_lossy(&buf[..len as usize]);
-    let name = path
-        .rsplit(|c: char| c == '\\' || c == '/')
-        .next()
-        .unwrap_or(&path)
-        .to_string();
+    let name = path.rsplit(['\\', '/']).next().unwrap_or(&path).to_string();
     if name.is_empty() {
         None
     } else {

--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -425,7 +425,7 @@ impl ThemeConfig {
         let startup_locale = &bootstrap_config.locale;
         let startup_locale_json =
             serde_json::to_string(&startup_locale).unwrap_or_else(|_| "\"zh-CN\"".to_string());
-        let startup_messages_json = Self::startup_messages_json(&startup_locale);
+        let startup_messages_json = Self::startup_messages_json(startup_locale);
         let show_startup_window_controls = !cfg!(target_os = "macos");
         let startup_trace_id_json = serde_json::to_string(startup_trace_id)
             .unwrap_or_else(|_| "\"desktop-unknown\"".to_string());
@@ -639,7 +639,7 @@ pub fn create_main_window(
                     .map(|v| v == "1")
                     .unwrap_or(false)
                 {
-                    let _ = window.open_devtools();
+                    window.open_devtools();
                 }
             }
 

--- a/src/apps/desktop/src/tray.rs
+++ b/src/apps/desktop/src/tray.rs
@@ -232,19 +232,19 @@ pub fn setup_tray(
                 });
             }
         })
-        .on_tray_icon_event(|tray, event| match event {
-            TrayIconEvent::Click {
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
                 ..
-            } => {
+            } = event
+            {
                 let app = tray.app_handle().clone();
                 toggle_main_window(&app);
                 tauri::async_runtime::spawn(async move {
                     rebuild_tray_menu(&app).await;
                 });
             }
-            _ => {}
         })
         .build(app)?;
     startup_trace.record_elapsed_step(TRAY_TRACE_CATEGORY, "setup_tray.build", step_started);

--- a/src/apps/relay-server/src/routes/websocket.rs
+++ b/src/apps/relay-server/src/routes/websocket.rs
@@ -217,30 +217,6 @@ async fn handle_text_message(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{send_json_best_effort, truncate_preview, OutboundProtocol};
-    use tokio::sync::mpsc;
-
-    #[test]
-    fn truncate_preview_respects_utf8_boundaries() {
-        let text = format!("{}{}", "a".repeat(199), "你");
-
-        assert_eq!(truncate_preview(&text, 200), "a".repeat(199));
-    }
-
-    #[test]
-    fn best_effort_control_response_does_not_block_on_full_queue() {
-        let (tx, _rx) = mpsc::channel(1);
-        assert!(send_json_best_effort(&tx, &OutboundProtocol::HeartbeatAck));
-
-        assert!(
-            send_json_best_effort(&tx, &OutboundProtocol::HeartbeatAck),
-            "full queue should drop best-effort control response without closing read loop"
-        );
-    }
-}
-
 async fn send_json<T: Serialize>(tx: &mpsc::Sender<OutboundMessage>, msg: &T) -> bool {
     match serde_json::to_string(msg) {
         Ok(json) => send_outbound_message(tx, OutboundMessage { text: json }).await,
@@ -271,4 +247,28 @@ fn send_json_best_effort<T: Serialize>(tx: &mpsc::Sender<OutboundMessage>, msg: 
 fn generate_room_id() -> String {
     let bytes: [u8; 6] = rand::random();
     bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{send_json_best_effort, truncate_preview, OutboundProtocol};
+    use tokio::sync::mpsc;
+
+    #[test]
+    fn truncate_preview_respects_utf8_boundaries() {
+        let text = format!("{}{}", "a".repeat(199), "你");
+
+        assert_eq!(truncate_preview(&text, 200), "a".repeat(199));
+    }
+
+    #[test]
+    fn best_effort_control_response_does_not_block_on_full_queue() {
+        let (tx, _rx) = mpsc::channel(1);
+        assert!(send_json_best_effort(&tx, &OutboundProtocol::HeartbeatAck));
+
+        assert!(
+            send_json_best_effort(&tx, &OutboundProtocol::HeartbeatAck),
+            "full queue should drop best-effort control response without closing read loop"
+        );
+    }
 }

--- a/src/crates/assembly/core/src/agentic/agents/registry/availability.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/availability.rs
@@ -8,8 +8,6 @@ use bitfun_agent_runtime::agents::{
     ResolvedSubagentAvailability, SubagentOverrideLayers as ResolvedOverrideLayers,
     SubagentOverrideState,
 };
-use std::collections::HashMap;
-
 fn to_runtime_override_state(state: AgentSubagentOverrideState) -> SubagentOverrideState {
     match state {
         AgentSubagentOverrideState::Enabled => SubagentOverrideState::Enabled,
@@ -120,7 +118,7 @@ pub(super) fn set_override_state(
     let profile_id = resolve_mode_config_profile_id(parent_agent_type).into_owned();
     overrides
         .entry(profile_id)
-        .or_insert_with(HashMap::new)
+        .or_default()
         .insert(subagent_key.to_string(), state);
 }
 
@@ -131,6 +129,7 @@ mod tests {
     use crate::agentic::agents::registry::types::{AgentCategory, AgentSource};
     use crate::agentic::agents::registry::visibility::SubagentVisibilityPolicy;
     use crate::service::config::types::AgentSubagentOverrideState;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     fn make_entry(source: SubAgentSource, id: &str) -> AgentEntry {

--- a/src/crates/assembly/core/src/agentic/agents/registry/support.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/support.rs
@@ -24,7 +24,11 @@ pub(super) async fn get_subagent_overrides() -> AgentSubagentOverrideConfig {
         .await
         .into_iter()
         .filter_map(|(profile_id, config)| {
-            (!config.subagent_overrides.is_empty()).then(|| (profile_id, config.subagent_overrides))
+            if config.subagent_overrides.is_empty() {
+                None
+            } else {
+                Some((profile_id, config.subagent_overrides))
+            }
         })
         .collect()
 }

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -5050,7 +5050,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         // coordinator-enforced timeouts can stop the same dialog turn.
         let subagent_cancel_token = cancel_token
             .map(CancellationToken::child_token)
-            .unwrap_or_else(CancellationToken::new);
+            .unwrap_or_default();
         self.execution_engine
             .register_cancel_token(&dialog_turn_id, subagent_cancel_token.clone());
 

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -1388,7 +1388,7 @@ impl DialogScheduler {
                                 .coordinator
                                 .prepare_goal_continuation_after_turn(
                                     &session_id,
-                                    &outcome.turn_id(),
+                                    outcome.turn_id(),
                                     active_turn.user_input(),
                                     active_turn.user_message_metadata(),
                                     turn_completed,

--- a/src/crates/assembly/core/src/agentic/execution/write_content_sanitizer.rs
+++ b/src/crates/assembly/core/src/agentic/execution/write_content_sanitizer.rs
@@ -63,10 +63,7 @@ pub fn strip_tool_invocation_artifacts(content: &str) -> String {
 
 fn strip_delimited_block(content: &str, open_prefix: &str, close_tag: &str) -> String {
     let mut result = content.to_string();
-    loop {
-        let Some(start) = result.find(open_prefix) else {
-            break;
-        };
+    while let Some(start) = result.find(open_prefix) {
         let Some(relative_end) = result[start..].find(close_tag) else {
             result = result[..start].to_string();
             break;

--- a/src/crates/assembly/core/src/agentic/insights/collector.rs
+++ b/src/crates/assembly/core/src/agentic/insights/collector.rs
@@ -268,12 +268,10 @@ impl InsightsCollector {
                 }
                 MessageContent::ToolResult {
                     tool_name,
-                    is_error,
+                    is_error: true,
                     ..
                 } => {
-                    if *is_error {
-                        *base_stats.tool_errors.entry(tool_name.clone()).or_insert(0) += 1;
-                    }
+                    *base_stats.tool_errors.entry(tool_name.clone()).or_insert(0) += 1;
                 }
                 _ => {}
             }

--- a/src/crates/assembly/core/src/agentic/insights/session_paths.rs
+++ b/src/crates/assembly/core/src/agentic/insights/session_paths.rs
@@ -18,7 +18,7 @@ pub async fn effective_session_storage_dir_for_workspace(ws: &WorkspaceInfo) -> 
         .filter(|s| !s.is_empty());
 
     if host.is_none() {
-        if let (Some(ref cid), Some(ws_service)) = (conn.as_ref(), get_global_workspace_service()) {
+        if let (Some(cid), Some(ws_service)) = (conn.as_ref(), get_global_workspace_service()) {
             host = ws_service
                 .remote_ssh_host_for_remote_workspace(cid.as_str(), &path_str)
                 .await;

--- a/src/crates/assembly/core/src/agentic/memories/db.rs
+++ b/src/crates/assembly/core/src/agentic/memories/db.rs
@@ -1456,7 +1456,7 @@ fn phase1_source_needs_update_in_conn(
             ))
         })?
         .flatten();
-    Ok(!last_success_watermark.is_some_and(|watermark| watermark >= session_finished_at_unix_secs))
+    Ok(last_success_watermark.is_none_or(|watermark| watermark < session_finished_at_unix_secs))
 }
 
 fn try_claim_phase1_job_in_tx(
@@ -1601,7 +1601,7 @@ fn phase1_source_needs_update_in_tx(
             ))
         })?
         .flatten();
-    Ok(!last_success_watermark.is_some_and(|watermark| watermark >= session_finished_at_unix_secs))
+    Ok(last_success_watermark.is_none_or(|watermark| watermark < session_finished_at_unix_secs))
 }
 
 fn phase1_owned_input_watermark(

--- a/src/crates/assembly/core/src/agentic/memories/runner.rs
+++ b/src/crates/assembly/core/src/agentic/memories/runner.rs
@@ -785,6 +785,56 @@ pub fn current_unix_secs() -> i64 {
         .unwrap_or_default()
 }
 
+async fn phase2_retry_delay_seconds() -> BitFunResult<i64> {
+    let config = get_phase2_runtime_config().await;
+    Ok(config
+        .memories
+        .phase2_retry_delay_seconds
+        .max(60)
+        .min(24 * 60 * 60))
+}
+
+async fn phase2_lease_seconds() -> BitFunResult<i64> {
+    let config = get_phase2_runtime_config().await;
+    Ok(config
+        .memories
+        .phase2_lease_seconds
+        .max(60)
+        .min(24 * 60 * 60))
+}
+
+fn select_phase2_model_id(
+    config: &crate::service::config::types::GlobalConfig,
+) -> BitFunResult<String> {
+    let ai = &config.ai;
+    let model_ref = config.memories.consolidation_model.as_deref().or(config
+        .ai
+        .default_models
+        .primary
+        .as_deref());
+
+    model_ref
+        .and_then(|model_ref| ai.resolve_model_selection(model_ref))
+        .or_else(|| ai.first_enabled_model_id())
+        .ok_or_else(|| {
+            BitFunError::service("No enabled model available for memory phase2".to_string())
+        })
+}
+
+fn build_phase2_user_prompt(memory_root: &std::path::Path) -> String {
+    format!(
+        "Consolidate the workspace at:\n{}\n\nFocus on the selected stage-1 memories in raw_memories.md and the rollout_summaries directory. Return a concise markdown result.",
+        memory_root.display()
+    )
+}
+
+async fn get_phase2_runtime_config() -> crate::service::config::types::GlobalConfig {
+    match get_global_config_service().await {
+        Ok(service) => service.get_config(None).await.unwrap_or_default(),
+        Err(_) => crate::service::config::types::GlobalConfig::default(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -964,7 +1014,7 @@ mod tests {
         ];
         for row in &rows {
             save_memory_row_metadata(&persistence, row, SessionMemoryMode::Enabled).await;
-            runner.db.upsert_memory(&row).await.unwrap();
+            runner.db.upsert_memory(row).await.unwrap();
         }
 
         let report = runner
@@ -1255,55 +1305,5 @@ mod tests {
         .await
         .unwrap();
         assert!(summary.starts_with("v1\n"));
-    }
-}
-
-async fn phase2_retry_delay_seconds() -> BitFunResult<i64> {
-    let config = get_phase2_runtime_config().await;
-    Ok(config
-        .memories
-        .phase2_retry_delay_seconds
-        .max(60)
-        .min(24 * 60 * 60))
-}
-
-async fn phase2_lease_seconds() -> BitFunResult<i64> {
-    let config = get_phase2_runtime_config().await;
-    Ok(config
-        .memories
-        .phase2_lease_seconds
-        .max(60)
-        .min(24 * 60 * 60))
-}
-
-fn select_phase2_model_id(
-    config: &crate::service::config::types::GlobalConfig,
-) -> BitFunResult<String> {
-    let ai = &config.ai;
-    let model_ref = config.memories.consolidation_model.as_deref().or(config
-        .ai
-        .default_models
-        .primary
-        .as_deref());
-
-    model_ref
-        .and_then(|model_ref| ai.resolve_model_selection(model_ref))
-        .or_else(|| ai.first_enabled_model_id())
-        .ok_or_else(|| {
-            BitFunError::service("No enabled model available for memory phase2".to_string())
-        })
-}
-
-fn build_phase2_user_prompt(memory_root: &std::path::Path) -> String {
-    format!(
-        "Consolidate the workspace at:\n{}\n\nFocus on the selected stage-1 memories in raw_memories.md and the rollout_summaries directory. Return a concise markdown result.",
-        memory_root.display()
-    )
-}
-
-async fn get_phase2_runtime_config() -> crate::service::config::types::GlobalConfig {
-    match get_global_config_service().await {
-        Ok(service) => service.get_config(None).await.unwrap_or_default(),
-        Err(_) => crate::service::config::types::GlobalConfig::default(),
     }
 }

--- a/src/crates/assembly/core/src/agentic/memories/transcript.rs
+++ b/src/crates/assembly/core/src/agentic/memories/transcript.rs
@@ -205,12 +205,14 @@ fn memory_tool_result_content(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(|value| truncate_middle_tokens(value, TOOL_ERROR_TOKEN_LIMIT));
-    if success || error.is_none() {
+    if success {
         content
-    } else if content.trim().is_empty() {
-        format!("Tool failed: {}", error.unwrap())
     } else {
-        format!("Tool failed: {}\n\n{}", error.unwrap(), content)
+        match error {
+            None => content,
+            Some(error) if content.trim().is_empty() => format!("Tool failed: {}", error),
+            Some(error) => format!("Tool failed: {}\n\n{}", error, content),
+        }
     }
 }
 

--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -494,14 +494,14 @@ impl PersistenceManager {
         &self,
         path: &Path,
     ) -> BitFunResult<Option<T>> {
-        JsonFileStore::default()
+        JsonFileStore
             .read_optional(path)
             .await
             .map_err(Self::json_store_error)
     }
 
     async fn write_json_atomic<T: Serialize>(&self, path: &Path, value: &T) -> BitFunResult<()> {
-        JsonFileStore::default()
+        JsonFileStore
             .write_atomic(path, value)
             .await
             .map_err(Self::json_store_error)

--- a/src/crates/assembly/core/src/agentic/session/compression/compressor.rs
+++ b/src/crates/assembly/core/src/agentic/session/compression/compressor.rs
@@ -410,7 +410,7 @@ impl ContextCompressor {
     }
 
     pub(crate) fn build_compact_prompt(&self) -> String {
-        format!(
+        String::from(
             r#"Your current task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.
 This summary should be thorough in capturing technical details, code patterns, and architectural decisions that would be essential for continuing development work without losing context.
 
@@ -494,7 +494,7 @@ Here's an example of how your output should be structured:
 
 Please provide your summary based on the conversation so far, following this structure and ensuring precision and thoroughness in your response.
 REMINDER: Do NOT call any tools. Respond with plain text only inside a single <summary> block. Tool calls will be rejected and you will fail the task.
-"#
+"#,
         )
     }
 }

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -1864,20 +1864,17 @@ impl SessionManager {
             return;
         };
 
-        match self
+        if let Err(error) = self
             .persistence_manager
             .save_skill_agent_baseline_override_snapshot(&workspace_path, session_id, &snapshot)
             .await
         {
-            Err(error) => {
-                warn!(
-                    "Failed to persist listing reminder baseline override snapshot: session_id={}, workspace_path={}, error={}",
-                    session_id,
-                    workspace_path.display(),
-                    error
-                );
-            }
-            Ok(()) => {}
+            warn!(
+                "Failed to persist listing reminder baseline override snapshot: session_id={}, workspace_path={}, error={}",
+                session_id,
+                workspace_path.display(),
+                error
+            );
         }
     }
 
@@ -2223,8 +2220,7 @@ impl SessionManager {
             session.updated_at = SystemTime::now();
             session.last_activity_at = SystemTime::now();
 
-            let persist = self.config.enable_persistence && Self::should_persist_session(&session);
-            persist
+            self.config.enable_persistence && Self::should_persist_session(&session)
         } else {
             return Err(BitFunError::NotFound(format!(
                 "Session not found: {}",
@@ -3172,7 +3168,7 @@ impl SessionManager {
         let metadata_started_at = Instant::now();
         if self
             .persistence_manager
-            .load_session_metadata(&session_storage_path, session_id)
+            .load_session_metadata(session_storage_path, session_id)
             .await?
             .is_some_and(|metadata| !include_internal && metadata.should_hide_from_user_lists())
         {
@@ -3192,7 +3188,7 @@ impl SessionManager {
             if let Some(tail_turn_count) = tail_turn_count {
                 self.persistence_manager
                     .load_session_with_tail_turns_timed(
-                        &session_storage_path,
+                        session_storage_path,
                         session_id,
                         tail_turn_count,
                     )
@@ -3200,7 +3196,7 @@ impl SessionManager {
             } else {
                 let (session, turns, timing) = self
                     .persistence_manager
-                    .load_session_with_turns_timed(&session_storage_path, session_id)
+                    .load_session_with_turns_timed(session_storage_path, session_id)
                     .await?;
                 let total_turn_count = turns.len();
                 (session, turns, total_turn_count, timing)
@@ -3360,7 +3356,7 @@ impl SessionManager {
         let metadata_started_at = Instant::now();
         let session_metadata = self
             .persistence_manager
-            .load_session_metadata(&session_storage_path, session_id)
+            .load_session_metadata(session_storage_path, session_id)
             .await?;
         if session_metadata
             .as_ref()
@@ -3383,7 +3379,7 @@ impl SessionManager {
         let session_started_at = Instant::now();
         let (mut session, persisted_turns) = self
             .persistence_manager
-            .load_session_with_turns(&session_storage_path, session_id)
+            .load_session_with_turns(session_storage_path, session_id)
             .await?;
         debug!(
             "Session restore phase completed: session_id={}, phase=load_session_with_turns, turn_count={}, duration_ms={}",
@@ -3476,13 +3472,13 @@ impl SessionManager {
         let context_snapshot_started_at = Instant::now();
         let mut messages = match self
             .persistence_manager
-            .load_latest_turn_context_snapshot(&session_storage_path, session_id)
+            .load_latest_turn_context_snapshot(session_storage_path, session_id)
             .await?
         {
             Some((turn_index, msgs)) => {
                 latest_turn_index = Some(turn_index);
                 self.sanitize_listing_diff_context_snapshot_if_needed(
-                    &session_storage_path,
+                    session_storage_path,
                     session_id,
                     turn_index,
                     msgs,
@@ -3605,7 +3601,7 @@ impl SessionManager {
 
         if should_persist_restored_session && self.should_persist_session_id(session_id) {
             self.persistence_manager
-                .save_session(&session_storage_path, &session)
+                .save_session(session_storage_path, &session)
                 .await?;
         }
 
@@ -4439,15 +4435,13 @@ impl SessionManager {
                                 order_index += 1;
                             }
                         }
-                        MessageContent::Multimodal { text, .. } => {
-                            if !text.trim().is_empty() {
-                                text_items.push(Self::make_text_item(
-                                    &format!("{}-text-{}", round_id, order_index),
-                                    text,
-                                    timestamp,
-                                    order_index,
-                                ));
-                            }
+                        MessageContent::Multimodal { text, .. } if !text.trim().is_empty() => {
+                            text_items.push(Self::make_text_item(
+                                &format!("{}-text-{}", round_id, order_index),
+                                text,
+                                timestamp,
+                                order_index,
+                            ));
                         }
                         _ => {}
                     }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/control_hub_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/control_hub_tool.rs
@@ -536,21 +536,19 @@ Branch on `ok` and `error.code`, not on English messages.
             "connect" => {
                 let mode = Self::browser_connect_mode_from_params(params);
 
-                if mode == "headless" {
-                    if !BrowserLauncher::is_cdp_available(port).await {
-                        return Ok(err_response(
-                            "browser",
-                            "connect",
-                            ControlHubError::new(
-                                ErrorCode::NotAvailable,
-                                format!(
-                                    "Headless browser test port {} is not available. Start the dedicated headless browser first, then connect via ControlHub browser actions.",
-                                    port
-                                ),
-                            )
-                            .with_hints(Self::headless_browser_connect_hints(port)),
-                        ));
-                    }
+                if mode == "headless" && !BrowserLauncher::is_cdp_available(port).await {
+                    return Ok(err_response(
+                        "browser",
+                        "connect",
+                        ControlHubError::new(
+                            ErrorCode::NotAvailable,
+                            format!(
+                                "Headless browser test port {} is not available. Start the dedicated headless browser first, then connect via ControlHub browser actions.",
+                                port
+                            ),
+                        )
+                        .with_hints(Self::headless_browser_connect_hints(port)),
+                    ));
                 }
 
                 let kind = if let Some(browser_str) = params.get("browser").and_then(|v| v.as_str())

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -223,211 +223,6 @@ Examples:
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::FileWriteTool;
-    use crate::agentic::tools::file_tool_guidance::{
-        file_tool_guidance_message, is_file_tool_guidance_message, FILE_TOOL_GUIDANCE_PREFIX,
-    };
-    use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
-    use crate::agentic::tools::ToolRuntimeRestrictions;
-    use crate::agentic::WorkspaceBinding;
-    use serde_json::json;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-
-    fn local_context(root: PathBuf) -> ToolUseContext {
-        ToolUseContext {
-            tool_call_id: None,
-            agent_type: None,
-            session_id: None,
-            dialog_turn_id: None,
-            workspace: Some(WorkspaceBinding::new(None, root)),
-            unlocked_collapsed_tools: Vec::new(),
-            primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
-            custom_data: HashMap::new(),
-            computer_use_host: None,
-            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
-            runtime_handles: bitfun_runtime_ports::ToolRuntimeHandles::default(),
-        }
-    }
-
-    #[test]
-    fn guidance_prefix_helpers_round_trip() {
-        let message = file_tool_guidance_message("Use Read first.");
-        assert!(is_file_tool_guidance_message(&message));
-        assert_eq!(
-            message.strip_prefix(FILE_TOOL_GUIDANCE_PREFIX).unwrap(),
-            "Use Read first."
-        );
-    }
-
-    #[tokio::test]
-    async fn preflight_write_error_allows_new_file_target() {
-        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&root).expect("create temp workspace");
-
-        let error =
-            FileWriteTool::preflight_write_error(&local_context(root.clone()), "new.txt").await;
-
-        let _ = std::fs::remove_dir_all(&root);
-
-        assert!(error.is_none());
-    }
-
-    #[tokio::test]
-    async fn preflight_write_error_allows_existing_file_without_read_state_tracking() {
-        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&root).expect("create temp workspace");
-        std::fs::write(root.join("existing.md"), "already here").expect("create existing file");
-
-        let error =
-            FileWriteTool::preflight_write_error(&local_context(root.clone()), "existing.md").await;
-
-        let _ = std::fs::remove_dir_all(&root);
-
-        assert!(error.is_none());
-    }
-
-    #[tokio::test]
-    async fn call_impl_treats_identical_existing_content_as_success() {
-        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&root).expect("create temp workspace");
-        std::fs::write(root.join("existing.md"), "same content").expect("create existing file");
-
-        let tool = FileWriteTool::new();
-        let results = tool
-            .call(
-                &json!({ "file_path": "existing.md", "content": "same content" }),
-                &local_context(root.clone()),
-            )
-            .await
-            .expect("identical retry should be idempotent");
-
-        let _ = std::fs::remove_dir_all(&root);
-
-        let ToolResult::Result {
-            data,
-            result_for_assistant,
-            ..
-        } = &results[0]
-        else {
-            panic!("expected result");
-        };
-        assert_eq!(data["success"], true);
-        assert_eq!(data["bytes_written"], 0);
-        assert_eq!(data["lines_written"], 0);
-        assert_eq!(data["status"], "already_exists_same_content");
-        assert!(result_for_assistant
-            .as_deref()
-            .unwrap_or_default()
-            .contains("identical content"));
-    }
-
-    #[tokio::test]
-    async fn call_impl_overwrites_different_existing_content() {
-        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&root).expect("create temp workspace");
-        std::fs::write(root.join("existing.md"), "old content").expect("create existing file");
-
-        let tool = FileWriteTool::new();
-        let results = tool
-            .call(
-                &json!({ "file_path": "existing.md", "content": "new content" }),
-                &local_context(root.clone()),
-            )
-            .await
-            .expect("write should overwrite existing files");
-
-        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
-        let _ = std::fs::remove_dir_all(&root);
-
-        assert_eq!(written, "new content");
-
-        let ToolResult::Result { data, .. } = &results[0] else {
-            panic!("expected result");
-        };
-        assert_eq!(data["status"], "overwritten");
-        assert_eq!(data["bytes_written"], "new content".len());
-        assert_eq!(data["lines_written"], 1);
-    }
-
-    #[tokio::test]
-    async fn call_impl_appends_when_mode_is_append() {
-        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&root).expect("create temp workspace");
-        std::fs::write(root.join("existing.md"), "old").expect("create existing file");
-
-        let tool = FileWriteTool::new();
-        let results = tool
-            .call(
-                &json!({ "file_path": "existing.md", "content": "\nnew", "mode": "a" }),
-                &local_context(root.clone()),
-            )
-            .await
-            .expect("append should succeed");
-
-        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
-        let _ = std::fs::remove_dir_all(&root);
-
-        assert_eq!(written, "old\nnew");
-
-        let ToolResult::Result { data, .. } = &results[0] else {
-            panic!("expected result");
-        };
-        assert_eq!(data["status"], "appended");
-        assert_eq!(data["mode"], "a");
-        assert_eq!(data["bytes_written"], "\nnew".len());
-    }
-
-    #[tokio::test]
-    async fn schema_requires_file_path_and_content() {
-        let tool = FileWriteTool::new();
-
-        let schema = tool.input_schema_for_model().await;
-
-        assert_eq!(
-            schema["required"],
-            serde_json::json!(["file_path", "content"])
-        );
-        assert!(schema["properties"].get("content").is_some());
-        assert_eq!(
-            schema["properties"]["mode"]["enum"],
-            serde_json::json!(["w", "a"])
-        );
-    }
-
-    #[tokio::test]
-    async fn validate_input_requires_content() {
-        let tool = FileWriteTool::new();
-
-        let validation = tool
-            .validate_input(&json!({ "file_path": "new.txt" }), None)
-            .await;
-
-        assert!(!validation.result);
-        assert_eq!(validation.message.as_deref(), Some("content is required"));
-    }
-
-    #[tokio::test]
-    async fn validate_input_rejects_invalid_mode() {
-        let tool = FileWriteTool::new();
-
-        let validation = tool
-            .validate_input(
-                &json!({ "file_path": "new.txt", "content": "hello", "mode": "x" }),
-                None,
-            )
-            .await;
-
-        assert!(!validation.result);
-        assert_eq!(
-            validation.message.as_deref(),
-            Some("mode must be either 'w' (overwrite) or 'a' (append), got 'x'")
-        );
-    }
-}
-
 #[async_trait]
 impl Tool for FileWriteTool {
     fn name(&self) -> &str {
@@ -683,5 +478,210 @@ impl Tool for FileWriteTool {
         let result = Self::write_success_result(&resolved.logical_path, mode, outcome);
 
         Ok(vec![result])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FileWriteTool;
+    use crate::agentic::tools::file_tool_guidance::{
+        file_tool_guidance_message, is_file_tool_guidance_message, FILE_TOOL_GUIDANCE_PREFIX,
+    };
+    use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::agentic::WorkspaceBinding;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn local_context(root: PathBuf) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: None,
+            agent_type: None,
+            session_id: None,
+            dialog_turn_id: None,
+            workspace: Some(WorkspaceBinding::new(None, root)),
+            unlocked_collapsed_tools: Vec::new(),
+            primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            runtime_handles: bitfun_runtime_ports::ToolRuntimeHandles::default(),
+        }
+    }
+
+    #[test]
+    fn guidance_prefix_helpers_round_trip() {
+        let message = file_tool_guidance_message("Use Read first.");
+        assert!(is_file_tool_guidance_message(&message));
+        assert_eq!(
+            message.strip_prefix(FILE_TOOL_GUIDANCE_PREFIX).unwrap(),
+            "Use Read first."
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_write_error_allows_new_file_target() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+
+        let error =
+            FileWriteTool::preflight_write_error(&local_context(root.clone()), "new.txt").await;
+
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn preflight_write_error_allows_existing_file_without_read_state_tracking() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        std::fs::write(root.join("existing.md"), "already here").expect("create existing file");
+
+        let error =
+            FileWriteTool::preflight_write_error(&local_context(root.clone()), "existing.md").await;
+
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn call_impl_treats_identical_existing_content_as_success() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        std::fs::write(root.join("existing.md"), "same content").expect("create existing file");
+
+        let tool = FileWriteTool::new();
+        let results = tool
+            .call(
+                &json!({ "file_path": "existing.md", "content": "same content" }),
+                &local_context(root.clone()),
+            )
+            .await
+            .expect("identical retry should be idempotent");
+
+        let _ = std::fs::remove_dir_all(&root);
+
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
+            panic!("expected result");
+        };
+        assert_eq!(data["success"], true);
+        assert_eq!(data["bytes_written"], 0);
+        assert_eq!(data["lines_written"], 0);
+        assert_eq!(data["status"], "already_exists_same_content");
+        assert!(result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("identical content"));
+    }
+
+    #[tokio::test]
+    async fn call_impl_overwrites_different_existing_content() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        std::fs::write(root.join("existing.md"), "old content").expect("create existing file");
+
+        let tool = FileWriteTool::new();
+        let results = tool
+            .call(
+                &json!({ "file_path": "existing.md", "content": "new content" }),
+                &local_context(root.clone()),
+            )
+            .await
+            .expect("write should overwrite existing files");
+
+        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(written, "new content");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result");
+        };
+        assert_eq!(data["status"], "overwritten");
+        assert_eq!(data["bytes_written"], "new content".len());
+        assert_eq!(data["lines_written"], 1);
+    }
+
+    #[tokio::test]
+    async fn call_impl_appends_when_mode_is_append() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        std::fs::write(root.join("existing.md"), "old").expect("create existing file");
+
+        let tool = FileWriteTool::new();
+        let results = tool
+            .call(
+                &json!({ "file_path": "existing.md", "content": "\nnew", "mode": "a" }),
+                &local_context(root.clone()),
+            )
+            .await
+            .expect("append should succeed");
+
+        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert_eq!(written, "old\nnew");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result");
+        };
+        assert_eq!(data["status"], "appended");
+        assert_eq!(data["mode"], "a");
+        assert_eq!(data["bytes_written"], "\nnew".len());
+    }
+
+    #[tokio::test]
+    async fn schema_requires_file_path_and_content() {
+        let tool = FileWriteTool::new();
+
+        let schema = tool.input_schema_for_model().await;
+
+        assert_eq!(
+            schema["required"],
+            serde_json::json!(["file_path", "content"])
+        );
+        assert!(schema["properties"].get("content").is_some());
+        assert_eq!(
+            schema["properties"]["mode"]["enum"],
+            serde_json::json!(["w", "a"])
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_input_requires_content() {
+        let tool = FileWriteTool::new();
+
+        let validation = tool
+            .validate_input(&json!({ "file_path": "new.txt" }), None)
+            .await;
+
+        assert!(!validation.result);
+        assert_eq!(validation.message.as_deref(), Some("content is required"));
+    }
+
+    #[tokio::test]
+    async fn validate_input_rejects_invalid_mode() {
+        let tool = FileWriteTool::new();
+
+        let validation = tool
+            .validate_input(
+                &json!({ "file_path": "new.txt", "content": "hello", "mode": "x" }),
+                None,
+            )
+            .await;
+
+        assert!(!validation.result);
+        assert_eq!(
+            validation.message.as_deref(),
+            Some("mode must be either 'w' (overwrite) or 'a' (append), got 'x'")
+        );
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/generative_ui_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/generative_ui_tool.rs
@@ -162,61 +162,6 @@ impl Default for GenerativeUITool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashSet;
-
-    #[test]
-    fn generated_theme_prompt_manifest_covers_default_themes() {
-        let manifest = GenerativeUITool::theme_prompt_snapshot_manifest();
-
-        assert_eq!(manifest.version, THEME_PROMPT_SNAPSHOT_VERSION);
-        assert!(manifest.themes.len() >= 2);
-
-        let unique_ids = manifest
-            .themes
-            .iter()
-            .map(|theme| theme.id.as_str())
-            .collect::<HashSet<_>>();
-        assert_eq!(unique_ids.len(), manifest.themes.len());
-        assert!(unique_ids.contains(manifest.default_light_theme_id.as_str()));
-        assert!(unique_ids.contains(manifest.default_dark_theme_id.as_str()));
-    }
-
-    #[test]
-    fn generated_theme_prompt_snapshots_have_required_prompt_fields() {
-        for snapshot in &GenerativeUITool::theme_prompt_snapshot_manifest().themes {
-            assert!(!snapshot.id.trim().is_empty());
-            assert!(!snapshot.theme_type.trim().is_empty());
-            assert!(!snapshot.bg_primary.trim().is_empty());
-            assert!(!snapshot.bg_secondary.trim().is_empty());
-            assert!(!snapshot.bg_scene.trim().is_empty());
-            assert!(!snapshot.text_primary.trim().is_empty());
-            assert!(!snapshot.text_muted.trim().is_empty());
-            assert!(!snapshot.accent_500.trim().is_empty());
-            assert!(!snapshot.accent_600.trim().is_empty());
-            assert!(!snapshot.border_base.trim().is_empty());
-            assert!(!snapshot.element_base.trim().is_empty());
-            assert!(!snapshot.shadow_base.trim().is_empty());
-            assert!(!snapshot.style_notes.trim().is_empty());
-        }
-    }
-
-    #[test]
-    fn theme_prompt_snapshot_does_not_surface_iframe_fallback_dimensions() {
-        for snapshot in &GenerativeUITool::theme_prompt_snapshot_manifest().themes {
-            let formatted = GenerativeUITool::format_theme_snapshot(snapshot);
-            assert!(!formatted.contains("radius.base="));
-            assert!(!formatted.contains("spacing.4="));
-        }
-
-        let context = GenerativeUITool::baseline_theme_context();
-        assert!(!context.contains("radius.base="));
-        assert!(!context.contains("spacing.4="));
-    }
-}
-
 #[async_trait]
 impl Tool for GenerativeUITool {
     fn name(&self) -> &str {
@@ -521,5 +466,60 @@ Input rules:
             )),
             image_attachments: None,
         }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn generated_theme_prompt_manifest_covers_default_themes() {
+        let manifest = GenerativeUITool::theme_prompt_snapshot_manifest();
+
+        assert_eq!(manifest.version, THEME_PROMPT_SNAPSHOT_VERSION);
+        assert!(manifest.themes.len() >= 2);
+
+        let unique_ids = manifest
+            .themes
+            .iter()
+            .map(|theme| theme.id.as_str())
+            .collect::<HashSet<_>>();
+        assert_eq!(unique_ids.len(), manifest.themes.len());
+        assert!(unique_ids.contains(manifest.default_light_theme_id.as_str()));
+        assert!(unique_ids.contains(manifest.default_dark_theme_id.as_str()));
+    }
+
+    #[test]
+    fn generated_theme_prompt_snapshots_have_required_prompt_fields() {
+        for snapshot in &GenerativeUITool::theme_prompt_snapshot_manifest().themes {
+            assert!(!snapshot.id.trim().is_empty());
+            assert!(!snapshot.theme_type.trim().is_empty());
+            assert!(!snapshot.bg_primary.trim().is_empty());
+            assert!(!snapshot.bg_secondary.trim().is_empty());
+            assert!(!snapshot.bg_scene.trim().is_empty());
+            assert!(!snapshot.text_primary.trim().is_empty());
+            assert!(!snapshot.text_muted.trim().is_empty());
+            assert!(!snapshot.accent_500.trim().is_empty());
+            assert!(!snapshot.accent_600.trim().is_empty());
+            assert!(!snapshot.border_base.trim().is_empty());
+            assert!(!snapshot.element_base.trim().is_empty());
+            assert!(!snapshot.shadow_base.trim().is_empty());
+            assert!(!snapshot.style_notes.trim().is_empty());
+        }
+    }
+
+    #[test]
+    fn theme_prompt_snapshot_does_not_surface_iframe_fallback_dimensions() {
+        for snapshot in &GenerativeUITool::theme_prompt_snapshot_manifest().themes {
+            let formatted = GenerativeUITool::format_theme_snapshot(snapshot);
+            assert!(!formatted.contains("radius.base="));
+            assert!(!formatted.contains("spacing.4="));
+        }
+
+        let context = GenerativeUITool::baseline_theme_context();
+        assert!(!context.contains("radius.base="));
+        assert!(!context.contains("spacing.4="));
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
@@ -868,13 +868,8 @@ impl GitTool {
                 // We treat exit code 0 and exit code 1 with non-empty stdout as success,
                 // but exit code >1 or exit code 1 with empty stdout and non-empty stderr as failure.
                 let is_diff_like = operation == "diff";
-                let success = if raw.exit_code == 0 {
-                    true
-                } else if is_diff_like && raw.exit_code == 1 && !raw.stdout.is_empty() {
-                    true
-                } else {
-                    false
-                };
+                let success = raw.exit_code == 0
+                    || is_diff_like && raw.exit_code == 1 && !raw.stdout.is_empty();
 
                 Ok(json!({
                     "success": success,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/grep_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/grep_tool.rs
@@ -461,303 +461,6 @@ fn render_workspace_search_content_lines(
     lines
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        render_workspace_search_content_lines, render_workspace_search_result_lines, GrepTool,
-        DEFAULT_HEAD_LIMIT,
-    };
-    use crate::infrastructure::{FileSearchOutcome, FileSearchResult, SearchMatchType};
-    use crate::service::search::{
-        ContentSearchResult, WorkspaceSearchBackend, WorkspaceSearchHit, WorkspaceSearchLine,
-        WorkspaceSearchMatch, WorkspaceSearchMatchLocation, WorkspaceSearchRepoPhase,
-        WorkspaceSearchRepoStatus,
-    };
-    use serde_json::json;
-    use tool_runtime::search::grep_search::relativize_result_text;
-
-    #[test]
-    fn head_limit_defaults_and_zero_escape_hatch() {
-        assert_eq!(
-            GrepTool::resolve_head_limit(&json!({})),
-            Some(DEFAULT_HEAD_LIMIT)
-        );
-        assert_eq!(
-            GrepTool::resolve_head_limit(&json!({ "head_limit": 25 })),
-            Some(25)
-        );
-        assert_eq!(
-            GrepTool::resolve_head_limit(&json!({ "head_limit": 0 })),
-            None
-        );
-    }
-
-    #[test]
-    fn backend_max_results_only_uses_explicit_limit() {
-        assert_eq!(
-            GrepTool::backend_max_results(&json!({}), 0, Some(DEFAULT_HEAD_LIMIT)),
-            None
-        );
-        assert_eq!(
-            GrepTool::backend_max_results(&json!({ "head_limit": 25 }), 3, Some(25)),
-            Some(28)
-        );
-        assert_eq!(
-            GrepTool::backend_max_results(&json!({ "head_limit": 0 }), 7, None),
-            None
-        );
-    }
-
-    #[test]
-    fn relativizes_prefixed_result_lines() {
-        let text = "/repo/src/main.rs:12:fn main()\n/repo/src/lib.rs:3:pub fn lib()";
-        let relativized = relativize_result_text(text, Some("/repo"));
-
-        assert_eq!(
-            relativized,
-            "src/main.rs:12:fn main()\nsrc/lib.rs:3:pub fn lib()"
-        );
-    }
-
-    #[test]
-    fn renders_workspace_search_context_lines_in_rg_style() {
-        let lines = render_workspace_search_content_lines(
-            &[WorkspaceSearchHit {
-                path: "/repo/src/main.rs".to_string(),
-                matches: vec![WorkspaceSearchMatch {
-                    location: WorkspaceSearchMatchLocation {
-                        line: 12,
-                        column: 5,
-                    },
-                    snippet: "panic!(\"x\")".to_string(),
-                    matched_text: "panic".to_string(),
-                }],
-                lines: vec![
-                    WorkspaceSearchLine::Context {
-                        value: crate::service::search::WorkspaceSearchContextLine {
-                            line_number: 10,
-                            snippet: "let a = 1".to_string(),
-                        },
-                    },
-                    WorkspaceSearchLine::Context {
-                        value: crate::service::search::WorkspaceSearchContextLine {
-                            line_number: 11,
-                            snippet: "let b = 2".to_string(),
-                        },
-                    },
-                    WorkspaceSearchLine::Match {
-                        value: WorkspaceSearchMatch {
-                            location: WorkspaceSearchMatchLocation {
-                                line: 12,
-                                column: 5,
-                            },
-                            snippet: "panic!(\"x\")".to_string(),
-                            matched_text: "panic".to_string(),
-                        },
-                    },
-                    WorkspaceSearchLine::Context {
-                        value: crate::service::search::WorkspaceSearchContextLine {
-                            line_number: 13,
-                            snippet: "cleanup()".to_string(),
-                        },
-                    },
-                    WorkspaceSearchLine::ContextBreak,
-                    WorkspaceSearchLine::Context {
-                        value: crate::service::search::WorkspaceSearchContextLine {
-                            line_number: 20,
-                            snippet: "return".to_string(),
-                        },
-                    },
-                ],
-            }],
-            true,
-        );
-
-        assert_eq!(
-            lines,
-            vec![
-                "/repo/src/main.rs-10:let a = 1",
-                "/repo/src/main.rs-11:let b = 2",
-                "/repo/src/main.rs:12:panic!(\"x\")",
-                "/repo/src/main.rs-13:cleanup()",
-                "--",
-                "/repo/src/main.rs-20:return",
-            ]
-        );
-    }
-
-    #[test]
-    fn content_workspace_output_uses_hits_for_context_lines() {
-        let tool = GrepTool::new();
-        let result = ContentSearchResult {
-            outcome: FileSearchOutcome {
-                results: Vec::new(),
-                truncated: false,
-            },
-            file_counts: Vec::new(),
-            hits: vec![WorkspaceSearchHit {
-                path: "/repo/src/main.rs".to_string(),
-                matches: vec![WorkspaceSearchMatch {
-                    location: WorkspaceSearchMatchLocation {
-                        line: 12,
-                        column: 5,
-                    },
-                    snippet: "panic!(\"x\")".to_string(),
-                    matched_text: "panic".to_string(),
-                }],
-                lines: vec![
-                    WorkspaceSearchLine::Context {
-                        value: crate::service::search::WorkspaceSearchContextLine {
-                            line_number: 11,
-                            snippet: "let b = 2".to_string(),
-                        },
-                    },
-                    WorkspaceSearchLine::Match {
-                        value: WorkspaceSearchMatch {
-                            location: WorkspaceSearchMatchLocation {
-                                line: 12,
-                                column: 5,
-                            },
-                            snippet: "panic!(\"x\")".to_string(),
-                            matched_text: "panic".to_string(),
-                        },
-                    },
-                ],
-            }],
-            backend: WorkspaceSearchBackend::Indexed,
-            repo_status: WorkspaceSearchRepoStatus {
-                repo_id: "repo".to_string(),
-                repo_path: "/repo".to_string(),
-                storage_root: "/repo/.bitfun/search/flashgrep-index".to_string(),
-                base_snapshot_root: "/repo/.bitfun/search/flashgrep-index/base-snapshot"
-                    .to_string(),
-                workspace_overlay_root: "/repo/.bitfun/search/flashgrep-index/workspace-overlay"
-                    .to_string(),
-                phase: WorkspaceSearchRepoPhase::Ready,
-                snapshot_key: None,
-                last_probe_unix_secs: None,
-                last_rebuild_unix_secs: None,
-                dirty_files: crate::service::search::WorkspaceSearchDirtyFiles {
-                    modified: 0,
-                    deleted: 0,
-                    new: 0,
-                },
-                rebuild_recommended: false,
-                active_task_id: None,
-                probe_healthy: true,
-                last_error: None,
-                overlay: None,
-            },
-            candidate_docs: 1,
-            matched_lines: 1,
-            matched_occurrences: 1,
-        };
-
-        let (rendered, file_count, total_matches) =
-            tool.format_workspace_search_output("content", true, 0, None, &result, Some("/repo"));
-
-        assert_eq!(
-            rendered,
-            "src/main.rs-11:let b = 2\nsrc/main.rs:12:panic!(\"x\")"
-        );
-        assert_eq!(file_count, 1);
-        assert_eq!(total_matches, 1);
-    }
-
-    #[test]
-    fn content_workspace_output_falls_back_to_converted_line_results() {
-        let tool = GrepTool::new();
-        let result = ContentSearchResult {
-            outcome: FileSearchOutcome {
-                results: vec![
-                    FileSearchResult {
-                        path: "/repo/src/main.rs".to_string(),
-                        name: "main.rs".to_string(),
-                        is_directory: false,
-                        match_type: SearchMatchType::Content,
-                        line_number: Some(12),
-                        matched_content: Some("panic!(\"x\")".to_string()),
-                        preview_before: None,
-                        preview_inside: Some("panic!(\"x\")".to_string()),
-                        preview_after: None,
-                    },
-                    FileSearchResult {
-                        path: "/repo/src/lib.rs".to_string(),
-                        name: "lib.rs".to_string(),
-                        is_directory: false,
-                        match_type: SearchMatchType::Content,
-                        line_number: Some(3),
-                        matched_content: Some("pub fn lib() {}".to_string()),
-                        preview_before: None,
-                        preview_inside: Some("pub fn lib() {}".to_string()),
-                        preview_after: None,
-                    },
-                ],
-                truncated: false,
-            },
-            file_counts: Vec::new(),
-            hits: Vec::new(),
-            backend: WorkspaceSearchBackend::Indexed,
-            repo_status: WorkspaceSearchRepoStatus {
-                repo_id: "repo".to_string(),
-                repo_path: "/repo".to_string(),
-                storage_root: "/repo/.bitfun/search/flashgrep-index".to_string(),
-                base_snapshot_root: "/repo/.bitfun/search/flashgrep-index/base-snapshot"
-                    .to_string(),
-                workspace_overlay_root: "/repo/.bitfun/search/flashgrep-index/workspace-overlay"
-                    .to_string(),
-                phase: WorkspaceSearchRepoPhase::Ready,
-                snapshot_key: None,
-                last_probe_unix_secs: None,
-                last_rebuild_unix_secs: None,
-                dirty_files: crate::service::search::WorkspaceSearchDirtyFiles {
-                    modified: 0,
-                    deleted: 0,
-                    new: 0,
-                },
-                rebuild_recommended: false,
-                active_task_id: None,
-                probe_healthy: true,
-                last_error: None,
-                overlay: None,
-            },
-            candidate_docs: 2,
-            matched_lines: 2,
-            matched_occurrences: 2,
-        };
-
-        let (rendered, file_count, total_matches) =
-            tool.format_workspace_search_output("content", true, 0, None, &result, Some("/repo"));
-
-        assert_eq!(
-            rendered,
-            "src/main.rs:12:panic!(\"x\")\nsrc/lib.rs:3:pub fn lib() {}"
-        );
-        assert_eq!(file_count, 2);
-        assert_eq!(total_matches, 2);
-    }
-
-    #[test]
-    fn renders_workspace_search_result_lines_without_line_numbers() {
-        let lines = render_workspace_search_result_lines(
-            &[FileSearchResult {
-                path: "/repo/src/main.rs".to_string(),
-                name: "main.rs".to_string(),
-                is_directory: false,
-                match_type: SearchMatchType::Content,
-                line_number: Some(12),
-                matched_content: Some("panic!(\"x\")".to_string()),
-                preview_before: None,
-                preview_inside: Some("panic!(\"x\")".to_string()),
-                preview_after: None,
-            }],
-            false,
-        );
-
-        assert_eq!(lines, vec!["/repo/src/main.rs:panic!(\"x\")"]);
-    }
-}
-
 #[async_trait]
 impl Tool for GrepTool {
     fn name(&self) -> &str {
@@ -1107,5 +810,302 @@ Usage:
             result_for_assistant: Some(result_text),
             image_attachments: None,
         }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        render_workspace_search_content_lines, render_workspace_search_result_lines, GrepTool,
+        DEFAULT_HEAD_LIMIT,
+    };
+    use crate::infrastructure::{FileSearchOutcome, FileSearchResult, SearchMatchType};
+    use crate::service::search::{
+        ContentSearchResult, WorkspaceSearchBackend, WorkspaceSearchHit, WorkspaceSearchLine,
+        WorkspaceSearchMatch, WorkspaceSearchMatchLocation, WorkspaceSearchRepoPhase,
+        WorkspaceSearchRepoStatus,
+    };
+    use serde_json::json;
+    use tool_runtime::search::grep_search::relativize_result_text;
+
+    #[test]
+    fn head_limit_defaults_and_zero_escape_hatch() {
+        assert_eq!(
+            GrepTool::resolve_head_limit(&json!({})),
+            Some(DEFAULT_HEAD_LIMIT)
+        );
+        assert_eq!(
+            GrepTool::resolve_head_limit(&json!({ "head_limit": 25 })),
+            Some(25)
+        );
+        assert_eq!(
+            GrepTool::resolve_head_limit(&json!({ "head_limit": 0 })),
+            None
+        );
+    }
+
+    #[test]
+    fn backend_max_results_only_uses_explicit_limit() {
+        assert_eq!(
+            GrepTool::backend_max_results(&json!({}), 0, Some(DEFAULT_HEAD_LIMIT)),
+            None
+        );
+        assert_eq!(
+            GrepTool::backend_max_results(&json!({ "head_limit": 25 }), 3, Some(25)),
+            Some(28)
+        );
+        assert_eq!(
+            GrepTool::backend_max_results(&json!({ "head_limit": 0 }), 7, None),
+            None
+        );
+    }
+
+    #[test]
+    fn relativizes_prefixed_result_lines() {
+        let text = "/repo/src/main.rs:12:fn main()\n/repo/src/lib.rs:3:pub fn lib()";
+        let relativized = relativize_result_text(text, Some("/repo"));
+
+        assert_eq!(
+            relativized,
+            "src/main.rs:12:fn main()\nsrc/lib.rs:3:pub fn lib()"
+        );
+    }
+
+    #[test]
+    fn renders_workspace_search_context_lines_in_rg_style() {
+        let lines = render_workspace_search_content_lines(
+            &[WorkspaceSearchHit {
+                path: "/repo/src/main.rs".to_string(),
+                matches: vec![WorkspaceSearchMatch {
+                    location: WorkspaceSearchMatchLocation {
+                        line: 12,
+                        column: 5,
+                    },
+                    snippet: "panic!(\"x\")".to_string(),
+                    matched_text: "panic".to_string(),
+                }],
+                lines: vec![
+                    WorkspaceSearchLine::Context {
+                        value: crate::service::search::WorkspaceSearchContextLine {
+                            line_number: 10,
+                            snippet: "let a = 1".to_string(),
+                        },
+                    },
+                    WorkspaceSearchLine::Context {
+                        value: crate::service::search::WorkspaceSearchContextLine {
+                            line_number: 11,
+                            snippet: "let b = 2".to_string(),
+                        },
+                    },
+                    WorkspaceSearchLine::Match {
+                        value: WorkspaceSearchMatch {
+                            location: WorkspaceSearchMatchLocation {
+                                line: 12,
+                                column: 5,
+                            },
+                            snippet: "panic!(\"x\")".to_string(),
+                            matched_text: "panic".to_string(),
+                        },
+                    },
+                    WorkspaceSearchLine::Context {
+                        value: crate::service::search::WorkspaceSearchContextLine {
+                            line_number: 13,
+                            snippet: "cleanup()".to_string(),
+                        },
+                    },
+                    WorkspaceSearchLine::ContextBreak,
+                    WorkspaceSearchLine::Context {
+                        value: crate::service::search::WorkspaceSearchContextLine {
+                            line_number: 20,
+                            snippet: "return".to_string(),
+                        },
+                    },
+                ],
+            }],
+            true,
+        );
+
+        assert_eq!(
+            lines,
+            vec![
+                "/repo/src/main.rs-10:let a = 1",
+                "/repo/src/main.rs-11:let b = 2",
+                "/repo/src/main.rs:12:panic!(\"x\")",
+                "/repo/src/main.rs-13:cleanup()",
+                "--",
+                "/repo/src/main.rs-20:return",
+            ]
+        );
+    }
+
+    #[test]
+    fn content_workspace_output_uses_hits_for_context_lines() {
+        let tool = GrepTool::new();
+        let result = ContentSearchResult {
+            outcome: FileSearchOutcome {
+                results: Vec::new(),
+                truncated: false,
+            },
+            file_counts: Vec::new(),
+            hits: vec![WorkspaceSearchHit {
+                path: "/repo/src/main.rs".to_string(),
+                matches: vec![WorkspaceSearchMatch {
+                    location: WorkspaceSearchMatchLocation {
+                        line: 12,
+                        column: 5,
+                    },
+                    snippet: "panic!(\"x\")".to_string(),
+                    matched_text: "panic".to_string(),
+                }],
+                lines: vec![
+                    WorkspaceSearchLine::Context {
+                        value: crate::service::search::WorkspaceSearchContextLine {
+                            line_number: 11,
+                            snippet: "let b = 2".to_string(),
+                        },
+                    },
+                    WorkspaceSearchLine::Match {
+                        value: WorkspaceSearchMatch {
+                            location: WorkspaceSearchMatchLocation {
+                                line: 12,
+                                column: 5,
+                            },
+                            snippet: "panic!(\"x\")".to_string(),
+                            matched_text: "panic".to_string(),
+                        },
+                    },
+                ],
+            }],
+            backend: WorkspaceSearchBackend::Indexed,
+            repo_status: WorkspaceSearchRepoStatus {
+                repo_id: "repo".to_string(),
+                repo_path: "/repo".to_string(),
+                storage_root: "/repo/.bitfun/search/flashgrep-index".to_string(),
+                base_snapshot_root: "/repo/.bitfun/search/flashgrep-index/base-snapshot"
+                    .to_string(),
+                workspace_overlay_root: "/repo/.bitfun/search/flashgrep-index/workspace-overlay"
+                    .to_string(),
+                phase: WorkspaceSearchRepoPhase::Ready,
+                snapshot_key: None,
+                last_probe_unix_secs: None,
+                last_rebuild_unix_secs: None,
+                dirty_files: crate::service::search::WorkspaceSearchDirtyFiles {
+                    modified: 0,
+                    deleted: 0,
+                    new: 0,
+                },
+                rebuild_recommended: false,
+                active_task_id: None,
+                probe_healthy: true,
+                last_error: None,
+                overlay: None,
+            },
+            candidate_docs: 1,
+            matched_lines: 1,
+            matched_occurrences: 1,
+        };
+
+        let (rendered, file_count, total_matches) =
+            tool.format_workspace_search_output("content", true, 0, None, &result, Some("/repo"));
+
+        assert_eq!(
+            rendered,
+            "src/main.rs-11:let b = 2\nsrc/main.rs:12:panic!(\"x\")"
+        );
+        assert_eq!(file_count, 1);
+        assert_eq!(total_matches, 1);
+    }
+
+    #[test]
+    fn content_workspace_output_falls_back_to_converted_line_results() {
+        let tool = GrepTool::new();
+        let result = ContentSearchResult {
+            outcome: FileSearchOutcome {
+                results: vec![
+                    FileSearchResult {
+                        path: "/repo/src/main.rs".to_string(),
+                        name: "main.rs".to_string(),
+                        is_directory: false,
+                        match_type: SearchMatchType::Content,
+                        line_number: Some(12),
+                        matched_content: Some("panic!(\"x\")".to_string()),
+                        preview_before: None,
+                        preview_inside: Some("panic!(\"x\")".to_string()),
+                        preview_after: None,
+                    },
+                    FileSearchResult {
+                        path: "/repo/src/lib.rs".to_string(),
+                        name: "lib.rs".to_string(),
+                        is_directory: false,
+                        match_type: SearchMatchType::Content,
+                        line_number: Some(3),
+                        matched_content: Some("pub fn lib() {}".to_string()),
+                        preview_before: None,
+                        preview_inside: Some("pub fn lib() {}".to_string()),
+                        preview_after: None,
+                    },
+                ],
+                truncated: false,
+            },
+            file_counts: Vec::new(),
+            hits: Vec::new(),
+            backend: WorkspaceSearchBackend::Indexed,
+            repo_status: WorkspaceSearchRepoStatus {
+                repo_id: "repo".to_string(),
+                repo_path: "/repo".to_string(),
+                storage_root: "/repo/.bitfun/search/flashgrep-index".to_string(),
+                base_snapshot_root: "/repo/.bitfun/search/flashgrep-index/base-snapshot"
+                    .to_string(),
+                workspace_overlay_root: "/repo/.bitfun/search/flashgrep-index/workspace-overlay"
+                    .to_string(),
+                phase: WorkspaceSearchRepoPhase::Ready,
+                snapshot_key: None,
+                last_probe_unix_secs: None,
+                last_rebuild_unix_secs: None,
+                dirty_files: crate::service::search::WorkspaceSearchDirtyFiles {
+                    modified: 0,
+                    deleted: 0,
+                    new: 0,
+                },
+                rebuild_recommended: false,
+                active_task_id: None,
+                probe_healthy: true,
+                last_error: None,
+                overlay: None,
+            },
+            candidate_docs: 2,
+            matched_lines: 2,
+            matched_occurrences: 2,
+        };
+
+        let (rendered, file_count, total_matches) =
+            tool.format_workspace_search_output("content", true, 0, None, &result, Some("/repo"));
+
+        assert_eq!(
+            rendered,
+            "src/main.rs:12:panic!(\"x\")\nsrc/lib.rs:3:pub fn lib() {}"
+        );
+        assert_eq!(file_count, 2);
+        assert_eq!(total_matches, 2);
+    }
+
+    #[test]
+    fn renders_workspace_search_result_lines_without_line_numbers() {
+        let lines = render_workspace_search_result_lines(
+            &[FileSearchResult {
+                path: "/repo/src/main.rs".to_string(),
+                name: "main.rs".to_string(),
+                is_directory: false,
+                match_type: SearchMatchType::Content,
+                line_number: Some(12),
+                matched_content: Some("panic!(\"x\")".to_string()),
+                preview_before: None,
+                preview_inside: Some("panic!(\"x\")".to_string()),
+                preview_after: None,
+            }],
+            false,
+        );
+
+        assert_eq!(lines, vec!["/repo/src/main.rs:panic!(\"x\")"]);
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/miniapp_init_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/miniapp_init_tool.rs
@@ -56,18 +56,6 @@ impl Default for InitMiniAppTool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::InitMiniAppTool;
-    use crate::agentic::tools::framework::{Tool, ToolExposure};
-
-    #[test]
-    fn init_miniapp_stays_expanded_for_assistant_creation() {
-        let tool = InitMiniAppTool::new();
-        assert_eq!(tool.default_exposure(), ToolExposure::Expanded);
-    }
-}
-
 #[async_trait]
 impl Tool for InitMiniAppTool {
     fn name(&self) -> &str {
@@ -227,5 +215,17 @@ Returns app_id and the app root directory. Use the root directory and file names
             result_for_assistant: Some(result_text),
             image_attachments: None,
         }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InitMiniAppTool;
+    use crate::agentic::tools::framework::{Tool, ToolExposure};
+
+    #[test]
+    fn init_miniapp_stays_expanded_for_assistant_creation() {
+        let tool = InitMiniAppTool::new();
+        assert_eq!(tool.default_exposure(), ToolExposure::Expanded);
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/skills/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/skills/catalog.rs
@@ -31,7 +31,7 @@ mod tests {
     fn runtime_catalog_covers_all_embedded_builtin_skills() {
         for dir_name in builtin_skill_dir_names() {
             assert!(
-                builtin_skill_group_key(&dir_name).is_some(),
+                builtin_skill_group_key(dir_name).is_some(),
                 "Missing built-in skill catalog entry for '{}'",
                 dir_name
             );

--- a/src/crates/assembly/core/src/agentic/tools/implementations/thread_goal_tools.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/thread_goal_tools.rs
@@ -71,38 +71,6 @@ impl GetGoalTool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn thread_goal_port_error_preserves_user_facing_policy() {
-        let invalid = thread_goal_port_error(PortError::new(
-            PortErrorKind::InvalidRequest,
-            "missing objective",
-        ));
-        let not_found = thread_goal_port_error(PortError::new(
-            PortErrorKind::NotFound,
-            "thread goal not found",
-        ));
-        let timeout = thread_goal_port_error(PortError::new(PortErrorKind::Timeout, "store lag"));
-
-        assert!(matches!(
-            invalid,
-            BitFunError::Validation(message) if message == "missing objective"
-        ));
-        assert!(matches!(
-            not_found,
-            BitFunError::NotFound(message) if message == "thread goal not found"
-        ));
-        assert!(matches!(
-            timeout,
-            BitFunError::Validation(message)
-                if message == "Thread goal operation failed. Check session state and try again."
-        ));
-    }
-}
-
 impl Default for GetGoalTool {
     fn default() -> Self {
         Self::new()
@@ -313,5 +281,37 @@ You cannot use this tool to pause, resume, budget-limit, or usage-limit a goal."
             result_for_assistant: Some(result.result_for_assistant),
             image_attachments: None,
         }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_goal_port_error_preserves_user_facing_policy() {
+        let invalid = thread_goal_port_error(PortError::new(
+            PortErrorKind::InvalidRequest,
+            "missing objective",
+        ));
+        let not_found = thread_goal_port_error(PortError::new(
+            PortErrorKind::NotFound,
+            "thread goal not found",
+        ));
+        let timeout = thread_goal_port_error(PortError::new(PortErrorKind::Timeout, "store lag"));
+
+        assert!(matches!(
+            invalid,
+            BitFunError::Validation(message) if message == "missing objective"
+        ));
+        assert!(matches!(
+            not_found,
+            BitFunError::NotFound(message) if message == "thread goal not found"
+        ));
+        assert!(matches!(
+            timeout,
+            BitFunError::Validation(message)
+                if message == "Thread goal operation failed. Check session state and try again."
+        ));
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -1714,10 +1714,7 @@ mod tests {
             .state_manager
             .create_task(ToolTask::new(
                 test_tool_call(&task_id, "ExecCommand"),
-                {
-                    let context = test_tool_execution_context();
-                    context
-                },
+                test_tool_execution_context(),
                 {
                     let mut options = ToolExecutionOptions::default();
                     options.confirm_before_run = true;

--- a/src/crates/assembly/core/src/agentic/tools/registry.rs
+++ b/src/crates/assembly/core/src/agentic/tools/registry.rs
@@ -164,6 +164,62 @@ impl DynamicToolProvider for ToolRegistry {
     }
 }
 
+/// Get all tools from the snapshot-aware global registry.
+pub async fn get_all_tools() -> Vec<Arc<dyn Tool>> {
+    let registry = get_global_tool_registry();
+    let registry_lock = registry.read().await;
+    registry_lock.get_all_tools()
+}
+
+/// Get readonly tools
+pub async fn get_readonly_tools() -> BitFunResult<Vec<Arc<dyn Tool>>> {
+    Ok(resolve_product_readonly_enabled_tools().await)
+}
+
+/// Create default tool registry - factory function
+pub fn create_tool_registry() -> ToolRegistry {
+    ToolRegistry::new()
+}
+
+// Global tool registry instance
+use std::sync::OnceLock;
+use tokio::sync::RwLock as TokioRwLock;
+
+static GLOBAL_TOOL_REGISTRY: OnceLock<Arc<TokioRwLock<ToolRegistry>>> = OnceLock::new();
+
+/// Get global tool registry
+pub fn get_global_tool_registry() -> Arc<TokioRwLock<ToolRegistry>> {
+    GLOBAL_TOOL_REGISTRY
+        .get_or_init(|| {
+            info!("Initializing global tool registry");
+            Arc::new(TokioRwLock::new(ToolRegistry::new()))
+        })
+        .clone()
+}
+
+/// Backward-compatible alias for callers that expect MCP tools to be included.
+pub async fn get_all_registered_tools() -> Vec<Arc<dyn Tool>> {
+    get_all_tools().await
+}
+
+/// Get all registered tool names
+pub async fn get_all_registered_tool_names() -> Vec<String> {
+    let all_tools = get_all_registered_tools().await;
+    all_tools
+        .into_iter()
+        .map(|tool| tool.name().to_string())
+        .collect()
+}
+
+pub async fn get_readonly_registered_tool_names() -> Vec<String> {
+    get_readonly_tools()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tool| tool.name().to_string())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::create_tool_registry;
@@ -783,60 +839,4 @@ mod tests {
             "readonly tool should not be snapshot wrapped: {read_text}"
         );
     }
-}
-
-/// Get all tools from the snapshot-aware global registry.
-pub async fn get_all_tools() -> Vec<Arc<dyn Tool>> {
-    let registry = get_global_tool_registry();
-    let registry_lock = registry.read().await;
-    registry_lock.get_all_tools()
-}
-
-/// Get readonly tools
-pub async fn get_readonly_tools() -> BitFunResult<Vec<Arc<dyn Tool>>> {
-    Ok(resolve_product_readonly_enabled_tools().await)
-}
-
-/// Create default tool registry - factory function
-pub fn create_tool_registry() -> ToolRegistry {
-    ToolRegistry::new()
-}
-
-// Global tool registry instance
-use std::sync::OnceLock;
-use tokio::sync::RwLock as TokioRwLock;
-
-static GLOBAL_TOOL_REGISTRY: OnceLock<Arc<TokioRwLock<ToolRegistry>>> = OnceLock::new();
-
-/// Get global tool registry
-pub fn get_global_tool_registry() -> Arc<TokioRwLock<ToolRegistry>> {
-    GLOBAL_TOOL_REGISTRY
-        .get_or_init(|| {
-            info!("Initializing global tool registry");
-            Arc::new(TokioRwLock::new(ToolRegistry::new()))
-        })
-        .clone()
-}
-
-/// Backward-compatible alias for callers that expect MCP tools to be included.
-pub async fn get_all_registered_tools() -> Vec<Arc<dyn Tool>> {
-    get_all_tools().await
-}
-
-/// Get all registered tool names
-pub async fn get_all_registered_tool_names() -> Vec<String> {
-    let all_tools = get_all_registered_tools().await;
-    all_tools
-        .into_iter()
-        .map(|tool| tool.name().to_string())
-        .collect()
-}
-
-pub async fn get_readonly_registered_tool_names() -> Vec<String> {
-    get_readonly_tools()
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .map(|tool| tool.name().to_string())
-        .collect()
 }

--- a/src/crates/assembly/core/src/function_agents/port_adapters.rs
+++ b/src/crates/assembly/core/src/function_agents/port_adapters.rs
@@ -172,10 +172,10 @@ impl CoreWorkStateAiAnalysisService {
     }
 
     fn parse_complete_analysis(&self, response: &str) -> AgentResult<AIGeneratedAnalysis> {
-        let parsed_analysis = parse_work_state_analysis_response(response).map_err(|error| {
-            error!("{}, response: {}", error.message, response);
-            error
-        })?;
+        let parsed_analysis =
+            parse_work_state_analysis_response(response).inspect_err(|error| {
+                error!("{}, response: {}", error.message, response);
+            })?;
 
         if parsed_analysis.predicted_actions_count < 3 {
             warn!(
@@ -456,7 +456,7 @@ not json
         fs::write(repo.path().join("src/lib.rs"), "pub fn demo() {}\n").unwrap();
         git(repo.path(), &["add", "Cargo.toml", "src/lib.rs"]);
 
-        let adapter = CoreFunctionAgentGitAdapter::default();
+        let adapter = CoreFunctionAgentGitAdapter;
         let snapshot = adapter
             .git_commit_snapshot(repo.path().to_path_buf())
             .await
@@ -482,7 +482,7 @@ not json
         fs::write(repo.path().join("staged.txt"), "staged only\n").unwrap();
         git(repo.path(), &["add", "staged.txt"]);
 
-        let adapter = CoreFunctionAgentGitAdapter::default();
+        let adapter = CoreFunctionAgentGitAdapter;
         let snapshot = adapter
             .git_commit_snapshot(repo.path().to_path_buf())
             .await
@@ -507,7 +507,7 @@ not json
         fs::write(repo.path().join("staged.txt"), "staged\n").unwrap();
         git(repo.path(), &["add", "staged.txt"]);
 
-        let adapter = CoreFunctionAgentGitAdapter::default();
+        let adapter = CoreFunctionAgentGitAdapter;
         let snapshot = adapter
             .startchat_git_snapshot(repo.path().to_path_buf())
             .await
@@ -529,7 +529,7 @@ not json
         init_git_repo(repo.path());
         fs::write(repo.path().join("new.txt"), "new\n").unwrap();
 
-        let adapter = CoreFunctionAgentGitAdapter::default();
+        let adapter = CoreFunctionAgentGitAdapter;
         let snapshot = adapter
             .startchat_git_snapshot(repo.path().to_path_buf())
             .await
@@ -548,7 +548,7 @@ not json
     async fn git_adapter_startchat_snapshot_matches_legacy_empty_state_when_not_git_repo() {
         let repo = TestTempDir::new("not-a-git-repo");
 
-        let adapter = CoreFunctionAgentGitAdapter::default();
+        let adapter = CoreFunctionAgentGitAdapter;
         let snapshot = adapter
             .startchat_git_snapshot(repo.path().to_path_buf())
             .await

--- a/src/crates/assembly/core/src/product_domain_runtime.rs
+++ b/src/crates/assembly/core/src/product_domain_runtime.rs
@@ -33,7 +33,7 @@ impl CoreProductDomainRuntime {
     }
 
     pub(crate) fn function_agent_git_adapter() -> CoreFunctionAgentGitAdapter {
-        CoreFunctionAgentGitAdapter::default()
+        CoreFunctionAgentGitAdapter
     }
 
     pub(crate) fn function_agent_ai_adapter(

--- a/src/crates/assembly/core/src/service/config/manager.rs
+++ b/src/crates/assembly/core/src/service/config/manager.rs
@@ -730,6 +730,103 @@ pub struct ConfigStatistics {
     pub last_modified: chrono::DateTime<chrono::Utc>,
 }
 
+/// Deeply merges JSON values.
+///
+/// Merges values from `overlay` into `base`:
+/// - For objects, recursively merges all key/value pairs
+/// - For other types, `overlay` overwrites `base`
+/// - Keeps fields that exist in `base` but not in `overlay`
+pub(crate) fn deep_merge(base: Value, overlay: Value) -> Value {
+    match (base, overlay) {
+        (Value::Object(mut base_obj), Value::Object(overlay_obj)) => {
+            for (key, overlay_value) in overlay_obj {
+                if let Some(base_value) = base_obj.get(&key) {
+                    base_obj.insert(key.clone(), deep_merge(base_value.clone(), overlay_value));
+                } else {
+                    base_obj.insert(key.clone(), overlay_value);
+                }
+            }
+            Value::Object(base_obj)
+        }
+        (_, overlay) => overlay,
+    }
+}
+
+/// Returns whether two versions match.
+pub(crate) fn versions_match(v1: &str, v2: &str) -> bool {
+    v1 == v2
+}
+
+/// Returns whether `v1 >= v2`.
+pub(crate) fn version_gte(v1: &str, v2: &str) -> bool {
+    parse_version(v1) >= parse_version(v2)
+}
+
+/// Returns whether `v1 < v2`.
+pub(crate) fn version_lt(v1: &str, v2: &str) -> bool {
+    parse_version(v1) < parse_version(v2)
+}
+
+/// Parses a version string into a tuple `(major, minor, patch)`.
+pub(crate) fn parse_version(version: &str) -> (u32, u32, u32) {
+    let parts: Vec<&str> = version.split('.').collect();
+    let major = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let patch = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    (major, minor, patch)
+}
+
+/// Migration function: `0.0.0 -> 1.0.0`.
+///
+/// This migration is an example showing how to handle configuration upgrades.
+pub(crate) fn migrate_0_0_0_to_1_0_0(mut config: Value) -> BitFunResult<Value> {
+    debug!("Executing config migration: 0.0.0 -> 1.0.0");
+
+    if let Some(app) = config.get_mut("app").and_then(|v| v.as_object_mut()) {
+        if !app.contains_key("ai_experience") {
+            app.insert(
+                "ai_experience".to_string(),
+                serde_json::json!({
+                    "enable_session_title_generation": true,
+                    "enable_welcome_panel_ai_analysis": false
+                }),
+            );
+        }
+    }
+
+    if let Some(ai) = config.get_mut("ai").and_then(|v| v.as_object_mut()) {
+        if !ai.contains_key("super_agent_models") {
+            ai.insert(
+                "super_agent_models".to_string(),
+                Value::Object(serde_json::Map::new()),
+            );
+        }
+        if !ai.contains_key("sub_agent_models") {
+            ai.insert("sub_agent_models".to_string(), serde_json::json!({}));
+        }
+        if !ai.contains_key("func_agent_models") {
+            let func_keys = [
+                "compression",
+                "startchat-func-agent",
+                "session-title-func-agent",
+                "git-func-agent",
+            ];
+            let mut fa = serde_json::Map::new();
+            if let Some(am) = ai.get("agent_models").and_then(|v| v.as_object()) {
+                for k in func_keys {
+                    if let Some(v) = am.get(k) {
+                        fa.insert(k.to_string(), v.clone());
+                    }
+                }
+            }
+            ai.insert("func_agent_models".to_string(), Value::Object(fa));
+        }
+    }
+
+    debug!("Migration 0.0.0 -> 1.0.0 completed");
+    Ok(config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -828,101 +925,4 @@ mod tests {
             }))
         );
     }
-}
-
-/// Deeply merges JSON values.
-///
-/// Merges values from `overlay` into `base`:
-/// - For objects, recursively merges all key/value pairs
-/// - For other types, `overlay` overwrites `base`
-/// - Keeps fields that exist in `base` but not in `overlay`
-pub(crate) fn deep_merge(base: Value, overlay: Value) -> Value {
-    match (base, overlay) {
-        (Value::Object(mut base_obj), Value::Object(overlay_obj)) => {
-            for (key, overlay_value) in overlay_obj {
-                if let Some(base_value) = base_obj.get(&key) {
-                    base_obj.insert(key.clone(), deep_merge(base_value.clone(), overlay_value));
-                } else {
-                    base_obj.insert(key.clone(), overlay_value);
-                }
-            }
-            Value::Object(base_obj)
-        }
-        (_, overlay) => overlay,
-    }
-}
-
-/// Returns whether two versions match.
-pub(crate) fn versions_match(v1: &str, v2: &str) -> bool {
-    v1 == v2
-}
-
-/// Returns whether `v1 >= v2`.
-pub(crate) fn version_gte(v1: &str, v2: &str) -> bool {
-    parse_version(v1) >= parse_version(v2)
-}
-
-/// Returns whether `v1 < v2`.
-pub(crate) fn version_lt(v1: &str, v2: &str) -> bool {
-    parse_version(v1) < parse_version(v2)
-}
-
-/// Parses a version string into a tuple `(major, minor, patch)`.
-pub(crate) fn parse_version(version: &str) -> (u32, u32, u32) {
-    let parts: Vec<&str> = version.split('.').collect();
-    let major = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
-    let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
-    let patch = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
-    (major, minor, patch)
-}
-
-/// Migration function: `0.0.0 -> 1.0.0`.
-///
-/// This migration is an example showing how to handle configuration upgrades.
-pub(crate) fn migrate_0_0_0_to_1_0_0(mut config: Value) -> BitFunResult<Value> {
-    debug!("Executing config migration: 0.0.0 -> 1.0.0");
-
-    if let Some(app) = config.get_mut("app").and_then(|v| v.as_object_mut()) {
-        if !app.contains_key("ai_experience") {
-            app.insert(
-                "ai_experience".to_string(),
-                serde_json::json!({
-                    "enable_session_title_generation": true,
-                    "enable_welcome_panel_ai_analysis": false
-                }),
-            );
-        }
-    }
-
-    if let Some(ai) = config.get_mut("ai").and_then(|v| v.as_object_mut()) {
-        if !ai.contains_key("super_agent_models") {
-            ai.insert(
-                "super_agent_models".to_string(),
-                Value::Object(serde_json::Map::new()),
-            );
-        }
-        if !ai.contains_key("sub_agent_models") {
-            ai.insert("sub_agent_models".to_string(), serde_json::json!({}));
-        }
-        if !ai.contains_key("func_agent_models") {
-            let func_keys = [
-                "compression",
-                "startchat-func-agent",
-                "session-title-func-agent",
-                "git-func-agent",
-            ];
-            let mut fa = serde_json::Map::new();
-            if let Some(am) = ai.get("agent_models").and_then(|v| v.as_object()) {
-                for k in func_keys {
-                    if let Some(v) = am.get(k) {
-                        fa.insert(k.to_string(), v.clone());
-                    }
-                }
-            }
-            ai.insert("func_agent_models".to_string(), Value::Object(fa));
-        }
-    }
-
-    debug!("Migration 0.0.0 -> 1.0.0 completed");
-    Ok(config)
 }

--- a/src/crates/assembly/core/src/service/config/providers.rs
+++ b/src/crates/assembly/core/src/service/config/providers.rs
@@ -88,7 +88,7 @@ impl ConfigProvider for AIConfigProvider {
                     }
                 }
                 if let Some(temperature) = model.temperature {
-                    if temperature < 0.0 || temperature > 2.0 {
+                    if !temperature.is_nan() && !(0.0..=2.0).contains(&temperature) {
                         warnings.push(format!(
                             "Model '{}' temperature should be between 0 and 2",
                             model.name

--- a/src/crates/assembly/core/src/service/cron/service.rs
+++ b/src/crates/assembly/core/src/service/cron/service.rs
@@ -132,9 +132,7 @@ impl CronService {
                 let target_matches = target_kind
                     .map(|target_kind| job.target_kind() == target_kind)
                     .unwrap_or(true);
-                let included = workspace_matches && session_matches && target_matches;
-
-                included
+                workspace_matches && session_matches && target_matches
             })
             .cloned()
             .collect::<Vec<_>>()

--- a/src/crates/assembly/core/src/service/i18n/generated_locale_contract.rs
+++ b/src/crates/assembly/core/src/service/i18n/generated_locale_contract.rs
@@ -617,13 +617,12 @@ pub fn generated_locale_entry_from_code(
             for entry in GENERATED_LOCALE_CONTRACT {
                 for alias in entry.aliases {
                     let alias = alias.to_ascii_lowercase();
-                    if normalized == alias || normalized.starts_with(&format!("{alias}-")) {
-                        if best_match
+                    if (normalized == alias || normalized.starts_with(&format!("{alias}-")))
+                        && best_match
                             .map(|(_, current_len)| alias.len() > current_len)
                             .unwrap_or(true)
-                        {
-                            best_match = Some((entry, alias.len()));
-                        }
+                    {
+                        best_match = Some((entry, alias.len()));
                     }
                 }
             }

--- a/src/crates/assembly/core/src/service/i18n/service.rs
+++ b/src/crates/assembly/core/src/service/i18n/service.rs
@@ -258,6 +258,46 @@ impl Default for I18nService {
     }
 }
 
+// Global singleton (optional)
+static GLOBAL_I18N_SERVICE: LazyLock<Arc<RwLock<Option<Arc<I18nService>>>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(None)));
+
+/// Gets the global i18n service.
+pub async fn get_global_i18n_service() -> Option<Arc<I18nService>> {
+    GLOBAL_I18N_SERVICE.read().await.clone()
+}
+
+/// Updates the global i18n service locale if it has been initialized.
+pub async fn sync_global_i18n_service_locale(locale: LocaleId) -> BitFunResult<bool> {
+    if let Some(service) = get_global_i18n_service().await {
+        service.set_locale(locale).await?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Sets the global i18n service.
+pub async fn set_global_i18n_service(service: Arc<I18nService>) {
+    let mut global = GLOBAL_I18N_SERVICE.write().await;
+    *global = Some(service);
+}
+
+/// Initializes the global i18n service.
+pub async fn initialize_global_i18n_service(
+    config_service: Option<Arc<ConfigService>>,
+) -> BitFunResult<Arc<I18nService>> {
+    let service = match config_service {
+        Some(cs) => Arc::new(I18nService::with_config_service(cs)),
+        None => Arc::new(I18nService::new()),
+    };
+
+    service.initialize().await?;
+    set_global_i18n_service(service.clone()).await;
+
+    Ok(service)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,44 +346,4 @@ mod tests {
             "shared.features.notReal"
         );
     }
-}
-
-// Global singleton (optional)
-static GLOBAL_I18N_SERVICE: LazyLock<Arc<RwLock<Option<Arc<I18nService>>>>> =
-    LazyLock::new(|| Arc::new(RwLock::new(None)));
-
-/// Gets the global i18n service.
-pub async fn get_global_i18n_service() -> Option<Arc<I18nService>> {
-    GLOBAL_I18N_SERVICE.read().await.clone()
-}
-
-/// Updates the global i18n service locale if it has been initialized.
-pub async fn sync_global_i18n_service_locale(locale: LocaleId) -> BitFunResult<bool> {
-    if let Some(service) = get_global_i18n_service().await {
-        service.set_locale(locale).await?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
-/// Sets the global i18n service.
-pub async fn set_global_i18n_service(service: Arc<I18nService>) {
-    let mut global = GLOBAL_I18N_SERVICE.write().await;
-    *global = Some(service);
-}
-
-/// Initializes the global i18n service.
-pub async fn initialize_global_i18n_service(
-    config_service: Option<Arc<ConfigService>>,
-) -> BitFunResult<Arc<I18nService>> {
-    let service = match config_service {
-        Some(cs) => Arc::new(I18nService::with_config_service(cs)),
-        None => Arc::new(I18nService::new()),
-    };
-
-    service.initialize().await?;
-    set_global_i18n_service(service.clone()).await;
-
-    Ok(service)
 }

--- a/src/crates/assembly/core/src/service/mcp/server/manager/lifecycle.rs
+++ b/src/crates/assembly/core/src/service/mcp/server/manager/lifecycle.rs
@@ -172,9 +172,8 @@ impl MCPServerManager {
         let config = self
             .runtime_server_config(server_id)
             .await
-            .map_err(|error| {
+            .inspect_err(|_| {
                 error!("MCP server config not found: id={}", server_id);
-                error
             })?;
 
         if !config.enabled {

--- a/src/crates/assembly/core/src/util/plain_output.rs
+++ b/src/crates/assembly/core/src/util/plain_output.rs
@@ -15,10 +15,7 @@ const THINK_CLOSE_TAG: &str = "</think>";
 pub fn sanitize_plain_model_output(raw: &str) -> String {
     let mut cleaned = raw.to_string();
 
-    loop {
-        let Some(open_idx) = cleaned.find(THINK_OPEN_TAG) else {
-            break;
-        };
+    while let Some(open_idx) = cleaned.find(THINK_OPEN_TAG) {
         let content_start = open_idx + THINK_OPEN_TAG.len();
 
         if let Some(relative_close_idx) = cleaned[content_start..].find(THINK_CLOSE_TAG) {

--- a/src/crates/contracts/events/src/agentic.rs
+++ b/src/crates/contracts/events/src/agentic.rs
@@ -458,6 +458,124 @@ impl PartialEq for AgenticEventEnvelope {
     }
 }
 
+impl Eq for AgenticEventEnvelope {}
+
+impl PartialOrd for AgenticEventEnvelope {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AgenticEventEnvelope {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.priority.cmp(&other.priority) {
+            std::cmp::Ordering::Equal => self.timestamp.cmp(&other.timestamp),
+            other => other,
+        }
+    }
+}
+
+impl AgenticEventEnvelope {
+    pub fn new(event: AgenticEvent, priority: AgenticEventPriority) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            event,
+            priority,
+            timestamp: SystemTime::now(),
+        }
+    }
+}
+
+impl AgenticEvent {
+    /// Get the session ID of the event
+    pub fn session_id(&self) -> Option<&str> {
+        match self {
+            Self::SessionCreated { session_id, .. }
+            | Self::SessionStateChanged { session_id, .. }
+            | Self::SessionDeleted { session_id }
+            | Self::SessionTitleGenerated { session_id, .. }
+            | Self::ImageAnalysisStarted { session_id, .. }
+            | Self::ImageAnalysisCompleted { session_id, .. }
+            | Self::DialogTurnStarted { session_id, .. }
+            | Self::SubagentSessionLinked { session_id, .. }
+            | Self::DialogTurnCompleted { session_id, .. }
+            | Self::TokenUsageUpdated { session_id, .. }
+            | Self::ContextCompressionStarted { session_id, .. }
+            | Self::ContextCompressionCompleted { session_id, .. }
+            | Self::ContextCompressionFailed { session_id, .. }
+            | Self::ThreadGoalUpdated { session_id, .. }
+            | Self::DialogTurnCancelled { session_id, .. }
+            | Self::DialogTurnFailed { session_id, .. }
+            | Self::ModelRoundStarted { session_id, .. }
+            | Self::TextChunk { session_id, .. }
+            | Self::ThinkingChunk { session_id, .. }
+            | Self::ModelRoundCompleted { session_id, .. }
+            | Self::ToolEvent { session_id, .. }
+            | Self::UserSteeringInjected { session_id, .. }
+            | Self::DeepReviewQueueStateChanged { session_id, .. }
+            | Self::SessionModelAutoMigrated { session_id, .. } => Some(session_id),
+            Self::SystemError { session_id, .. } => session_id.as_deref(),
+        }
+    }
+
+    /// Get the default priority
+    pub fn default_priority(&self) -> AgenticEventPriority {
+        match self {
+            Self::SystemError { .. }
+            | Self::DialogTurnFailed { .. }
+            | Self::DialogTurnCancelled { .. } => AgenticEventPriority::Critical,
+
+            Self::SessionStateChanged { .. }
+            | Self::SessionTitleGenerated { .. }
+            | Self::SessionModelAutoMigrated { .. }
+            | Self::SubagentSessionLinked { .. }
+            | Self::DeepReviewQueueStateChanged { .. }
+            | Self::ContextCompressionFailed { .. } => AgenticEventPriority::High,
+
+            Self::ImageAnalysisStarted { .. }
+            | Self::ImageAnalysisCompleted { .. }
+            | Self::TextChunk { .. }
+            | Self::ThinkingChunk { .. }
+            | Self::ModelRoundStarted { .. }
+            | Self::ModelRoundCompleted { .. }
+            | Self::TokenUsageUpdated { .. }
+            | Self::DialogTurnCompleted { .. }
+            | Self::ContextCompressionStarted { .. }
+            | Self::ThreadGoalUpdated { .. }
+            | Self::UserSteeringInjected { .. }
+            | Self::ContextCompressionCompleted { .. } => AgenticEventPriority::Normal,
+
+            Self::ToolEvent { tool_event, .. } => tool_event.default_priority(),
+
+            _ => AgenticEventPriority::Low,
+        }
+    }
+}
+
+impl ToolEventData {
+    /// Get the default priority for a specific tool event variant.
+    pub fn default_priority(&self) -> AgenticEventPriority {
+        match self {
+            Self::Cancelled { .. } => AgenticEventPriority::Critical,
+
+            Self::Started { .. }
+            | Self::Completed { .. }
+            | Self::Failed { .. }
+            | Self::ConfirmationNeeded { .. } => AgenticEventPriority::High,
+
+            Self::EarlyDetected { .. }
+            | Self::ParamsPartial { .. }
+            | Self::Queued { .. }
+            | Self::Waiting { .. }
+            | Self::Progress { .. }
+            | Self::Streaming { .. }
+            | Self::StreamChunk { .. }
+            | Self::Confirmed { .. }
+            | Self::Rejected { .. } => AgenticEventPriority::Normal,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -652,123 +770,5 @@ mod tests {
         assert_eq!(serialized["parent_dialog_turn_id"], "turn-1");
         assert_eq!(serialized["parent_tool_call_id"], "tool-1");
         assert_eq!(serialized["agent_type"], "GeneralPurpose");
-    }
-}
-
-impl Eq for AgenticEventEnvelope {}
-
-impl PartialOrd for AgenticEventEnvelope {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for AgenticEventEnvelope {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match self.priority.cmp(&other.priority) {
-            std::cmp::Ordering::Equal => self.timestamp.cmp(&other.timestamp),
-            other => other,
-        }
-    }
-}
-
-impl AgenticEventEnvelope {
-    pub fn new(event: AgenticEvent, priority: AgenticEventPriority) -> Self {
-        Self {
-            id: uuid::Uuid::new_v4().to_string(),
-            event,
-            priority,
-            timestamp: SystemTime::now(),
-        }
-    }
-}
-
-impl AgenticEvent {
-    /// Get the session ID of the event
-    pub fn session_id(&self) -> Option<&str> {
-        match self {
-            Self::SessionCreated { session_id, .. }
-            | Self::SessionStateChanged { session_id, .. }
-            | Self::SessionDeleted { session_id }
-            | Self::SessionTitleGenerated { session_id, .. }
-            | Self::ImageAnalysisStarted { session_id, .. }
-            | Self::ImageAnalysisCompleted { session_id, .. }
-            | Self::DialogTurnStarted { session_id, .. }
-            | Self::SubagentSessionLinked { session_id, .. }
-            | Self::DialogTurnCompleted { session_id, .. }
-            | Self::TokenUsageUpdated { session_id, .. }
-            | Self::ContextCompressionStarted { session_id, .. }
-            | Self::ContextCompressionCompleted { session_id, .. }
-            | Self::ContextCompressionFailed { session_id, .. }
-            | Self::ThreadGoalUpdated { session_id, .. }
-            | Self::DialogTurnCancelled { session_id, .. }
-            | Self::DialogTurnFailed { session_id, .. }
-            | Self::ModelRoundStarted { session_id, .. }
-            | Self::TextChunk { session_id, .. }
-            | Self::ThinkingChunk { session_id, .. }
-            | Self::ModelRoundCompleted { session_id, .. }
-            | Self::ToolEvent { session_id, .. }
-            | Self::UserSteeringInjected { session_id, .. }
-            | Self::DeepReviewQueueStateChanged { session_id, .. }
-            | Self::SessionModelAutoMigrated { session_id, .. } => Some(session_id),
-            Self::SystemError { session_id, .. } => session_id.as_deref(),
-        }
-    }
-
-    /// Get the default priority
-    pub fn default_priority(&self) -> AgenticEventPriority {
-        match self {
-            Self::SystemError { .. }
-            | Self::DialogTurnFailed { .. }
-            | Self::DialogTurnCancelled { .. } => AgenticEventPriority::Critical,
-
-            Self::SessionStateChanged { .. }
-            | Self::SessionTitleGenerated { .. }
-            | Self::SessionModelAutoMigrated { .. }
-            | Self::SubagentSessionLinked { .. }
-            | Self::DeepReviewQueueStateChanged { .. }
-            | Self::ContextCompressionFailed { .. } => AgenticEventPriority::High,
-
-            Self::ImageAnalysisStarted { .. }
-            | Self::ImageAnalysisCompleted { .. }
-            | Self::TextChunk { .. }
-            | Self::ThinkingChunk { .. }
-            | Self::ModelRoundStarted { .. }
-            | Self::ModelRoundCompleted { .. }
-            | Self::TokenUsageUpdated { .. }
-            | Self::DialogTurnCompleted { .. }
-            | Self::ContextCompressionStarted { .. }
-            | Self::ThreadGoalUpdated { .. }
-            | Self::UserSteeringInjected { .. }
-            | Self::ContextCompressionCompleted { .. } => AgenticEventPriority::Normal,
-
-            Self::ToolEvent { tool_event, .. } => tool_event.default_priority(),
-
-            _ => AgenticEventPriority::Low,
-        }
-    }
-}
-
-impl ToolEventData {
-    /// Get the default priority for a specific tool event variant.
-    pub fn default_priority(&self) -> AgenticEventPriority {
-        match self {
-            Self::Cancelled { .. } => AgenticEventPriority::Critical,
-
-            Self::Started { .. }
-            | Self::Completed { .. }
-            | Self::Failed { .. }
-            | Self::ConfirmationNeeded { .. } => AgenticEventPriority::High,
-
-            Self::EarlyDetected { .. }
-            | Self::ParamsPartial { .. }
-            | Self::Queued { .. }
-            | Self::Waiting { .. }
-            | Self::Progress { .. }
-            | Self::Streaming { .. }
-            | Self::StreamChunk { .. }
-            | Self::Confirmed { .. }
-            | Self::Rejected { .. } => AgenticEventPriority::Normal,
-        }
     }
 }

--- a/src/crates/execution/agent-runtime/src/deep_review/shared_context.rs
+++ b/src/crates/execution/agent-runtime/src/deep_review/shared_context.rs
@@ -66,13 +66,12 @@ pub(crate) fn shared_context_measurement_snapshot_from_uses(
         .sum();
     let mut repeated_contexts: Vec<DeepReviewSharedContextDuplicate> = uses
         .iter()
-        .filter_map(|(key, record)| {
-            (record.call_count > 1).then(|| DeepReviewSharedContextDuplicate {
-                tool_name: key.tool_name.clone(),
-                file_path: key.file_path.clone(),
-                call_count: record.call_count,
-                reviewer_count: record.reviewer_types.len(),
-            })
+        .filter(|(_, record)| record.call_count > 1)
+        .map(|(key, record)| DeepReviewSharedContextDuplicate {
+            tool_name: key.tool_name.clone(),
+            file_path: key.file_path.clone(),
+            call_count: record.call_count,
+            reviewer_count: record.reviewer_types.len(),
         })
         .collect();
     repeated_contexts.sort_by(|left, right| {

--- a/src/crates/execution/agent-runtime/src/turn_cancellation.rs
+++ b/src/crates/execution/agent-runtime/src/turn_cancellation.rs
@@ -17,7 +17,7 @@ impl DialogTurnCancellationTokenStore {
     pub fn get_or_insert_new(&self, dialog_turn_id: &str) -> CancellationToken {
         self.tokens
             .entry(dialog_turn_id.to_string())
-            .or_insert_with(CancellationToken::new)
+            .or_default()
             .clone()
     }
 

--- a/src/crates/execution/agent-stream/src/hidden_text.rs
+++ b/src/crates/execution/agent-stream/src/hidden_text.rs
@@ -148,12 +148,12 @@ fn longest_tag_prefix_suffix_len(text: &str, tags: &[HiddenTextTag]) -> usize {
     tags.iter()
         .filter(|tag| !tag.open.is_empty())
         .flat_map(|tag| {
-            (1..tag.open.len()).filter_map(move |len| {
+            (1..tag.open.len()).filter(move |&len| {
                 if text.len() < len || !text.is_char_boundary(text.len() - len) {
-                    return None;
+                    return false;
                 }
                 let suffix = &text[text.len() - len..];
-                tag.open.starts_with(suffix).then_some(len)
+                tag.open.starts_with(suffix)
             })
         })
         .max()

--- a/src/crates/execution/tool-contracts/src/framework.rs
+++ b/src/crates/execution/tool-contracts/src/framework.rs
@@ -1535,9 +1535,8 @@ impl<Tool: ToolRegistryItem + ?Sized> ToolRegistry<Tool> {
     pub fn get_collapsed_tool_names(&self) -> Vec<String> {
         self.tools
             .iter()
-            .filter_map(|(name, tool)| {
-                (tool.default_exposure() == ToolExposure::Collapsed).then(|| name.clone())
-            })
+            .filter(|(_, tool)| tool.default_exposure() == ToolExposure::Collapsed)
+            .map(|(name, _)| name.clone())
             .collect()
     }
 

--- a/src/crates/execution/tool-execution/src/util/ansi_cleaner.rs
+++ b/src/crates/execution/tool-execution/src/util/ansi_cleaner.rs
@@ -297,16 +297,14 @@ impl Perform for AnsiCleaner {
                     _ => {}
                 }
             }
-            'J' => {
+            'J' if *param == 2 => {
                 // \033[J - Erase in Display
-                if *param == 2 {
-                    // \033[2J - Erase entire display
-                    self.lines.clear();
-                    self.line_is_real.clear();
-                    self.current_line.clear();
-                    self.cursor_col = 0;
-                    self.cursor_row = 0;
-                }
+                // \033[2J - Erase entire display
+                self.lines.clear();
+                self.line_is_real.clear();
+                self.current_line.clear();
+                self.cursor_col = 0;
+                self.cursor_row = 0;
             }
             // All other CSI sequences are ignored (colors, etc.)
             _ => {}

--- a/src/crates/interfaces/acp/src/client/manager.rs
+++ b/src/crates/interfaces/acp/src/client/manager.rs
@@ -561,9 +561,8 @@ impl AcpClientService {
                 .await
             }
         }
-        .map_err(|error| {
+        .inspect_err(|_| {
             self.clients.remove(connection_id);
-            error
         })?;
         *connection.child.lock().await = child;
         let service = self.clone();

--- a/src/crates/interfaces/acp/src/client/requirements.rs
+++ b/src/crates/interfaces/acp/src/client/requirements.rs
@@ -194,7 +194,7 @@ pub(crate) async fn probe_remote_executable(
         .execute_command(connection_id, &resolve_command)
         .await
     {
-        Ok((stdout, _stderr, exit_code)) if exit_code == 0 => {
+        Ok((stdout, _stderr, 0)) => {
             let resolved_path = stdout
                 .lines()
                 .map(str::trim)
@@ -221,7 +221,7 @@ pub(crate) async fn probe_remote_executable(
             .execute_command(connection_id, &version_command)
             .await
         {
-            Ok((stdout, stderr, exit_code)) if exit_code == 0 => {
+            Ok((stdout, stderr, 0)) => {
                 item.version = parse_version_text(stdout.as_bytes())
                     .or_else(|| parse_version_text(stderr.as_bytes()));
             }
@@ -257,7 +257,7 @@ pub(crate) async fn probe_remote_npx_adapter(
         .execute_command(connection_id, &resolve_command)
         .await
     {
-        Ok((stdout, _stderr, exit_code)) if exit_code == 0 => {
+        Ok((stdout, _stderr, 0)) => {
             item.installed = true;
             item.path = stdout
                 .lines()

--- a/src/crates/interfaces/acp/src/client/tool_card_bridge/tool_params.rs
+++ b/src/crates/interfaces/acp/src/client/tool_card_bridge/tool_params.rs
@@ -74,17 +74,19 @@ pub(super) fn normalize_tool_params(
             }
         }
         "Glob" => {
-            if !normalized.contains_key("pattern") {
-                if let Some(value) = normalized
+            let pattern = if !normalized.contains_key("pattern") {
+                normalized
                     .get("glob")
                     .or_else(|| normalized.get("glob_pattern"))
                     .or_else(|| normalized.get("globPattern"))
                     .or_else(|| normalized.get("file_pattern"))
                     .or_else(|| normalized.get("filePattern"))
                     .cloned()
-                {
-                    normalized.insert("pattern".to_string(), value);
-                }
+            } else {
+                None
+            };
+            if let Some(value) = pattern {
+                normalized.insert("pattern".to_string(), value);
             }
         }
         _ => {}

--- a/src/crates/services/services-core/src/filesystem/tree.rs
+++ b/src/crates/services/services-core/src/filesystem/tree.rs
@@ -1317,13 +1317,11 @@ impl FileTreeService {
         }
 
         let mut end_index = text.len();
-        let mut char_count = 0;
-        for (byte_index, _) in text.char_indices() {
+        for (char_count, (byte_index, _)) in text.char_indices().enumerate() {
             if char_count == max_chars {
                 end_index = byte_index;
                 break;
             }
-            char_count += 1;
         }
 
         text[..end_index].to_string()

--- a/src/crates/services/services-core/src/session_usage/redaction.rs
+++ b/src/crates/services/services-core/src/session_usage/redaction.rs
@@ -10,7 +10,7 @@ pub struct RedactedLabel {
 pub fn redact_usage_label(input: &str, max_chars: usize) -> RedactedLabel {
     let mut value: String = input
         .chars()
-        .filter_map(|ch| if ch.is_control() { Some(' ') } else { Some(ch) })
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
         .collect::<String>()
         .split_whitespace()
         .collect::<Vec<_>>()

--- a/src/crates/services/services-core/tests/json_store_contracts.rs
+++ b/src/crates/services/services-core/tests/json_store_contracts.rs
@@ -38,7 +38,7 @@ impl Drop for TestTempDir {
 #[tokio::test]
 async fn json_store_returns_none_for_missing_file() {
     let root = TestTempDir::new("missing");
-    let store = JsonFileStore::default();
+    let store = JsonFileStore;
 
     let value = store
         .read_optional::<TestPayload>(&root.path().join("missing.json"))
@@ -51,7 +51,7 @@ async fn json_store_returns_none_for_missing_file() {
 #[tokio::test]
 async fn json_store_creates_parent_dirs_and_round_trips_payload() {
     let root = TestTempDir::new("round-trip");
-    let store = JsonFileStore::default();
+    let store = JsonFileStore;
     let path = root.path().join("nested").join("payload.json");
     let payload = TestPayload {
         label: "session metadata".to_string(),
@@ -72,7 +72,7 @@ async fn json_store_creates_parent_dirs_and_round_trips_payload() {
 
 #[tokio::test]
 async fn json_store_reports_no_parent_directory() {
-    let store = JsonFileStore::default();
+    let store = JsonFileStore;
 
     let error = store
         .write_atomic(

--- a/src/crates/services/services-integrations/src/browser_control/launcher.rs
+++ b/src/crates/services/services-integrations/src/browser_control/launcher.rs
@@ -462,14 +462,12 @@ impl BrowserLauncher {
             std::env::var("LOCALAPPDATA").ok(),
         ];
 
-        for root_opt in &env_roots {
-            if let Some(root) = root_opt {
-                for rel in &rel_paths {
-                    let candidate = format!(r"{}\{}", root.trim_end_matches('\\'), rel);
-                    if std::path::Path::new(&candidate).exists() {
-                        debug!("Found browser at {}", candidate);
-                        return candidate;
-                    }
+        for root in env_roots.iter().flatten() {
+            for rel in &rel_paths {
+                let candidate = format!(r"{}\{}", root.trim_end_matches('\\'), rel);
+                if std::path::Path::new(&candidate).exists() {
+                    debug!("Found browser at {}", candidate);
+                    return candidate;
                 }
             }
         }

--- a/src/crates/services/services-integrations/src/git/utils.rs
+++ b/src/crates/services/services-integrations/src/git/utils.rs
@@ -358,43 +358,6 @@ pub async fn execute_git_readonly_command(
     }
 }
 
-#[cfg(test)]
-mod review_git_output_tests {
-    use super::*;
-
-    #[test]
-    fn repository_root_ignores_an_invalid_lexical_git_marker() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let nested = temp.path().join("nested");
-        std::fs::create_dir_all(temp.path().join(".git")).expect("fake git marker");
-        std::fs::create_dir_all(&nested).expect("nested directory");
-
-        assert!(get_repository_root(&nested).is_err());
-    }
-
-    #[test]
-    fn repository_root_preserves_a_valid_lexical_worktree_root() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        Repository::init(temp.path()).expect("repository");
-        let nested = temp.path().join("nested");
-        std::fs::create_dir_all(&nested).expect("nested directory");
-
-        assert_eq!(
-            get_repository_root(&nested).expect("repository root"),
-            temp.path().to_string_lossy()
-        );
-    }
-
-    #[tokio::test]
-    async fn bounded_reader_rejects_output_before_unbounded_buffering() {
-        let reader = tokio::io::repeat(b'x');
-        let error = read_bounded_review_git_stream(reader)
-            .await
-            .expect_err("unbounded output must be rejected");
-        assert!(error.to_string().contains("8 MiB safety limit"));
-    }
-}
-
 /// Executes a Git command synchronously and returns the raw output including exit code.
 pub fn execute_git_command_sync_raw(
     repo_path: &str,
@@ -446,4 +409,41 @@ pub fn check_git_available() -> bool {
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod review_git_output_tests {
+    use super::*;
+
+    #[test]
+    fn repository_root_ignores_an_invalid_lexical_git_marker() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let nested = temp.path().join("nested");
+        std::fs::create_dir_all(temp.path().join(".git")).expect("fake git marker");
+        std::fs::create_dir_all(&nested).expect("nested directory");
+
+        assert!(get_repository_root(&nested).is_err());
+    }
+
+    #[test]
+    fn repository_root_preserves_a_valid_lexical_worktree_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        Repository::init(temp.path()).expect("repository");
+        let nested = temp.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("nested directory");
+
+        assert_eq!(
+            get_repository_root(&nested).expect("repository root"),
+            temp.path().to_string_lossy()
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_reader_rejects_output_before_unbounded_buffering() {
+        let reader = tokio::io::repeat(b'x');
+        let error = read_bounded_review_git_stream(reader)
+            .await
+            .expect_err("unbounded output must be rejected");
+        assert!(error.to_string().contains("8 MiB safety limit"));
+    }
 }

--- a/src/crates/services/services-integrations/src/mcp/server/connection.rs
+++ b/src/crates/services/services-integrations/src/mcp/server/connection.rs
@@ -76,7 +76,7 @@ impl MCPConnection {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     fn with_initialize_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.initialize_timeout = timeout;
         self

--- a/src/crates/services/services-integrations/src/remote_connect/mobile_web_upload.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/mobile_web_upload.rs
@@ -39,56 +39,6 @@ fn mobile_web_upload_manifest(
         .collect()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn manifest_preserves_forward_slash_paths_and_hashes() {
-        let base = std::env::temp_dir().join(format!(
-            "bitfun-remote-mobile-web-manifest-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let assets = base.join("assets");
-        std::fs::create_dir_all(&assets).unwrap();
-        std::fs::write(base.join("index.html"), b"<html></html>").unwrap();
-        std::fs::write(assets.join("app.js"), b"console.log('ok');").unwrap();
-
-        let files = collect_mobile_web_files(&base).unwrap();
-        let mut manifest = mobile_web_upload_manifest(&files);
-        manifest.sort_by(|left, right| left.path.cmp(&right.path));
-
-        assert_eq!(manifest.len(), 2);
-        assert_eq!(manifest[0].path, "assets/app.js");
-        assert_eq!(manifest[0].size, b"console.log('ok');".len() as u64);
-        assert_eq!(
-            manifest[0].hash,
-            "16ba942cc0730b9c1416eb532c015b5d26bf8419618e315abe2544b87ae63a16"
-        );
-        assert_eq!(manifest[1].path, "index.html");
-        assert_eq!(manifest[1].size, b"<html></html>".len() as u64);
-
-        let _ = std::fs::remove_dir_all(base);
-    }
-
-    #[test]
-    fn manifest_rejects_missing_index_html() {
-        let base = std::env::temp_dir().join(format!(
-            "bitfun-remote-mobile-web-missing-index-{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&base).unwrap();
-
-        let error = match collect_mobile_web_files(&base) {
-            Ok(_) => panic!("missing index.html should be rejected"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("missing index.html"));
-        let _ = std::fs::remove_dir_all(base);
-    }
-}
-
 /// Upload mobile-web assets to a relay server.
 pub async fn upload_mobile_web_to_relay(
     relay_url: &str,
@@ -391,4 +341,54 @@ fn collect_files_with_hash(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_preserves_forward_slash_paths_and_hashes() {
+        let base = std::env::temp_dir().join(format!(
+            "bitfun-remote-mobile-web-manifest-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let assets = base.join("assets");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(base.join("index.html"), b"<html></html>").unwrap();
+        std::fs::write(assets.join("app.js"), b"console.log('ok');").unwrap();
+
+        let files = collect_mobile_web_files(&base).unwrap();
+        let mut manifest = mobile_web_upload_manifest(&files);
+        manifest.sort_by(|left, right| left.path.cmp(&right.path));
+
+        assert_eq!(manifest.len(), 2);
+        assert_eq!(manifest[0].path, "assets/app.js");
+        assert_eq!(manifest[0].size, b"console.log('ok');".len() as u64);
+        assert_eq!(
+            manifest[0].hash,
+            "16ba942cc0730b9c1416eb532c015b5d26bf8419618e315abe2544b87ae63a16"
+        );
+        assert_eq!(manifest[1].path, "index.html");
+        assert_eq!(manifest[1].size, b"<html></html>".len() as u64);
+
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn manifest_rejects_missing_index_html() {
+        let base = std::env::temp_dir().join(format!(
+            "bitfun-remote-mobile-web-missing-index-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+
+        let error = match collect_mobile_web_files(&base) {
+            Ok(_) => panic!("missing index.html should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("missing index.html"));
+        let _ = std::fs::remove_dir_all(base);
+    }
 }

--- a/src/crates/services/services-integrations/src/remote_ssh/manager.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/manager.rs
@@ -66,9 +66,9 @@ fn ssh_cfg_has(settings: &std::collections::HashMap<&str, &str>, canonical_key: 
 /// quoted value or the first whitespace-delimited token for unquoted values.
 fn parse_ssh_config_value(value: &str) -> Option<&str> {
     let value = value.trim();
-    if value.starts_with('"') {
-        if let Some(end) = value[1..].find('"') {
-            let inner = &value[1..1 + end];
+    if let Some(quoted) = value.strip_prefix('"') {
+        if let Some(end) = quoted.find('"') {
+            let inner = &quoted[..end];
             return if inner.is_empty() { None } else { Some(inner) };
         }
     }
@@ -1661,15 +1661,12 @@ impl SSHConnectionManager {
         let result = SSHCommandResult {
             stdout,
             stderr,
-            exit_code: exit_status.unwrap_or_else(|| {
-                if timed_out {
-                    124
-                } else if interrupted {
-                    130
-                } else {
-                    -1
-                }
-            }),
+            exit_code: match exit_status {
+                Some(exit_code) => exit_code,
+                None if timed_out => 124,
+                None if interrupted => 130,
+                None => -1,
+            },
             interrupted,
             timed_out,
         };
@@ -2390,9 +2387,8 @@ impl SSHConnectionManager {
         }
 
         for dir in sftp_mkdir_all_prefixes(&path) {
-            match sftp.as_ref().try_exists(&dir).await {
-                Ok(true) => continue,
-                Ok(false) | Err(_) => {}
+            if let Ok(true) = sftp.as_ref().try_exists(&dir).await {
+                continue;
             }
 
             if let Err(error) = sftp.as_ref().create_dir(&dir).await {

--- a/src/crates/services/services-integrations/src/workspace_search/flashgrep/rpc_client.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/flashgrep/rpc_client.rs
@@ -222,10 +222,7 @@ where
 pub(crate) fn drain_content_length_messages(buffer: &mut Vec<u8>) -> Result<Vec<ServerMessage>> {
     let mut messages = Vec::new();
 
-    loop {
-        let Some(header_end) = find_header_end(buffer) else {
-            break;
-        };
+    while let Some(header_end) = find_header_end(buffer) {
         let header = String::from_utf8_lossy(&buffer[..header_end]);
         let mut content_length = None;
         for line in header.lines() {


### PR DESCRIPTION
## Summary

This PR completes the first low-risk phase of the Rust Clippy backlog cleanup without changing the lint policy or making Clippy a blocking CI gate.

- resolves all 135 findings selected for Scheme A across expression simplification, control-flow readability, test-module ordering, and test-only dead code
- removes one additional stale test import exposed by the cleanup
- reduces the deduplicated Rust warning inventory from 488 to 352
- introduces no new `allow` or `expect` exceptions
- preserves public API, protocol compatibility, runtime behavior, evaluation order, error propagation, async boundaries, and performance characteristics

## Scope and safety

The changes are intentionally limited to behavior-preserving Rust idioms and mechanical test-module relocation. Eager-evaluation rewrites were avoided where they could alter side effects or cost, floating-point range handling retains the previous NaN behavior, and error inspection continues to propagate the original errors unchanged.

The remaining 352 findings belong to later, higher-judgment categories such as unsafe-operation hygiene, unsafe-block documentation, argument-shape design, and initialization refactors. They remain non-blocking and are not weakened or hidden in this PR.

CI policy and repository documentation are unchanged.

## Verification

- `pnpm run lint:rs`
- `pnpm run lint:rs:desktop`
- `pnpm run lint:rs:installer`
- Core library tests: 965 passed, 1 ignored
- CLI all-target tests passed
- ACP tests: 80 passed
- Desktop library tests: 89 passed
- Relay server tests: 7 passed
- affected execution-layer package tests passed
- services integration tests passed with MCP, Git, remote, browser-control, SSH, and workspace-search features
- i18n contract tests: 37 passed
- core boundary tests and repository hygiene checks passed
- theme color audit passed
- changed Rust formatting and `git diff --check` passed

An independent full-range review found no Critical, Important, or Minor issues and no API, locking, async, or performance regressions.