### PR TITLE
refactor: reduce Rust lint backlog

### DIFF
--- a/src/apps/cli/src/config.rs
+++ b/src/apps/cli/src/config.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 /// CLI configuration (contains only CLI-specific config)
 /// AI model configuration uses core's GlobalConfig
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub(crate) struct CliConfig {
     /// UI configuration
@@ -114,17 +114,6 @@ impl Default for ShortcutsConfig {
     }
 }
 
-impl Default for CliConfig {
-    fn default() -> Self {
-        Self {
-            ui: UiConfig::default(),
-            behavior: BehaviorConfig::default(),
-            workspace: WorkspaceConfig::default(),
-            shortcuts: ShortcutsConfig::default(),
-        }
-    }
-}
-
 impl CliConfig {
     /// Get configuration file path
     pub(crate) fn config_path() -> Result<PathBuf> {
@@ -188,5 +177,32 @@ impl CliConfig {
 
         fs::create_dir_all(&config_dir)?;
         Ok(config_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CliConfig;
+
+    #[test]
+    fn cli_config_default_composes_owner_defaults() {
+        let config = CliConfig::default();
+
+        assert_eq!(config.ui.theme, "dark");
+        assert_eq!(config.ui.theme_id, "bitfun-dark");
+        assert!(config.ui.show_tips);
+        assert!(config.ui.animation);
+        assert_eq!(config.ui.color_scheme, "default");
+        assert!(config.behavior.auto_save);
+        assert!(config.behavior.confirm_dangerous);
+        assert_eq!(config.behavior.default_agent, "agentic");
+        assert_eq!(config.workspace.default_path, ".");
+        assert_eq!(
+            config.workspace.exclude_patterns,
+            ["node_modules", ".git", "target", "dist"]
+        );
+        assert_eq!(config.shortcuts.send_message, "Ctrl+D");
+        assert_eq!(config.shortcuts.interrupt, "Ctrl+C");
+        assert_eq!(config.shortcuts.menu, "Esc");
     }
 }

--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -118,6 +118,16 @@ struct NonKeyEventOutcome {
     resize_seen: bool,
 }
 
+struct ChatEventContext<'a> {
+    this: &'a mut ChatMode,
+    chat_view: &'a mut ChatView,
+    chat_state: &'a mut ChatState,
+    session_id: &'a mut String,
+    rt_handle: &'a tokio::runtime::Handle,
+    should_quit: &'a mut bool,
+    exit_reason: &'a mut ChatExitReason,
+}
+
 pub(crate) struct ChatMode {
     config: CliConfig,
     /// Current agent type (e.g. "agentic", "plan", "debug")
@@ -736,13 +746,15 @@ impl ChatMode {
                         for ev in non_key_events {
                             let outcome = Self::handle_non_key_event(
                                 ev,
-                                self,
-                                &mut chat_view,
-                                &mut chat_state,
-                                &mut session_id,
-                                &rt_handle,
-                                &mut should_quit,
-                                &mut exit_reason,
+                                ChatEventContext {
+                                    this: self,
+                                    chat_view: &mut chat_view,
+                                    chat_state: &mut chat_state,
+                                    session_id: &mut session_id,
+                                    rt_handle: &rt_handle,
+                                    should_quit: &mut should_quit,
+                                    exit_reason: &mut exit_reason,
+                                },
                             )?;
                             if outcome.request_redraw {
                                 needs_redraw = true;
@@ -764,13 +776,15 @@ impl ChatMode {
                                     )? {
                                         Self::apply_exit_reason(
                                             reason,
-                                            self,
-                                            &mut chat_view,
-                                            &mut chat_state,
-                                            &mut session_id,
-                                            &rt_handle,
-                                            &mut should_quit,
-                                            &mut exit_reason,
+                                            ChatEventContext {
+                                                this: self,
+                                                chat_view: &mut chat_view,
+                                                chat_state: &mut chat_state,
+                                                session_id: &mut session_id,
+                                                rt_handle: &rt_handle,
+                                                should_quit: &mut should_quit,
+                                                exit_reason: &mut exit_reason,
+                                            },
                                         );
                                     }
                                     if key.kind == KeyEventKind::Press
@@ -782,13 +796,15 @@ impl ChatMode {
                                 other => {
                                     let outcome = Self::handle_non_key_event(
                                         other,
-                                        self,
-                                        &mut chat_view,
-                                        &mut chat_state,
-                                        &mut session_id,
-                                        &rt_handle,
-                                        &mut should_quit,
-                                        &mut exit_reason,
+                                        ChatEventContext {
+                                            this: self,
+                                            chat_view: &mut chat_view,
+                                            chat_state: &mut chat_state,
+                                            session_id: &mut session_id,
+                                            rt_handle: &rt_handle,
+                                            should_quit: &mut should_quit,
+                                            exit_reason: &mut exit_reason,
+                                        },
                                     )?;
                                     if outcome.request_redraw {
                                         needs_redraw = true;
@@ -1367,16 +1383,16 @@ impl ChatMode {
     }
 
     /// Apply an exit reason from handle_key_event (shared by normal and batch paths).
-    fn apply_exit_reason(
-        reason: ChatExitReason,
-        this: &mut Self,
-        chat_view: &mut ChatView,
-        chat_state: &mut ChatState,
-        session_id: &mut String,
-        rt_handle: &tokio::runtime::Handle,
-        should_quit: &mut bool,
-        exit_reason: &mut ChatExitReason,
-    ) {
+    fn apply_exit_reason(reason: ChatExitReason, context: ChatEventContext<'_>) {
+        let ChatEventContext {
+            this,
+            chat_view,
+            chat_state,
+            session_id,
+            rt_handle,
+            should_quit,
+            exit_reason,
+        } = context;
         match reason {
             ChatExitReason::SwitchSession(new_session_id) => {
                 match this.switch_to_session(
@@ -1413,124 +1429,152 @@ impl ChatMode {
     /// Handle non-key events (Mouse, Paste, Resize, etc.).
     fn handle_non_key_event(
         event: Event,
-        this: &mut Self,
-        chat_view: &mut ChatView,
-        chat_state: &mut ChatState,
-        session_id: &mut String,
-        rt_handle: &tokio::runtime::Handle,
-        should_quit: &mut bool,
-        exit_reason: &mut ChatExitReason,
+        context: ChatEventContext<'_>,
     ) -> Result<NonKeyEventOutcome> {
         let mut outcome = NonKeyEventOutcome::default();
         match event {
             Event::Mouse(mouse) => {
-                if chat_view.command_palette_captures_mouse(&mouse) {
-                    let action = chat_view.command_palette_handle_mouse(&mouse);
+                if context.chat_view.command_palette_captures_mouse(&mouse) {
+                    let action = context.chat_view.command_palette_handle_mouse(&mouse);
                     match action {
                         PaletteAction::Execute(id) => {
-                            if let Some(reason) =
-                                this.handle_palette_action(&id, chat_view, chat_state, rt_handle)?
-                            {
+                            if let Some(reason) = context.this.handle_palette_action(
+                                &id,
+                                context.chat_view,
+                                context.chat_state,
+                                context.rt_handle,
+                            )? {
                                 Self::apply_exit_reason(
                                     reason,
-                                    this,
-                                    chat_view,
-                                    chat_state,
-                                    session_id,
-                                    rt_handle,
-                                    should_quit,
-                                    exit_reason,
+                                    ChatEventContext {
+                                        this: &mut *context.this,
+                                        chat_view: &mut *context.chat_view,
+                                        chat_state: &mut *context.chat_state,
+                                        session_id: &mut *context.session_id,
+                                        rt_handle: context.rt_handle,
+                                        should_quit: &mut *context.should_quit,
+                                        exit_reason: &mut *context.exit_reason,
+                                    },
                                 );
                             }
                         }
                         PaletteAction::Dismiss | PaletteAction::None => {}
                     }
-                } else if chat_view.provider_selector_captures_mouse(&mouse) {
-                    if let Some(selection) = chat_view.provider_selector_handle_mouse(&mouse) {
-                        this.handle_provider_selection(selection, chat_view);
+                } else if context.chat_view.provider_selector_captures_mouse(&mouse) {
+                    if let Some(selection) =
+                        context.chat_view.provider_selector_handle_mouse(&mouse)
+                    {
+                        context
+                            .this
+                            .handle_provider_selection(selection, context.chat_view);
                     }
-                } else if chat_view.handle_mouse_event(&mouse) {
-                    if let Some(action) = chat_view.take_pending_skill_action() {
-                        this.handle_skill_selector_action(action, chat_view, chat_state, rt_handle);
+                } else if context.chat_view.handle_mouse_event(&mouse) {
+                    if let Some(action) = context.chat_view.take_pending_skill_action() {
+                        context.this.handle_skill_selector_action(
+                            action,
+                            context.chat_view,
+                            context.chat_state,
+                            context.rt_handle,
+                        );
                     }
-                    if let Some(action) = chat_view.take_pending_subagent_action() {
-                        this.handle_subagent_selector_action(
-                            action, chat_view, chat_state, rt_handle,
+                    if let Some(action) = context.chat_view.take_pending_subagent_action() {
+                        context.this.handle_subagent_selector_action(
+                            action,
+                            context.chat_view,
+                            context.chat_state,
+                            context.rt_handle,
                         );
                     }
                 } else {
                     match mouse.kind {
                         MouseEventKind::ScrollUp => {
-                            let total = chat_view.count_message_lines(chat_state);
-                            chat_view.scroll_up(3, total);
+                            let total = context.chat_view.count_message_lines(context.chat_state);
+                            context.chat_view.scroll_up(3, total);
                         }
                         MouseEventKind::ScrollDown => {
-                            chat_view.scroll_down(3);
+                            context.chat_view.scroll_down(3);
                         }
                         MouseEventKind::Down(MouseButton::Left) => {
-                            let _ = chat_view.begin_mouse_selection(mouse.column, mouse.row);
+                            let _ = context
+                                .chat_view
+                                .begin_mouse_selection(mouse.column, mouse.row);
                         }
                         MouseEventKind::Drag(MouseButton::Left) => {
-                            let _ = chat_view.update_mouse_selection(mouse.column, mouse.row);
+                            let _ = context
+                                .chat_view
+                                .update_mouse_selection(mouse.column, mouse.row);
                         }
                         MouseEventKind::Up(MouseButton::Left) => {
-                            match chat_view
+                            match context
+                                .chat_view
                                 .complete_mouse_selection_or_click(mouse.column, mouse.row)
                             {
                                 MouseGestureOutcome::CopyText(text) => {
                                     match Clipboard::new().and_then(|mut cb| cb.set_text(text)) {
-                                        Ok(()) => chat_view
+                                        Ok(()) => context
+                                            .chat_view
                                             .set_status(Some("Copied to clipboard".to_string())),
-                                        Err(_) => chat_view.set_status(Some(
+                                        Err(_) => context.chat_view.set_status(Some(
                                             "Failed to copy selection".to_string(),
                                         )),
                                     }
                                 }
                                 MouseGestureOutcome::Click(col, row) => {
-                                    chat_view.handle_mouse_click(col, row);
+                                    context.chat_view.handle_mouse_click(col, row);
                                 }
                                 MouseGestureOutcome::None => {}
                             }
                         }
                         MouseEventKind::Moved
-                            if !chat_view.update_mouse_selection(mouse.column, mouse.row) =>
+                            if !context
+                                .chat_view
+                                .update_mouse_selection(mouse.column, mouse.row) =>
                         {
-                            chat_view.handle_mouse_move(mouse.column, mouse.row);
+                            context.chat_view.handle_mouse_move(mouse.column, mouse.row);
                         }
                         _ => {}
                     }
                 }
-                if let Some(cmd) = chat_view.take_pending_command() {
-                    if let Some(reason) =
-                        this.handle_command(&cmd, chat_view, chat_state, rt_handle)?
-                    {
+                if let Some(cmd) = context.chat_view.take_pending_command() {
+                    if let Some(reason) = context.this.handle_command(
+                        &cmd,
+                        context.chat_view,
+                        context.chat_state,
+                        context.rt_handle,
+                    )? {
                         Self::apply_exit_reason(
                             reason,
-                            this,
-                            chat_view,
-                            chat_state,
-                            session_id,
-                            rt_handle,
-                            should_quit,
-                            exit_reason,
+                            ChatEventContext {
+                                this: &mut *context.this,
+                                chat_view: &mut *context.chat_view,
+                                chat_state: &mut *context.chat_state,
+                                session_id: &mut *context.session_id,
+                                rt_handle: context.rt_handle,
+                                should_quit: &mut *context.should_quit,
+                                exit_reason: &mut *context.exit_reason,
+                            },
                         );
                     }
                 }
-                if let Some(theme) = chat_view.take_pending_theme_preview() {
-                    this.preview_theme_selection(&theme, chat_view);
+                if let Some(theme) = context.chat_view.take_pending_theme_preview() {
+                    context
+                        .this
+                        .preview_theme_selection(&theme, context.chat_view);
                 }
-                if let Some(server_id) = chat_view.take_pending_mcp_toggle() {
-                    this.toggle_mcp_server(&server_id, chat_view);
+                if let Some(server_id) = context.chat_view.take_pending_mcp_toggle() {
+                    context
+                        .this
+                        .toggle_mcp_server(&server_id, context.chat_view);
                 }
                 outcome.request_redraw = true;
             }
             Event::Paste(text) => {
-                if chat_view.mcp_add_dialog_visible() {
-                    chat_view.mcp_add_dialog_handle_paste(&text);
+                if context.chat_view.mcp_add_dialog_visible() {
+                    context.chat_view.mcp_add_dialog_handle_paste(&text);
                 } else {
                     let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
                     for c in normalized.chars() {
-                        chat_view.handle_char(c);
+                        context.chat_view.handle_char(c);
                     }
                 }
                 outcome.request_redraw = true;

--- a/src/apps/cli/src/ui/agent_selector.rs
+++ b/src/apps/cli/src/ui/agent_selector.rs
@@ -183,10 +183,7 @@ impl AgentSelectorState {
             return None;
         }
 
-        let area = match self.last_area {
-            Some(area) => area,
-            None => return None,
-        };
+        let area = self.last_area?;
 
         let in_popup = mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)

--- a/src/apps/cli/src/ui/command_menu.rs
+++ b/src/apps/cli/src/ui/command_menu.rs
@@ -172,10 +172,7 @@ impl CommandMenuState {
             return None;
         }
 
-        let area = match self.last_area {
-            Some(area) => area,
-            None => return None,
-        };
+        let area = self.last_area?;
 
         let in_menu = mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)

--- a/src/apps/cli/src/ui/mcp_add_dialog.rs
+++ b/src/apps/cli/src/ui/mcp_add_dialog.rs
@@ -642,9 +642,7 @@ fn render_input_line<'a>(
     let total_chars = buffer.chars().count();
 
     // Calculate scroll offset to keep cursor visible
-    let scroll = if field_width == 0 {
-        0
-    } else if cursor < field_width / 3 {
+    let scroll = if field_width == 0 || cursor < field_width / 3 {
         0
     } else {
         cursor.saturating_sub(field_width / 3)

--- a/src/apps/cli/src/ui/model_selector.rs
+++ b/src/apps/cli/src/ui/model_selector.rs
@@ -210,10 +210,7 @@ impl ModelSelectorState {
             return None;
         }
 
-        let area = match self.last_area {
-            Some(area) => area,
-            None => return None,
-        };
+        let area = self.last_area?;
 
         let in_popup = mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)

--- a/src/apps/cli/src/ui/provider_selector.rs
+++ b/src/apps/cli/src/ui/provider_selector.rs
@@ -297,10 +297,7 @@ impl ProviderSelectorState {
             return None;
         }
 
-        let area = match self.last_area {
-            Some(a) => a,
-            None => return None,
-        };
+        let area = self.last_area?;
 
         let in_popup = mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)

--- a/src/apps/cli/src/ui/skill_selector.rs
+++ b/src/apps/cli/src/ui/skill_selector.rs
@@ -231,10 +231,7 @@ impl SkillSelectorState {
             return None;
         }
 
-        let area = match self.last_area {
-            Some(area) => area,
-            None => return None,
-        };
+        let area = self.last_area?;
 
         let in_popup = mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)

--- a/src/apps/cli/src/ui/startup.rs
+++ b/src/apps/cli/src/ui/startup.rs
@@ -497,7 +497,7 @@ impl StartupPage {
         let visual_lines =
             self.text_input
                 .visual_line_count_with_prefix(input_content_width, 0) as u16;
-        let content_lines = visual_lines.max(1).min(6);
+        let content_lines = visual_lines.clamp(1, 6);
         let input_box_height = content_lines + 3; // +1 top padding, +1 gap, +1 agent label
 
         let v_chunks = Layout::default()

--- a/src/apps/cli/src/ui/subagent_selector.rs
+++ b/src/apps/cli/src/ui/subagent_selector.rs
@@ -232,10 +232,7 @@ impl SubagentSelectorState {
             return None;
         }
 
-        let area = match self.last_area {
-            Some(area) => area,
-            None => return None,
-        };
+        let area = self.last_area?;
 
         let in_popup = mouse.column >= area.x
             && mouse.column < area.x.saturating_add(area.width)

--- a/src/apps/cli/src/ui/text_input.rs
+++ b/src/apps/cli/src/ui/text_input.rs
@@ -16,6 +16,10 @@ pub(crate) struct TextInput {
     scroll_offset: usize,
 }
 
+fn wrapped_visual_line_count(text_width: usize, available_width: usize) -> usize {
+    text_width.div_ceil(available_width)
+}
+
 /// Style configuration for rendering a TextInput.
 pub(super) struct TextInputStyle {
     pub(super) first_line_prefix: &'static str,
@@ -221,7 +225,7 @@ impl TextInput {
                 if text_w == 0 {
                     1
                 } else {
-                    (text_w + avail - 1) / avail
+                    wrapped_visual_line_count(text_w, avail)
                 }
             })
             .sum()
@@ -254,7 +258,7 @@ impl TextInput {
             if text_w == 0 {
                 visual_row += 1;
             } else {
-                visual_row += (text_w + avail - 1) / avail;
+                visual_row += wrapped_visual_line_count(text_w, avail);
             }
         }
 
@@ -393,5 +397,43 @@ impl TextInput {
                 ));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TextInput;
+
+    #[test]
+    fn empty_text_has_one_visual_line_and_prefix_cursor_position() {
+        let mut input = TextInput::new();
+        input.set_text("");
+
+        assert_eq!(input.visual_line_count_with_prefix(6, 2), 1);
+        assert_eq!(input.cursor_visual_position(6, 2), (0, 2));
+    }
+
+    #[test]
+    fn exact_width_multiple_preserves_line_count_and_cursor_position() {
+        let mut input = TextInput::new();
+        input.set_text("abcdefgh");
+
+        assert_eq!(input.visual_line_count_with_prefix(6, 2), 2);
+        assert_eq!(input.cursor_visual_position(6, 2), (1, 6));
+    }
+
+    #[test]
+    fn remainder_adds_visual_line_and_places_cursor_on_it() {
+        let mut input = TextInput::new();
+        input.set_text("abcdefghi");
+
+        assert_eq!(input.visual_line_count_with_prefix(6, 2), 3);
+        assert_eq!(input.cursor_visual_position(6, 2), (2, 3));
+    }
+
+    #[test]
+    fn available_visual_width_is_always_nonzero() {
+        assert_eq!(TextInput::avail_width(0, usize::MAX), 1);
+        assert_eq!(TextInput::avail_width(u16::MAX, 0), u16::MAX as usize);
     }
 }

--- a/src/apps/cli/src/ui/tool_cards.rs
+++ b/src/apps/cli/src/ui/tool_cards.rs
@@ -43,6 +43,18 @@ pub(super) struct ToolCardRenderOutput {
     pub(super) plain_lines: Vec<String>,
 }
 
+struct BlockAssembly<'a> {
+    title: &'a str,
+    content_lines: Vec<Line<'static>>,
+    theme: &'a Theme,
+    is_running: bool,
+    error: Option<&'a str>,
+    focused: bool,
+    tool_state: &'a ToolDisplayState,
+    spinner_frame: &'a str,
+    available_width: u16,
+}
+
 /// Clear the tool card render cache (call on session switch or /clear)
 pub(super) fn clear_tool_card_cache() {
     TOOL_CARD_CACHE.with(|cache| cache.borrow_mut().clear());
@@ -1004,8 +1016,8 @@ fn render_hmos_compilation_block(
         None
     };
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
         is_running,
@@ -1014,7 +1026,7 @@ fn render_hmos_compilation_block(
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a Bash tool as a block (command + output + expand/collapse)
@@ -1104,8 +1116,8 @@ fn render_bash_block(
         None
     };
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
         is_running,
@@ -1114,7 +1126,7 @@ fn render_bash_block(
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render an Edit tool as a block (file path + diff preview)
@@ -1197,17 +1209,17 @@ fn render_edit_block(
         None
     };
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
-        false,
+        is_running: false,
         error,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a Write tool as a block (file path + syntax-highlighted content preview)
@@ -1287,17 +1299,17 @@ fn render_write_block(
             None
         };
 
-        return assemble_block(
-            &title,
+        return assemble_block(BlockAssembly {
+            title: &title,
             content_lines,
             theme,
-            false,
+            is_running: false,
             error,
             focused,
             tool_state,
             spinner_frame,
             available_width,
-        );
+        });
     }
 
     // Fallback: no content available
@@ -1321,17 +1333,17 @@ fn render_write_block(
         None
     };
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
-        false,
+        is_running: false,
         error,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a Delete tool as a block
@@ -1367,17 +1379,17 @@ fn render_delete_block(
         None
     };
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
-        false,
+        is_running: false,
         error,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a Task tool as a block (sub-agent type + description + real-time progress)
@@ -1446,17 +1458,17 @@ fn render_task_block(
         }
     }
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
         is_running,
-        None,
+        error: None,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a TodoWrite tool as a block (todo list with upgraded icons)
@@ -1522,17 +1534,17 @@ fn render_todo_block(
         )));
     }
 
-    assemble_block(
-        "Todos",
+    assemble_block(BlockAssembly {
+        title: "Todos",
         content_lines,
         theme,
-        false,
-        None,
+        is_running: false,
+        error: None,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render an AskUserQuestion tool as a block
@@ -1662,17 +1674,17 @@ fn render_question_block(
         }
     }
 
-    assemble_block(
-        "Questions",
+    assemble_block(BlockAssembly {
+        title: "Questions",
         content_lines,
         theme,
-        false,
-        None,
+        is_running: false,
+        error: None,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a CreatePlan tool as a block
@@ -1722,17 +1734,17 @@ fn render_plan_block(
         )));
     }
 
-    assemble_block(
-        &title_text,
+    assemble_block(BlockAssembly {
+        title: &title_text,
         content_lines,
         theme,
-        false,
-        None,
+        is_running: false,
+        error: None,
         focused,
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 /// Render a generic block tool (fallback for unknown block tools)
@@ -1791,8 +1803,8 @@ fn render_generic_block(
         None
     };
 
-    assemble_block(
-        &title,
+    assemble_block(BlockAssembly {
+        title: &title,
         content_lines,
         theme,
         is_running,
@@ -1801,7 +1813,7 @@ fn render_generic_block(
         tool_state,
         spinner_frame,
         available_width,
-    )
+    })
 }
 
 // ============ Block Assembly ============
@@ -1818,17 +1830,18 @@ fn render_generic_block(
 ///   │    error message (if any)                     │
 ///   ╰──────────────────────────────────────────────╯
 /// ```
-fn assemble_block(
-    title: &str,
-    content_lines: Vec<Line<'static>>,
-    theme: &Theme,
-    is_running: bool,
-    error: Option<&str>,
-    focused: bool,
-    tool_state: &ToolDisplayState,
-    spinner_frame: &str,
-    available_width: u16,
-) -> ToolCardRenderOutput {
+fn assemble_block(assembly: BlockAssembly<'_>) -> ToolCardRenderOutput {
+    let BlockAssembly {
+        title,
+        content_lines,
+        theme,
+        is_running,
+        error,
+        focused,
+        tool_state,
+        spinner_frame,
+        available_width,
+    } = assembly;
     let mut items = Vec::new();
     let mut plain_lines = Vec::new();
 

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -97,9 +97,7 @@ fn register_search(
     state: &State<'_, AppState>,
     search_id: Option<&str>,
 ) -> Option<Arc<AtomicBool>> {
-    let Some(search_id) = search_id.filter(|value| !value.is_empty()) else {
-        return None;
-    };
+    let search_id = search_id.filter(|value| !value.is_empty())?;
 
     let cancel_flag = Arc::new(AtomicBool::new(false));
     let mut active_searches = lock_active_searches(state);
@@ -700,7 +698,7 @@ fn remote_filename_search_result(entry: &RemoteDirEntry) -> FileSearchResult {
     }
 }
 
-async fn search_remote_file_names_with_progress(
+struct RemoteFilenameSearch {
     remote_fs: RemoteFileService,
     entry: RemoteWorkspaceEntry,
     root_path: String,
@@ -712,7 +710,24 @@ async fn search_remote_file_names_with_progress(
     limit: usize,
     cancel_flag: Option<Arc<AtomicBool>>,
     progress_sink: Option<Arc<dyn FileSearchProgressSink>>,
+}
+
+async fn search_remote_file_names_with_progress(
+    search: RemoteFilenameSearch,
 ) -> Result<FileSearchOutcome, String> {
+    let RemoteFilenameSearch {
+        remote_fs,
+        entry,
+        root_path,
+        pattern,
+        case_sensitive,
+        use_regex,
+        whole_word,
+        include_directories,
+        limit,
+        cancel_flag,
+        progress_sink,
+    } = search;
     let matcher = compile_filename_search_regex(&pattern, case_sensitive, use_regex, whole_word)?;
     let mut stack = vec![root_path];
     let mut results = Vec::new();
@@ -3442,9 +3457,7 @@ fn archive_stem(file_name: &str) -> String {
     // Double extensions (7 chars for .tar.gz / .tar.xz / etc., 6 for .tar.zst).
     if lower.ends_with(".tar.gz") || lower.ends_with(".tar.xz") {
         file_name[..file_name.len() - 7].to_string()
-    } else if lower.ends_with(".tar.bz2") {
-        file_name[..file_name.len() - 8].to_string()
-    } else if lower.ends_with(".tar.zst") {
+    } else if lower.ends_with(".tar.bz2") || lower.ends_with(".tar.zst") {
         file_name[..file_name.len() - 8].to_string()
     // Short aliases (5 chars for .tbz2 / .txz, 5 for .tzst).
     } else if lower.ends_with(".tgz") || lower.ends_with(".txz") {
@@ -3816,19 +3829,19 @@ pub async fn search_filenames(
             requested_path,
             entry,
         }) => match state.get_remote_file_service_async().await {
-            Ok(remote_fs) => search_remote_file_names_with_progress(
+            Ok(remote_fs) => search_remote_file_names_with_progress(RemoteFilenameSearch {
                 remote_fs,
                 entry,
-                requested_path,
-                request.pattern.clone(),
-                request.case_sensitive,
-                request.use_regex,
-                request.whole_word,
-                request.include_directories,
+                root_path: requested_path,
+                pattern: request.pattern.clone(),
+                case_sensitive: request.case_sensitive,
+                use_regex: request.use_regex,
+                whole_word: request.whole_word,
+                include_directories: request.include_directories,
                 limit,
                 cancel_flag,
-                None,
-            )
+                progress_sink: None,
+            })
             .await
             .map_err(bitfun_core::util::errors::BitFunError::service),
             Err(error) => Err(bitfun_core::util::errors::BitFunError::service(format!(
@@ -4004,19 +4017,19 @@ pub async fn start_search_filenames_stream(
 
     tokio::spawn(async move {
         let result = if let Some((remote_fs, entry, requested_path)) = remote_search_target {
-            search_remote_file_names_with_progress(
+            search_remote_file_names_with_progress(RemoteFilenameSearch {
                 remote_fs,
                 entry,
-                requested_path,
-                pattern.clone(),
+                root_path: requested_path,
+                pattern: pattern.clone(),
                 case_sensitive,
                 use_regex,
                 whole_word,
                 include_directories,
                 limit,
-                cancel_flag.clone(),
-                Some(progress_sink),
-            )
+                cancel_flag: cancel_flag.clone(),
+                progress_sink: Some(progress_sink),
+            })
             .await
             .map_err(bitfun_core::util::errors::BitFunError::service)
         } else {

--- a/src/apps/desktop/src/computer_use/som_overlay.rs
+++ b/src/apps/desktop/src/computer_use/som_overlay.rs
@@ -74,7 +74,20 @@ pub(crate) fn render_overlay(
         // with another element's badge (cap retries to avoid blowups).
         for _ in 0..6 {
             let collides = placed_badges.iter().any(|(px, py, pw, ph)| {
-                rects_overlap(bx, by, badge_w, badge_h, *px, *py, *pw, *ph)
+                rects_overlap(
+                    Rectangle {
+                        x: bx,
+                        y: by,
+                        width: badge_w,
+                        height: badge_h,
+                    },
+                    Rectangle {
+                        x: *px,
+                        y: *py,
+                        width: *pw,
+                        height: *ph,
+                    },
+                )
             });
             if !collides {
                 break;
@@ -129,8 +142,18 @@ fn role_color(role: &str, subrole: Option<&str>) -> Rgba<u8> {
     }
 }
 
-fn rects_overlap(ax: i32, ay: i32, aw: i32, ah: i32, bx: i32, by: i32, bw: i32, bh: i32) -> bool {
-    !(ax + aw <= bx || bx + bw <= ax || ay + ah <= by || by + bh <= ay)
+struct Rectangle {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+}
+
+fn rects_overlap(first: Rectangle, second: Rectangle) -> bool {
+    !(first.x + first.width <= second.x
+        || second.x + second.width <= first.x
+        || first.y + first.height <= second.y
+        || second.y + second.height <= first.y)
 }
 
 fn draw_rect_outline(
@@ -329,5 +352,55 @@ mod tests {
         let out = render_overlay(&jpeg, &elements, None).expect("overlay");
         let decoded = image::load_from_memory(&out).expect("decode overlay");
         assert_eq!(decoded.width(), 80);
+    }
+
+    #[test]
+    fn rectangles_touching_edges_do_not_overlap() {
+        assert!(!rects_overlap(
+            Rectangle {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+            Rectangle {
+                x: 10,
+                y: 0,
+                width: 5,
+                height: 5,
+            },
+        ));
+        assert!(!rects_overlap(
+            Rectangle {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+            Rectangle {
+                x: 0,
+                y: 10,
+                width: 5,
+                height: 5,
+            },
+        ));
+    }
+
+    #[test]
+    fn rectangles_with_shared_area_overlap() {
+        assert!(rects_overlap(
+            Rectangle {
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            },
+            Rectangle {
+                x: 9,
+                y: 9,
+                width: 5,
+                height: 5,
+            },
+        ));
     }
 }

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -82,16 +82,11 @@ pub struct QueuedTurn {
     execution: QueuedTurnExecution,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) enum QueuedTurnExecution {
+    #[default]
     Standard,
     HiddenSubagent(HiddenSubagentQueuedExecution),
-}
-
-impl Default for QueuedTurnExecution {
-    fn default() -> Self {
-        Self::Standard
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1804,6 +1799,14 @@ pub fn clear_thread_goal_continuation_abort(session_id: &str) {
 mod tests {
     use super::*;
     use bitfun_runtime_ports::{AgentDialogPrependedReminder, AgentInputAttachment, PortErrorKind};
+
+    #[test]
+    fn queued_turn_execution_default_is_standard() {
+        assert!(matches!(
+            QueuedTurnExecution::default(),
+            QueuedTurnExecution::Standard
+        ));
+    }
 
     fn agent_session_active_turn(source_session_id: &str) -> ActiveDialogTurn {
         ActiveDialogTurn::new(

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -3842,8 +3842,10 @@ mod tests {
 
     #[test]
     fn resolve_configured_fast_model_falls_back_to_primary_when_fast_is_stale() {
-        let mut ai_config = AIConfig::default();
-        ai_config.models = vec![build_model("model-primary", "Primary", "claude-sonnet-4.5")];
+        let mut ai_config = AIConfig {
+            models: vec![build_model("model-primary", "Primary", "claude-sonnet-4.5")],
+            ..Default::default()
+        };
         ai_config.default_models.primary = Some("model-primary".to_string());
         ai_config.default_models.fast = Some("deleted-fast-model".to_string());
 

--- a/src/crates/assembly/core/src/agentic/execution/model_exchange_trace.rs
+++ b/src/crates/assembly/core/src/agentic/execution/model_exchange_trace.rs
@@ -373,9 +373,7 @@ pub(super) async fn prepare_model_exchange_trace_for_workspace(
     operation: ModelExchangeTraceOperation<'_>,
     ai_client: &AIClient,
 ) -> Option<ModelExchangeTraceConfig> {
-    let Some(policy) = current_model_exchange_trace_policy().await else {
-        return None;
-    };
+    let policy = current_model_exchange_trace_policy().await?;
 
     let Some(workspace) = workspace else {
         debug!(

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -216,11 +216,7 @@ impl RoundExecutor {
                             delay_ms,
                             err_msg
                         );
-                        if let Err(cancel_err) =
-                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await
-                        {
-                            return Err(cancel_err);
-                        }
+                        Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                         attempt_index += 1;
                         continue;
                     }
@@ -329,11 +325,7 @@ impl RoundExecutor {
                                     .count(),
                                 err_msg
                             );
-                            if let Err(cancel_err) =
-                                Self::sleep_with_cancellation(delay_ms, &cancel_token).await
-                            {
-                                return Err(cancel_err);
-                            }
+                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                             attempt_index += 1;
                             continue;
                         }
@@ -420,11 +412,7 @@ impl RoundExecutor {
                             result.tool_calls.len(),
                             partial_recovery_reason
                         );
-                        if let Err(cancel_err) =
-                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await
-                        {
-                            return Err(cancel_err);
-                        }
+                        Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                         attempt_index += 1;
                         continue;
                     }
@@ -452,11 +440,7 @@ impl RoundExecutor {
                                 delay_ms,
                                 result.tool_calls.len()
                             );
-                            if let Err(cancel_err) =
-                                Self::sleep_with_cancellation(delay_ms, &cancel_token).await
-                            {
-                                return Err(cancel_err);
-                            }
+                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                             attempt_index += 1;
                             continue;
                         }
@@ -503,11 +487,7 @@ impl RoundExecutor {
                             max_attempts,
                             delay_ms
                         );
-                        if let Err(cancel_err) =
-                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await
-                        {
-                            return Err(cancel_err);
-                        }
+                        Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                         attempt_index += 1;
                         continue;
                     }
@@ -555,11 +535,7 @@ impl RoundExecutor {
                             delay_ms,
                             err_msg
                         );
-                        if let Err(cancel_err) =
-                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await
-                        {
-                            return Err(cancel_err);
-                        }
+                        Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                         attempt_index += 1;
                         continue;
                     }

--- a/src/crates/assembly/core/src/agentic/memories/runner.rs
+++ b/src/crates/assembly/core/src/agentic/memories/runner.rs
@@ -200,11 +200,11 @@ impl MemoryPhase2Runner {
         info!(
             "Memory phase2 run started: generate_memories={}, limit={}, max_unused_days={}, phase2_lease_seconds={}, phase2_success_cooldown_seconds={}, phase2_retry_delay_seconds={}, memory_root={}",
             config.memories.generate_memories,
-            config.memories.max_raw_memories_for_consolidation.max(1).min(4096),
-            config.memories.max_unused_days.max(0).min(365),
-            config.memories.phase2_lease_seconds.max(60).min(24 * 60 * 60),
-            config.memories.phase2_success_cooldown_seconds.max(0).min(7 * 24 * 60 * 60),
-            config.memories.phase2_retry_delay_seconds.max(60).min(24 * 60 * 60),
+            config.memories.max_raw_memories_for_consolidation.clamp(1, 4096),
+            config.memories.max_unused_days.clamp(0, 365),
+            config.memories.phase2_lease_seconds.clamp(60, 24 * 60 * 60),
+            config.memories.phase2_success_cooldown_seconds.clamp(0, 7 * 24 * 60 * 60),
+            config.memories.phase2_retry_delay_seconds.clamp(60, 24 * 60 * 60),
             self.memory_root.display()
         );
         if !config.memories.generate_memories {
@@ -218,8 +218,7 @@ impl MemoryPhase2Runner {
                 config
                     .memories
                     .phase2_success_cooldown_seconds
-                    .max(0)
-                    .min(7 * 24 * 60 * 60),
+                    .clamp(0, 7 * 24 * 60 * 60),
             );
             if cooldown_until.is_some_and(|until| until > now) {
                 info!(
@@ -272,10 +271,9 @@ impl MemoryPhase2Runner {
         let limit = config
             .memories
             .max_raw_memories_for_consolidation
-            .max(1)
-            .min(4096);
+            .clamp(1, 4096);
         let candidate_scan_limit = 4096;
-        let max_unused_days = config.memories.max_unused_days.max(0).min(365);
+        let max_unused_days = config.memories.max_unused_days.clamp(0, 365);
         let candidate_rows = self
             .db
             .list_phase2_input_candidates(candidate_scan_limit, max_unused_days)
@@ -790,17 +788,12 @@ async fn phase2_retry_delay_seconds() -> BitFunResult<i64> {
     Ok(config
         .memories
         .phase2_retry_delay_seconds
-        .max(60)
-        .min(24 * 60 * 60))
+        .clamp(60, 24 * 60 * 60))
 }
 
 async fn phase2_lease_seconds() -> BitFunResult<i64> {
     let config = get_phase2_runtime_config().await;
-    Ok(config
-        .memories
-        .phase2_lease_seconds
-        .max(60)
-        .min(24 * 60 * 60))
+    Ok(config.memories.phase2_lease_seconds.clamp(60, 24 * 60 * 60))
 }
 
 fn select_phase2_model_id(

--- a/src/crates/assembly/core/src/agentic/memories/service.rs
+++ b/src/crates/assembly/core/src/agentic/memories/service.rs
@@ -76,13 +76,13 @@ impl MemoryPhase1RuntimeConfig {
         Self {
             generate_memories: memories.generate_memories,
             external_context_policy: memories.external_context_policy,
-            max_scan_sessions: memories.max_rollouts_scan_limit.max(1).min(50_000),
-            max_claimed_sessions: memories.max_rollouts_per_startup.max(1).min(128),
-            min_idle_hours: memories.min_rollout_idle_hours.max(1).min(48) as u64,
-            max_session_age_days: memories.max_rollout_age_days.max(0).min(90) as u64,
-            max_running_jobs: memories.phase1_max_concurrency.max(1).min(16),
-            retry_backoff_seconds: memories.phase1_retry_backoff_minutes.max(1).min(24 * 60) * 60,
-            lease_seconds: memories.phase1_lease_seconds.max(60).min(24 * 60 * 60),
+            max_scan_sessions: memories.max_rollouts_scan_limit.clamp(1, 50_000),
+            max_claimed_sessions: memories.max_rollouts_per_startup.clamp(1, 128),
+            min_idle_hours: memories.min_rollout_idle_hours.clamp(1, 48) as u64,
+            max_session_age_days: memories.max_rollout_age_days.clamp(0, 90) as u64,
+            max_running_jobs: memories.phase1_max_concurrency.clamp(1, 16),
+            retry_backoff_seconds: memories.phase1_retry_backoff_minutes.clamp(1, 24 * 60) * 60,
+            lease_seconds: memories.phase1_lease_seconds.clamp(60, 24 * 60 * 60),
             extract_model_selector: memories
                 .extract_model
                 .clone()

--- a/src/crates/assembly/core/src/agentic/memories/types.rs
+++ b/src/crates/assembly/core/src/agentic/memories/types.rs
@@ -20,7 +20,7 @@ pub struct MemoryExtractionRecord {
     pub created_at_unix_secs: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct MemoryPhase1RunStats {
     pub scanned_sessions: usize,
     pub candidate_sessions: usize,
@@ -29,14 +29,21 @@ pub struct MemoryPhase1RunStats {
     pub failed_sessions: usize,
 }
 
-impl Default for MemoryPhase1RunStats {
-    fn default() -> Self {
-        Self {
-            scanned_sessions: 0,
-            candidate_sessions: 0,
-            extracted_sessions: 0,
-            skipped_sessions: 0,
-            failed_sessions: 0,
-        }
+#[cfg(test)]
+mod tests {
+    use super::MemoryPhase1RunStats;
+
+    #[test]
+    fn phase1_run_stats_default_is_all_zeroes() {
+        assert_eq!(
+            MemoryPhase1RunStats::default(),
+            MemoryPhase1RunStats {
+                scanned_sessions: 0,
+                candidate_sessions: 0,
+                extracted_sessions: 0,
+                skipped_sessions: 0,
+                failed_sessions: 0,
+            }
+        );
     }
 }

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -674,9 +674,7 @@ impl SessionManager {
                     .map(str::trim)
                     .filter(|value| !value.is_empty())
                     .map(str::to_string);
-                if config.remote_connection_id.is_none() {
-                    return None;
-                }
+                config.remote_connection_id.as_ref()?;
             }
         } else if remote_hostname.is_some() {
             return None;
@@ -690,9 +688,7 @@ impl SessionManager {
         workspace_path: &str,
         ssh_host: Option<&str>,
     ) -> Option<WorkspaceInfo> {
-        let Some(ssh_host) = ssh_host.map(str::trim).filter(|value| !value.is_empty()) else {
-            return None;
-        };
+        let ssh_host = ssh_host.map(str::trim).filter(|value| !value.is_empty())?;
 
         let normalized_workspace_path =
             crate::service::remote_ssh::normalize_remote_workspace_path(workspace_path);
@@ -5456,8 +5452,10 @@ mod tests {
 
     #[test]
     fn sync_session_context_window_refreshes_stale_explicit_model_window() {
-        let mut ai_config = ServiceAIConfig::default();
-        ai_config.models = vec![test_model("deepseek-v4-pro", 1_000_000)];
+        let ai_config = ServiceAIConfig {
+            models: vec![test_model("deepseek-v4-pro", 1_000_000)],
+            ..Default::default()
+        };
 
         let mut session = Session::new_with_id(
             "session-804".to_string(),
@@ -5479,11 +5477,13 @@ mod tests {
 
     #[test]
     fn sync_session_context_window_resolves_auto_through_agent_model_then_primary() {
-        let mut ai_config = ServiceAIConfig::default();
-        ai_config.models = vec![
-            test_model("primary-model", 512_000),
-            test_model("agent-model", 1_000_000),
-        ];
+        let mut ai_config = ServiceAIConfig {
+            models: vec![
+                test_model("primary-model", 512_000),
+                test_model("agent-model", 1_000_000),
+            ],
+            ..Default::default()
+        };
         ai_config.default_models.primary = Some("primary-model".to_string());
         ai_config
             .agent_models

--- a/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
@@ -69,25 +69,13 @@ const ALLOWED_OPERATIONS: &[&str] = &[
 const DANGEROUS_OPERATIONS: &[&str] = &["push --force", "reset --hard", "clean -fd", "rebase"];
 
 /// Parsed result of a `git diff` args string.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 struct ParsedDiffArgs {
     staged: bool,
     stat: bool,
     source: Option<String>,
     target: Option<String>,
     files: Option<Vec<String>>,
-}
-
-impl Default for ParsedDiffArgs {
-    fn default() -> Self {
-        Self {
-            staged: false,
-            stat: false,
-            source: None,
-            target: None,
-            files: None,
-        }
-    }
 }
 
 /// Git tool
@@ -398,10 +386,11 @@ impl GitTool {
     /// - `--staged` → staged=true
     /// - `origin/main...HEAD` → source=origin/main, target=HEAD (three-dot)
     fn parse_diff_args(args_str: &str) -> ParsedDiffArgs {
-        let mut result = ParsedDiffArgs::default();
-
-        result.staged = args_str.contains("--staged") || args_str.contains("--cached");
-        result.stat = args_str.contains("--stat");
+        let mut result = ParsedDiffArgs {
+            staged: args_str.contains("--staged") || args_str.contains("--cached"),
+            stat: args_str.contains("--stat"),
+            ..Default::default()
+        };
 
         // Split on " -- " to separate options/refs from file paths
         let (refs_part, files_part) = if let Some(sep_pos) = args_str.find(GIT_DIFF_FILE_SEPARATOR)
@@ -1345,6 +1334,20 @@ mod tests {
 
     use super::{git_operation_needs_light_checkpoint, GitTool, ParsedDiffArgs};
     use serde_json::json;
+
+    #[test]
+    fn parsed_diff_args_default_is_empty_and_unset() {
+        assert_eq!(
+            ParsedDiffArgs::default(),
+            ParsedDiffArgs {
+                staged: false,
+                stat: false,
+                source: None,
+                target: None,
+                files: None,
+            }
+        );
+    }
 
     #[tokio::test]
     async fn git_schema_requires_explicit_operation_instead_of_args_only() {

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -397,9 +397,7 @@ impl ToolPipeline {
         task_ids: Vec<String>,
         interrupt: Option<crate::agentic::round_preempt::DialogRoundInjectionInterrupt>,
     ) -> Option<tokio::task::JoinHandle<()>> {
-        if interrupt.is_none() {
-            return None;
-        }
+        interrupt.as_ref()?;
 
         let pipeline = self.clone();
         Some(tokio::spawn(async move {
@@ -1715,11 +1713,10 @@ mod tests {
             .create_task(ToolTask::new(
                 test_tool_call(&task_id, "ExecCommand"),
                 test_tool_execution_context(),
-                {
-                    let mut options = ToolExecutionOptions::default();
-                    options.confirm_before_run = true;
-                    options.confirmation_timeout_secs = Some(1);
-                    options
+                ToolExecutionOptions {
+                    confirm_before_run: true,
+                    confirmation_timeout_secs: Some(1),
+                    ..Default::default()
                 },
             ))
             .await;
@@ -1731,10 +1728,9 @@ mod tests {
             .execute_tools(
                 vec![test_tool_call("tool_1", "ExecCommand")],
                 test_tool_execution_context(),
-                {
-                    let mut options = ToolExecutionOptions::default();
-                    options.confirmation_timeout_secs = Some(0);
-                    options
+                ToolExecutionOptions {
+                    confirmation_timeout_secs: Some(0),
+                    ..Default::default()
                 },
             )
             .await
@@ -2015,8 +2011,10 @@ mod tests {
             "turn_1".to_string(),
             buffer,
         ));
-        let mut options = ToolExecutionOptions::default();
-        options.allow_parallel = false;
+        let options = ToolExecutionOptions {
+            allow_parallel: false,
+            ..Default::default()
+        };
 
         let results = pipeline
             .execute_tools(vec![test_tool_call("tool_1", "Read")], context, options)

--- a/src/crates/assembly/core/src/infrastructure/ai/mod.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/mod.rs
@@ -41,8 +41,10 @@ mod tests {
     #[test]
     fn model_reasoning_mode_does_not_override_stream_timeouts() {
         let config = AIConfig::default();
-        let mut model = AIModelConfig::default();
-        model.reasoning_mode = Some(crate::service::config::types::ReasoningMode::Enabled);
+        let model = AIModelConfig {
+            reasoning_mode: Some(crate::service::config::types::ReasoningMode::Enabled),
+            ..Default::default()
+        };
 
         let options = build_stream_options_for_model(&config, Some(&model));
 
@@ -52,9 +54,11 @@ mod tests {
 
     #[test]
     fn explicit_none_stream_timeouts_mean_wait_indefinitely() {
-        let mut config = AIConfig::default();
-        config.stream_idle_timeout_secs = None;
-        config.stream_ttft_timeout_secs = None;
+        let config = AIConfig {
+            stream_idle_timeout_secs: None,
+            stream_ttft_timeout_secs: None,
+            ..Default::default()
+        };
 
         let options = build_stream_options_for_model(&config, None);
 

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -694,7 +694,7 @@ impl AIConfig {
 /// Shared agent-profile configuration.
 ///
 /// Model mapping has moved to `AIConfig.agent_models`, keyed by agent id.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct AgentProfileConfig {
     /// Shared profile ID (e.g. agentic, coding_shared, requirement, ui-design).
@@ -722,7 +722,7 @@ pub struct AgentProfileConfig {
 }
 
 /// API view of a mode configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct AgentProfileView {
     pub profile_id: String,
@@ -822,31 +822,6 @@ pub const DEFAULT_MAX_ROUNDS: usize = 200;
 
 fn default_max_rounds() -> usize {
     DEFAULT_MAX_ROUNDS
-}
-
-impl Default for AgentProfileConfig {
-    fn default() -> Self {
-        Self {
-            profile_id: String::new(),
-            added_tools: Vec::new(),
-            removed_tools: Vec::new(),
-            disabled_user_skills: Vec::new(),
-            enabled_user_skills: Vec::new(),
-            subagent_overrides: HashMap::new(),
-        }
-    }
-}
-
-impl Default for AgentProfileView {
-    fn default() -> Self {
-        Self {
-            profile_id: String::new(),
-            enabled_tools: Vec::new(),
-            default_tools: Vec::new(),
-            disabled_user_skills: Vec::new(),
-            enabled_user_skills: Vec::new(),
-        }
-    }
 }
 
 /// Debug-mode configuration.
@@ -1778,10 +1753,28 @@ impl AIModelConfig {
 #[cfg(test)]
 mod tests {
     use super::{
-        AIConfig, AIExperienceConfig, AIModelConfig, AppLoggingConfig, GlobalConfig,
-        MemoryExternalContextPolicy, ModelExchangeTracingMode, ReasoningMode,
-        SubagentBatchExecutionPolicy,
+        AIConfig, AIExperienceConfig, AIModelConfig, AgentProfileConfig, AgentProfileView,
+        AppLoggingConfig, GlobalConfig, MemoryExternalContextPolicy, ModelExchangeTracingMode,
+        ReasoningMode, SubagentBatchExecutionPolicy,
     };
+
+    #[test]
+    fn agent_profile_defaults_keep_all_collections_empty() {
+        let config = AgentProfileConfig::default();
+        assert!(config.profile_id.is_empty());
+        assert!(config.added_tools.is_empty());
+        assert!(config.removed_tools.is_empty());
+        assert!(config.disabled_user_skills.is_empty());
+        assert!(config.enabled_user_skills.is_empty());
+        assert!(config.subagent_overrides.is_empty());
+
+        let view = AgentProfileView::default();
+        assert!(view.profile_id.is_empty());
+        assert!(view.enabled_tools.is_empty());
+        assert!(view.default_tools.is_empty());
+        assert!(view.disabled_user_skills.is_empty());
+        assert!(view.enabled_user_skills.is_empty());
+    }
 
     #[test]
     fn deserializes_compatibility_thinking_flag_into_reasoning_mode() {

--- a/src/crates/contracts/product-domains/src/canvas/types.rs
+++ b/src/crates/contracts/product-domains/src/canvas/types.rs
@@ -63,32 +63,22 @@ impl CanvasWorkspaceId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CanvasScope {
+    #[default]
     Session,
 }
 
-impl Default for CanvasScope {
-    fn default() -> Self {
-        Self::Session
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CanvasStatus {
+    #[default]
     SourceSaved,
     Compiled,
     CompileFailed,
     RuntimeFailed,
     Unsupported,
-}
-
-impl Default for CanvasStatus {
-    fn default() -> Self {
-        Self::SourceSaved
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/crates/contracts/product-domains/tests/canvas_contracts.rs
+++ b/src/crates/contracts/product-domains/tests/canvas_contracts.rs
@@ -7,6 +7,20 @@ use bitfun_product_domains::canvas::{
 };
 
 #[test]
+fn canvas_enum_defaults_preserve_variants_and_wire_values() {
+    assert_eq!(CanvasScope::default(), CanvasScope::Session);
+    assert_eq!(CanvasStatus::default(), CanvasStatus::SourceSaved);
+    assert_eq!(
+        serde_json::to_string(&CanvasScope::default()).unwrap(),
+        "\"session\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CanvasStatus::default()).unwrap(),
+        "\"source_saved\""
+    );
+}
+
+#[test]
 fn canvas_artifact_ref_uses_logical_uri_not_path() {
     let reference =
         CanvasArtifactRef::new(CanvasSessionId::new("session 1"), CanvasId::new("canvas 1"));

--- a/src/crates/execution/agent-runtime/src/deep_review/execution_policy.rs
+++ b/src/crates/execution/agent-runtime/src/deep_review/execution_policy.rs
@@ -34,17 +34,12 @@ pub enum DeepReviewSubagentRole {
     Judge,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DeepReviewStrategyLevel {
     Quick,
+    #[default]
     Normal,
     Deep,
-}
-
-impl Default for DeepReviewStrategyLevel {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 impl DeepReviewStrategyLevel {
@@ -59,25 +54,13 @@ impl DeepReviewStrategyLevel {
 }
 
 /// Risk factors used for automatic strategy selection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ChangeRiskFactors {
     pub file_count: usize,
     pub total_lines_changed: usize,
     pub files_in_security_paths: usize,
     pub max_cyclomatic_complexity_delta: usize,
     pub cross_crate_changes: usize,
-}
-
-impl Default for ChangeRiskFactors {
-    fn default() -> Self {
-        Self {
-            file_count: 0,
-            total_lines_changed: 0,
-            files_in_security_paths: 0,
-            max_cyclomatic_complexity_delta: 0,
-            cross_crate_changes: 0,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -360,8 +343,7 @@ impl DeepReviewExecutionPolicy {
         }
         // Split into chunks of roughly `reviewer_file_split_threshold` files
         // each, but never exceed `max_same_role_instances`.
-        let needed = (file_count + self.reviewer_file_split_threshold - 1)
-            / self.reviewer_file_split_threshold;
+        let needed = file_count.div_ceil(self.reviewer_file_split_threshold);
         needed.clamp(1, self.max_same_role_instances)
     }
 
@@ -545,8 +527,26 @@ fn number_as_i64(value: &Value) -> Option<i64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DeepReviewExecutionPolicy, DeepReviewStrategyLevel};
+    use super::{ChangeRiskFactors, DeepReviewExecutionPolicy, DeepReviewStrategyLevel};
     use serde_json::json;
+
+    #[test]
+    fn derivable_defaults_preserve_strategy_and_zero_risk_factors() {
+        assert_eq!(
+            DeepReviewStrategyLevel::default(),
+            DeepReviewStrategyLevel::Normal
+        );
+        assert_eq!(
+            ChangeRiskFactors::default(),
+            ChangeRiskFactors {
+                file_count: 0,
+                total_lines_changed: 0,
+                files_in_security_paths: 0,
+                max_cyclomatic_complexity_delta: 0,
+                cross_crate_changes: 0,
+            }
+        );
+    }
 
     #[test]
     fn run_manifest_strategy_applies_builtin_quick_budget_without_execution_policy() {
@@ -584,8 +584,10 @@ mod tests {
 
     #[test]
     fn run_manifest_strategy_preserves_deep_budget_and_respects_lower_threshold_override() {
-        let mut policy = DeepReviewExecutionPolicy::default();
-        policy.reviewer_file_split_threshold = 10;
+        let policy = DeepReviewExecutionPolicy {
+            reviewer_file_split_threshold: 10,
+            ..Default::default()
+        };
         let manifest = json!({
             "reviewMode": "deep",
             "strategyLevel": "deep"
@@ -598,5 +600,41 @@ mod tests {
         assert_eq!(effective.judge_timeout_seconds, 2400);
         assert_eq!(effective.reviewer_file_split_threshold, 10);
         assert_eq!(effective.max_same_role_instances, 3);
+    }
+
+    fn split_policy(threshold: usize) -> DeepReviewExecutionPolicy {
+        DeepReviewExecutionPolicy {
+            reviewer_file_split_threshold: threshold,
+            max_same_role_instances: usize::MAX,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn same_role_instance_count_handles_zero_files() {
+        assert_eq!(split_policy(3).same_role_instance_count(0), 1);
+    }
+
+    #[test]
+    fn same_role_instance_count_avoids_division_for_zero_threshold() {
+        assert_eq!(split_policy(0).same_role_instance_count(usize::MAX), 1);
+    }
+
+    #[test]
+    fn same_role_instance_count_preserves_exact_multiples() {
+        assert_eq!(split_policy(3).same_role_instance_count(6), 2);
+    }
+
+    #[test]
+    fn same_role_instance_count_rounds_up_remainders() {
+        assert_eq!(split_policy(3).same_role_instance_count(7), 3);
+    }
+
+    #[test]
+    fn same_role_instance_count_supports_maximum_file_count() {
+        assert_eq!(
+            split_policy(3).same_role_instance_count(usize::MAX),
+            usize::MAX / 3
+        );
     }
 }

--- a/src/crates/execution/agent-runtime/tests/prompt_cache_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/prompt_cache_contracts.rs
@@ -78,14 +78,16 @@ fn prompt_cache_scope_key_preserves_legacy_mode_switch_shape() {
 
 #[test]
 fn prompt_cache_restore_decision_prunes_expired_persisted_entries() {
-    let mut restored = SessionPromptCache::default();
-    restored.system_prompt = Some(CachedSystemPrompt {
-        text: CachedPromptText {
-            content: "stale prompt".to_string(),
-            created_at_ms: 0,
-        },
-        identity: SystemPromptCacheIdentity::new("template:agentic_mode"),
-    });
+    let mut restored = SessionPromptCache {
+        system_prompt: Some(CachedSystemPrompt {
+            text: CachedPromptText {
+                content: "stale prompt".to_string(),
+                created_at_ms: 0,
+            },
+            identity: SystemPromptCacheIdentity::new("template:agentic_mode"),
+        }),
+        ..Default::default()
+    };
     restored.user_context = Some(CachedUserContext::new(
         UserContextCacheIdentity::new("workspace_context"),
         "fresh context",
@@ -107,14 +109,16 @@ fn prompt_cache_restore_decision_prunes_expired_persisted_entries() {
 
 #[test]
 fn prompt_cache_restore_decision_deletes_empty_expired_cache() {
-    let mut restored = SessionPromptCache::default();
-    restored.system_prompt = Some(CachedSystemPrompt {
-        text: CachedPromptText {
-            content: "stale prompt".to_string(),
-            created_at_ms: 0,
-        },
-        identity: SystemPromptCacheIdentity::new("template:agentic_mode"),
-    });
+    let restored = SessionPromptCache {
+        system_prompt: Some(CachedSystemPrompt {
+            text: CachedPromptText {
+                content: "stale prompt".to_string(),
+                created_at_ms: 0,
+            },
+            identity: SystemPromptCacheIdentity::new("template:agentic_mode"),
+        }),
+        ..Default::default()
+    };
 
     let decision =
         reconcile_prompt_cache_restore(restored, Some(Duration::from_secs(60 * 60 * 24 * 365)));
@@ -129,11 +133,13 @@ fn prompt_cache_persist_action_deletes_empty_cache_and_saves_non_empty_cache() {
         PromptCachePersistenceWriteAction::Delete
     );
 
-    let mut cache = SessionPromptCache::default();
-    cache.user_context = Some(CachedUserContext::new(
-        UserContextCacheIdentity::new("workspace_context"),
-        "context",
-    ));
+    let cache = SessionPromptCache {
+        user_context: Some(CachedUserContext::new(
+            UserContextCacheIdentity::new("workspace_context"),
+            "context",
+        )),
+        ..Default::default()
+    };
     assert_eq!(
         prompt_cache_persist_action(&cache),
         PromptCachePersistenceWriteAction::Save

--- a/src/crates/interfaces/acp/src/client/config.rs
+++ b/src/crates/interfaces/acp/src/client/config.rs
@@ -27,18 +27,13 @@ pub struct AcpClientConfig {
     pub permission_mode: AcpClientPermissionMode,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum AcpClientPermissionMode {
+    #[default]
     Ask,
     AllowOnce,
     RejectOnce,
-}
-
-impl Default for AcpClientPermissionMode {
-    fn default() -> Self {
-        Self::Ask
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,4 +97,17 @@ pub enum AcpClientStatus {
 
 fn default_true() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AcpClientPermissionMode;
+
+    #[test]
+    fn permission_mode_default_remains_ask_on_the_wire() {
+        let mode = AcpClientPermissionMode::default();
+
+        assert_eq!(mode, AcpClientPermissionMode::Ask);
+        assert_eq!(serde_json::to_string(&mode).unwrap(), "\"ask\"");
+    }
 }

--- a/src/crates/services/services-integrations/src/announcement/types.rs
+++ b/src/crates/services/services-integrations/src/announcement/types.rs
@@ -94,52 +94,37 @@ pub struct ToastConfig {
 }
 
 /// Preferred modal size.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ModalSize {
     Sm,
     Md,
+    #[default]
     Lg,
     Xl,
 }
 
-impl Default for ModalSize {
-    fn default() -> Self {
-        ModalSize::Lg
-    }
-}
-
 /// What happens when the user finishes or closes the modal.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CompletionAction {
     /// Only dismiss for this session; may reappear next launch if conditions match.
+    #[default]
     Dismiss,
     /// Permanently suppress via `never_show_ids`.
     NeverShowAgain,
 }
 
-impl Default for CompletionAction {
-    fn default() -> Self {
-        CompletionAction::Dismiss
-    }
-}
-
 /// Layout template for a single modal page.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PageLayout {
     TextOnly,
     MediaLeft,
     MediaRight,
+    #[default]
     MediaTop,
     FullscreenMedia,
-}
-
-impl Default for PageLayout {
-    fn default() -> Self {
-        PageLayout::MediaTop
-    }
 }
 
 /// Media asset type.

--- a/src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/workspace_search/service.rs
@@ -760,8 +760,12 @@ impl RemoteWorkspaceSearchService {
                 context.binary_path.clone(),
             )
             .await?;
-            let mut repo_config = RepoConfig::default();
-            repo_config.max_file_size = self.provider.repo_max_file_size().await;
+            let default_repo_config = RepoConfig::default();
+            let max_file_size = self.provider.repo_max_file_size().await;
+            let repo_config = RepoConfig {
+                max_file_size,
+                ..default_repo_config
+            };
             let session = match client
                 .open_repo(OpenRepoParams {
                     repo_path: PathBuf::from(&context.repo_root),

--- a/src/crates/services/services-integrations/src/workspace_search/service.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/service.rs
@@ -38,9 +38,11 @@ impl Default for WorkspaceSearchRepoConfig {
 
 impl From<WorkspaceSearchRepoConfig> for RepoConfig {
     fn from(value: WorkspaceSearchRepoConfig) -> Self {
-        let mut config = RepoConfig::default();
-        config.max_file_size = value.max_file_size;
-        config
+        let default = RepoConfig::default();
+        RepoConfig {
+            max_file_size: value.max_file_size,
+            ..default
+        }
     }
 }
 

--- a/src/crates/services/services-integrations/tests/announcement_contracts.rs
+++ b/src/crates/services/services-integrations/tests/announcement_contracts.rs
@@ -7,6 +7,28 @@ use bitfun_services_integrations::announcement::{
 };
 
 #[test]
+fn announcement_enum_defaults_preserve_variants_and_wire_values() {
+    assert!(matches!(ModalSize::default(), ModalSize::Lg));
+    assert!(matches!(
+        CompletionAction::default(),
+        CompletionAction::Dismiss
+    ));
+    assert!(matches!(PageLayout::default(), PageLayout::MediaTop));
+    assert_eq!(
+        serde_json::to_string(&ModalSize::default()).unwrap(),
+        "\"lg\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CompletionAction::default()).unwrap(),
+        "\"dismiss\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PageLayout::default()).unwrap(),
+        "\"media_top\""
+    );
+}
+
+#[test]
 fn announcement_card_deserialization_preserves_default_contract() {
     let card: AnnouncementCard = serde_json::from_value(serde_json::json!({
         "id": "feature_v1",
@@ -123,8 +145,10 @@ async fn announcement_state_store_round_trips_state_and_defaults_missing_file() 
     assert!(missing.never_show_ids.is_empty());
     assert_eq!(missing.last_remote_fetch_at, None);
 
-    let mut state = AnnouncementState::default();
-    state.app_open_count = 7;
+    let mut state = AnnouncementState {
+        app_open_count: 7,
+        ..Default::default()
+    };
     state.seen_ids.insert("feature-a".to_string());
     state.dismissed_ids.insert("tip-b".to_string());
     store.save(&state).await.expect("save state");

--- a/src/crates/services/terminal/src/shell/mod.rs
+++ b/src/crates/services/terminal/src/shell/mod.rs
@@ -19,9 +19,10 @@ pub use scripts_manager::ScriptsManager;
 use serde::{Deserialize, Serialize};
 
 /// Supported shell types
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum ShellType {
     /// Bash shell
+    #[cfg_attr(not(windows), default)]
     Bash,
     /// Zsh shell
     Zsh,
@@ -30,6 +31,7 @@ pub enum ShellType {
     /// PowerShell (Windows PowerShell)
     PowerShell,
     /// PowerShell Core (cross-platform)
+    #[cfg_attr(windows, default)]
     PowerShellCore,
     /// Windows CMD
     Cmd,
@@ -131,19 +133,6 @@ impl ShellType {
     }
 }
 
-impl Default for ShellType {
-    fn default() -> Self {
-        #[cfg(windows)]
-        {
-            ShellType::PowerShellCore
-        }
-        #[cfg(not(windows))]
-        {
-            ShellType::Bash
-        }
-    }
-}
-
 impl std::fmt::Display for ShellType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -158,5 +147,18 @@ impl std::fmt::Display for ShellType {
             ShellType::Csh => write!(f, "csh"),
             ShellType::Custom(name) => write!(f, "{}", name),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShellType;
+
+    #[test]
+    fn shell_default_remains_platform_specific() {
+        #[cfg(windows)]
+        assert_eq!(ShellType::default(), ShellType::PowerShellCore);
+        #[cfg(not(windows))]
+        assert_eq!(ShellType::default(), ShellType::Bash);
     }
 }


### PR DESCRIPTION
## Summary

This PR continues the non-blocking Rust Clippy backlog cleanup after the shared lint policy landed. It focuses on behavior-preserving simplifications in CLI, desktop, agent runtime, contracts, and services code while keeping public compatibility surfaces unchanged.

The cleanup replaces redundant control flow, manual bounds/default patterns, and private positional parameter lists with clearer equivalent forms. It also fixes an existing extreme-value overflow in Deep Review reviewer splitting by using the standard integer ceiling-division operation with a regression test.

## Scope and compatibility

- Preserves existing CLI event handling, session exit behavior, tool-card rendering, and text layout semantics.
- Preserves desktop remote filename search progress, cancellation, limits, error propagation, and Computer Use overlay behavior.
- Preserves agent execution, retry/cancellation, memory/session, configuration, Canvas, ACP, announcement, workspace-search, and shell-default contracts.
- Does not change public or wire APIs, ACP/OpenCode compatibility boundaries, remote workspace routing, lock scopes, async boundaries, retry counts, or IO behavior.
- Adds no `allow` or `expect` suppression and does not make Clippy blocking in CI.
- Intentionally retains public-family long-argument APIs, unsafe/safety-documentation debt, large enum/error findings, MCP capability deprecations, and other higher-risk items for later focused work.
- Contains no documentation changes.

## Lint impact

The deduplicated inventory across the main workspace, desktop, and installer decreased from 352 to 276 diagnostics, a net reduction of 76. The remaining 276 diagnostics are explicitly non-blocking and consist of:

- 224 unsafe-operation or unsafe-documentation diagnostics
- 34 long-argument diagnostics, primarily compatibility-sensitive/public-family or later private work
- 5 large enum variants
- 4 private Windows FFI acronym names
- 4 deprecations, including MCP capability compatibility items and stream spelling follow-ups
- 3 type-complexity findings
- 2 large error variants

The previous manual ceiling-division finding is resolved.

## Review

Two independent adversarial reviews examined the complete branch from senior architecture/concurrency/performance and product/compatibility perspectives. Both final reviews returned MERGE with no Critical, Important, or Minor findings after the Deep Review overflow boundary was fixed and re-reviewed.

The reviews specifically traced CLI event and tool-card flows, desktop remote search and cancellation, agent retry/cancellation and Deep Review budgeting, remote workspace behavior, serde/wire defaults, ACP/OpenCode compatibility, lock/await boundaries, allocation/clone behavior, and IO/retry counts.

## Validation

- `cargo clippy --workspace --all-targets`
- fresh deduplicated Clippy inventory across main workspace, desktop, and installer
- `cargo test -p bitfun-cli --all-targets`
- `cargo test -p bitfun-desktop --lib`
- `cargo test -p bitfun-agent-runtime`
- `cargo test -p bitfun-core --lib`
- `cargo test -p bitfun-acp`
- `cargo test -p bitfun-product-domains --no-default-features`
- `cargo test -p bitfun-services-integrations --test announcement_contracts`
- focused Deep Review maximum-value regression test
- changed-file formatting checks and `git diff --check`

A broad terminal test run during adversarial review exposed two pre-existing process-exit timing failures in unchanged `exec.rs` code. The changed shell-default contract test passed, and the final verification scope contains no evidence linking those timing failures to this PR.