### PR TITLE
fix(review): restore slash selection and target parsing

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -30,6 +30,10 @@ import { SmartRecommendations } from './smart-recommendations';
 import { useCurrentWorkspace, useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { createImageContextFromFile, createImageContextFromClipboard } from '../utils/imageUtils';
 import { getSlashCommandPickerQuery, isSlashCommand, stripSlashCommand } from '../utils/slashCommand';
+import {
+  resolveSlashActionInputValue,
+  type SlashActionId,
+} from '../utils/slashActionSelection';
 import { notificationService } from '@/shared/notification-system';
 import { inputReducer, initialInputState } from '../reducers/inputReducer';
 import { modeReducer, initialModeState } from '../reducers/modeReducer';
@@ -115,7 +119,7 @@ export interface ChatInputProps {
 
 type SlashActionItem = {
   kind: 'action';
-  id: string;
+  id: SlashActionId;
   command: string;
   label: string;
 };
@@ -1802,7 +1806,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       ...(isPrimarySlashActionVisible({ actionId: 'btw', isBtwSession, canLaunchReview })
         ? [{
             kind: 'action' as const,
-            id: 'btw',
+            id: 'btw' as const,
             command: '/btw',
             label: t('btw.title'),
           }]
@@ -1810,27 +1814,27 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       ...(isPrimarySlashActionVisible({ actionId: 'review', isBtwSession, canLaunchReview })
         ? [{
             kind: 'action' as const,
-            id: 'review',
+            id: 'review' as const,
             command: '/review',
             label: t('chatInput.reviewAction'),
           }]
         : []),
       {
         kind: 'action',
-        id: 'goal',
+        id: 'goal' as const,
         command: '/goal',
         label: t('chatInput.goalAction'),
       },
       {
         kind: 'action',
-        id: 'usage',
+        id: 'usage' as const,
         command: '/usage',
         label: t('chatInput.usageAction'),
       },
       ...(canUseSkillsForTarget
         ? [{
             kind: 'action' as const,
-            id: 'reload-skills',
+            id: 'reload-skills' as const,
             command: '/reload-skills',
             label: t('chatInput.reloadSkillsAction'),
           }]
@@ -1839,13 +1843,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         ? [
             {
               kind: 'action' as const,
-              id: 'compact',
+              id: 'compact' as const,
               command: '/compact',
               label: t('chatInput.compactAction'),
             },
             {
               kind: 'action' as const,
-              id: 'init',
+              id: 'init' as const,
               command: '/init',
               label: t('chatInput.initAction'),
             },
@@ -2953,58 +2957,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     });
   }, [requestModeChange]);
 
-  const selectSlashCommandAction = useCallback((actionId: string) => {
+  const selectSlashCommandAction = useCallback((actionId: SlashActionId) => {
     const raw = inputState.value || '';
-    const lower = raw.trimStart().toLowerCase();
-
-    let next = raw;
-
-    if (actionId === 'btw') {
-      if (isBtwSession) {
-        return;
-      }
-      if (!isSlashCommand(lower, '/btw')) {
-        next = '/btw ';
-      } else {
-        // Normalize to "/btw " + rest, preserving any already typed question.
-        const m = raw.match(/^(\s*)\/btw\b/i);
-        if (m) {
-          const leadingWs = m[1] || '';
-          const rest = raw.slice(m[0].length);
-          next = `${leadingWs}/btw ${rest.trimStart()}`;
-        } else {
-          next = '/btw ';
-        }
-      }
-    } else if (actionId === 'compact') {
-      next = '/compact';
-    } else if (actionId === 'goal') {
-      if (!isSlashCommand(lower, '/goal')) {
-        next = '/goal ';
-      } else {
-        const m = raw.match(/^(\s*)\/goal\b/i);
-        if (m) {
-          const leadingWs = m[1] || '';
-          const rest = raw.slice(m[0].length);
-          next = `${leadingWs}/goal ${rest.trimStart()}`;
-        } else {
-          next = '/goal ';
-        }
-      }
-    } else if (actionId === 'usage') {
-      next = '/usage';
-    } else if (actionId === 'init') {
-      next = '/init';
-    } else if (actionId === 'reload-skills') {
-      // /reload-skills takes no arguments. Setting the value to the bare
-      // command lets the user immediately press Enter to dispatch it
-      // (which is the same path /usage and /init use).
-      next = '/reload-skills';
-    } else {
+    const next = resolveSlashActionInputValue(actionId, raw, isBtwSession);
+    if (next === null) {
       return;
     }
 
     dispatchInput({ type: 'SET_VALUE', payload: next });
+    inputValueRef.current = next;
     // Clear the machine's queued input so the queuedInput sync effect does not overwrite
     // the just-set "/btw ..." value back to the stale "/" that was queued while processing.
     setQueuedInput(null);

--- a/src/web-ui/src/flow_chat/deep-review/launch/commandParser.test.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/commandParser.test.ts
@@ -127,6 +127,13 @@ describe('Deep Review launch command parser', () => {
     expect(parseSlashCommandGitTarget('review --flag docs only')).toBeNull();
   });
 
+  it('preserves permissive legacy commit parsing independently of composition', () => {
+    expect(parseSlashCommandGitTarget('please inspect commit abc123')).toEqual({
+      source: 'abc123^',
+      target: 'abc123',
+    });
+  });
+
   it('collects each renamed change once using its current path', () => {
     expect(
       collectChangedFilePaths([

--- a/src/web-ui/src/flow_chat/deep-review/launch/commandParser.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/commandParser.ts
@@ -67,6 +67,18 @@ const EXPLICIT_REVIEW_EXTENSIONLESS_FILES = new Set([
   'justfile',
 ]);
 
+const PROSE_SLASH_COMPOUNDS = new Set(['ui/ux', 'read/write']);
+const RECOGNIZED_PROJECT_ROOTS = new Set([
+  'src',
+  'docs',
+  'tests',
+  'scripts',
+  'packages',
+  'apps',
+  'crates',
+  'bitfun-installer',
+]);
+
 export function isDeepReviewSlashCommand(commandText: string): boolean {
   return DEEP_REVIEW_COMMAND_RE.test(commandText.trim());
 }
@@ -92,13 +104,16 @@ function cleanPotentialFileToken(token: string): string {
   return token
     .trim()
     .replace(/^[`"']+/, '')
-    .replace(/[`"',;]+$/, '')
+    .replace(/[`"']+$/, '')
+    .replace(/[.,;!?]+$/, '')
     .replace(/:(?:\d+)(?::\d+)?$/, '');
 }
 
 interface ReviewFocusToken {
   value: string;
   quoted: boolean;
+  start: number;
+  end: number;
 }
 
 function tokenizeReviewFocus(commandFocus: string): ReviewFocusToken[] {
@@ -111,6 +126,8 @@ function tokenizeReviewFocus(commandFocus: string): ReviewFocusToken[] {
       tokens.push({
         value: token,
         quoted: match[4] === undefined,
+        start: match.index,
+        end: match.index + match[0].length,
       });
     }
   }
@@ -126,25 +143,44 @@ function getPathExtension(path: string): string {
   return path.slice(lastDot).toLowerCase();
 }
 
-function looksLikeExplicitReviewPath(token: string): boolean {
+function looksLikeExplicitReviewPath(
+  token: string,
+  quoted = false,
+  strict = false,
+): boolean {
   const cleaned = cleanPotentialFileToken(token);
   const normalizedPath = normalizeReviewPath(cleaned);
   const basename = normalizedPath.split('/').at(-1)?.toLowerCase() ?? '';
+  const lowerPath = normalizedPath.toLowerCase();
   if (
     cleaned.includes('://') ||
-    (cleaned.includes('..') && !cleaned.startsWith('../'))
+    (cleaned.includes('..') && !cleaned.startsWith('../')) ||
+    (PROSE_SLASH_COMPOUNDS.has(lowerPath) && !quoted)
   ) {
     return false;
   }
+  const hasRecognizedName =
+    EXPLICIT_REVIEW_FILE_EXTENSIONS.has(getPathExtension(normalizedPath)) ||
+    EXPLICIT_REVIEW_EXTENSIONLESS_FILES.has(basename) ||
+    (basename.startsWith('.') && basename.length > 1);
+  const isDotRelative = /^(?:\.\.?)[\\/]/.test(cleaned);
+  const isAbsolute = /^[A-Za-z]:[\\/]/.test(cleaned) || /^[\\/]/.test(cleaned);
+  const hasSeparator = /[\\/]/.test(cleaned);
+  const startsAtProjectRoot =
+    hasSeparator &&
+    RECOGNIZED_PROJECT_ROOTS.has(lowerPath.split('/')[0]);
+  const hasExplicitTrailingSlash = /[\\/]$/.test(cleaned);
+  const hasStrongEvidence =
+    hasRecognizedName ||
+    isDotRelative ||
+    isAbsolute ||
+    startsAtProjectRoot ||
+    hasExplicitTrailingSlash ||
+    (quoted && hasSeparator);
   return (
     (
-      EXPLICIT_REVIEW_FILE_EXTENSIONS.has(getPathExtension(normalizedPath)) ||
-      EXPLICIT_REVIEW_EXTENSIONLESS_FILES.has(basename) ||
-      (basename.startsWith('.') && basename.length > 1) ||
-      cleaned.startsWith('./') ||
-      cleaned.startsWith('../') ||
-      /[\\/]/.test(cleaned) ||
-      /[\\/]$/.test(cleaned)
+      hasStrongEvidence ||
+      (!strict && hasSeparator)
     ) &&
     !normalizedPath.startsWith('-') &&
     normalizedPath.length > 0
@@ -152,41 +188,183 @@ function looksLikeExplicitReviewPath(token: string): boolean {
 }
 
 export function hasUnresolvedPathLikeReviewFocus(commandFocus: string): boolean {
+  return extractUnresolvedPathLikeReviewFocusFragments(commandFocus).length > 0;
+}
+
+export function extractUnresolvedPathLikeReviewFocusFragments(
+  commandFocus: string,
+): string[] {
   const tokens = tokenizeReviewFocus(commandFocus).map((token) => ({
+    ...token,
     value: cleanPotentialFileToken(token.value),
-    quoted: token.quoted,
   }));
-  return tokens.some(({ value: token, quoted }, index) => {
-    if (!token || looksLikeExplicitReviewPath(token)) return false;
-    if (
-      token.toLowerCase() === 'commit' ||
-      tokens[index - 1]?.value.toLowerCase() === 'commit'
-    ) {
-      return false;
+  return tokens.flatMap(({ value: token, quoted }, index) => {
+    if (!token || looksLikeExplicitReviewPath(token, quoted, true)) return [];
+    if (token.includes('://')) return [];
+    if (isThreeDotRange(token)) return [token];
+    const previousKeyword = tokens[index - 1]?.value.toLowerCase() ?? '';
+    if (['commit', 'ref'].includes(token.toLowerCase())) {
+      return [];
     }
-    if (token.includes('://') || token.includes('..')) return false;
+    if (['commit', 'ref'].includes(previousKeyword)) {
+      return isValidExplicitRef(token) ? [] : [token];
+    }
+    if (PROSE_SLASH_COMPOUNDS.has(token.toLowerCase())) return [];
+    if (token.includes('..')) {
+      return parseTwoDotRange(token) ? [] : [token];
+    }
     const normalized = normalizeReviewPath(token);
     const basename = normalized.split('/').at(-1) ?? '';
-    return (
+    const unresolved = (
       quoted ||
       /[\\/]/.test(token) ||
       (basename.startsWith('.') && basename.length > 1) ||
       (basename.includes('.') && !/^v?\d+(?:\.\d+)+$/i.test(basename)) ||
       /^[A-Z][A-Z0-9]*(?:[_-][A-Z0-9]+)+$/.test(basename)
     );
+    return unresolved ? [token] : [];
   });
 }
 
-export function extractExplicitReviewFilePaths(commandFocus: string): string[] {
-  const tokens = tokenizeReviewFocus(commandFocus).map((token) => cleanPotentialFileToken(token.value));
-  const paths = tokens.filter((token, index) => {
-    if (!token) return false;
-    if (token.toLowerCase() === 'commit') return false;
-    if (tokens[index - 1]?.toLowerCase() === 'commit') return false;
-    return looksLikeExplicitReviewPath(token);
-  });
+export interface ExplicitReviewFilePathMatch {
+  path: string;
+  start: number;
+  end: number;
+}
 
-  return Array.from(new Set(paths));
+export interface ExplicitReviewFilePathOptions {
+  strict?: boolean;
+}
+
+export function extractExplicitReviewFilePathMatches(
+  commandFocus: string,
+  options: ExplicitReviewFilePathOptions = {},
+): ExplicitReviewFilePathMatch[] {
+  const tokens = tokenizeReviewFocus(commandFocus).map((token) => ({
+    ...token,
+    path: cleanPotentialFileToken(token.value),
+  }));
+
+  return tokens.flatMap(({ path, quoted, start, end }, index) => {
+    if (!path || path.toLowerCase() === 'commit') return [];
+    const previous = tokens[index - 1]?.path.toLowerCase();
+    if (previous === 'commit' || previous === 'ref') return [];
+    return looksLikeExplicitReviewPath(path, quoted, options.strict)
+      ? [{ path, start, end }]
+      : [];
+  });
+}
+
+export function extractExplicitReviewFilePaths(
+  commandFocus: string,
+  options: ExplicitReviewFilePathOptions = {},
+): string[] {
+  return Array.from(new Set(
+    extractExplicitReviewFilePathMatches(commandFocus, options).map(({ path }) => path),
+  ));
+}
+
+export interface ReviewGitTargetMatch {
+  source: string;
+  target: string;
+  start: number;
+  end: number;
+}
+
+function parseTwoDotRange(token: string): [string, string] | null {
+  if (token.startsWith('-') || token.includes('://')) return null;
+  const separator = token.indexOf('..');
+  if (
+    separator <= 0 ||
+    token.lastIndexOf('..') !== separator ||
+    token[separator - 1] === '.' ||
+    token[separator + 2] === '.'
+  ) {
+    return null;
+  }
+  const source = token.slice(0, separator);
+  const target = token.slice(separator + 2);
+  return isValidExplicitRef(source) && isValidExplicitRef(target)
+    ? [source, target]
+    : null;
+}
+
+function isThreeDotRange(token: string): boolean {
+  const separator = token.indexOf('...');
+  return separator > 0 && separator + 3 < token.length;
+}
+
+function isValidExplicitRef(ref: string): boolean {
+  if (
+    !ref ||
+    ref === '@' ||
+    ref.startsWith('-') ||
+    ref.startsWith('/') ||
+    ref.endsWith('/') ||
+    ref.endsWith('.') ||
+    ref.includes('://') ||
+    ref.includes('..') ||
+    ref.includes('@{') ||
+    ref.includes('//') ||
+    /[\u0000-\u0020\u007F~^:?*[\]\\]/.test(ref)
+  ) {
+    return false;
+  }
+  return ref
+    .split('/')
+    .every((component) => !component.startsWith('.') && !component.endsWith('.lock'));
+}
+
+function isExplicitRefKeywordPosition(commandFocus: string, start: number): boolean {
+  const prefix = commandFocus.slice(0, start).trimEnd();
+  return (
+    prefix.length === 0 ||
+    prefix.toLowerCase() === 'review' ||
+    /[,;:([{]$/.test(prefix) ||
+    /(?:^|\s)(?:and|\u4ee5\u53ca|\u548c|\u4e0e)$/iu.test(prefix)
+  );
+}
+
+export function extractReviewGitTargetMatches(
+  commandFocus: string,
+): ReviewGitTargetMatch[] {
+  const tokens = tokenizeReviewFocus(commandFocus).map((token) => ({
+    ...token,
+    cleaned: cleanPotentialFileToken(token.value),
+  }));
+  const matches: ReviewGitTargetMatch[] = [];
+
+  for (const token of tokens) {
+    const range = parseTwoDotRange(token.cleaned);
+    if (range) {
+      matches.push({
+        source: range[0],
+        target: range[1],
+        start: token.start,
+        end: token.end,
+      });
+    }
+  }
+
+  for (let index = 0; index < tokens.length - 1; index += 1) {
+    const keyword = tokens[index];
+    if (
+      !['commit', 'ref'].includes(keyword.cleaned.toLowerCase()) ||
+      !isExplicitRefKeywordPosition(commandFocus, keyword.start)
+    ) {
+      continue;
+    }
+    const refToken = tokens[index + 1];
+    if (!isValidExplicitRef(refToken.cleaned)) continue;
+    matches.push({
+      source: `${refToken.cleaned}^`,
+      target: refToken.cleaned,
+      start: keyword.start,
+      end: refToken.end,
+    });
+  }
+
+  return matches.sort((left, right) => left.start - right.start);
 }
 
 export function parseSlashCommandGitTarget(commandFocus: string): GitChangedFilesParams | null {

--- a/src/web-ui/src/flow_chat/deep-review/launch/subjectCandidates.test.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/subjectCandidates.test.ts
@@ -1,0 +1,667 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractReviewSubjectCandidates,
+  trimReviewUrlToken,
+} from './subjectCandidates';
+
+describe('Review subject candidate extraction', () => {
+  it('extracts a GitHub issue without creating a workspace candidate', () => {
+    const result = extractReviewSubjectCandidates(
+      'https://github.com/org/repo/issues/42',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'issue',
+        id: 'candidate-1',
+        web_url: 'https://github.com/org/repo/issues/42',
+        host: 'github.com',
+        project_path: 'org/repo',
+        issue_id: '42',
+      },
+    ]);
+    expect(result.candidates.some((candidate) => candidate.kind === 'workspace')).toBe(false);
+    expect(result.remainingFocus).toBe('');
+    expect(result.unparsedFragments).toEqual([]);
+  });
+
+  it('preserves issue, pull request, and local files in textual order', () => {
+    const result = extractReviewSubjectCandidates(
+      'using https://github.com/org/repo/issues/42 compare https://github.com/org/repo/pull/57 with src/runtime',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates.map((candidate) => candidate.kind)).toEqual([
+      'issue',
+      'pull_request',
+      'explicit_files',
+    ]);
+    expect(result.candidates.map((candidate) => candidate.id)).toEqual([
+      'candidate-1',
+      'candidate-2',
+      'candidate-3',
+    ]);
+    expect(result.candidates[2]).toMatchObject({ paths: ['src/runtime'] });
+    expect(result.remainingFocus).toBe('using compare with');
+  });
+
+  it('parses nested GitLab projects with query, fragment, and trailing slash variants', () => {
+    const result = extractReviewSubjectCandidates(
+      [
+        'https://gitlab.com/group/subgroup/project/-/issues/7/?scope=all#note_1',
+        'https://gitlab.com/group/subgroup/project/-/merge_requests/9#diffs',
+      ].join(' '),
+    );
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        kind: 'issue',
+        id: 'candidate-1',
+        host: 'gitlab.com',
+        project_path: 'group/subgroup/project',
+        issue_id: '7',
+      }),
+      expect.objectContaining({
+        kind: 'pull_request',
+        id: 'candidate-2',
+        host: 'gitlab.com',
+        project_path: 'group/subgroup/project',
+        pull_request_id: '9',
+      }),
+    ]);
+  });
+
+  it('deduplicates repeated URL subject identities while preserving first occurrence', () => {
+    const focus = [
+      'https://github.com/org/repo/issues/42?view=1#discussion',
+      'https://docs.example.com/review-guide/',
+      'https://github.com/org/repo/issues/42?view=1#discussion',
+    ].join(' then ');
+
+    const first = extractReviewSubjectCandidates(focus);
+    const second = extractReviewSubjectCandidates(focus);
+
+    expect(first.candidates.map((candidate) => candidate.kind)).toEqual([
+      'issue',
+      'external_reference',
+    ]);
+    expect(first.candidates.map((candidate) => candidate.id)).toEqual([
+      'candidate-1',
+      'candidate-2',
+    ]);
+    expect(second.candidates).toEqual(first.candidates);
+  });
+
+  it('does not interpret unknown URL path fragments as local files', () => {
+    const result = extractReviewSubjectCandidates(
+      'review https://example.com/compare/main..feature?file=src/runtime/file.ts#change',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'external_reference',
+        id: 'candidate-1',
+        url: 'https://example.com/compare/main..feature?file=src/runtime/file.ts#change',
+      },
+    ]);
+    expect(result.remainingFocus).toBe('review');
+  });
+
+  it('does not interpret an unknown URL after commit as a Git ref', () => {
+    const commitUrlResult = extractReviewSubjectCandidates(
+      'commit https://example.com/releases/commit-notes',
+      'D:/workspace/repo',
+    );
+    expect(commitUrlResult.candidates).toEqual([
+      {
+        kind: 'external_reference',
+        id: 'candidate-1',
+        url: 'https://example.com/releases/commit-notes',
+      },
+    ]);
+  });
+
+  it('preserves an explicit Windows path alongside a URL subject', () => {
+    const result = extractReviewSubjectCandidates(
+      'D:\\workspace\\repo\\src\\App.tsx and https://github.com/org/repo/pull/8',
+      'D:\\workspace\\repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'explicit_files',
+        id: 'candidate-1',
+        paths: ['D:\\workspace\\repo\\src\\App.tsx'],
+      },
+      expect.objectContaining({
+        kind: 'pull_request',
+        id: 'candidate-2',
+        pull_request_id: '8',
+      }),
+    ]);
+  });
+
+  it('keeps issue-shaped URLs on unknown hosts as external references', () => {
+    const result = extractReviewSubjectCandidates(
+      'src/first.ts https://unknown.example/team/project/issues/5 docs/second.md',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'explicit_files',
+        id: 'candidate-1',
+        paths: ['src/first.ts', 'docs/second.md'],
+      },
+      {
+        kind: 'external_reference',
+        id: 'candidate-2',
+        url: 'https://unknown.example/team/project/issues/5',
+      },
+    ]);
+  });
+
+  it('extracts Git ranges through the command parser and retains prose as focus', () => {
+    const result = extractReviewSubjectCandidates(
+      'compare main..feature for authorization regressions',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'git_range',
+        id: 'candidate-1',
+        source_ref: 'main',
+        target_ref: 'feature',
+      },
+    ]);
+    expect(result.remainingFocus).toBe('compare for authorization regressions');
+  });
+
+  it('keeps Chinese prose and unresolved fragments out of target identity', () => {
+    const result = extractReviewSubjectCandidates(
+      '请重点检查身份验证流程 "config.custom"，不要扩大审查范围',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([]);
+    expect(result.remainingFocus).toContain('请重点检查身份验证流程');
+    expect(result.unparsedFragments).toEqual(['config.custom']);
+  });
+
+  it('does not add workspace identity when no workspace is available', () => {
+    const result = extractReviewSubjectCandidates('只检查安全边界');
+
+    expect(result.candidates).toEqual([]);
+    expect(result.remainingFocus).toBe('只检查安全边界');
+    expect(result.unparsedFragments).toEqual([]);
+  });
+
+  it('keeps unresolved explicit fragments fail-closed while ordinary prose uses workspace', () => {
+    const unresolved = extractReviewSubjectCandidates(
+      'inspect "config.custom" carefully',
+      'D:/workspace/repo',
+    );
+    expect(unresolved.candidates).toEqual([]);
+    expect(unresolved.remainingFocus).toBe('inspect "config.custom" carefully');
+    expect(unresolved.unparsedFragments).toEqual(['config.custom']);
+
+    const prose = extractReviewSubjectCandidates(
+      'review authentication behavior',
+      'D:/workspace/repo',
+    );
+    expect(prose.candidates).toEqual([
+      {
+        kind: 'workspace',
+        id: 'candidate-1',
+        workspace_path: 'D:/workspace/repo',
+      },
+    ]);
+  });
+
+  it('extracts every distinct two-dot Git range in textual order', () => {
+    const result = extractReviewSubjectCandidates(
+      'compare main..feature with release/v1..release/v2 and main..feature',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'git_range',
+        id: 'candidate-1',
+        source_ref: 'main',
+        target_ref: 'feature',
+      },
+      {
+        kind: 'git_range',
+        id: 'candidate-2',
+        source_ref: 'release/v1',
+        target_ref: 'release/v2',
+      },
+    ]);
+    expect(result.remainingFocus).toBe('compare with and');
+  });
+
+  it('keeps three-dot ranges unparsed and does not widen to workspace', () => {
+    const result = extractReviewSubjectCandidates(
+      'compare main...feature for regressions',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([]);
+    expect(result.remainingFocus).toBe('compare main...feature for regressions');
+    expect(result.unparsedFragments).toEqual(['main...feature']);
+
+    const explicit = extractReviewSubjectCandidates(
+      'commit main...feature',
+      'D:/workspace/repo',
+    );
+    expect(explicit.candidates).toEqual([]);
+    expect(explicit.remainingFocus).toBe('commit main...feature');
+    expect(explicit.unparsedFragments).toEqual(['main...feature']);
+  });
+
+  it('extracts explicit commit and ref syntax with exact spans', () => {
+    const result = extractReviewSubjectCandidates(
+      'commit "feature/auth"; ref release/v2, then compare main..next',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'git_range',
+        id: 'candidate-1',
+        source_ref: 'feature/auth^',
+        target_ref: 'feature/auth',
+      },
+      {
+        kind: 'git_range',
+        id: 'candidate-2',
+        source_ref: 'release/v2^',
+        target_ref: 'release/v2',
+      },
+      {
+        kind: 'git_range',
+        id: 'candidate-3',
+        source_ref: 'main',
+        target_ref: 'next',
+      },
+    ]);
+    expect(result.remainingFocus).toBe('then compare');
+    expect(result.unparsedFragments).toEqual([]);
+  });
+
+  it('does not infer commit syntax from prose', () => {
+    const result = extractReviewSubjectCandidates(
+      'review the commit handling logic',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'workspace',
+        id: 'candidate-1',
+        workspace_path: 'D:/workspace/repo',
+      },
+    ]);
+    expect(result.remainingFocus).toBe('review the commit handling logic');
+  });
+
+  it('uses configured trusted provider mappings for self-hosted instances', () => {
+    const result = extractReviewSubjectCandidates(
+      'https://git.example.com/group/sub/project/-/merge_requests/12',
+      undefined,
+      {
+        trustedProviderHosts: {
+          'git.example.com': 'gitlab',
+        },
+      },
+    );
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        kind: 'pull_request',
+        host: 'git.example.com',
+        project_path: 'group/sub/project',
+        pull_request_id: '12',
+      }),
+    ]);
+  });
+
+  it('normalizes trusted hosts and safely decodes provider path segments', () => {
+    const result = extractReviewSubjectCandidates(
+      'https://GITHUB.COM/m%C3%BD-org/repo/issues/42',
+    );
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        kind: 'issue',
+        host: 'github.com',
+        project_path: 'mý-org/repo',
+        issue_id: '42',
+      }),
+    ]);
+  });
+
+  it('rejects unsafe encoded provider paths and userinfo URLs', () => {
+    for (const url of [
+      'https://github.com/org%2Frepo/project/issues/42',
+      'https://github.com/org%5Crepo/project/issues/42',
+      'https://gitlab.com/group/%2e%2e/project/-/issues/42',
+      'https://user@github.com/org/repo/issues/42',
+    ]) {
+      const result = extractReviewSubjectCandidates(url);
+      expect(result.candidates).toEqual([
+        {
+          kind: 'external_reference',
+          id: 'candidate-1',
+          url,
+        },
+      ]);
+    }
+  });
+
+  it('uses only provider pathname identity and ignores query or fragment spoofing', () => {
+    for (const url of [
+      'https://github.com/docs?target=/org/repo/issues/42',
+      'https://gitlab.com/help#group/project/-/issues/42',
+      'https://github.com/org/repo/issues/42/extra',
+      'https://github.com/org/repo/issues/42suffix',
+    ]) {
+      expect(extractReviewSubjectCandidates(url).candidates).toEqual([
+        {
+          kind: 'external_reference',
+          id: 'candidate-1',
+          url,
+        },
+      ]);
+    }
+
+    const valid = 'https://github.com/org/repo/issues/42?redirect=%2Fdocs#note';
+    expect(extractReviewSubjectCandidates(valid).candidates).toEqual([
+      expect.objectContaining({
+        kind: 'issue',
+        web_url: valid,
+        issue_id: '42',
+      }),
+    ]);
+  });
+
+  it('rejects control characters and residual percent escapes in provider paths', () => {
+    for (const url of [
+      'https://github.com/org%00/repo/issues/42',
+      'https://github.com/org%252Frepo/project/issues/42',
+      'https://gitlab.com/group/%252e%252e/project/-/issues/42',
+    ]) {
+      expect(extractReviewSubjectCandidates(url).candidates).toEqual([
+        {
+          kind: 'external_reference',
+          id: 'candidate-1',
+          url,
+        },
+      ]);
+    }
+  });
+
+  it.each([
+    'https://github.com/org%3F/repo/issues/42',
+    'https://gitlab.com/group/proj%23/-/issues/42',
+    'https://github.com/my%20org/repo/issues/42',
+    'https://gitlab.com/group/proj%E2%80%83/-/issues/42',
+  ])('rejects decoded provider delimiters or whitespace in %s', (url) => {
+    expect(extractReviewSubjectCandidates(url).candidates).toEqual([
+      {
+        kind: 'external_reference',
+        id: 'candidate-1',
+        url,
+      },
+    ]);
+  });
+
+  it('does not treat prose slash compounds as file paths', () => {
+    const result = extractReviewSubjectCandidates(
+      'review UI/UX and read/write behavior',
+      'D:/workspace/repo',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'workspace',
+        id: 'candidate-1',
+        workspace_path: 'D:/workspace/repo',
+      },
+    ]);
+    expect(result.unparsedFragments).toEqual([]);
+  });
+
+  it('accepts quoted slash compounds as explicit user-selected paths', () => {
+    const result = extractReviewSubjectCandidates('"UI/UX" "read/write"');
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'explicit_files',
+        id: 'candidate-1',
+        paths: ['UI/UX', 'read/write'],
+      },
+    ]);
+  });
+
+  it('accepts recognized project-root directories and explicit trailing slashes', () => {
+    for (const path of [
+      'src/runtime',
+      'src/runtime/',
+      'docs/design',
+      'tests/fixtures',
+      'scripts/release',
+      'packages/client',
+      'apps/desktop',
+      'crates/runtime',
+      'BitFun-Installer/assets',
+      'custom/directory/',
+    ]) {
+      expect(extractReviewSubjectCandidates(path).candidates).toEqual([
+        {
+          kind: 'explicit_files',
+          id: 'candidate-1',
+          paths: [path],
+        },
+      ]);
+    }
+  });
+
+  it('accepts strong path evidence and strips sentence punctuation', () => {
+    const result = extractReviewSubjectCandidates(
+      'review src/file.ts. "docs/review notes.md" /tmp/check.rs ./src and C:\\repo\\App.tsx',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'explicit_files',
+        id: 'candidate-1',
+        paths: [
+          'src/file.ts',
+          'docs/review notes.md',
+          '/tmp/check.rs',
+          './src',
+          'C:\\repo\\App.tsx',
+        ],
+      },
+    ]);
+  });
+
+  it('stops known provider URLs before adjacent Chinese focus text', () => {
+    const result = extractReviewSubjectCandidates(
+      'https://github.com/org/repo/issues/42请检查权限边界',
+    );
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        kind: 'issue',
+        web_url: 'https://github.com/org/repo/issues/42',
+        issue_id: '42',
+      }),
+    ]);
+    expect(result.remainingFocus).toBe('请检查权限边界');
+  });
+
+  it('stops public provider URLs before Chinese sentence punctuation', () => {
+    const result = extractReviewSubjectCandidates(
+      'https://github.com/org/repo/issues/42\u3002\u8bf7\u68c0\u67e5',
+    );
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        kind: 'issue',
+        web_url: 'https://github.com/org/repo/issues/42',
+        issue_id: '42',
+      }),
+    ]);
+    expect(result.remainingFocus).toBe('\u3002\u8bf7\u68c0\u67e5');
+  });
+
+  it('stops trusted self-hosted provider URLs before adjacent Chinese focus text', () => {
+    const result = extractReviewSubjectCandidates(
+      'https://git.example.com/group/project/-/issues/42\u8bf7\u68c0\u67e5',
+      undefined,
+      {
+        trustedProviderHosts: {
+          'git.example.com': 'gitlab',
+        },
+      },
+    );
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        kind: 'issue',
+        host: 'git.example.com',
+        project_path: 'group/project',
+        issue_id: '42',
+      }),
+    ]);
+    expect(result.remainingFocus).toBe('\u8bf7\u68c0\u67e5');
+  });
+
+  it('preserves complete Unicode external URLs and public-provider query text', () => {
+    const external = 'https://例え.テスト/路径/页面?查询=值#片段';
+    expect(extractReviewSubjectCandidates(external)).toMatchObject({
+      candidates: [
+        {
+          kind: 'external_reference',
+          id: 'candidate-1',
+          url: external,
+        },
+      ],
+      remainingFocus: '',
+    });
+
+    const provider = 'https://github.com/org/repo/issues/42?note=请检查#讨论';
+    expect(extractReviewSubjectCandidates(provider)).toMatchObject({
+      candidates: [
+        expect.objectContaining({
+          kind: 'issue',
+          web_url: provider,
+          issue_id: '42',
+        }),
+      ],
+      remainingFocus: '',
+    });
+  });
+
+  it('extracts multiple explicit refs after English and Chinese conjunctions', () => {
+    const result = extractReviewSubjectCandidates(
+      'commit abc123 and ref release/v2; commit def456 以及 ref release/v3; commit fedcba 和 ref release/v4; commit 123abc 与 ref release/v5',
+    );
+
+    expect(result.candidates).toEqual([
+      ['abc123^', 'abc123'],
+      ['release/v2^', 'release/v2'],
+      ['def456^', 'def456'],
+      ['release/v3^', 'release/v3'],
+      ['fedcba^', 'fedcba'],
+      ['release/v4^', 'release/v4'],
+      ['123abc^', '123abc'],
+      ['release/v5^', 'release/v5'],
+    ].map(([source_ref, target_ref], index) => ({
+      kind: 'git_range',
+      id: `candidate-${index + 1}`,
+      source_ref,
+      target_ref,
+    })));
+    expect(result.unparsedFragments).toEqual([]);
+  });
+
+  it('keeps invalid Git refs and ranges unparsed and fail-closed', () => {
+    for (const fragment of [
+      'main..bad~ref',
+      'main..bad.lock',
+      'main..bad//ref',
+      'main..@',
+      'commit bad^ref',
+    ]) {
+      const result = extractReviewSubjectCandidates(fragment, 'D:/workspace/repo');
+      expect(result.candidates).toEqual([]);
+      expect(result.remainingFocus).toBe(fragment);
+      expect(result.unparsedFragments).toEqual([
+        fragment.startsWith('commit ') ? fragment.slice('commit '.length) : fragment,
+      ]);
+    }
+  });
+
+  it('preserves balanced URL parentheses and strips unmatched sentence punctuation', () => {
+    const result = extractReviewSubjectCandidates(
+      'see https://example.com/docs/(draft) and https://example.com/end).',
+    );
+
+    expect(result.candidates).toEqual([
+      {
+        kind: 'external_reference',
+        id: 'candidate-1',
+        url: 'https://example.com/docs/(draft)',
+      },
+      {
+        kind: 'external_reference',
+        id: 'candidate-2',
+        url: 'https://example.com/end',
+      },
+    ]);
+  });
+
+  it('trims URL punctuation and unmatched closers in one helper pass', () => {
+    expect(trimReviewUrlToken('https://example.com/docs/(draft)')).toBe(
+      'https://example.com/docs/(draft)',
+    );
+    expect(trimReviewUrlToken('https://example.com/docs/(draft))).')).toBe(
+      'https://example.com/docs/(draft)',
+    );
+    expect(
+      trimReviewUrlToken(`https://example.com/end${')'.repeat(10_000)}`),
+    ).toBe('https://example.com/end');
+  });
+
+  it('deduplicates normalized provider subjects, ranges, and file paths uniformly', () => {
+    const result = extractReviewSubjectCandidates(
+      [
+        'https://github.com/org/repo/issues/42',
+        'https://github.com/org/repo/issues/42?view=all#note',
+        'main..feature',
+        'main..feature',
+        'src/file.ts',
+        'src/file.ts',
+      ].join(' '),
+    );
+
+    expect(result.candidates.map((candidate) => candidate.kind)).toEqual([
+      'issue',
+      'git_range',
+      'explicit_files',
+    ]);
+    expect(result.candidates[2]).toMatchObject({ paths: ['src/file.ts'] });
+    expect(result.candidates.map((candidate) => candidate.id)).toEqual([
+      'candidate-1',
+      'candidate-2',
+      'candidate-3',
+    ]);
+  });
+});

--- a/src/web-ui/src/flow_chat/deep-review/launch/subjectCandidates.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/subjectCandidates.ts
@@ -1,0 +1,433 @@
+import {
+  extractExplicitReviewFilePathMatches,
+  extractExplicitReviewFilePaths,
+  extractReviewGitTargetMatches,
+  extractUnresolvedPathLikeReviewFocusFragments,
+} from './commandParser';
+
+export type ReviewSubjectCandidate =
+  | {
+      kind: 'issue';
+      id: string;
+      web_url: string;
+      host: string;
+      project_path: string;
+      issue_id: string;
+    }
+  | {
+      kind: 'pull_request';
+      id: string;
+      web_url: string;
+      host: string;
+      project_path: string;
+      pull_request_id: string;
+    }
+  | {
+      kind: 'git_range';
+      id: string;
+      source_ref: string;
+      target_ref: string;
+    }
+  | {
+      kind: 'workspace';
+      id: string;
+      workspace_path: string;
+    }
+  | {
+      kind: 'explicit_files';
+      id: string;
+      paths: string[];
+    }
+  | {
+      kind: 'external_reference';
+      id: string;
+      url: string;
+    };
+
+const URL_TOKEN = /https?:\/\/[^\s`"'<>]+/giu;
+const GITHUB_PROVIDER_RESOURCE = /^https?:\/\/[^/?#\s]+\/[^/?#\s]+\/[^/?#\s]+\/(?:issues|pull)\/\d+/i;
+const GITLAB_PROVIDER_RESOURCE = /^https?:\/\/[^/?#\s]+\/(?:[^/?#\s]+\/)+-\/(?:issues|merge_requests)\/\d+/i;
+const PROVIDER_ADJACENT_CJK = /^[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\u3000-\u303F\uFF00-\uFFEF]/u;
+
+type ReviewProvider = 'github' | 'gitlab';
+
+export interface ReviewSubjectCandidateExtractionOptions {
+  trustedProviderHosts?: Readonly<Record<string, ReviewProvider>>;
+}
+
+type CandidateWithoutId = ReviewSubjectCandidate extends infer Candidate
+  ? Candidate extends ReviewSubjectCandidate
+    ? Omit<Candidate, 'id'>
+    : never
+  : never;
+
+declare const reviewSubjectIdentityBrand: unique symbol;
+
+/**
+ * A launch-local normalized subject identity. Candidate mentions with the same
+ * identity collapse to the first textual occurrence before IDs are assigned.
+ */
+type ReviewSubjectIdentity = string & {
+  readonly [reviewSubjectIdentityBrand]: true;
+};
+
+interface CandidateSpan {
+  start: number;
+  end: number;
+  candidate: CandidateWithoutId;
+  identity: ReviewSubjectIdentity;
+}
+
+export interface ReviewSubjectCandidateExtraction {
+  candidates: ReviewSubjectCandidate[];
+  remainingFocus: string;
+  unparsedFragments: string[];
+}
+
+function asSubjectIdentity(value: string): ReviewSubjectIdentity {
+  return value as ReviewSubjectIdentity;
+}
+
+export function trimReviewUrlToken(value: string): string {
+  const openerForCloser: Record<string, string> = {
+    ')': '(',
+    ']': '[',
+    '}': '{',
+  };
+  const openers = new Set(Object.values(openerForCloser));
+  const stack: string[] = [];
+  const unmatchedClosers = new Set<number>();
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (openers.has(character)) {
+      stack.push(character);
+      continue;
+    }
+    const opener = openerForCloser[character];
+    if (!opener) continue;
+    if (stack.at(-1) === opener) {
+      stack.pop();
+    } else {
+      unmatchedClosers.add(index);
+    }
+  }
+
+  let end = value.length;
+  while (
+    end > 0 &&
+    (/[.,;:!?]/.test(value[end - 1]) || unmatchedClosers.has(end - 1))
+  ) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+function normalizeProviderHost(host: string): string | null {
+  try {
+    return new URL(`https://${host}`).hostname.toLowerCase().replace(/\.$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function trustedProviders(
+  options: ReviewSubjectCandidateExtractionOptions,
+): Map<string, ReviewProvider> {
+  const providers = new Map<string, ReviewProvider>([
+    ['github.com', 'github'],
+    ['gitlab.com', 'gitlab'],
+  ]);
+  for (const [host, provider] of Object.entries(options.trustedProviderHosts ?? {})) {
+    const normalized = normalizeProviderHost(host);
+    if (normalized) providers.set(normalized, provider);
+  }
+  return providers;
+}
+
+function decodeSafePathSegments(pathname: string): string[] | null {
+  const rawSegments = pathname.split('/').slice(1);
+  if (rawSegments.at(-1) === '') rawSegments.pop();
+  if (rawSegments.some((segment) => segment.length === 0)) return null;
+
+  const decoded: string[] = [];
+  for (const segment of rawSegments) {
+    try {
+      const value = decodeURIComponent(segment);
+      if (
+        value === '.' ||
+        value === '..' ||
+        /[\\/]/.test(value) ||
+        /[?#]/.test(value) ||
+        /\p{White_Space}/u.test(value) ||
+        /[\u0000-\u001F\u007F]/.test(value) ||
+        /%[0-9A-F]{2}/i.test(value)
+      ) {
+        return null;
+      }
+      decoded.push(value);
+    } catch {
+      return null;
+    }
+  }
+  return decoded;
+}
+
+function externalReference(rawUrl: string): CandidateWithoutId {
+  return {
+    kind: 'external_reference',
+    url: rawUrl,
+  };
+}
+
+function classifyProviderUrl(
+  rawUrl: string,
+  providers: Map<string, ReviewProvider>,
+): CandidateWithoutId {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return externalReference(rawUrl);
+  }
+  if (url.username || url.password) return externalReference(rawUrl);
+
+  const host = url.hostname.toLowerCase().replace(/\.$/, '');
+  const provider = providers.get(host);
+  if (!provider) return externalReference(rawUrl);
+  const segments = decodeSafePathSegments(url.pathname);
+  if (!segments) return externalReference(rawUrl);
+
+  if (provider === 'github' && segments.length === 4) {
+    const [owner, repository, resource, id] = segments;
+    if (/^\d+$/.test(id) && resource === 'issues') {
+      return {
+        kind: 'issue',
+        web_url: rawUrl,
+        host,
+        project_path: `${owner}/${repository}`,
+        issue_id: id,
+      };
+    }
+    if (/^\d+$/.test(id) && resource === 'pull') {
+      return {
+        kind: 'pull_request',
+        web_url: rawUrl,
+        host,
+        project_path: `${owner}/${repository}`,
+        pull_request_id: id,
+      };
+    }
+  }
+
+  if (provider === 'gitlab') {
+    const delimiter = segments.lastIndexOf('-');
+    const project = segments.slice(0, delimiter);
+    const resource = segments[delimiter + 1];
+    const id = segments[delimiter + 2];
+    if (
+      delimiter >= 2 &&
+      delimiter + 3 === segments.length &&
+      /^\d+$/.test(id)
+    ) {
+      if (resource === 'issues') {
+        return {
+          kind: 'issue',
+          web_url: rawUrl,
+          host,
+          project_path: project.join('/'),
+          issue_id: id,
+        };
+      }
+      if (resource === 'merge_requests') {
+        return {
+          kind: 'pull_request',
+          web_url: rawUrl,
+          host,
+          project_path: project.join('/'),
+          pull_request_id: id,
+        };
+      }
+    }
+  }
+
+  return externalReference(rawUrl);
+}
+
+function candidateIdentity(candidate: CandidateWithoutId): ReviewSubjectIdentity {
+  switch (candidate.kind) {
+    case 'issue':
+      return asSubjectIdentity(
+        `issue:${candidate.host}:${candidate.project_path}:${candidate.issue_id}`,
+      );
+    case 'pull_request':
+      return asSubjectIdentity(
+        `pull-request:${candidate.host}:${candidate.project_path}:${candidate.pull_request_id}`,
+      );
+    case 'git_range':
+      return asSubjectIdentity(`git:${candidate.source_ref}..${candidate.target_ref}`);
+    case 'explicit_files':
+      return asSubjectIdentity(`files:${candidate.paths.join('\u0000')}`);
+    case 'external_reference': {
+      let normalized = candidate.url;
+      try {
+        normalized = new URL(candidate.url).href;
+      } catch {
+        // Keep the scanned URL when URL normalization is unavailable.
+      }
+      return asSubjectIdentity(`external:${normalized}`);
+    }
+    case 'workspace':
+      return asSubjectIdentity(`workspace:${candidate.workspace_path}`);
+  }
+}
+
+function isolateKnownProviderResource(
+  token: string,
+  providers: Map<string, ReviewProvider>,
+): string {
+  const authority = token.match(/^https?:\/\/[^/?#\s]+/iu)?.[0];
+  if (!authority) return token;
+
+  let authorityUrl: URL;
+  try {
+    authorityUrl = new URL(authority);
+  } catch {
+    return token;
+  }
+  if (authorityUrl.username || authorityUrl.password) return token;
+
+  const host = authorityUrl.hostname.toLowerCase().replace(/\.$/, '');
+  const provider = providers.get(host);
+  const match = provider === 'github'
+    ? token.match(GITHUB_PROVIDER_RESOURCE)
+    : provider === 'gitlab'
+      ? token.match(GITLAB_PROVIDER_RESOURCE)
+      : null;
+  if (!match) return token;
+  const suffix = token.slice(match[0].length);
+  return PROVIDER_ADJACENT_CJK.test(suffix) ? match[0] : token;
+}
+
+function extractUrlSpans(
+  focus: string,
+  options: ReviewSubjectCandidateExtractionOptions,
+): CandidateSpan[] {
+  const providers = trustedProviders(options);
+  return Array.from(focus.matchAll(URL_TOKEN), (match) => {
+    const scanned = isolateKnownProviderResource(match[0], providers);
+    const rawUrl = trimReviewUrlToken(scanned);
+    const candidate = classifyProviderUrl(rawUrl, providers);
+    const start = match.index;
+    return {
+      start,
+      end: start + scanned.length,
+      candidate,
+      identity: candidateIdentity(candidate),
+    };
+  }).filter(({ candidate }) => (
+    candidate.kind !== 'external_reference' || candidate.url.length > 0
+  ));
+}
+
+function stripSpans(
+  focus: string,
+  spans: Array<Pick<CandidateSpan, 'start' | 'end'>>,
+): string {
+  const orderedSpans = [...spans].sort((left, right) => left.start - right.start);
+  const remaining: string[] = [];
+  let cursor = 0;
+  for (const { start, end } of orderedSpans) {
+    if (end <= cursor) continue;
+    remaining.push(focus.slice(cursor, Math.max(cursor, start)));
+    cursor = end;
+  }
+  remaining.push(focus.slice(cursor));
+  return remaining
+    .join(' ')
+    .replace(/(^|\s)[,;:]+(?=\s|$)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function distinctCandidateSpans(spans: CandidateSpan[]): CandidateSpan[] {
+  const seen = new Set<ReviewSubjectIdentity>();
+  return [...spans]
+    .sort((left, right) => left.start - right.start)
+    .filter(({ identity }) => {
+      if (seen.has(identity)) return false;
+      seen.add(identity);
+      return true;
+    });
+}
+
+export function extractReviewSubjectCandidates(
+  focus: string,
+  workspacePath?: string,
+  options: ReviewSubjectCandidateExtractionOptions = {},
+): ReviewSubjectCandidateExtraction {
+  const urlSpans = extractUrlSpans(focus, options);
+  const gitSpans: CandidateSpan[] = extractReviewGitTargetMatches(focus).map((match) => {
+    const candidate: CandidateWithoutId = {
+      kind: 'git_range',
+      source_ref: match.source,
+      target_ref: match.target,
+    };
+    return {
+      start: match.start,
+      end: match.end,
+      candidate,
+      identity: candidateIdentity(candidate),
+    };
+  });
+  const explicitFileMatches = extractExplicitReviewFilePathMatches(focus, {
+    strict: true,
+  });
+  const explicitPaths = extractExplicitReviewFilePaths(focus, { strict: true });
+  const candidateSpans: CandidateSpan[] = [...urlSpans, ...gitSpans];
+
+  if (explicitPaths.length > 0) {
+    const candidate: CandidateWithoutId = {
+      kind: 'explicit_files',
+      paths: explicitPaths,
+    };
+    candidateSpans.push({
+      start: Math.min(...explicitFileMatches.map(({ start }) => start)),
+      end: Math.max(...explicitFileMatches.map(({ end }) => end)),
+      candidate,
+      identity: candidateIdentity(candidate),
+    });
+  }
+
+  const distinctSpans = distinctCandidateSpans(candidateSpans);
+  const candidates: ReviewSubjectCandidate[] = distinctSpans.map(
+    ({ candidate }, index) => ({
+      ...candidate,
+      id: `candidate-${index + 1}`,
+    }) as ReviewSubjectCandidate,
+  );
+  const unparsedFragments = Array.from(new Set(
+    extractUnresolvedPathLikeReviewFocusFragments(focus),
+  ));
+  if (
+    candidates.length === 0 &&
+    unparsedFragments.length === 0 &&
+    workspacePath?.trim()
+  ) {
+    candidates.push({
+      kind: 'workspace',
+      id: 'candidate-1',
+      workspace_path: workspacePath,
+    });
+  }
+
+  return {
+    candidates,
+    remainingFocus: stripSpans(focus, [
+      ...urlSpans,
+      ...gitSpans,
+      ...explicitFileMatches,
+    ]),
+    unparsedFragments,
+  };
+}

--- a/src/web-ui/src/flow_chat/utils/slashActionSelection.test.ts
+++ b/src/web-ui/src/flow_chat/utils/slashActionSelection.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSlashActionInputValue } from './slashActionSelection';
+
+describe('resolveSlashActionInputValue', () => {
+  it('fills review with a trailing space so arguments can be added', () => {
+    expect(resolveSlashActionInputValue('review', '/', false)).toBe('/review ');
+  });
+
+  it('preserves argument-bearing action input behavior', () => {
+    expect(resolveSlashActionInputValue('btw', '/', false)).toBe('/btw ');
+    expect(resolveSlashActionInputValue('btw', '/btw explain this', false)).toBe('/btw explain this');
+    expect(resolveSlashActionInputValue('btw', '/', true)).toBeNull();
+    expect(resolveSlashActionInputValue('goal', '/', false)).toBe('/goal ');
+    expect(resolveSlashActionInputValue('goal', '/goal ship it', false)).toBe('/goal ship it');
+  });
+
+  it.each([
+    ['compact', '/compact'],
+    ['usage', '/usage'],
+    ['init', '/init'],
+    ['reload-skills', '/reload-skills'],
+  ] as const)('fills the %s action', (actionId, expected) => {
+    expect(resolveSlashActionInputValue(actionId, '/', false)).toBe(expected);
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/slashActionSelection.ts
+++ b/src/web-ui/src/flow_chat/utils/slashActionSelection.ts
@@ -1,0 +1,60 @@
+import { isSlashCommand } from './slashCommand';
+
+export type SlashActionId =
+  | 'btw'
+  | 'review'
+  | 'goal'
+  | 'usage'
+  | 'reload-skills'
+  | 'compact'
+  | 'init';
+
+export function resolveSlashActionInputValue(
+  actionId: SlashActionId,
+  raw: string,
+  isBtwSession: boolean,
+): string | null {
+  const lower = raw.trimStart().toLowerCase();
+
+  switch (actionId) {
+    case 'btw': {
+      if (isBtwSession) {
+        return null;
+      }
+      if (!isSlashCommand(lower, '/btw')) {
+        return '/btw ';
+      }
+
+      const match = raw.match(/^(\s*)\/btw\b/i);
+      if (!match) {
+        return '/btw ';
+      }
+      const leadingWhitespace = match[1] || '';
+      const rest = raw.slice(match[0].length);
+      return `${leadingWhitespace}/btw ${rest.trimStart()}`;
+    }
+    case 'review':
+      return '/review ';
+    case 'compact':
+      return '/compact';
+    case 'goal': {
+      if (!isSlashCommand(lower, '/goal')) {
+        return '/goal ';
+      }
+
+      const match = raw.match(/^(\s*)\/goal\b/i);
+      if (!match) {
+        return '/goal ';
+      }
+      const leadingWhitespace = match[1] || '';
+      const rest = raw.slice(match[0].length);
+      return `${leadingWhitespace}/goal ${rest.trimStart()}`;
+    }
+    case 'usage':
+      return '/usage';
+    case 'init':
+      return '/init';
+    case 'reload-skills':
+      return '/reload-skills';
+  }
+}


### PR DESCRIPTION
## Summary

This change restores reliable slash-command selection for Review and introduces a strict, typed parser for explicit Review targets.

- Keyboard and mouse selection now share one action path, keep the input ref synchronized, and insert `/review ` so users can continue typing immediately.
- Review focus parsing distinguishes prose from explicit file paths and Git refs, rejects ambiguous or unsafe range forms, and preserves unresolved fragments for honest error handling.
- Typed candidate extraction recognizes GitHub/GitLab Issue and pull-request URLs, Git ranges, workspace paths, explicit files, and unsupported external references without inventing targets.
- Provider URL parsing fails closed for unsafe identities and encoded path tricks, supports explicitly trusted self-hosted authorities, and separates adjacent CJK focus text and punctuation from the URL.

## Root cause

Slash menu selection used separate keyboard and pointer flows that did not consistently apply the selected action to the editor state. Review target parsing also relied on token-level heuristics that could confuse prose, paths, refs, and provider URLs or consume adjacent focus text.

The fix centralizes slash selection behavior and makes target extraction span-aware, identity-normalized, deterministic, and conservative when input is ambiguous.

## Scope

This is intentionally the first narrow Review PR. It provides the interaction fix and parsing primitives only. It does not add model planning, provider evidence acquisition, multi-subject session persistence, prompt changes, UI status projection, or Agent-loop behavior.

The typed URL candidate parser is introduced as an isolated primitive; wiring it into the later multi-subject Review launch flow will be handled separately.

## Validation

- 90 focused Web UI tests covering slash selection, command parsing, typed subject extraction, target resolution, and existing Review launch behavior.
- Web TypeScript type-check.
- `git diff --check`.
- Independent review identified adjacent Chinese punctuation and trusted self-hosted URL truncation gaps; both cases were added as regressions and revalidated.
