### PR TITLE
fix(agent-runtime): align shared coding mode defaults

### DIFF
--- a/src/crates/execution/agent-runtime/src/agents.rs
+++ b/src/crates/execution/agent-runtime/src/agents.rs
@@ -168,7 +168,14 @@ pub fn builtin_agent_definition_specs() -> Vec<BuiltinAgentDefinitionSpec> {
             "CodeReview",
             SubAgent,
             "primary",
-            SubagentVisibilityPolicy::hidden(["agentic", "Cowork", "debug", "Multitask", "Team"]),
+            SubagentVisibilityPolicy::hidden([
+                "agentic",
+                "Cowork",
+                "Plan",
+                "debug",
+                "Multitask",
+                "Team",
+            ]),
         ),
         builtin_agent_spec(
             "DeepReview",

--- a/src/crates/execution/agent-runtime/src/skills/catalog.rs
+++ b/src/crates/execution/agent-runtime/src/skills/catalog.rs
@@ -27,7 +27,7 @@ pub(super) struct BuiltinSkillSpec {
     pub(super) group: BuiltinSkillGroup,
 }
 
-const BUILTIN_SKILL_SPECS: &[BuiltinSkillSpec] = &[
+pub(super) const BUILTIN_SKILL_SPECS: &[BuiltinSkillSpec] = &[
     BuiltinSkillSpec {
         dir_name: "agent-browser",
         group: BuiltinSkillGroup::ComputerUse,

--- a/src/crates/execution/agent-runtime/src/skills/policy.rs
+++ b/src/crates/execution/agent-runtime/src/skills/policy.rs
@@ -4,11 +4,7 @@ use crate::agents::{resolve_mode_config_profile_id, SHARED_CODING_MODE_CONFIG_PR
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SkillModeId {
     CodingShared,
-    Agentic,
-    Multitask,
     Cowork,
-    Plan,
-    Debug,
     Team,
     Claw,
     ComputerUse,
@@ -20,11 +16,7 @@ impl SkillModeId {
     fn parse(mode_id: &str) -> Self {
         match mode_id.trim() {
             SHARED_CODING_MODE_CONFIG_PROFILE_ID => Self::CodingShared,
-            "agentic" => Self::Agentic,
-            "Multitask" => Self::Multitask,
             "Cowork" => Self::Cowork,
-            "Plan" => Self::Plan,
-            "debug" => Self::Debug,
             "Team" => Self::Team,
             "Claw" => Self::Claw,
             "ComputerUse" => Self::ComputerUse,
@@ -93,13 +85,6 @@ const OPEN_META_ONLY_POLICY: ModeSkillPolicy = ModeSkillPolicy {
     rules: &[ENABLE_META],
 };
 
-const PLAN_POLICY: ModeSkillPolicy = ModeSkillPolicy {
-    builtin_default: PolicyEffect::Disable,
-    rules: &[],
-};
-
-const DEBUG_POLICY: ModeSkillPolicy = PLAN_POLICY;
-
 const AGENTIC_POLICY: ModeSkillPolicy = ModeSkillPolicy {
     builtin_default: PolicyEffect::Enable,
     rules: &[DISABLE_OFFICE, DISABLE_GSTACK],
@@ -118,10 +103,7 @@ const TEAM_POLICY: ModeSkillPolicy = ModeSkillPolicy {
 fn policy_for_mode(mode_id: &str) -> ModeSkillPolicy {
     let policy_scope = resolve_mode_config_profile_id(mode_id);
     match SkillModeId::parse(policy_scope.as_ref()) {
-        SkillModeId::CodingShared => AGENTIC_POLICY,
-        SkillModeId::Plan => PLAN_POLICY,
-        SkillModeId::Debug => DEBUG_POLICY,
-        SkillModeId::Agentic | SkillModeId::Multitask | SkillModeId::Claw => AGENTIC_POLICY,
+        SkillModeId::CodingShared | SkillModeId::Claw => AGENTIC_POLICY,
         SkillModeId::Cowork => COWORK_POLICY,
         SkillModeId::Team => TEAM_POLICY,
         SkillModeId::ComputerUse | SkillModeId::DeepResearch | SkillModeId::Other => {
@@ -152,4 +134,27 @@ fn resolve_builtin_default_effect(spec: &BuiltinSkillSpec, mode_id: &str) -> Pol
 pub fn resolve_builtin_default_enabled(dir_name: &str, mode_id: &str) -> Option<bool> {
     builtin_skill_spec(dir_name)
         .map(|spec| resolve_builtin_default_effect(spec, mode_id).is_enabled())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::SHARED_CODING_MODE_IDS;
+    use crate::skills::catalog::BUILTIN_SKILL_SPECS;
+
+    #[test]
+    fn shared_coding_modes_use_identical_builtin_skill_defaults() {
+        for spec in BUILTIN_SKILL_SPECS {
+            let expected = resolve_builtin_default_enabled(spec.dir_name, "agentic");
+            for mode_id in SHARED_CODING_MODE_IDS {
+                assert_eq!(
+                    resolve_builtin_default_enabled(spec.dir_name, mode_id),
+                    expected,
+                    "builtin skill {} differs for shared coding mode {}",
+                    spec.dir_name,
+                    mode_id
+                );
+            }
+        }
+    }
 }

--- a/src/crates/execution/agent-runtime/tests/agent_registry_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/agent_registry_contracts.rs
@@ -251,3 +251,33 @@ fn builtin_agent_definition_catalog_preserves_order_categories_models_and_visibi
         .expect("ResearchSpecialist spec should exist");
     assert_eq!(research_specialist.default_model_id, "fast");
 }
+
+#[test]
+fn shared_coding_modes_have_identical_builtin_subagent_defaults() {
+    let specs = builtin_agent_definition_specs();
+
+    for spec in specs
+        .iter()
+        .filter(|spec| spec.category == BuiltinAgentCategory::SubAgent)
+    {
+        let expected = resolve_subagent_default_enabled(
+            SubagentSourceKind::Builtin,
+            &spec.visibility_policy,
+            Some("agentic"),
+        );
+
+        for mode_id in SHARED_CODING_MODE_IDS {
+            assert_eq!(
+                resolve_subagent_default_enabled(
+                    SubagentSourceKind::Builtin,
+                    &spec.visibility_policy,
+                    Some(mode_id),
+                ),
+                expected,
+                "builtin subagent {} differs for shared coding mode {}",
+                spec.id,
+                mode_id
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Plan` to the hidden `CodeReview` subagent allowlist so `agentic`,
  `Plan`, `debug`, and `Multitask` expose the same builtin subagent defaults.
- Remove unreachable `PLAN_POLICY` and `DEBUG_POLICY` branches, along with
  their unreachable mode parsing variants, because shared coding modes resolve
  through the `coding_shared` profile.
- Add regression tests that verify all builtin subagent and skill defaults are
  identical across the four shared coding modes.

Fixes #

## Type and Areas

Type:

bug fix

Areas:

Rust core / agent runtime

## Motivation / Impact

`Plan` previously could not invoke the hidden `CodeReview` subagent even though
the other shared coding modes could. This made builtin subagent visibility
inconsistent across the shared coding profile.

The skill policy implementation also retained unreachable `Plan` and `debug`
branches despite both modes resolving to `coding_shared`. Removing them makes
the implementation match the actual policy-routing behavior.

`CodeReview` remains hidden from the global registry; this change only makes it
available to `Plan` through the existing allowlisted `Task` query path.

## Verification

- `pnpm run fmt:rs` — passed; formatted the four changed Rust files.
- `cargo test -p bitfun-agent-runtime` — passed.
- `cargo check --workspace` — passed.

`cargo check --workspace` emitted existing Windows `unsafe-op-in-unsafe-fn`
warnings in `bitfun-webdriver` and `bitfun-desktop`; no new errors were
introduced.

## Reviewer Notes

- No migration or compatibility action is required.
- Regression coverage iterates over the builtin catalogs rather than asserting
  only the current `CodeReview` and representative skill cases, preventing
  future shared-mode drift.
- `BUILTIN_SKILL_SPECS` visibility was widened only to `pub(super)` within the
  `skills` module to support the policy-level catalog regression test; it does
  not expand the crate public API.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable; no user-facing copy changed.