### PR TITLE
feat(tools): standardize Write input on a single payload parameter

### DIFF
--- a/src/apps/cli/src/chat_state.rs
+++ b/src/apps/cli/src/chat_state.rs
@@ -991,7 +991,24 @@ fn extract_tool_title(tool_name: &str, params: &serde_json::Value) -> Option<Str
 
     // Tool-specific extraction for common tools
     match tool_name {
-        "Read" | "Write" | "Edit" | "Delete" | "GetFileDiff" => obj
+        "Write" => obj
+            .get("payload")
+            .and_then(|value| value.as_str())
+            .and_then(|value| {
+                let first_line = value.split_once('\n').map_or(value, |(path, _)| path);
+                first_line
+                    .strip_suffix('\r')
+                    .unwrap_or(first_line)
+                    .strip_prefix("+++ ")
+            })
+            .filter(|path| !path.trim().is_empty())
+            .or_else(|| {
+                obj.get("file_path")
+                    .or_else(|| obj.get("path"))
+                    .and_then(|value| value.as_str())
+            })
+            .map(|path| truncate_string(path, 50)),
+        "Read" | "Edit" | "Delete" | "GetFileDiff" => obj
             .get("path")
             .and_then(|v| v.as_str())
             .map(|s| truncate_string(s, 50)),

--- a/src/apps/cli/src/ui/permission.rs
+++ b/src/apps/cli/src/ui/permission.rs
@@ -474,10 +474,24 @@ fn build_tool_detail(prompt: &PermissionPrompt) -> String {
         "Write" | "write_file" | "write_file_tool" => {
             let path = prompt
                 .params
-                .get("file_path")
-                .or_else(|| prompt.params.get("target_file"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
+                .get("payload")
+                .and_then(|value| value.as_str())
+                .and_then(|value| {
+                    let first_line = value.split_once('\n').map_or(value, |(path, _)| path);
+                    first_line
+                        .strip_suffix('\r')
+                        .unwrap_or(first_line)
+                        .strip_prefix("+++ ")
+                })
+                .filter(|path| !path.trim().is_empty())
+                .or_else(|| {
+                    prompt
+                        .params
+                        .get("file_path")
+                        .or_else(|| prompt.params.get("target_file"))
+                        .and_then(|value| value.as_str())
+                })
+                .unwrap_or("workspace temporary file");
             format!("Write {}", path)
         }
         "Delete" => {

--- a/src/apps/cli/src/ui/tool_cards.rs
+++ b/src/apps/cli/src/ui/tool_cards.rs
@@ -1231,19 +1231,43 @@ fn render_write_block(
     spinner_frame: &str,
     available_width: u16,
 ) -> ToolCardRenderOutput {
-    let file_path = param_str(
-        &tool_state.parameters,
-        &["file_path", "target_file", "path"],
-    );
+    let payload = tool_state
+        .parameters
+        .get("payload")
+        .and_then(|value| value.as_str());
+    let combined = payload.and_then(|value| {
+        let (first_line, content) = value.split_once('\n').unwrap_or((value, ""));
+        let first_line = first_line.strip_suffix('\r').unwrap_or(first_line);
+        let file_path = first_line.strip_prefix("+++ ")?;
+        (!file_path.trim().is_empty()).then_some((file_path, content))
+    });
+    let file_path = combined
+        .map(|(file_path, _)| file_path.to_string())
+        .unwrap_or_else(|| {
+            let legacy_path = param_str(
+                &tool_state.parameters,
+                &["file_path", "target_file", "path"],
+            );
+            if legacy_path.is_empty() && payload.is_some() {
+                "workspace temporary file".to_string()
+            } else {
+                legacy_path
+            }
+        });
 
     let mut content_lines = Vec::new();
 
     // Show content preview with syntax highlighting and line numbers
-    if let Some(content) = tool_state
-        .parameters
-        .get("contents")
-        .or_else(|| tool_state.parameters.get("content"))
-        .and_then(|v| v.as_str())
+    if let Some(content) = combined
+        .map(|(_, content)| content)
+        .or(payload.filter(|_| combined.is_none()))
+        .or_else(|| {
+            tool_state
+                .parameters
+                .get("contents")
+                .or_else(|| tool_state.parameters.get("content"))
+                .and_then(|value| value.as_str())
+        })
     {
         let total_lines = content.lines().count();
         let max = if expanded { usize::MAX } else { 8 };

--- a/src/apps/desktop/src/api/tool_api.rs
+++ b/src/apps/desktop/src/api/tool_api.rs
@@ -232,11 +232,25 @@ fn is_relative_path(value: Option<&serde_json::Value>) -> bool {
         .is_some_and(|path| !path.is_empty() && !PathBuf::from(path).is_absolute())
 }
 
+fn write_file_path(input: &serde_json::Value) -> Option<&str> {
+    let value = input.get("payload")?.as_str()?;
+    let first_line = value
+        .split_once('\n')
+        .map_or(value, |(file_path, _)| file_path);
+    let first_line = first_line.strip_suffix('\r').unwrap_or(first_line);
+    let file_path = first_line.strip_prefix("+++ ")?;
+    (!file_path.trim().is_empty()).then_some(file_path)
+}
+
 fn tool_requires_workspace_path(tool_name: &str, input: &serde_json::Value) -> bool {
     match tool_name {
         "Bash" => true,
         "Glob" | "Grep" => input.get("path").is_none() || is_relative_path(input.get("path")),
-        "Read" | "Write" | "Edit" | "GetFileDiff" => is_relative_path(input.get("file_path")),
+        "Write" => write_file_path(input).map_or_else(
+            || input.get("payload").is_some(),
+            |path| !PathBuf::from(path).is_absolute(),
+        ),
+        "Read" | "Edit" | "GetFileDiff" => is_relative_path(input.get("file_path")),
         _ => false,
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -17,12 +17,33 @@ use serde_json::{json, Value};
 use std::path::Path;
 use tokio::fs;
 use tool_runtime::fs::{
-    parse_write_local_file_mode, write_file_success_outcome, write_local_file,
-    write_same_content_outcome, WriteLocalFileMode, WriteLocalFileOutcome, WriteLocalFileRequest,
+    write_file_success_outcome, write_local_file, write_same_content_outcome,
+    WriteLocalFileOutcome, WriteLocalFileRequest,
 };
 
 pub struct FileWriteTool;
 
+#[derive(Debug, PartialEq, Eq)]
+enum ParsedWritePayload<'a> {
+    Target {
+        file_path: &'a str,
+        content: &'a str,
+    },
+    MissingPath {
+        content: &'a str,
+    },
+}
+
+impl<'a> ParsedWritePayload<'a> {
+    fn content(&self) -> &'a str {
+        match self {
+            Self::Target { content, .. } | Self::MissingPath { content } => content,
+        }
+    }
+}
+
+const WRITE_PAYLOAD_PATH_PREFIX: &str = "+++ ";
+const WRITE_FALLBACK_FILE_ATTEMPTS: usize = 16;
 const LARGE_WRITE_SOFT_LINE_LIMIT: usize = 200;
 const LARGE_WRITE_SOFT_BYTE_LIMIT: usize = 20 * 1024;
 
@@ -160,20 +181,85 @@ impl FileWriteTool {
         Self::write_guardrail_preflight_error(context, &resolved).await
     }
 
+    fn parse_payload(input: &Value) -> Result<ParsedWritePayload<'_>, String> {
+        let value = input
+            .get("payload")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "payload is required".to_string())?;
+        let (first_line, content) = value.split_once('\n').unwrap_or((value, ""));
+        let first_line = first_line.strip_suffix('\r').unwrap_or(first_line);
+        let Some(file_path) = first_line.strip_prefix(WRITE_PAYLOAD_PATH_PREFIX) else {
+            return Ok(ParsedWritePayload::MissingPath { content: value });
+        };
+        if file_path.trim().is_empty() {
+            return Ok(ParsedWritePayload::MissingPath { content: value });
+        }
+
+        Ok(ParsedWritePayload::Target { file_path, content })
+    }
+
+    async fn unused_fallback_file_path(context: &ToolUseContext) -> BitFunResult<String> {
+        for _ in 0..WRITE_FALLBACK_FILE_ATTEMPTS {
+            let random_id = uuid::Uuid::new_v4().simple().to_string();
+            let file_path = format!("write_{}.tmp", &random_id[..6]);
+            let resolved = context.resolve_tool_path(&file_path)?;
+            context.enforce_path_operation(ToolPathOperation::Write, &resolved)?;
+            if !Self::file_exists(context, &resolved).await {
+                return Ok(file_path);
+            }
+        }
+
+        Err(BitFunError::tool(
+            "Failed to allocate a unique fallback file for Write".to_string(),
+        ))
+    }
+
+    fn ignored_top_level_parameter_names(input: &Value) -> Vec<String> {
+        let mut parameter_names = input
+            .as_object()
+            .into_iter()
+            .flat_map(|object| object.keys())
+            .filter(|name| name.as_str() != "payload")
+            .cloned()
+            .collect::<Vec<_>>();
+        parameter_names.sort();
+        parameter_names
+    }
+
     fn write_success_result(
         logical_path: &str,
-        mode: WriteLocalFileMode,
         outcome: WriteLocalFileOutcome,
+        missing_path_fallback: bool,
+        ignored_parameter_names: &[String],
     ) -> ToolResult {
-        let assistant_message = outcome.assistant_message;
+        let mut assistant_message = if missing_path_fallback {
+            format!(
+                "The Write payload did not start with the required '+++ {{file_path}}' marker. The entire payload was saved to {}. Rename this temporary file to the intended path before continuing; this way, you do not need to rewrite the entire content.",
+                logical_path
+            )
+        } else {
+            outcome.assistant_message
+        };
+        if !ignored_parameter_names.is_empty() {
+            let formatted_names = ignored_parameter_names
+                .iter()
+                .map(|name| format!("`{}`", name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            assistant_message.push_str(&format!(
+                " The Write tool accepts only the `payload` parameter; these additional parameters were ignored and should not be passed again: {}.",
+                formatted_names
+            ));
+        }
         ToolResult::Result {
             data: json!({
                 "file_path": logical_path,
-                "mode": mode.as_str(),
                 "bytes_written": outcome.bytes_written,
                 "lines_written": outcome.lines_written,
                 "success": true,
                 "status": outcome.status.as_str(),
+                "missing_path_fallback": missing_path_fallback,
+                "rename_required": missing_path_fallback,
                 "message": assistant_message,
             }),
             result_for_assistant: Some(assistant_message),
@@ -185,40 +271,58 @@ impl FileWriteTool {
         json!({
             "type": "object",
             "properties": {
-                "file_path": {
+                "payload": {
                     "type": "string",
-                    "description": "The absolute path to the file to write (must be absolute, not relative)"
-                },
-                "mode": {
-                    "type": "string",
-                    "enum": ["w", "a"],
-                    "description": "Write mode: 'w' overwrites the file (default), 'a' appends to the file and creates it if missing"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "The content to write to the file"
+                    "description": "A path-first Write payload in the format `+++ {absolute_file_path}\n{file_content}`. Content lines do not need a leading `+`."
                 }
             },
-            "required": ["file_path", "content"],
+            "required": ["payload"],
             "additionalProperties": false
         })
     }
 
     fn description() -> String {
-        r#"Writes a file to the local filesystem.
+        r#"Create or overwrite a file.
+
+Parameter: `payload` (a single string)
+- Format: `+++ {file_path}\n{file_content}`
+- This is a path-first Write payload format: the first line uses Git's `+++` marker to specify the target file, but content lines do NOT need a leading `+`. Do not include `---`, `@@`, or other Git diff headers.
+- `{file_path}` must be absolute. Everything after the first newline is the complete content to write to that file.
+- The `+++ ` marker is required. If it is missing or has no file path, the tool saves the entire `payload` unchanged to `write_{random id}.tmp` in the workspace root.
+- Do NOT pass `path`, `file_path`, or `content`, etc. They are not valid parameters for this tool. Only `payload` is accepted.
 
 Usage:
-- Always order arguments as: `file_path`, optional `mode`, then `content` last.
-- This tool defaults to `mode=\"w\"`, which overwrites the existing file if there is one at the provided path.
-- Use `mode=\"a\"` to append content; it also creates the file if it does not exist.
+- This tool creates the file if it does not exist; otherwise, it overwrites the existing file.
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
 - Prefer the Edit tool for modifying existing files — it only sends the diff. Only use this tool to create new files or for complete rewrites.
 - NEVER create documentation files (*.md) or README files unless explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
 
 Examples:
-- Overwrite or create: `{"file_path": "/path/to/main.rs", "content": "fn main() {}"}`
-- Append: `{"file_path": "/path/to/main.rs", "mode": "a", "content": "more text"}`"#
+<good-example>
+`{"payload":"+++ /path/to/main.py\ndef main():\n\tprint(\"Hello world\")\n\nmain()"}`
+
+This call creates or overwrites `/path/to/main.py` with the following content:
+```
+def main():
+	print("Hello world")
+
+main()
+```
+</good-example>
+
+<bad-example>
+`{"file_path":"/path/to/main.py","content":"print(\"Hello world\")"}`
+
+This call is invalid because Write requires the single `payload` parameter. Do not pass `file_path` and `content` separately.
+</bad-example>
+
+<bad-example>
+`{"payload":"+++ /path/to/main.py\nprint(\"Hello world\")","file_path":"/path/to/main.py"}`
+
+This call includes an unnecessary `file_path` parameter. Write only uses `payload`; specify the target path in the first `+++ {file_path}` line and do not pass additional parameters.
+</bad-example>
+"#
             .to_string()
     }
 }
@@ -276,56 +380,46 @@ impl Tool for FileWriteTool {
         input: &Value,
         context: Option<&ToolUseContext>,
     ) -> ValidationResult {
-        let file_path = match input.get("file_path").and_then(|v| v.as_str()) {
-            Some(path) if !path.is_empty() => path,
-            _ => {
+        let parsed = match Self::parse_payload(input) {
+            Ok(parsed) => parsed,
+            Err(message) => {
                 return ValidationResult {
                     result: false,
-                    message: Some("file_path is required and cannot be empty".to_string()),
+                    message: Some(message),
                     error_code: Some(400),
                     meta: None,
                 };
             }
         };
 
-        if input.get("content").is_none() {
-            return ValidationResult {
-                result: false,
-                message: Some("content is required".to_string()),
-                error_code: Some(400),
-                meta: None,
-            };
-        }
-
-        if let Err(message) =
-            parse_write_local_file_mode(input.get("mode").and_then(|value| value.as_str()))
+        let content = parsed.content();
+        let line_count = content.lines().count();
+        let byte_count = content.len();
+        let large_write_warning = if line_count > LARGE_WRITE_SOFT_LINE_LIMIT
+            || byte_count > LARGE_WRITE_SOFT_BYTE_LIMIT
         {
-            return ValidationResult {
-                result: false,
-                message: Some(message),
-                error_code: Some(400),
-                meta: None,
-            };
-        }
-
-        let large_write_warning =
-            input
-                .get("content")
-                .and_then(|v| v.as_str())
-                .and_then(|content| {
-                    let line_count = content.lines().count();
-                    let byte_count = content.len();
-                    if line_count > LARGE_WRITE_SOFT_LINE_LIMIT
-                        || byte_count > LARGE_WRITE_SOFT_BYTE_LIMIT
-                    {
-                        Some((line_count, byte_count))
-                    } else {
-                        None
-                    }
-                });
+            Some((line_count, byte_count))
+        } else {
+            None
+        };
 
         if let Some(ctx) = context {
-            if let Some(message) = Self::preflight_write_error(ctx, file_path).await {
+            let preflight_error = match &parsed {
+                ParsedWritePayload::Target { file_path, .. } => {
+                    Self::preflight_write_error(ctx, file_path).await
+                }
+                ParsedWritePayload::MissingPath { .. } => {
+                    let fallback_path = "write_000000.tmp";
+                    match ctx.resolve_tool_path(fallback_path) {
+                        Ok(resolved) => ctx
+                            .enforce_path_operation(ToolPathOperation::Write, &resolved)
+                            .err()
+                            .map(|error| error.to_string()),
+                        Err(error) => Some(error.to_string()),
+                    }
+                }
+            };
+            if let Some(message) = preflight_error {
                 let is_guidance = is_file_tool_guidance_message(&message);
                 return ValidationResult {
                     result: false,
@@ -358,31 +452,25 @@ impl Tool for FileWriteTool {
     }
 
     fn render_tool_use_message(&self, input: &Value, options: &ToolRenderOptions) -> String {
-        let mode = parse_write_local_file_mode(input.get("mode").and_then(|v| v.as_str()))
-            .unwrap_or(WriteLocalFileMode::Write);
-        if let Some(file_path) = input.get("file_path").and_then(|v| v.as_str()) {
-            if options.verbose {
-                let content_len = input
-                    .get("content")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.len())
-                    .unwrap_or(0);
-                match mode {
-                    WriteLocalFileMode::Write => {
-                        format!("Writing {} characters to {}", content_len, file_path)
-                    }
-                    WriteLocalFileMode::Append => {
-                        format!("Appending {} characters to {}", content_len, file_path)
-                    }
-                }
-            } else {
-                match mode {
-                    WriteLocalFileMode::Write => format!("Write {}", file_path),
-                    WriteLocalFileMode::Append => format!("Append {}", file_path),
+        match Self::parse_payload(input) {
+            Ok(ParsedWritePayload::Target { file_path, content }) => {
+                if options.verbose {
+                    format!("Writing {} characters to {}", content.len(), file_path)
+                } else {
+                    format!("Write {}", file_path)
                 }
             }
-        } else {
-            "Writing file".to_string()
+            Ok(ParsedWritePayload::MissingPath { content }) => {
+                if options.verbose {
+                    format!(
+                        "Writing {} characters to a workspace temporary file",
+                        content.len()
+                    )
+                } else {
+                    "Write workspace temporary file".to_string()
+                }
+            }
+            Err(_) => "Writing file".to_string(),
         }
     }
 
@@ -391,12 +479,20 @@ impl Tool for FileWriteTool {
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
-        let file_path = input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
+        let ignored_parameter_names = Self::ignored_top_level_parameter_names(input);
+        let parsed = Self::parse_payload(input).map_err(BitFunError::tool)?;
+        let (file_path, content, missing_path_fallback) = match parsed {
+            ParsedWritePayload::Target { file_path, content } => {
+                (file_path.to_string(), content.to_string(), false)
+            }
+            ParsedWritePayload::MissingPath { content } => (
+                Self::unused_fallback_file_path(context).await?,
+                content.to_string(),
+                true,
+            ),
+        };
 
-        let resolved = context.resolve_tool_path(file_path)?;
+        let resolved = context.resolve_tool_path(&file_path)?;
         context.enforce_path_operation(ToolPathOperation::Write, &resolved)?;
         context
             .record_light_checkpoint(
@@ -406,57 +502,37 @@ impl Tool for FileWriteTool {
             )
             .await;
 
-        let content = input
-            .get("content")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| BitFunError::tool("content is required".to_string()))?;
-        let content = content.to_string();
-        let mode = parse_write_local_file_mode(input.get("mode").and_then(|v| v.as_str()))
-            .map_err(BitFunError::tool)?;
-
         let file_already_exists = Self::file_exists(context, &resolved).await;
-        if mode == WriteLocalFileMode::Write
-            && file_already_exists
+        if file_already_exists
             && Self::existing_file_matches_content(context, &resolved, &content).await == Some(true)
         {
             let result = Self::write_success_result(
                 &resolved.logical_path,
-                mode,
                 write_same_content_outcome(&resolved.logical_path),
+                missing_path_fallback,
+                &ignored_parameter_names,
             );
             return Ok(vec![result]);
         }
 
         Self::assert_atomic_write_freshness_if_exists(context, &resolved).await?;
-        let final_content = match (mode, file_already_exists) {
-            (WriteLocalFileMode::Append, true) => {
-                let mut existing = read_current_file_content(context, &resolved).await?;
-                existing.push_str(&content);
-                existing
-            }
-            _ => content.clone(),
-        };
 
         if resolved.uses_remote_workspace_backend() {
             let ws_fs = context.ws_fs().ok_or_else(|| {
                 BitFunError::tool("Remote workspace file system is unavailable".to_string())
             })?;
             ws_fs
-                .write_file(&resolved.resolved_path, final_content.as_bytes())
+                .write_file(&resolved.resolved_path, content.as_bytes())
                 .await
                 .map_err(|e| BitFunError::tool(format!("Failed to write file: {}", e)))?;
             let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
-            update_file_read_state_after_mutation(context, &resolved, &final_content, timestamp_ms);
+            update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
 
             let result = Self::write_success_result(
                 &resolved.logical_path,
-                mode,
-                write_file_success_outcome(
-                    &resolved.logical_path,
-                    mode,
-                    file_already_exists,
-                    &content,
-                ),
+                write_file_success_outcome(&resolved.logical_path, file_already_exists, &content),
+                missing_path_fallback,
+                &ignored_parameter_names,
             );
             return Ok(vec![result]);
         }
@@ -465,7 +541,6 @@ impl Tool for FileWriteTool {
             logical_path: resolved.logical_path.clone(),
             resolved_path: Path::new(&resolved.resolved_path).to_path_buf(),
             content: content.clone(),
-            mode,
         };
         let outcome = tokio::task::spawn_blocking(move || write_local_file(write_request))
             .await
@@ -473,9 +548,14 @@ impl Tool for FileWriteTool {
             .map_err(BitFunError::tool)?;
 
         let timestamp_ms = file_mutation_timestamp_ms(context, &resolved).await;
-        update_file_read_state_after_mutation(context, &resolved, &final_content, timestamp_ms);
+        update_file_read_state_after_mutation(context, &resolved, &content, timestamp_ms);
 
-        let result = Self::write_success_result(&resolved.logical_path, mode, outcome);
+        let result = Self::write_success_result(
+            &resolved.logical_path,
+            outcome,
+            missing_path_fallback,
+            &ignored_parameter_names,
+        );
 
         Ok(vec![result])
     }
@@ -492,7 +572,7 @@ mod tests {
     use crate::agentic::WorkspaceBinding;
     use serde_json::json;
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     fn local_context(root: PathBuf) -> ToolUseContext {
         ToolUseContext {
@@ -556,7 +636,7 @@ mod tests {
         let tool = FileWriteTool::new();
         let results = tool
             .call(
-                &json!({ "file_path": "existing.md", "content": "same content" }),
+                &json!({ "payload": "+++ existing.md\nsame content" }),
                 &local_context(root.clone()),
             )
             .await
@@ -591,7 +671,7 @@ mod tests {
         let tool = FileWriteTool::new();
         let results = tool
             .call(
-                &json!({ "file_path": "existing.md", "content": "new content" }),
+                &json!({ "payload": "+++ existing.md\nnew content" }),
                 &local_context(root.clone()),
             )
             .await
@@ -611,77 +691,202 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn call_impl_appends_when_mode_is_append() {
+    async fn call_impl_appends_warning_for_ignored_top_level_parameters() {
         let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).expect("create temp workspace");
-        std::fs::write(root.join("existing.md"), "old").expect("create existing file");
+
+        let tool = FileWriteTool::new();
+        let input = json!({
+            "payload": "+++ new.txt\nalpha",
+            "content": "ignored content",
+            "file_path": "ignored.txt"
+        });
+        let validation = tool.validate_input(&input, None).await;
+        assert!(validation.result);
+
+        let results = tool
+            .call(&input, &local_context(root.clone()))
+            .await
+            .expect("extra parameters should be ignored");
+
+        let _ = std::fs::remove_dir_all(&root);
+
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
+            panic!("expected result");
+        };
+        let result_path = data["file_path"].as_str().expect("result file path");
+        let expected = format!(
+            "Successfully created {} (1 lines, 5 bytes). The Write tool accepts only the `payload` parameter; these additional parameters were ignored and should not be passed again: `content`, `file_path`.",
+            result_path
+        );
+        assert_eq!(result_for_assistant.as_deref(), Some(expected.as_str()));
+        assert_eq!(data["message"], expected);
+    }
+
+    #[tokio::test]
+    async fn call_impl_accepts_path_only_for_empty_file() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
 
         let tool = FileWriteTool::new();
         let results = tool
             .call(
-                &json!({ "file_path": "existing.md", "content": "\nnew", "mode": "a" }),
+                &json!({ "payload": "+++ empty.txt" }),
                 &local_context(root.clone()),
             )
             .await
-            .expect("append should succeed");
+            .expect("path-only input should create an empty file");
 
-        let written = std::fs::read_to_string(root.join("existing.md")).expect("read file");
+        let written = std::fs::read(root.join("empty.txt")).expect("read empty file");
         let _ = std::fs::remove_dir_all(&root);
 
-        assert_eq!(written, "old\nnew");
-
+        assert!(written.is_empty());
         let ToolResult::Result { data, .. } = &results[0] else {
             panic!("expected result");
         };
-        assert_eq!(data["status"], "appended");
-        assert_eq!(data["mode"], "a");
-        assert_eq!(data["bytes_written"], "\nnew".len());
+        assert_eq!(data["bytes_written"], 0);
+        assert_eq!(data["lines_written"], 0);
+    }
+
+    #[test]
+    fn description_includes_bad_examples_for_invalid_parameter_shapes() {
+        let description = FileWriteTool::description();
+
+        assert_eq!(description.matches("<bad-example>").count(), 2);
+        assert!(description
+            .contains(r#"{"file_path":"/path/to/main.py","content":"print(\"Hello world\")"}"#));
+        assert!(description.contains(
+            r#"{"payload":"+++ /path/to/main.py\nprint(\"Hello world\")","file_path":"/path/to/main.py"}"#
+        ));
     }
 
     #[tokio::test]
-    async fn schema_requires_file_path_and_content() {
+    async fn schema_requires_single_payload_parameter() {
         let tool = FileWriteTool::new();
 
         let schema = tool.input_schema_for_model().await;
 
+        assert_eq!(schema["required"], serde_json::json!(["payload"]));
         assert_eq!(
-            schema["required"],
-            serde_json::json!(["file_path", "content"])
+            schema["properties"].as_object().map(|value| value.len()),
+            Some(1)
         );
-        assert!(schema["properties"].get("content").is_some());
-        assert_eq!(
-            schema["properties"]["mode"]["enum"],
-            serde_json::json!(["w", "a"])
-        );
+        assert!(schema["properties"].get("payload").is_some());
+        assert!(schema["properties"].get("mode").is_none());
     }
 
     #[tokio::test]
-    async fn validate_input_requires_content() {
+    async fn validate_input_requires_payload() {
         let tool = FileWriteTool::new();
 
-        let validation = tool
-            .validate_input(&json!({ "file_path": "new.txt" }), None)
-            .await;
+        let validation = tool.validate_input(&json!({}), None).await;
 
         assert!(!validation.result);
-        assert_eq!(validation.message.as_deref(), Some("content is required"));
+        assert_eq!(validation.message.as_deref(), Some("payload is required"));
     }
 
     #[tokio::test]
-    async fn validate_input_rejects_invalid_mode() {
+    async fn validate_input_accepts_path_only_for_empty_file() {
         let tool = FileWriteTool::new();
 
         let validation = tool
-            .validate_input(
-                &json!({ "file_path": "new.txt", "content": "hello", "mode": "x" }),
-                None,
+            .validate_input(&json!({ "payload": "+++ C:/workspace/empty.txt" }), None)
+            .await;
+
+        assert!(validation.result);
+        assert!(validation.message.is_none());
+    }
+
+    #[test]
+    fn parse_payload_recognizes_marked_path_with_lf_or_crlf() {
+        for value in [
+            "+++ C:/workspace/main.rs\nfn main() {}",
+            "+++ C:/workspace/main.rs\r\nfn main() {}",
+        ] {
+            let input = json!({ "payload": value });
+            let parsed = FileWriteTool::parse_payload(&input).expect("valid payload");
+
+            assert_eq!(
+                parsed,
+                super::ParsedWritePayload::Target {
+                    file_path: "C:/workspace/main.rs",
+                    content: "fn main() {}",
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn parse_payload_treats_missing_or_empty_marker_path_as_fallback_content() {
+        for value in ["content", "\ncontent", "+++", "+++ \ncontent"] {
+            let input = json!({ "payload": value });
+            let parsed = FileWriteTool::parse_payload(&input).expect("fallback payload");
+
+            assert_eq!(
+                parsed,
+                super::ParsedWritePayload::MissingPath { content: value }
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn call_impl_preserves_malformed_payload_in_workspace_temp_file() {
+        let root = std::env::temp_dir().join(format!("bitfun-write-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("create temp workspace");
+        let original_payload = "def main():\n    print(\"Hello world\")";
+
+        let results = FileWriteTool::new()
+            .call(
+                &json!({ "payload": original_payload }),
+                &local_context(root.clone()),
             )
-            .await;
+            .await
+            .expect("malformed payload should be preserved");
 
-        assert!(!validation.result);
+        let entries = std::fs::read_dir(&root)
+            .expect("read workspace root")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect workspace entries");
+        assert_eq!(entries.len(), 1);
+        let file_name = entries[0].file_name().to_string_lossy().into_owned();
+        assert!(file_name.starts_with("write_"));
+        assert!(file_name.ends_with(".tmp"));
+        assert_eq!(file_name.len(), "write_000000.tmp".len());
+        assert!(file_name[6..12]
+            .chars()
+            .all(|character| character.is_ascii_hexdigit()));
         assert_eq!(
-            validation.message.as_deref(),
-            Some("mode must be either 'w' (overwrite) or 'a' (append), got 'x'")
+            std::fs::read_to_string(entries[0].path()).expect("read fallback file"),
+            original_payload
         );
+
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
+            panic!("expected result");
+        };
+        let result_path = data["file_path"].as_str().expect("result file path");
+        assert_eq!(
+            Path::new(result_path)
+                .file_name()
+                .and_then(|value| value.to_str()),
+            Some(file_name.as_str())
+        );
+        assert_eq!(data["missing_path_fallback"], true);
+        assert_eq!(data["rename_required"], true);
+        assert!(result_for_assistant
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Rename this temporary file"));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -286,6 +286,19 @@ fn map_tool_execution_admission_rejection(error: ToolExecutionAdmissionRejection
     }
 }
 
+fn recovered_write_has_potentially_truncated_marked_path(
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    recovered_from_truncation: bool,
+) -> bool {
+    recovered_from_truncation
+        && tool_name == "Write"
+        && arguments
+            .get("payload")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value.starts_with("+++ ") && !value.contains('\n'))
+}
+
 const SUBAGENT_LAUNCH_TOOL_NAME: &str = "Task";
 
 /// Tool pipeline
@@ -632,26 +645,32 @@ impl ToolPipeline {
             tool_name, tool_id, queue_wait_ms
         );
 
-        if recovered_from_truncation {
-            warn!(
-                "Tool '{}' arguments were recovered from a truncated stream (tool_id={}, session_id={}). Executing with patched arguments — content may be incomplete.",
-                tool_name, tool_id, task.context.session_id
-            );
-        }
-
-        if tool_name.is_empty() || tool_is_error {
+        let invalid_call_error = if tool_name.is_empty() || tool_is_error {
             let raw_arguments_preview = task
                 .tool_call
                 .raw_arguments
                 .as_deref()
                 .map(truncate_raw_tool_arguments_preview);
-            let error_msg = build_invalid_tool_call_error_message(
+            Some(build_invalid_tool_call_error_message(
                 &tool_name,
                 tool_is_error,
                 recovered_from_truncation,
                 raw_arguments_preview,
-            );
+            ))
+        } else if recovered_write_has_potentially_truncated_marked_path(
+            &tool_name,
+            &tool_args,
+            recovered_from_truncation,
+        ) {
+            Some(
+                "Recovered Write arguments are missing the newline separator between the path and content; refusing to execute because the path may be truncated."
+                    .to_string(),
+            )
+        } else {
+            None
+        };
 
+        if let Some(error_msg) = invalid_call_error {
             self.state_manager
                 .update_state(
                     &tool_id,
@@ -668,6 +687,13 @@ impl ToolPipeline {
                 .await;
 
             return Err(BitFunError::Validation(error_msg));
+        }
+
+        if recovered_from_truncation {
+            warn!(
+                "Tool '{}' arguments were recovered from a truncated stream (tool_id={}, session_id={}). Executing with patched arguments — content may be incomplete.",
+                tool_name, tool_id, task.context.session_id
+            );
         }
 
         // Repetition alone is not execution failure: polling and status checks
@@ -1468,6 +1494,43 @@ mod tests {
     use std::time::SystemTime;
     use tokio::time::{sleep, Duration};
 
+    #[test]
+    fn recovered_write_without_separator_is_rejected_as_potentially_truncated_path() {
+        assert!(recovered_write_has_potentially_truncated_marked_path(
+            "Write",
+            &json!({ "payload": "+++ C:/workspace/truncated" }),
+            true,
+        ));
+    }
+
+    #[test]
+    fn complete_path_only_write_is_not_treated_as_truncation_recovery() {
+        assert!(!recovered_write_has_potentially_truncated_marked_path(
+            "Write",
+            &json!({ "payload": "+++ C:/workspace/empty.txt" }),
+            false,
+        ));
+        assert!(!recovered_write_has_potentially_truncated_marked_path(
+            "Write",
+            &json!({ "payload": "+++ C:/workspace/empty.txt\n" }),
+            true,
+        ));
+    }
+
+    #[test]
+    fn recovered_write_without_marker_can_fall_back_safely() {
+        assert!(!recovered_write_has_potentially_truncated_marked_path(
+            "Write",
+            &json!({ "payload": "partial content without a path" }),
+            true,
+        ));
+        assert!(!recovered_write_has_potentially_truncated_marked_path(
+            "Write",
+            &json!({ "payload": "+++ C:/workspace/main.rs\npartial content" }),
+            true,
+        ));
+    }
+
     struct StaticTestTool {
         name: String,
         response: serde_json::Value,
@@ -2066,8 +2129,7 @@ mod tests {
 
         assert!(notice.contains("file may have been written with partial content"));
         assert!(notice.contains("latest Read result"));
-        assert!(notice.contains("issue ONE Write call"));
-        assert!(notice.contains("`mode`: \"a\""));
+        assert!(notice.contains("use Edit to add only the missing continuation"));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
@@ -518,7 +518,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn product_manifest_write_schema_requires_content() {
+    async fn product_manifest_write_schema_requires_payload() {
         let context = tool_context(Some("test-agent"));
 
         let manifest = resolve_product_resolved_tool_manifest(
@@ -534,11 +534,9 @@ mod tests {
             .find(|tool| tool.name == "Write")
             .expect("Write definition should exist");
 
-        assert_eq!(
-            write.parameters["required"],
-            json!(["file_path", "content"])
-        );
-        assert!(write.parameters["properties"].get("content").is_some());
+        assert_eq!(write.parameters["required"], json!(["payload"]));
+        assert!(write.parameters["properties"].get("payload").is_some());
+        assert!(write.parameters["properties"].get("mode").is_none());
         assert!(write.description.contains("Read tool first"));
     }
 

--- a/src/crates/execution/agent-stream/src/tool_call_accumulator.rs
+++ b/src/crates/execution/agent-stream/src/tool_call_accumulator.rs
@@ -85,10 +85,11 @@ pub struct PendingToolCalls {
     pending: BTreeMap<ToolCallStreamKey, PendingToolCall>,
 }
 
-/// Tools where executing a truncated tool call is **safe and meaningful** —
-/// the model intended to write content and a partial file is strictly more
-/// useful than a hard failure. For everything else (Bash, Edit, Task, ...) we
-/// surface the truncation as an error: a partial shell command or a partial
+/// Tools where a repaired truncation can be passed to schema validation.
+/// Write requires its path/content separator before execution, so a truncation
+/// inside the path is rejected while a truncation in the content can still
+/// write the safe prefix. For everything else (Bash, Edit, Task, ...) we surface
+/// the truncation as an error: a partial shell command or a partial
 /// `old_string`/`new_string` for Edit can change semantics destructively.
 pub fn is_write_like_tool_name(tool_name: &str) -> bool {
     matches!(tool_name, "Write" | "file_write" | "write_notebook")
@@ -933,10 +934,9 @@ mod tests {
 
     #[test]
     fn write_truncated_mid_content_string_is_recovered() {
-        // Reproduces the deep-research dump: the model hit max_tokens while
-        // streaming `content`, so the JSON ends inside the string literal
-        // with no closing `"` and no closing `}`.
-        let raw = "{\"file_path\": \"/tmp/report.md\", \"content\": \"# Report\\n\\nA long body that was cut";
+        // The path and its separating newline have already been emitted, so
+        // truncation can only remove a suffix of the file content.
+        let raw = r#"{"payload":"+++ /tmp/report.md\n# Report\n\nA long body that was cut"#;
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("Write".to_string()));
         pending.append_arguments(raw);
@@ -950,8 +950,7 @@ mod tests {
         assert_eq!(
             finalized.arguments,
             json!({
-                "file_path": "/tmp/report.md",
-                "content": "# Report\n\nA long body that was cut"
+                "payload": "+++ /tmp/report.md\n# Report\n\nA long body that was cut"
             })
         );
     }
@@ -977,7 +976,7 @@ mod tests {
 
     #[test]
     fn write_truncated_with_chinese_multibyte_is_recovered() {
-        let raw = "{\"file_path\": \"/tmp/r.md\", \"content\": \"深度研究报告：未完";
+        let raw = r#"{"payload":"+++ /tmp/r.md\n深度研究报告：未完"#;
         let mut pending = PendingToolCall::default();
         pending.start_new("call_1".to_string(), Some("Write".to_string()));
         pending.append_arguments(raw);
@@ -989,8 +988,8 @@ mod tests {
         assert!(!finalized.is_error);
         assert!(finalized.recovered_from_truncation);
         assert_eq!(
-            finalized.arguments["content"].as_str(),
-            Some("深度研究报告：未完")
+            finalized.arguments["payload"].as_str(),
+            Some("+++ /tmp/r.md\n深度研究报告：未完")
         );
     }
 

--- a/src/crates/execution/tool-contracts/src/tool_execution_presentation.rs
+++ b/src/crates/execution/tool-contracts/src/tool_execution_presentation.rs
@@ -28,7 +28,7 @@ pub fn is_write_like_tool_name(tool_name: &str) -> bool {
 pub fn build_tool_call_truncation_recovery_notice(tool_name: &str) -> String {
     if is_write_like_tool_name(tool_name) {
         return format!(
-            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file may have been written with partial content. Use the latest Read result for that file (or call Read once if no current Read result is available) to inspect what is on disk. To finish it, issue ONE {tool_name} call with `mode`: \"a\" and `content` set only to the missing continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens). Do NOT rewrite the whole file with overwrite mode.]\n\nOriginal tool result follows.\n\n"
+            "[Your previous {tool_name} call was truncated mid-stream by max_tokens and was auto-repaired before execution; the file may have been written with partial content. Use the latest Read result for that file (or call Read once if no current Read result is available) to inspect what is on disk. To finish it, use Edit to add only the missing continuation. If you do not have a concrete plan for the continuation, stop tool-calling and tell the user the output was truncated (suggest raising max_tokens).]\n\nOriginal tool result follows.\n\n"
         );
     }
 

--- a/src/crates/execution/tool-contracts/tests/tool_contracts.rs
+++ b/src/crates/execution/tool-contracts/tests/tool_contracts.rs
@@ -517,10 +517,9 @@ fn truncation_recovery_notice_preserves_write_like_guidance() {
     let notice = build_tool_call_truncation_recovery_notice("Write");
 
     assert!(notice.contains("latest Read result"));
-    assert!(notice.contains("ONE Write call"));
-    assert!(notice.contains("`mode`: \"a\""));
-    assert!(notice.contains("missing continuation"));
-    assert!(notice.contains("Do NOT rewrite the whole file with overwrite mode"));
+    assert!(notice.contains("use Edit to add only the missing continuation"));
+    assert!(notice.contains("stop tool-calling and tell the user"));
+    assert!(!notice.contains("`mode`"));
     assert!(notice.ends_with("Original tool result follows.\n\n"));
 }
 

--- a/src/crates/execution/tool-execution/src/fs/mod.rs
+++ b/src/crates/execution/tool-execution/src/fs/mod.rs
@@ -19,7 +19,6 @@ pub use list_dir::{
     build_remote_list_commands, parse_remote_list_entries, RemoteListCommandPlan, RemoteListEntry,
 };
 pub use write_file::{
-    parse_write_local_file_mode, write_file_success_outcome, write_local_file,
-    write_same_content_outcome, WriteLocalFileMode, WriteLocalFileOutcome, WriteLocalFileRequest,
-    WriteLocalFileStatus,
+    write_file_success_outcome, write_local_file, write_same_content_outcome,
+    WriteLocalFileOutcome, WriteLocalFileRequest, WriteLocalFileStatus,
 };

--- a/src/crates/execution/tool-execution/src/fs/write_file.rs
+++ b/src/crates/execution/tool-execution/src/fs/write_file.rs
@@ -1,12 +1,10 @@
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WriteLocalFileStatus {
     Created,
     Overwritten,
-    Appended,
     AlreadyExistsSameContent,
 }
 
@@ -15,23 +13,7 @@ impl WriteLocalFileStatus {
         match self {
             Self::Created => "created",
             Self::Overwritten => "overwritten",
-            Self::Appended => "appended",
             Self::AlreadyExistsSameContent => "already_exists_same_content",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WriteLocalFileMode {
-    Write,
-    Append,
-}
-
-impl WriteLocalFileMode {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Write => "w",
-            Self::Append => "a",
         }
     }
 }
@@ -41,7 +23,6 @@ pub struct WriteLocalFileRequest {
     pub logical_path: String,
     pub resolved_path: PathBuf,
     pub content: String,
-    pub mode: WriteLocalFileMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,17 +31,6 @@ pub struct WriteLocalFileOutcome {
     pub bytes_written: usize,
     pub lines_written: usize,
     pub assistant_message: String,
-}
-
-pub fn parse_write_local_file_mode(mode: Option<&str>) -> Result<WriteLocalFileMode, String> {
-    match mode.unwrap_or("w") {
-        "w" => Ok(WriteLocalFileMode::Write),
-        "a" => Ok(WriteLocalFileMode::Append),
-        other => Err(format!(
-            "mode must be either 'w' (overwrite) or 'a' (append), got '{}'",
-            other
-        )),
-    }
 }
 
 fn count_written_lines(content: &str) -> usize {
@@ -85,31 +55,25 @@ pub fn write_same_content_outcome(logical_path: &str) -> WriteLocalFileOutcome {
 
 pub fn write_file_success_outcome(
     logical_path: &str,
-    mode: WriteLocalFileMode,
     file_already_exists: bool,
     content: &str,
 ) -> WriteLocalFileOutcome {
-    let status = match (mode, file_already_exists) {
-        (WriteLocalFileMode::Write, true) => WriteLocalFileStatus::Overwritten,
-        (WriteLocalFileMode::Write, false) => WriteLocalFileStatus::Created,
-        (WriteLocalFileMode::Append, true) => WriteLocalFileStatus::Appended,
-        (WriteLocalFileMode::Append, false) => WriteLocalFileStatus::Created,
-    };
-    let verb = match status {
-        WriteLocalFileStatus::Created => "created",
-        WriteLocalFileStatus::Overwritten => "overwrote",
-        WriteLocalFileStatus::Appended => "appended to",
-        WriteLocalFileStatus::AlreadyExistsSameContent => unreachable!(),
+    let (status, verb) = if file_already_exists {
+        (WriteLocalFileStatus::Overwritten, "overwrote")
+    } else {
+        (WriteLocalFileStatus::Created, "created")
     };
 
+    let lines_written = count_written_lines(content);
     WriteLocalFileOutcome {
         status,
         bytes_written: content.len(),
-        lines_written: count_written_lines(content),
+        lines_written,
         assistant_message: format!(
-            "Successfully {} {} ({} bytes).",
+            "Successfully {} {} ({} lines, {} bytes).",
             verb,
             logical_path,
+            lines_written,
             content.len()
         ),
     }
@@ -117,7 +81,7 @@ pub fn write_file_success_outcome(
 
 pub fn write_local_file(request: WriteLocalFileRequest) -> Result<WriteLocalFileOutcome, String> {
     let file_already_exists = request.resolved_path.exists();
-    if request.mode == WriteLocalFileMode::Write && file_already_exists {
+    if file_already_exists {
         let existing = fs::read(&request.resolved_path).map_err(|error| {
             format!(
                 "Failed to read existing file {}: {}",
@@ -134,36 +98,11 @@ pub fn write_local_file(request: WriteLocalFileRequest) -> Result<WriteLocalFile
             .map_err(|error| format!("Failed to create directory: {}", error))?;
     }
 
-    match request.mode {
-        WriteLocalFileMode::Write => {
-            fs::write(&request.resolved_path, &request.content).map_err(|error| {
-                format!("Failed to write file {}: {}", request.logical_path, error)
-            })?;
-        }
-        WriteLocalFileMode::Append => {
-            let mut file = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&request.resolved_path)
-                .map_err(|error| {
-                    format!(
-                        "Failed to open file {} for append: {}",
-                        request.logical_path, error
-                    )
-                })?;
-            file.write_all(request.content.as_bytes())
-                .map_err(|error| {
-                    format!(
-                        "Failed to append to file {}: {}",
-                        request.logical_path, error
-                    )
-                })?;
-        }
-    };
+    fs::write(&request.resolved_path, &request.content)
+        .map_err(|error| format!("Failed to write file {}: {}", request.logical_path, error))?;
 
     Ok(write_file_success_outcome(
         &request.logical_path,
-        request.mode,
         file_already_exists,
         &request.content,
     ))
@@ -172,25 +111,9 @@ pub fn write_local_file(request: WriteLocalFileRequest) -> Result<WriteLocalFile
 #[cfg(test)]
 mod tests {
     use super::{
-        count_written_lines, parse_write_local_file_mode, write_file_success_outcome,
-        write_same_content_outcome, WriteLocalFileMode, WriteLocalFileStatus,
+        count_written_lines, write_file_success_outcome, write_same_content_outcome,
+        WriteLocalFileStatus,
     };
-
-    #[test]
-    fn parses_write_modes_with_default() {
-        assert_eq!(
-            parse_write_local_file_mode(None).expect("default mode"),
-            WriteLocalFileMode::Write
-        );
-        assert_eq!(
-            parse_write_local_file_mode(Some("a")).expect("append mode"),
-            WriteLocalFileMode::Append
-        );
-        assert_eq!(
-            parse_write_local_file_mode(Some("x")).expect_err("invalid mode"),
-            "mode must be either 'w' (overwrite) or 'a' (append), got 'x'"
-        );
-    }
 
     #[test]
     fn counts_empty_and_trailing_newline_writes_like_existing_tool() {
@@ -201,24 +124,22 @@ mod tests {
     }
 
     #[test]
-    fn builds_success_outcome_for_write_and_append_modes() {
-        let created =
-            write_file_success_outcome("new.txt", WriteLocalFileMode::Write, false, "alpha");
+    fn builds_success_outcome_for_create_and_overwrite() {
+        let created = write_file_success_outcome("new.txt", false, "alpha");
         assert_eq!(created.status, WriteLocalFileStatus::Created);
         assert_eq!(created.bytes_written, 5);
         assert_eq!(created.lines_written, 1);
         assert_eq!(
             created.assistant_message,
-            "Successfully created new.txt (5 bytes)."
+            "Successfully created new.txt (1 lines, 5 bytes)."
         );
 
-        let appended =
-            write_file_success_outcome("log.txt", WriteLocalFileMode::Append, true, "\nalpha");
-        assert_eq!(appended.status, WriteLocalFileStatus::Appended);
-        assert_eq!(appended.lines_written, 2);
+        let overwritten = write_file_success_outcome("existing.txt", true, "alpha");
+        assert_eq!(overwritten.status, WriteLocalFileStatus::Overwritten);
+        assert_eq!(overwritten.lines_written, 1);
         assert_eq!(
-            appended.assistant_message,
-            "Successfully appended to log.txt (6 bytes)."
+            overwritten.assistant_message,
+            "Successfully overwrote existing.txt (1 lines, 5 bytes)."
         );
     }
 

--- a/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
+++ b/src/crates/execution/tool-execution/tests/tool_io_contracts.rs
@@ -6,8 +6,8 @@ use tool_runtime::fs::read_file::{build_remote_read_command, parse_remote_read_o
 use tool_runtime::fs::{
     build_remote_delete_command, build_remote_list_commands, delete_local_path, edit_local_file,
     inspect_local_delete_target, parse_remote_list_entries, write_local_file,
-    DeleteLocalPathRequest, EditLocalFileRequest, LocalDeleteTarget, WriteLocalFileMode,
-    WriteLocalFileRequest, WriteLocalFileStatus,
+    DeleteLocalPathRequest, EditLocalFileRequest, LocalDeleteTarget, WriteLocalFileRequest,
+    WriteLocalFileStatus,
 };
 use tool_runtime::search::glob_search::{
     build_remote_find_command, build_remote_rg_command, collect_remote_glob_matches,
@@ -52,7 +52,6 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
         logical_path: "nested/file.txt".to_string(),
         resolved_path: target.clone(),
         content: "hello\nworld\n".to_string(),
-        mode: WriteLocalFileMode::Write,
     })
     .expect("write should create file");
 
@@ -68,7 +67,6 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
         logical_path: "nested/file.txt".to_string(),
         resolved_path: target.clone(),
         content: "hello\nworld\n".to_string(),
-        mode: WriteLocalFileMode::Write,
     })
     .expect("identical retry should be successful and idempotent");
 
@@ -83,7 +81,6 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
         logical_path: "nested/file.txt".to_string(),
         resolved_path: target.clone(),
         content: "replacement".to_string(),
-        mode: WriteLocalFileMode::Write,
     })
     .expect("write should overwrite file");
 
@@ -91,47 +88,6 @@ fn write_local_file_reports_created_overwritten_and_identical_retry() {
     assert_eq!(
         fs::read_to_string(&target).expect("file should exist"),
         "replacement"
-    );
-
-    let _ = fs::remove_dir_all(root);
-}
-
-#[test]
-fn write_local_file_append_mode_appends_and_creates_when_missing() {
-    let root = make_temp_dir("write-append");
-    let existing_target = root.join("nested").join("file.txt");
-    fs::create_dir_all(existing_target.parent().expect("parent should exist"))
-        .expect("parent should be created");
-    fs::write(&existing_target, "hello").expect("seed file should exist");
-
-    let appended = write_local_file(WriteLocalFileRequest {
-        logical_path: "nested/file.txt".to_string(),
-        resolved_path: existing_target.clone(),
-        content: "\nworld".to_string(),
-        mode: WriteLocalFileMode::Append,
-    })
-    .expect("append should succeed");
-
-    assert_eq!(appended.status, WriteLocalFileStatus::Appended);
-    assert_eq!(appended.bytes_written, "\nworld".len());
-    assert_eq!(
-        fs::read_to_string(&existing_target).expect("file should exist"),
-        "hello\nworld"
-    );
-
-    let new_target = root.join("new.txt");
-    let created = write_local_file(WriteLocalFileRequest {
-        logical_path: "new.txt".to_string(),
-        resolved_path: new_target.clone(),
-        content: "first".to_string(),
-        mode: WriteLocalFileMode::Append,
-    })
-    .expect("append should create file when missing");
-
-    assert_eq!(created.status, WriteLocalFileStatus::Created);
-    assert_eq!(
-        fs::read_to_string(&new_target).expect("file should exist"),
-        "first"
     );
 
     let _ = fs::remove_dir_all(root);

--- a/src/crates/interfaces/acp/src/runtime/events.rs
+++ b/src/crates/interfaces/acp/src/runtime/events.rs
@@ -354,11 +354,23 @@ fn tool_kind(tool_name: &str) -> ToolKind {
     }
 }
 
+fn split_write_payload(input: &serde_json::Value) -> Option<(&str, &str)> {
+    let value = input.get("payload")?.as_str()?;
+    let (first_line, content) = value.split_once('\n').unwrap_or((value, ""));
+    let first_line = first_line.strip_suffix('\r').unwrap_or(first_line);
+    let file_path = first_line.strip_prefix("+++ ")?;
+    (!file_path.trim().is_empty()).then_some((file_path, content))
+}
+
 fn tool_locations(input: &serde_json::Value) -> Vec<ToolCallLocation> {
-    input
-        .get("file_path")
-        .or_else(|| input.get("path"))
-        .and_then(|value| value.as_str())
+    split_write_payload(input)
+        .map(|(file_path, _)| file_path)
+        .or_else(|| {
+            input
+                .get("file_path")
+                .or_else(|| input.get("path"))
+                .and_then(|value| value.as_str())
+        })
         .filter(|path| !path.trim().is_empty())
         .map(|path| vec![ToolCallLocation::new(PathBuf::from(path))])
         .unwrap_or_default()
@@ -413,6 +425,19 @@ fn is_large_text_payload_tool(tool_name: &str) -> bool {
 }
 
 fn sanitize_large_text_fields(object: &mut serde_json::Map<String, serde_json::Value>) {
+    if let Some(value) = object.get_mut("payload") {
+        if let Some(combined) = value.as_str() {
+            let combined_len = combined.len();
+            if let Some((file_path, content)) = combined.split_once('\n') {
+                if let Some(preview) = large_text_preview(content) {
+                    *value = serde_json::Value::String(format!("{}\n{}", file_path, preview));
+                    object.insert("payload_bytes".to_string(), serde_json::json!(combined_len));
+                    object.insert("payload_truncated".to_string(), serde_json::json!(true));
+                }
+            }
+        }
+    }
+
     for key in ["content", "contents", "old_string", "new_string"] {
         let Some(value) = object.get_mut(key) else {
             continue;
@@ -440,17 +465,34 @@ fn large_text_preview(content: &str) -> Option<String> {
 }
 
 fn write_input_status_text(input: &serde_json::Value) -> String {
-    let path = input
-        .get("file_path")
-        .or_else(|| input.get("path"))
-        .and_then(|value| value.as_str())
-        .unwrap_or("file");
-    let content_len = input
-        .get("content")
-        // Legacy alias kept for replaying older Write tool-call transcripts.
-        .or_else(|| input.get("contents"))
-        .and_then(|value| value.as_str())
-        .map(str::len)
+    let combined = split_write_payload(input);
+    let raw_payload = input.get("payload").and_then(serde_json::Value::as_str);
+    let path = combined
+        .map(|(file_path, _)| file_path)
+        .or_else(|| {
+            input
+                .get("file_path")
+                .or_else(|| input.get("path"))
+                .and_then(|value| value.as_str())
+        })
+        .unwrap_or_else(|| {
+            if raw_payload.is_some() {
+                "workspace temporary file"
+            } else {
+                "file"
+            }
+        });
+    let content_len = combined
+        .map(|(_, content)| content.len())
+        .or_else(|| raw_payload.map(str::len))
+        .or_else(|| {
+            input
+                .get("content")
+                // Legacy alias kept for replaying older Write tool-call transcripts.
+                .or_else(|| input.get("contents"))
+                .and_then(|value| value.as_str())
+                .map(str::len)
+        })
         .unwrap_or(0);
 
     format!("Writing {} ({} bytes).", path, content_len)
@@ -569,6 +611,84 @@ mod tests {
             update.fields.raw_output,
             Some(serde_json::json!({ "stdout": "ok" }))
         );
+    }
+
+    #[test]
+    fn write_started_supports_combined_payload_input() {
+        let mut seen = HashSet::new();
+        let event = ToolEventData::Started {
+            tool_id: "tool-1".to_string(),
+            tool_name: "Write".to_string(),
+            params: serde_json::json!({
+                "payload": "+++ src/lib.rs\nhello\n",
+            }),
+            timeout_seconds: None,
+        };
+
+        let updates = tool_event_updates(&event, &mut seen);
+        let SessionUpdate::ToolCallUpdate(update) = &updates[1] else {
+            panic!("expected tool call update");
+        };
+
+        assert_eq!(
+            update.fields.locations.as_ref().unwrap()[0].path,
+            PathBuf::from("src/lib.rs")
+        );
+        assert_eq!(
+            update.fields.raw_input,
+            Some(serde_json::json!({
+                "payload": "+++ src/lib.rs\nhello\n",
+            }))
+        );
+    }
+
+    #[test]
+    fn write_started_supports_path_only_empty_file_input() {
+        let mut seen = HashSet::new();
+        let event = ToolEventData::Started {
+            tool_id: "tool-1".to_string(),
+            tool_name: "Write".to_string(),
+            params: serde_json::json!({
+                "payload": "+++ src/empty.rs",
+            }),
+            timeout_seconds: None,
+        };
+
+        let updates = tool_event_updates(&event, &mut seen);
+        let SessionUpdate::ToolCallUpdate(update) = &updates[1] else {
+            panic!("expected tool call update");
+        };
+
+        assert_eq!(
+            update.fields.locations.as_ref().unwrap()[0].path,
+            PathBuf::from("src/empty.rs")
+        );
+        assert_eq!(
+            write_input_status_text(&serde_json::json!({
+                "payload": "+++ src/empty.rs",
+            })),
+            "Writing src/empty.rs (0 bytes)."
+        );
+    }
+
+    #[test]
+    fn combined_write_sanitization_preserves_path_and_truncates_only_content() {
+        let file_path = "src/generated.rs";
+        let content = "x".repeat(ACP_LARGE_TEXT_PREVIEW_CHARS + 10);
+        let combined = format!("+++ {}\n{}", file_path, content);
+
+        let sanitized = sanitize_tool_input("Write", serde_json::json!({ "payload": combined }));
+        let sanitized_combined = sanitized["payload"]
+            .as_str()
+            .expect("combined input should remain a string");
+        let (sanitized_path, sanitized_content) = sanitized_combined
+            .split_once('\n')
+            .expect("sanitized combined input should retain its separator");
+
+        assert_eq!(sanitized_path, format!("+++ {}", file_path));
+        assert_eq!(sanitized_content.len(), ACP_LARGE_TEXT_PREVIEW_CHARS);
+        assert_eq!(sanitized["payload_bytes"], combined.len());
+        assert_eq!(sanitized["payload_truncated"], true);
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -50,6 +50,7 @@ import { buildDeepReviewCapacityQueueStateFromEvent } from '../../utils/deepRevi
 import { useBackgroundCommandActivityStore } from '../../store/backgroundCommandActivityStore';
 import { useBackgroundSubagentActivityStore } from '../../store/backgroundSubagentActivityStore';
 import { createTab } from '@/shared/utils/tabUtils';
+import { splitFilePathAndContent } from '@/shared/utils/partialJsonParser';
 
 const pendingImageAnalysisTurns = new Map<string, string>();
 import { 
@@ -2659,7 +2660,10 @@ function detectModifiedPlanFiles(dialogTurn: DialogTurn): string[] {
       
       if (['Edit', 'Write'].includes(toolItem.toolName) && toolItem.toolResult?.success) {
         const input = toolItem.toolCall?.input;
-        const filePath = input?.file_path || input?.target_file || '';
+        const filePath = splitFilePathAndContent(input?.payload)?.filePath
+          || input?.file_path
+          || input?.target_file
+          || '';
         if (filePath.endsWith('.plan.md')) {
           planFiles.push(filePath);
         }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
@@ -130,6 +130,43 @@ describe('processToolParamsPartialInternal', () => {
     expect(updatedTool.toolCall.input).toEqual(existingParams);
   });
 
+  it('derives path and content from the combined Write parameter while streaming', () => {
+    const tool: FlowToolItem = {
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'Write',
+      timestamp: 1001,
+      status: 'preparing',
+      toolCall: {
+        id: 'tool-1',
+        input: {},
+      },
+      isParamsStreaming: true,
+      partialParams: {},
+      _paramsBuffer: '',
+    };
+
+    FlowChatStore.getInstance().setState(() => ({
+      sessions: new Map([['session-1', createSessionWithTool(tool)]]),
+      activeSessionId: 'session-1',
+    }));
+
+    processToolParamsPartialInternal('session-1', 'turn-1', {
+      event_type: 'ParamsPartial',
+      tool_id: 'tool-1',
+      tool_name: 'Write',
+      params: '{"payload":"+++ src/app.ts\\nconst value = 1;',
+    });
+
+    const updatedTool = FlowChatStore.getInstance()
+      .findToolItem('session-1', 'turn-1', 'tool-1') as FlowToolItem;
+
+    expect(updatedTool.partialParams?.file_path).toBe('src/app.ts');
+    expect(updatedTool.partialParams?.content).toBe('const value = 1;');
+    expect(updatedTool.status).toBe('receiving');
+    expect(updatedTool._contentSize).toBe('const value = 1;'.length);
+  });
+
   it('injects file_path from write params buffer when content streams first', () => {
     const tool: FlowToolItem = {
       id: 'tool-1',

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -4,7 +4,7 @@
  */
 
 import { FlowChatStore } from '../../store/FlowChatStore';
-import { extractFilePathFromJsonBuffer, parsePartialJson } from '../../../shared/utils/partialJsonParser';
+import { extractFilePathFromJsonBuffer, parsePartialJson, splitFilePathAndContent } from '../../../shared/utils/partialJsonParser';
 import { createLogger } from '@/shared/utils/logger';
 import type { FlowChatContext, FlowToolItem, ToolEventOptions, DialogTurn } from './types';
 import { immediateSaveDialogTurn } from './PersistenceModule';
@@ -216,11 +216,23 @@ function applyParamsPartial(
     }
 
     if (isWriteTool) {
-      const extractedPath = extractFilePathFromJsonBuffer(newBuffer);
-      const hasPath = ['file_path', 'filePath', 'filepath', 'target_file', 'targetFile', 'path', 'filename']
-        .some((key) => typeof parsedParams[key] === 'string' && parsedParams[key].length > 0);
-      if (extractedPath && !hasPath) {
-        parsedParams = { ...parsedParams, file_path: extractedPath };
+      const combinedParts = splitFilePathAndContent(parsedParams.payload);
+      if (combinedParts) {
+        parsedParams = {
+          ...parsedParams,
+          file_path: combinedParts.filePath,
+          content: combinedParts.content,
+        };
+      } else {
+        if (typeof parsedParams.payload === 'string') {
+          parsedParams = { ...parsedParams, content: parsedParams.payload };
+        }
+        const extractedPath = extractFilePathFromJsonBuffer(newBuffer);
+        const hasPath = ['file_path', 'filePath', 'filepath', 'target_file', 'targetFile', 'path', 'filename']
+          .some((key) => typeof parsedParams[key] === 'string' && parsedParams[key].length > 0);
+        if (extractedPath && !hasPath) {
+          parsedParams = { ...parsedParams, file_path: extractedPath };
+        }
       }
     }
     

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -51,7 +51,7 @@ import {
   displayFileToolGuidanceMessage,
   isFileToolGuidanceMessage,
 } from './fileToolGuidance';
-import { extractFilePathFromJsonBuffer } from '@/shared/utils/partialJsonParser';
+import { extractFilePathFromJsonBuffer, splitFilePathAndContent } from '@/shared/utils/partialJsonParser';
 import { i18nService } from '@/infrastructure/i18n';
 import { useFlowChatContext } from '../components/modern/FlowChatContext';
 import {
@@ -189,7 +189,8 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     
     if (Object.keys(params).length === 0) return '';
     
-    return firstStringValue(params, [
+    const combinedParts = splitFilePathAndContent(params.payload);
+    return combinedParts?.filePath || firstStringValue(params, [
       'file_path',
       'filePath',
       'filepath',
@@ -221,6 +222,9 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   const getContent = useCallback((): string => {
     const params = partialParams || toolCall?.input;
     if (!params) return '';
+    const combinedParts = splitFilePathAndContent(params.payload);
+    if (combinedParts) return combinedParts.content;
+    if (typeof params.payload === 'string') return params.payload;
     return params.content || params.contents || '';
   }, [toolCall, partialParams]);
 

--- a/src/web-ui/src/flow_chat/utils/modifiedFilePaths.test.ts
+++ b/src/web-ui/src/flow_chat/utils/modifiedFilePaths.test.ts
@@ -42,6 +42,8 @@ describe('collectModifiedFilePathsFromTurns', () => {
       turn('baseline', [tool('Write', { file_path: 'src/before.ts' })]),
       turn('fix', [
         tool('Write', { file_path: 'D:/workspace/project/src/auth.ts' }),
+        tool('Write', { payload: '+++ D:/workspace/project/src/combined.ts\nexport {};' }),
+        tool('Write', { payload: '+++ D:/workspace/project/src/empty.ts' }),
         tool('Edit', { filePath: 'src/helper.ts' }),
         tool('write_file', { path: 'src/auth.ts' }),
         tool('Write', { file_path: 'src/failed.ts' }, false),
@@ -49,7 +51,7 @@ describe('collectModifiedFilePathsFromTurns', () => {
       ]),
     ], 'baseline', 'D:/workspace/project');
 
-    expect(paths).toEqual(['src/auth.ts', 'src/helper.ts']);
+    expect(paths).toEqual(['src/auth.ts', 'src/combined.ts', 'src/empty.ts', 'src/helper.ts']);
   });
 
   it('marks command and Git tools as requiring a conservative workspace fallback', () => {

--- a/src/web-ui/src/flow_chat/utils/modifiedFilePaths.ts
+++ b/src/web-ui/src/flow_chat/utils/modifiedFilePaths.ts
@@ -1,3 +1,5 @@
+import { splitFilePathAndContent } from '@/shared/utils/partialJsonParser';
+
 import type { DialogTurn, FlowToolItem } from '../types/flow-chat';
 
 const FILE_MUTATION_TOOLS = new Set([
@@ -70,7 +72,8 @@ export function collectModifiedFilePathsFromTurns(
           continue;
         }
 
-        const filePath = input.file_path ?? input.filePath ?? input.path;
+        const combinedFilePath = splitFilePathAndContent(input.payload)?.filePath;
+        const filePath = combinedFilePath ?? input.file_path ?? input.filePath ?? input.path;
         if (typeof filePath === 'string' && filePath.trim()) {
           paths.add(workspaceRelativePath(filePath, workspacePath));
         }

--- a/src/web-ui/src/shared/utils/partialJsonParser.test.ts
+++ b/src/web-ui/src/shared/utils/partialJsonParser.test.ts
@@ -4,6 +4,7 @@ import {
   getFirstAvailableField,
   isFieldComplete,
   parsePartialJson,
+  splitFilePathAndContent,
 } from './partialJsonParser';
 
 describe('partialJsonParser', () => {
@@ -41,4 +42,33 @@ describe('partialJsonParser', () => {
   it('extracts partial file_path values without a closing quote', () => {
     expect(extractFilePathFromJsonBuffer('{"file_path":"src/gener')).toBe('src/gener');
   });
+  it('splits the first line from Write file content', () => {
+    expect(splitFilePathAndContent('+++ C:/workspace/app.ts\r\nconst value = 1;')).toEqual({
+      filePath: 'C:/workspace/app.ts',
+      content: 'const value = 1;',
+    });
+  });
+
+  it('extracts the first-line path while combined Write content is streaming', () => {
+    const buffer = '{"payload":"+++ src/app.ts\\nconst value = 1;';
+
+    expect(extractFilePathFromJsonBuffer(buffer)).toBe('src/app.ts');
+  });
+
+  it('treats a combined Write value without a newline as a partial path', () => {
+    const buffer = '{"payload":"+++ C:/workspace/src/gener';
+
+    expect(extractFilePathFromJsonBuffer(buffer)).toBe('C:/workspace/src/gener');
+    expect(splitFilePathAndContent('+++ C:/workspace/src/gener')).toEqual({
+      filePath: 'C:/workspace/src/gener',
+      content: '',
+    });
+  });
+  it('does not treat malformed payload content as a file path', () => {
+    const buffer = '{"payload":"def main():\\n  pass';
+
+    expect(extractFilePathFromJsonBuffer(buffer)).toBe('');
+    expect(splitFilePathAndContent('def main():\n  pass')).toBeNull();
+  });
+
 });

--- a/src/web-ui/src/shared/utils/partialJsonParser.ts
+++ b/src/web-ui/src/shared/utils/partialJsonParser.ts
@@ -59,6 +59,34 @@ export function getFirstAvailableField<T = any>(
   return defaultValue;
 }
 
+export interface FilePathAndContentParts {
+  filePath: string;
+  content: string;
+}
+
+export function splitFilePathAndContent(value: unknown): FilePathAndContentParts | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const separatorIndex = value.indexOf('\n');
+  const firstLine = separatorIndex < 0 ? value : value.slice(0, separatorIndex);
+  const normalizedFirstLine = firstLine.endsWith('\r') ? firstLine.slice(0, -1) : firstLine;
+  if (!normalizedFirstLine.startsWith('+++ ')) {
+    return null;
+  }
+
+  const filePath = normalizedFirstLine.slice(4);
+  if (!filePath.trim()) {
+    return null;
+  }
+
+  return {
+    filePath,
+    content: separatorIndex < 0 ? '' : value.slice(separatorIndex + 1),
+  };
+}
+
 const DEFAULT_FILE_PATH_FIELD_NAMES = [
   'file_path',
   'filePath',
@@ -105,14 +133,25 @@ function extractQuotedFieldFromRegion(
 /**
  * Best-effort file_path extraction from a streaming Write tool JSON buffer.
  *
- * Scans only the prefix before `"content":` so we do not false-match paths
- * embedded inside the file body string when content is streamed first.
+ * For the current Write payload, parse the path-first `payload` value before
+ * falling back to legacy fields. The fallback scans only the prefix before
+ * `"content":` so we do not false-match paths embedded in a streamed body.
  */
 export function extractFilePathFromJsonBuffer(
   jsonStr: unknown,
   fieldNames: readonly string[] = DEFAULT_FILE_PATH_FIELD_NAMES,
 ): string {
   if (typeof jsonStr !== 'string' || jsonStr.trim() === '') {
+    return '';
+  }
+
+  const parsed = parsePartialJson(jsonStr);
+  const combined = parsed.payload;
+  if (typeof combined === 'string') {
+    const parts = splitFilePathAndContent(combined);
+    if (parts) {
+      return parts.filePath;
+    }
     return '';
   }
 


### PR DESCRIPTION
## Summary

Standardize the `Write` tool on a single `payload` parameter:

```text
+++ {absolute_file_path}
{file_content}
```

This replaces the previous `file_path`, optional `mode`, and `content`
arguments. The change also updates truncation recovery, CLI/Desktop/Web UI
rendering, ACP event projection, partial parameter parsing, and modified-file
tracking to understand the combined payload.

Fixes #<issue-number>

## Type and Areas

Type:

Bug fix / reliability improvement

Areas:

Rust core, tool execution, agent stream, ACP, desktop/Tauri, CLI, and web UI.

## Motivation / Impact

Long `Write` calls can be cut off by `max_tokens`. Previously, Write accepted
separate `file_path` and `content` fields, and the recovery path depended on
the model following the prompt's requested JSON field order: emit `file_path`
before `content`.

That ordering was advisory rather than enforceable. This made recovery unsafe
or lossy in two cases:

- If truncation occurred while the model was still emitting `file_path`, the
  repaired call could contain a partial path and risk writing to an unintended
  target.
- If the model emitted content before a complete path, the already-streamed
  content had no trustworthy destination and could not be safely persisted.

The new `payload` parameter makes the path an explicit, ordered prefix of the same
string as the content. Once the newline after `+++ {file_path}` has been
received, the target path is known to be complete and a truncation can only
leave partial file content.

For recovered Write calls, the pipeline now refuses to execute a `+++ ...`
payload that has no newline separator, because it may be a truncated path
rather than a valid empty-file write. A non-recovered path-only payload remains
valid for intentionally creating or overwriting an empty file.

If a payload does not contain a valid `+++ {file_path}` header, Write stores the
original payload in a unique temporary file in the workspace instead of losing
the generated content. Truncation guidance now asks the model to use `Edit` to
append only the missing continuation after inspecting the saved file.

The invocation contract intentionally changes: new Write calls must provide
`payload`. UI and event projections retain path extraction fallbacks where
needed to display existing legacy-shaped records.

## Verification

pnpm run fmt:rs
cargo check --workspace
cargo test -p bitfun-core file_write_tool
cargo test -p bitfun-agent-stream tool_call_accumulator
cargo test -p bitfun-agent-tools tool_contracts
cargo test -p tool-runtime tool_io_contracts
pnpm run type-check:web
pnpm --dir src/web-ui run test:run src/shared/utils/partialJsonParser.test.ts src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts src/flow_chat/utils/modifiedFilePaths.test.ts

Covered scenarios added or updated in this change include:

- parsing a combined Write path and content payload;
- recovering a Write call truncated during content, including multibyte text;
- rejecting a recovered payload with a potentially truncated path header;
- allowing an intentional non-recovered path-only empty-file write;
- preserving malformed payload input through a temporary-file fallback;
- extracting paths from partial Web UI payloads and ACP event data;
- retaining the path while truncating large content previews.

## Reviewer Notes

- `Write` no longer supports append mode. After a recovered partial write, the
  model is instructed to inspect the file and use `Edit` for the missing
  continuation.
- The product-facing Write contract changes from multiple JSON properties to
  one `payload` string. This is deliberate so path-before-content ordering is
  structurally represented in the payload, rather than depending on JSON
  object serialization order.
- The change touches all major tool-call presentation paths so that permission
  prompts, tool cards, ACP locations/status text, partial streaming previews,
  and modified-file detection continue to show the actual target path.
- Rollback is straightforward: restore the former Write schema and recovery
  guidance, but doing so reintroduces the ordering-dependent truncation risk.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.