### PR TITLE
fix(built-in-browser): stabilize H.264 streaming in embedded browser

### DIFF
--- a/src/apps/desktop/src/api/browser_api.rs
+++ b/src/apps/desktop/src/api/browser_api.rs
@@ -1,12 +1,67 @@
 //! Browser API — commands for the embedded browser feature.
 //!
-//! Browser webviews are created on the Rust side so that we can attach an
-//! `on_page_load` handler that safely catches panics from the upstream wry
-//! `url_from_webview` bug (WKWebView.URL() returning nil).
-//! See: <https://github.com/tauri-apps/wry/pull/1554>
+//! Browser webviews are created as native child webviews by this desktop
+//! adapter so stream-specific initialization can run before page scripts.
 
 use serde::Deserialize;
 use tauri::Manager;
+
+const VIDEO_DECODER_MODE_ENV: &str = "BITFUN_BROWSER_VIDEO_DECODER_MODE";
+
+fn video_decoder_compatibility_script() -> String {
+    let mode =
+        std::env::var(VIDEO_DECODER_MODE_ENV).unwrap_or_else(|_| "prefer-software".to_string());
+    let mode = match mode.as_str() {
+        "prefer-hardware" | "prefer-software" => mode,
+        _ => String::new(),
+    };
+    let mode_json = serde_json::to_string(&mode).unwrap_or_else(|_| "\"\"".to_string());
+    let script = format!(
+        r#"
+const isWebView2 = Boolean(window.chrome && window.chrome.webview);
+const isBitFunDocument = location.protocol === 'tauri:'
+  || location.hostname === 'tauri.localhost'
+  || (location.hostname === 'localhost' && location.port === '1422');
+if (isWebView2 && !isBitFunDocument) {{
+  const decoderMode = {mode_json};
+  if (decoderMode && typeof VideoDecoder === 'function') {{
+    const originalConfigure = VideoDecoder.prototype.configure;
+    VideoDecoder.prototype.configure = function(config) {{
+      const codec = typeof config?.codec === 'string' ? config.codec : '';
+      const isH264 = /^avc[13]\./i.test(codec);
+      if (isH264 && !config.hardwareAcceleration) {{
+        return originalConfigure.call(this, {{ ...config, hardwareAcceleration: decoderMode }});
+      }}
+      return originalConfigure.call(this, config);
+    }};
+
+    // #region agent log
+    if (location.hostname === '127.0.0.1' && location.port === '41953') {{
+      void fetch('http://127.0.0.1:7469/log', {{
+        method: 'POST',
+        headers: {{ 'Content-Type': 'application/json' }},
+        body: JSON.stringify({{
+          hypothesis: 'D',
+          location: 'browser_api.video_decoder_init',
+          message: 'video decoder mode installed',
+          data: {{ decoderMode }},
+          timestamp: new Date().toISOString()
+        }})
+      }}).catch(() => {{}});
+    }}
+    // #endregion
+  }}
+}}
+"#
+    );
+
+    script
+}
+
+fn find_browser_webview(app: &tauri::AppHandle, label: &str) -> Result<tauri::Webview, String> {
+    app.get_webview(label)
+        .ok_or_else(|| format!("Webview not found: {label}"))
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,24 +70,162 @@ pub struct WebviewEvalRequest {
     pub script: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebviewNavigateRequest {
+    pub label: String,
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebviewBoundsRequest {
+    pub label: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebviewCreateRequest {
+    pub label: String,
+    pub url: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+fn validate_browser_label(label: &str) -> Result<(), String> {
+    if label.starts_with("embedded-browser-view-")
+        || label.starts_with("embedded-browser-panel-view-")
+    {
+        Ok(())
+    } else {
+        Err("invalid browser webview label".to_string())
+    }
+}
+
+fn validate_webview_bounds(x: f64, y: f64, width: f64, height: f64) -> Result<(), String> {
+    if !x.is_finite()
+        || !y.is_finite()
+        || !width.is_finite()
+        || !height.is_finite()
+        || width <= 1.0
+        || height <= 1.0
+    {
+        Err("invalid webview bounds".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[tauri::command]
+pub async fn browser_webview_create(
+    app: tauri::AppHandle,
+    request: WebviewCreateRequest,
+) -> Result<(), String> {
+    validate_browser_label(&request.label)?;
+    validate_webview_bounds(request.x, request.y, request.width, request.height)?;
+
+    let url = request
+        .url
+        .parse::<tauri::Url>()
+        .map_err(|e| format!("invalid url: {e}"))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        scheme => return Err(format!("unsupported protocol: {scheme}")),
+    }
+
+    let window = app
+        .get_window("main")
+        .ok_or_else(|| "main window not found".to_string())?;
+    let mut builder =
+        tauri::webview::WebviewBuilder::new(request.label, tauri::WebviewUrl::External(url))
+            .initialization_script(video_decoder_compatibility_script())
+            .transparent(false)
+            .background_color(tauri::window::Color(0, 0, 0, 255));
+
+    #[cfg(any(debug_assertions, feature = "devtools"))]
+    {
+        builder = builder.devtools(true);
+    }
+
+    window
+        .add_child(
+            builder,
+            tauri::LogicalPosition::new(request.x, request.y),
+            tauri::LogicalSize::new(request.width, request.height),
+        )
+        .map(|_| ())
+        .map_err(|e| format!("failed to create browser webview: {e}"))
+}
+
 #[tauri::command]
 pub async fn browser_webview_eval(
     app: tauri::AppHandle,
     request: WebviewEvalRequest,
 ) -> Result<(), String> {
-    let webview = app
-        .get_webview(&request.label)
-        .ok_or_else(|| format!("Webview not found: {}", request.label))?;
-
-    webview
+    find_browser_webview(&app, &request.label)?
         .eval(&request.script)
         .map_err(|e| format!("eval failed: {e}"))
+}
+
+#[tauri::command]
+pub async fn browser_webview_navigate(
+    app: tauri::AppHandle,
+    request: WebviewNavigateRequest,
+) -> Result<(), String> {
+    let url = request
+        .url
+        .parse::<tauri::Url>()
+        .map_err(|e| format!("invalid url: {e}"))?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        scheme => return Err(format!("unsupported protocol: {scheme}")),
+    }
+
+    find_browser_webview(&app, &request.label)?
+        .navigate(url)
+        .map_err(|e| format!("navigate failed: {e}"))
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebviewLabelRequest {
     pub label: String,
+}
+
+#[tauri::command]
+pub async fn browser_webview_reload(
+    app: tauri::AppHandle,
+    request: WebviewLabelRequest,
+) -> Result<(), String> {
+    find_browser_webview(&app, &request.label)?
+        .reload()
+        .map_err(|e| format!("reload failed: {e}"))
+}
+
+#[tauri::command]
+pub async fn browser_webview_set_bounds(
+    app: tauri::AppHandle,
+    request: WebviewBoundsRequest,
+) -> Result<(), String> {
+    validate_webview_bounds(request.x, request.y, request.width, request.height)?;
+
+    let webview = app
+        .get_webview(&request.label)
+        .ok_or_else(|| format!("Webview not found: {}", request.label))?;
+
+    webview
+        .set_bounds(tauri::Rect {
+            position: tauri::Position::Logical(tauri::LogicalPosition::new(request.x, request.y)),
+            size: tauri::Size::Logical(tauri::LogicalSize::new(request.width, request.height)),
+        })
+        .map_err(|e| format!("set bounds failed: {e}"))
 }
 
 /// Return the current URL of a browser webview.
@@ -45,10 +238,7 @@ pub async fn browser_get_url(
     app: tauri::AppHandle,
     request: WebviewLabelRequest,
 ) -> Result<String, String> {
-    let webview = app
-        .get_webview(&request.label)
-        .ok_or_else(|| format!("Webview not found: {}", request.label))?;
-
+    let webview = find_browser_webview(&app, &request.label)?;
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| webview.url()));
 
     match result {

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -85,6 +85,7 @@ static MAIN_WINDOW_HIDDEN_ON_MACOS: AtomicBool = AtomicBool::new(false);
 static MAIN_WINDOW_CLOSE_PENDING_ON_MACOS: AtomicBool = AtomicBool::new(false);
 
 const MAIN_WINDOW_CLOSE_REQUESTED_EVENT: &str = "bitfun_main_window_close_requested";
+const BROWSER_WEBVIEW_PAGE_LOAD_EVENT: &str = "browser-webview-page-load";
 const CRON_DESKTOP_START_FALLBACK_DELAY: Duration = Duration::from_secs(120);
 
 #[cfg(target_os = "macos")]
@@ -429,6 +430,26 @@ pub async fn run() {
         .manage(scheduler)
         .manage(terminal_state)
         .manage(startup_trace.clone())
+        .on_page_load(|webview, payload| {
+            let label = webview.label();
+            if label.starts_with("embedded-browser-view-")
+                || label.starts_with("embedded-browser-panel-view-")
+            {
+                let event = match payload.event() {
+                    tauri::webview::PageLoadEvent::Started => "started",
+                    tauri::webview::PageLoadEvent::Finished => "finished",
+                };
+                let _ = webview.emit_to(
+                    "main",
+                    BROWSER_WEBVIEW_PAGE_LOAD_EVENT,
+                    serde_json::json!({
+                        "label": label,
+                        "event": event,
+                        "url": payload.url(),
+                    }),
+                );
+            }
+        })
         .setup(move |app| {
             let setup_started = Instant::now();
             startup_trace.record_phase("tauri_setup_start", "native_setup");
@@ -1302,6 +1323,10 @@ pub async fn run() {
             api::miniapp_export_api::miniapp_render_slide_page,
             // Browser API (embedded webview)
             api::browser_api::browser_webview_eval,
+            api::browser_api::browser_webview_create,
+            api::browser_api::browser_webview_navigate,
+            api::browser_api::browser_webview_reload,
+            api::browser_api::browser_webview_set_bounds,
             api::browser_api::browser_get_url,
             // Browser Control API (CDP-based user browser control)
             api::browser_control_api::browser_control_list_browsers,

--- a/src/web-ui/src/app/scenes/browser/BrowserPanel.tsx
+++ b/src/web-ui/src/app/scenes/browser/BrowserPanel.tsx
@@ -2,11 +2,11 @@
  * BrowserPanel — embeds a browser into the AuxPane right panel.
  *
  * Uses a Tauri native Webview overlay positioned over the panel's DOM element.
- * When the panel is not active (tab switch / scene switch / AuxPane collapse),
- * the webview is reparented to a hidden holder window to preserve page state.
+ * The webview is kept attached to the main window and reused across navigations
+ * so video/WebRTC surfaces are not repeatedly torn down or reparented.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AlertTriangle, ChevronLeft, ChevronRight, Globe, RefreshCw, MousePointer2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { IconButton } from '@/component-library';
@@ -14,86 +14,12 @@ import { createLogger } from '@/shared/utils/logger';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import { useContextStore } from '@/shared/context-system';
 import type { WebElementContext } from '@/shared/types/context';
-import { createInspectorScript, CANCEL_INSPECTOR_SCRIPT, BLANK_TARGET_INTERCEPT_SCRIPT } from './browserInspectorScript';
-import { validateUrl, checkConnectivity } from './browserUrlCheck';
+import { createInspectorScript, CANCEL_INSPECTOR_SCRIPT } from './browserInspectorScript';
+import { useEmbeddedBrowserWebview } from './useEmbeddedBrowserWebview';
 import './BrowserPanel.scss';
 
 const log = createLogger('BrowserPanel');
 const DEFAULT_URL = 'https://openbitfun.com/';
-const PANEL_HOLDER_WINDOW_LABEL = 'embedded-browser-panel-holder';
-
-function isTauriEnvironment(): boolean {
-  return typeof window !== 'undefined' && '__TAURI__' in window;
-}
-
-type BrowserWebviewHandle = {
-  close: () => Promise<void>;
-  hide: () => Promise<void>;
-  label: string;
-  once: (event: string, handler: (event?: unknown) => void) => Promise<() => void>;
-  reparent: (window: string | unknown) => Promise<void>;
-  setFocus: () => Promise<void>;
-  setPosition: (position: unknown) => Promise<void>;
-  setSize: (size: unknown) => Promise<void>;
-  show: () => Promise<void>;
-};
-
-async function evalWebview(label: string, script: string): Promise<void> {
-  const { invoke } = await import('@tauri-apps/api/core');
-  await invoke('browser_webview_eval', { request: { label, script } });
-}
-
-type BrowserHolderWindowHandle = {
-  close: () => Promise<void>;
-  hide: () => Promise<void>;
-  once: (event: string, handler: (event?: unknown) => void) => Promise<() => void>;
-};
-
-function formatUnknownError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  if (error && typeof error === 'object') {
-    const record = error as Record<string, unknown>;
-    const payload = 'payload' in record ? record.payload : undefined;
-    const message =
-      (typeof record.message === 'string' && record.message) ||
-      (payload && typeof payload === 'object' && typeof (payload as Record<string, unknown>).message === 'string'
-        ? String((payload as Record<string, unknown>).message)
-        : null);
-    if (message) return message;
-    try { return JSON.stringify(error); } catch { return String(error); }
-  }
-  return String(error);
-}
-
-function isWebviewNotFoundError(error: unknown): boolean {
-  return formatUnknownError(error).toLowerCase().includes('webview not found');
-}
-
-async function waitForWebviewCreated(handle: BrowserWebviewHandle): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const finish = (cb: () => void) => { if (!settled) { settled = true; cb(); } };
-    void handle.once('tauri://created', () => finish(resolve));
-    void handle.once('tauri://error', (event) => finish(() => reject(new Error(formatUnknownError(event)))));
-  });
-}
-
-async function waitForWindowCreated(handle: BrowserHolderWindowHandle): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const finish = (cb: () => void) => { if (!settled) { settled = true; cb(); } };
-    void handle.once('tauri://created', () => finish(resolve));
-    void handle.once('tauri://error', (event) => finish(() => reject(new Error(formatUnknownError(event)))));
-  });
-}
-
-function normalizeUrl(raw: string): string {
-  const value = raw.trim();
-  if (!value) return DEFAULT_URL;
-  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value)) return value;
-  return `https://${value}`;
-}
 
 interface InspectorElementData {
   tagName: string;
@@ -113,340 +39,70 @@ export interface BrowserPanelProps {
 const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => {
   const { t } = useTranslation('common');
   const activeTabId = useSceneStore((s) => s.activeTabId);
-  // Show webview only when this tab is active AND the session scene is visible
-  const isSceneActive = activeTabId === 'session';
-  const shouldShowWebview = isActive && isSceneActive;
-
-  const isTauri = useMemo(() => isTauriEnvironment(), []);
-
-  const startUrl = initialUrl ?? DEFAULT_URL;
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const webviewRef = useRef<BrowserWebviewHandle | null>(null);
-  const holderWindowRef = useRef<BrowserHolderWindowHandle | null>(null);
-  const webviewSequenceRef = useRef(0);
-  const currentUrlRef = useRef<string>(startUrl);
-  const resizeFrameRef = useRef<number | null>(null);
-  const webviewLabelRef = useRef<string>('');
+  const shouldShowWebview = isActive && activeTabId === 'session';
+  const addContext = useContextStore((s) => s.addContext);
   const inspectorUnlistenRef = useRef<(() => void) | null>(null);
-  const urlPollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const [inputValue, setInputValue] = useState(startUrl);
-  const [currentUrl, setCurrentUrl] = useState(startUrl);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [isInspectorActive, setIsInspectorActive] = useState(false);
 
-  const addContext = useContextStore((s) => s.addContext);
+  const browser = useEmbeddedBrowserWebview({
+    defaultUrl: DEFAULT_URL,
+    initialUrl,
+    isVisible: shouldShowWebview,
+    labelPrefix: 'embedded-browser-panel-view',
+    log,
+  });
 
-  /**
-   * Sync webview bounds to the panel container.
-   * Hides the webview if the container has no visible area (AuxPane collapsed, etc.).
-   */
-  const syncWebviewBounds = useCallback(async (handle?: BrowserWebviewHandle | null) => {
-    const target = handle ?? webviewRef.current;
-    if (!isTauri || !target || !viewportRef.current) return;
+  const {
+    currentUrl,
+    error,
+    evalInWebview,
+    getCurrentUrl,
+    getWebviewLabel,
+    goBack,
+    goForward,
+    hasWebview,
+    inputValue,
+    isLoading,
+    isTauri,
+    loadUrl,
+    reload,
+    setInputValue,
+    viewportRef,
+    webviewLabel,
+  } = browser;
 
-    const rect = viewportRef.current.getBoundingClientRect();
-    if (rect.width <= 1 || rect.height <= 1) {
-      await target.hide().catch(() => {});
-      return;
+  const stopInspector = useCallback(() => {
+    if (getWebviewLabel()) {
+      void evalInWebview(CANCEL_INSPECTOR_SCRIPT).catch(() => {});
     }
-
-    const { LogicalPosition, LogicalSize } = await import('@tauri-apps/api/dpi');
-    await Promise.all([
-      target.setPosition(new LogicalPosition(rect.left, rect.top)),
-      target.setSize(new LogicalSize(rect.width, rect.height)),
-    ]);
-    if (shouldShowWebview) {
-      await target.show().catch(() => {});
-    }
-  }, [isTauri, shouldShowWebview]);
-
-  const closeWebview = useCallback(async (handle?: BrowserWebviewHandle | null) => {
-    const target = handle ?? webviewRef.current;
-    if (!target) return;
-    try {
-      await target.close();
-    } catch (e) {
-      if (!isWebviewNotFoundError(e)) log.warn('Close browser panel webview failed', e);
-    } finally {
-      if (!handle || target === webviewRef.current) webviewRef.current = null;
-    }
-  }, []);
-
-  const ensureHolderWindow = useCallback(async (): Promise<BrowserHolderWindowHandle> => {
-    if (holderWindowRef.current) return holderWindowRef.current;
-
-    const { Window } = await import('@tauri-apps/api/window');
-    const existing = (await Window.getByLabel(PANEL_HOLDER_WINDOW_LABEL)) as BrowserHolderWindowHandle | null;
-    if (existing) {
-      holderWindowRef.current = existing;
-      return existing;
-    }
-
-    const holder = new Window(PANEL_HOLDER_WINDOW_LABEL, {
-      visible: false,
-      decorations: false,
-      skipTaskbar: true,
-      shadow: false,
-      width: 1,
-      height: 1,
-      x: -10000,
-      y: -10000,
-      title: 'Browser Panel Holder',
-    }) as BrowserHolderWindowHandle;
-
-    await waitForWindowCreated(holder);
-    await holder.hide().catch(() => {});
-    holderWindowRef.current = holder;
-    return holder;
-  }, []);
-
-  const recreateWebview = useCallback(async (url: string) => {
-    const previous = webviewRef.current;
-    if (previous) await closeWebview(previous);
-
-    const [{ Webview }, { getCurrentWindow }] = await Promise.all([
-      import('@tauri-apps/api/webview'),
-      import('@tauri-apps/api/window'),
-    ]);
-    const label = `embedded-browser-panel-view-${webviewSequenceRef.current++}`;
-    webviewLabelRef.current = label;
-    const handle = new Webview(getCurrentWindow(), label, {
-      url,
-      x: 0,
-      y: 0,
-      width: 960,
-      height: 640,
-    }) as unknown as BrowserWebviewHandle;
-
-    await waitForWebviewCreated(handle);
-    webviewRef.current = handle;
-    return handle;
-  }, [closeWebview]);
-
-  const loadUrl = useCallback(async (rawUrl: string) => {
-    const nextUrl = normalizeUrl(rawUrl);
-    setInputValue(nextUrl);
-    setCurrentUrl(nextUrl);
-    currentUrlRef.current = nextUrl;
-    setError(null);
-    setIsLoading(true);
-    if (inspectorUnlistenRef.current && webviewLabelRef.current) {
-      void evalWebview(webviewLabelRef.current, CANCEL_INSPECTOR_SCRIPT).catch(() => {});
-      inspectorUnlistenRef.current();
-      inspectorUnlistenRef.current = null;
-    }
+    inspectorUnlistenRef.current?.();
+    inspectorUnlistenRef.current = null;
     setIsInspectorActive(false);
+  }, [evalInWebview, getWebviewLabel]);
 
-    if (!isTauri) {
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      validateUrl(nextUrl);
-      await checkConnectivity(nextUrl);
-
-      if (urlPollTimerRef.current) {
-        clearInterval(urlPollTimerRef.current);
-        urlPollTimerRef.current = null;
-      }
-
-      const handle = await recreateWebview(nextUrl);
-      await syncWebviewBounds(handle);
-      if (shouldShowWebview) {
-        await handle.show();
-        await handle.setFocus();
-      }
-
-      const label = webviewLabelRef.current;
-      await evalWebview(label, BLANK_TARGET_INTERCEPT_SCRIPT);
-
-      const { invoke } = await import('@tauri-apps/api/core');
-      urlPollTimerRef.current = setInterval(() => {
-        invoke<string>('browser_get_url', { request: { label } })
-          .then((url) => {
-            if (url && url !== currentUrlRef.current) {
-              currentUrlRef.current = url;
-              setInputValue(url);
-              setCurrentUrl(url);
-              setError(null);
-              evalWebview(label, BLANK_TARGET_INTERCEPT_SCRIPT).catch(() => {});
-            }
-          })
-          .catch(() => {});
-      }, 500);
-    } catch (loadError) {
-      const message = formatUnknownError(loadError);
-      log.error('Load browser panel url failed', loadError);
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isTauri, recreateWebview, shouldShowWebview, syncWebviewBounds]);
-
-  const queueSync = useCallback(() => {
-    if (resizeFrameRef.current !== null) window.cancelAnimationFrame(resizeFrameRef.current);
-    resizeFrameRef.current = window.requestAnimationFrame(() => {
-      resizeFrameRef.current = null;
-      void syncWebviewBounds().catch((e) => log.warn('Sync browser panel webview bounds failed', e));
-    });
-  }, [syncWebviewBounds]);
-
-  // Activate / deactivate webview based on shouldShowWebview
-  useEffect(() => {
-    if (!isTauri) return;
-
-    if (shouldShowWebview) {
-      if (!webviewRef.current) {
-        void loadUrl(currentUrlRef.current).catch((e) => log.warn('Restore browser panel webview failed', e));
-        return;
-      }
-
-      void (async () => {
-        const { getCurrentWindow } = await import('@tauri-apps/api/window');
-        await webviewRef.current?.reparent(getCurrentWindow());
-        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-        await syncWebviewBounds();
-      })()
-        .then(() => webviewRef.current?.show())
-        .then(() => webviewRef.current?.setFocus())
-        .catch((e) => log.warn('Activate browser panel webview failed', e));
-      return;
-    }
-
-    if (webviewRef.current) {
-      void ensureHolderWindow()
-        .then((holder) => webviewRef.current?.reparent(holder))
-        .then(() => holderWindowRef.current?.hide())
-        .catch((e) => {
-          log.warn('Reparent browser panel webview to holder failed', e);
-          return closeWebview();
-        })
-        .catch((e) => log.warn('Close browser panel webview on deactivate failed', e));
-    }
-  }, [closeWebview, ensureHolderWindow, loadUrl, shouldShowWebview, syncWebviewBounds, isTauri]);
-
-  // ResizeObserver + window resize → sync bounds
-  useEffect(() => {
-    if (!isTauri) return;
-
-    const observer = new ResizeObserver(() => {
-      if (shouldShowWebview) queueSync();
-    });
-
-    if (viewportRef.current) observer.observe(viewportRef.current);
-
-    const handleResize = () => { if (shouldShowWebview) queueSync(); };
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('resize', handleResize);
-      if (resizeFrameRef.current !== null) {
-        window.cancelAnimationFrame(resizeFrameRef.current);
-        resizeFrameRef.current = null;
-      }
-    };
-  }, [isTauri, queueSync, shouldShowWebview]);
-
-  // Cleanup on unmount
-  useEffect(() => () => {
-    if (urlPollTimerRef.current) {
-      clearInterval(urlPollTimerRef.current);
-      urlPollTimerRef.current = null;
-    }
-    if (inspectorUnlistenRef.current) {
-      inspectorUnlistenRef.current();
-      inspectorUnlistenRef.current = null;
-    }
-    if (webviewLabelRef.current) {
-      void evalWebview(webviewLabelRef.current, CANCEL_INSPECTOR_SCRIPT).catch(() => {});
-    }
-    void closeWebview();
-  }, [closeWebview]);
-
-  // Hide webview when any overlay (modal, mission-control, toolbar-mode) is present.
-  // Uses MutationObserver on document.body to detect overlay DOM nodes, so no
-  // coupling with individual overlay components is needed.
-  useEffect(() => {
-    if (!isTauri) return;
-
-    const OVERLAY_SELECTOR = '.modal-overlay, .canvas-mission-control';
-    let hiddenByOverlay = false;
-
-    const checkOverlays = () => {
-      const hasOverlay = document.querySelector(OVERLAY_SELECTOR) !== null;
-      if (hasOverlay && !hiddenByOverlay) {
-        hiddenByOverlay = true;
-        void webviewRef.current?.hide().catch(() => {});
-      } else if (!hasOverlay && hiddenByOverlay) {
-        hiddenByOverlay = false;
-        if (shouldShowWebview) {
-          void syncWebviewBounds()
-            .then(() => webviewRef.current?.show())
-            .catch(() => {});
-        }
-      }
-    };
-
-    const observer = new MutationObserver(checkOverlays);
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    const handleToolbarActivating = () => {
-      void webviewRef.current?.hide().catch(() => {});
-    };
-    window.addEventListener('toolbar-mode-activating', handleToolbarActivating);
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('toolbar-mode-activating', handleToolbarActivating);
-    };
-  }, [isTauri, shouldShowWebview, syncWebviewBounds]);
+  const loadPanelUrl = useCallback(async (rawUrl: string) => {
+    stopInspector();
+    await loadUrl(rawUrl);
+  }, [loadUrl, stopInspector]);
 
   useEffect(() => () => {
-    if (holderWindowRef.current) {
-      void holderWindowRef.current.close().catch((e) => log.warn('Close browser panel holder window failed', e));
-    }
-  }, []);
+    stopInspector();
+  }, [stopInspector]);
 
   const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    void loadUrl(inputValue);
-  }, [inputValue, loadUrl]);
-
-  const handleGoBack = useCallback(() => {
-    if (!isTauri || !webviewLabelRef.current) return;
-    void evalWebview(webviewLabelRef.current, 'history.back()').catch(() => {});
-  }, [isTauri]);
-
-  const handleGoForward = useCallback(() => {
-    if (!isTauri || !webviewLabelRef.current) return;
-    void evalWebview(webviewLabelRef.current, 'history.forward()').catch(() => {});
-  }, [isTauri]);
-
-  const handleRefresh = useCallback(() => {
-    if (!isTauri || !webviewLabelRef.current) return;
-    void evalWebview(webviewLabelRef.current, 'location.reload()').catch(() => {});
-  }, [isTauri]);
+    void loadPanelUrl(inputValue);
+  }, [inputValue, loadPanelUrl]);
 
   const handleInspector = useCallback(async () => {
-    if (!isTauri || !webviewRef.current) return;
+    if (!isTauri || !hasWebview()) return;
 
     if (isInspectorActive) {
-      try {
-        await evalWebview(webviewLabelRef.current, CANCEL_INSPECTOR_SCRIPT);
-      } catch (e) {
-        log.warn('Cancel inspector eval failed', e);
-      }
-      setIsInspectorActive(false);
-      inspectorUnlistenRef.current?.();
-      inspectorUnlistenRef.current = null;
+      stopInspector();
       return;
     }
 
-    const label = webviewLabelRef.current;
+    const label = getWebviewLabel();
     if (!label) return;
 
     try {
@@ -468,7 +124,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => 
             attributes: data.attributes,
             textContent: data.textContent,
             outerHTML: data.outerHTML,
-            sourceUrl: currentUrlRef.current,
+            sourceUrl: getCurrentUrl(),
           };
 
           addContext(context);
@@ -493,14 +149,13 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => 
         unlistenCancelled();
       };
 
-      await evalWebview(label, createInspectorScript(label));
+      await evalInWebview(createInspectorScript(label));
       setIsInspectorActive(true);
-
-    } catch (e) {
-      log.error('Start inspector failed', e);
+    } catch (inspectorError) {
+      log.error('Start inspector failed', inspectorError);
       setIsInspectorActive(false);
     }
-  }, [addContext, isInspectorActive, isTauri]);
+  }, [addContext, evalInWebview, getCurrentUrl, getWebviewLabel, hasWebview, isInspectorActive, isTauri, stopInspector]);
 
   return (
     <div className="browser-panel" data-testid="browser-panel">
@@ -509,7 +164,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => 
           type="button"
           variant="ghost"
           size="small"
-          onClick={handleGoBack}
+          onClick={goBack}
           aria-label={t('nav.back')}
           data-testid="browser-back-button"
         >
@@ -519,7 +174,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => 
           type="button"
           variant="ghost"
           size="small"
-          onClick={handleGoForward}
+          onClick={goForward}
           aria-label={t('nav.forward')}
           data-testid="browser-forward-button"
         >
@@ -529,7 +184,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => 
           type="button"
           variant="ghost"
           size="small"
-          onClick={handleRefresh}
+          onClick={reload}
           disabled={isLoading}
           aria-label={t('actions.refresh')}
           data-testid="browser-refresh-button"
@@ -581,7 +236,11 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ isActive, initialUrl }) => 
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
           />
         ) : (
-          <div ref={viewportRef} className="browser-panel__webview-host">
+          <div
+            ref={viewportRef}
+            className="browser-panel__webview-host"
+            data-webview-label={webviewLabel}
+          >
             <div className="browser-panel__webview-placeholder">
               <Globe size={20} />
               <span data-testid="browser-current-url">{currentUrl}</span>

--- a/src/web-ui/src/app/scenes/browser/BrowserScene.tsx
+++ b/src/web-ui/src/app/scenes/browser/BrowserScene.tsx
@@ -1,463 +1,30 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback } from 'react';
 import { AlertTriangle, ChevronLeft, ChevronRight, Globe, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { IconButton } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
 import { useSceneStore } from '@/app/stores/sceneStore';
-import { BLANK_TARGET_INTERCEPT_SCRIPT } from './browserInspectorScript';
-import { validateUrl, checkConnectivity } from './browserUrlCheck';
+import { useEmbeddedBrowserWebview } from './useEmbeddedBrowserWebview';
 import './BrowserScene.scss';
 
 const log = createLogger('BrowserScene');
 const DEFAULT_URL = 'https://openbitfun.com/';
-const BROWSER_HOLDER_WINDOW_LABEL = 'embedded-browser-holder-window';
-
-function isTauriEnvironment(): boolean {
-  return typeof window !== 'undefined' && '__TAURI__' in window;
-}
-
-type BrowserWebviewHandle = {
-  close: () => Promise<void>;
-  hide: () => Promise<void>;
-  label: string;
-  once: (event: string, handler: (event?: unknown) => void) => Promise<() => void>;
-  reparent: (window: string | unknown) => Promise<void>;
-  setFocus: () => Promise<void>;
-  setPosition: (position: unknown) => Promise<void>;
-  setSize: (size: unknown) => Promise<void>;
-  show: () => Promise<void>;
-};
-
-type BrowserHolderWindowHandle = {
-  close: () => Promise<void>;
-  hide: () => Promise<void>;
-  once: (event: string, handler: (event?: unknown) => void) => Promise<() => void>;
-};
-
-function formatUnknownError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  if (error && typeof error === 'object') {
-    const record = error as Record<string, unknown>;
-    const payload = 'payload' in record ? record.payload : undefined;
-    const message =
-      (typeof record.message === 'string' && record.message) ||
-      (payload && typeof payload === 'object' && typeof (payload as Record<string, unknown>).message === 'string'
-        ? String((payload as Record<string, unknown>).message)
-        : null);
-
-    if (message) {
-      return message;
-    }
-
-    try {
-      return JSON.stringify(error);
-    } catch {
-      return String(error);
-    }
-  }
-
-  return String(error);
-}
-
-function isWebviewNotFoundError(error: unknown): boolean {
-  const message = formatUnknownError(error);
-  return message.toLowerCase().includes('webview not found');
-}
-
-async function evalWebview(label: string, script: string): Promise<void> {
-  const { invoke } = await import('@tauri-apps/api/core');
-  await invoke('browser_webview_eval', { request: { label, script } });
-}
-
-async function waitForWebviewCreated(handle: BrowserWebviewHandle): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-
-    const finish = (callback: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      callback();
-    };
-
-    void handle.once('tauri://created', () => {
-      finish(resolve);
-    });
-
-    void handle.once('tauri://error', (event) => {
-      finish(() => reject(new Error(formatUnknownError(event))));
-    });
-  });
-}
-
-async function waitForWindowCreated(handle: BrowserHolderWindowHandle): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-
-    const finish = (callback: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      callback();
-    };
-
-    void handle.once('tauri://created', () => {
-      finish(resolve);
-    });
-
-    void handle.once('tauri://error', (event) => {
-      finish(() => reject(new Error(formatUnknownError(event))));
-    });
-  });
-}
-
-function normalizeUrl(raw: string): string {
-  const value = raw.trim();
-  if (!value) {
-    return DEFAULT_URL;
-  }
-
-  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value)) {
-    return value;
-  }
-
-  return `https://${value}`;
-}
 
 const BrowserScene: React.FC = () => {
   const { t } = useTranslation('common');
   const activeTabId = useSceneStore((state) => state.activeTabId);
   const isActive = activeTabId === 'browser';
-  const isTauri = useMemo(() => isTauriEnvironment(), []);
-
-  const viewportRef = useRef<HTMLDivElement>(null);
-  const webviewRef = useRef<BrowserWebviewHandle | null>(null);
-  const holderWindowRef = useRef<BrowserHolderWindowHandle | null>(null);
-  const webviewSequenceRef = useRef(0);
-  const currentUrlRef = useRef<string>(DEFAULT_URL);
-  const resizeFrameRef = useRef<number | null>(null);
-  const webviewLabelRef = useRef<string>('');
-  const urlPollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const [inputValue, setInputValue] = useState(DEFAULT_URL);
-  const [currentUrl, setCurrentUrl] = useState(DEFAULT_URL);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const syncWebviewBounds = useCallback(async (handle?: BrowserWebviewHandle | null) => {
-    const target = handle ?? webviewRef.current;
-    if (!isTauri || !isActive || !viewportRef.current || !target) {
-      return;
-    }
-
-    const rect = viewportRef.current.getBoundingClientRect();
-    if (rect.width <= 1 || rect.height <= 1) {
-      return;
-    }
-
-    const [{ LogicalPosition, LogicalSize }] = await Promise.all([
-      import('@tauri-apps/api/dpi'),
-    ]);
-
-    await Promise.all([
-      target.setPosition(new LogicalPosition(rect.left, rect.top)),
-      target.setSize(new LogicalSize(rect.width, rect.height)),
-    ]);
-  }, [isActive, isTauri]);
-
-  const closeWebview = useCallback(async (handle?: BrowserWebviewHandle | null) => {
-    const target = handle ?? webviewRef.current;
-    if (!target) {
-      return;
-    }
-
-    try {
-      await target.close();
-    } catch (closeError) {
-      if (!isWebviewNotFoundError(closeError)) {
-        log.warn('Close browser webview failed', closeError);
-      }
-    } finally {
-      if (!handle || target === webviewRef.current) {
-        webviewRef.current = null;
-      }
-    }
-  }, []);
-
-  const ensureHolderWindow = useCallback(async (): Promise<BrowserHolderWindowHandle> => {
-    if (holderWindowRef.current) {
-      return holderWindowRef.current;
-    }
-
-    const { Window } = await import('@tauri-apps/api/window');
-    const existing = (await Window.getByLabel(BROWSER_HOLDER_WINDOW_LABEL)) as BrowserHolderWindowHandle | null;
-    if (existing) {
-      holderWindowRef.current = existing;
-      return existing;
-    }
-
-    const holder = new Window(BROWSER_HOLDER_WINDOW_LABEL, {
-      visible: false,
-      decorations: false,
-      skipTaskbar: true,
-      shadow: false,
-      width: 1,
-      height: 1,
-      x: -10000,
-      y: -10000,
-      title: 'Browser Holder',
-    }) as BrowserHolderWindowHandle;
-
-    await waitForWindowCreated(holder);
-    await holder.hide().catch(() => {});
-    holderWindowRef.current = holder;
-    return holder;
-  }, []);
-
-  const recreateWebview = useCallback(async (url: string) => {
-    const previous = webviewRef.current;
-    if (previous) {
-      await closeWebview(previous);
-    }
-
-    const [{ Webview }, { getCurrentWindow }] = await Promise.all([
-      import('@tauri-apps/api/webview'),
-      import('@tauri-apps/api/window'),
-    ]);
-    const nextLabel = `embedded-browser-view-${webviewSequenceRef.current++}`;
-    webviewLabelRef.current = nextLabel;
-    const handle = new Webview(getCurrentWindow(), nextLabel, {
-      url,
-      x: 0,
-      y: 0,
-      width: 960,
-      height: 640,
-    }) as unknown as BrowserWebviewHandle;
-
-    await waitForWebviewCreated(handle);
-    webviewRef.current = handle;
-    return handle;
-  }, [closeWebview]);
-
-  const loadUrl = useCallback(async (rawUrl: string) => {
-    const nextUrl = normalizeUrl(rawUrl);
-    setInputValue(nextUrl);
-    setCurrentUrl(nextUrl);
-    currentUrlRef.current = nextUrl;
-    setError(null);
-    setIsLoading(true);
-
-    if (!isTauri) {
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      validateUrl(nextUrl);
-      await checkConnectivity(nextUrl);
-
-      if (urlPollTimerRef.current) {
-        clearInterval(urlPollTimerRef.current);
-        urlPollTimerRef.current = null;
-      }
-
-      const handle = await recreateWebview(nextUrl);
-      await syncWebviewBounds(handle);
-      if (isActive) {
-        await handle.show();
-        await handle.setFocus();
-      }
-
-      const label = webviewLabelRef.current;
-      await evalWebview(label, BLANK_TARGET_INTERCEPT_SCRIPT);
-
-      const { invoke } = await import('@tauri-apps/api/core');
-      urlPollTimerRef.current = setInterval(() => {
-        invoke<string>('browser_get_url', { request: { label } })
-          .then((url) => {
-            if (url && url !== currentUrlRef.current) {
-              currentUrlRef.current = url;
-              setInputValue(url);
-              setCurrentUrl(url);
-              setError(null);
-              evalWebview(label, BLANK_TARGET_INTERCEPT_SCRIPT).catch(() => {});
-            }
-          })
-          .catch(() => {});
-      }, 500);
-    } catch (loadError) {
-      const message = formatUnknownError(loadError);
-      log.error('Load browser url failed', loadError);
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isActive, isTauri, recreateWebview, syncWebviewBounds]);
-
-  const queueSync = useCallback(() => {
-    if (resizeFrameRef.current !== null) {
-      window.cancelAnimationFrame(resizeFrameRef.current);
-    }
-    resizeFrameRef.current = window.requestAnimationFrame(() => {
-      resizeFrameRef.current = null;
-      void syncWebviewBounds().catch((syncError) => {
-        log.warn('Sync browser webview bounds failed', syncError);
-      });
-    });
-  }, [syncWebviewBounds]);
-
-  useEffect(() => {
-    if (!isTauri) {
-      return;
-    }
-
-    if (isActive) {
-      if (!webviewRef.current) {
-        void loadUrl(currentUrlRef.current).catch((loadError) => {
-          log.warn('Restore browser webview failed', loadError);
-        });
-        return;
-      }
-
-      void (async () => {
-        const { getCurrentWindow } = await import('@tauri-apps/api/window');
-        await webviewRef.current?.reparent(getCurrentWindow());
-        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-        await syncWebviewBounds();
-      })()
-        .then(() => webviewRef.current?.show())
-        .then(() => webviewRef.current?.setFocus())
-        .catch((syncError) => {
-          log.warn('Activate browser webview failed', syncError);
-        });
-      return;
-    }
-
-    if (webviewRef.current) {
-      void ensureHolderWindow()
-        .then((holderWindow) => webviewRef.current?.reparent(holderWindow))
-        .then(() => holderWindowRef.current?.hide())
-        .catch((reparentError) => {
-          log.warn('Reparent browser webview to holder window failed', reparentError);
-          return closeWebview();
-        })
-        .catch((closeError) => {
-          log.warn('Close browser webview on tab switch failed', closeError);
-        });
-    }
-  }, [closeWebview, ensureHolderWindow, isActive, isTauri, loadUrl, syncWebviewBounds]);
-
-  useEffect(() => () => {
-    if (holderWindowRef.current) {
-      void holderWindowRef.current.close().catch((closeError) => {
-        log.warn('Close browser holder window failed', closeError);
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isTauri) {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      if (isActive) {
-        queueSync();
-      }
-    });
-
-    if (viewportRef.current) {
-      observer.observe(viewportRef.current);
-    }
-
-    const handleResize = () => {
-      if (isActive) {
-        queueSync();
-      }
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('resize', handleResize);
-      if (resizeFrameRef.current !== null) {
-        window.cancelAnimationFrame(resizeFrameRef.current);
-        resizeFrameRef.current = null;
-      }
-    };
-  }, [isActive, isTauri, queueSync]);
-
-  useEffect(() => () => {
-    if (urlPollTimerRef.current) {
-      clearInterval(urlPollTimerRef.current);
-      urlPollTimerRef.current = null;
-    }
-    void closeWebview();
-  }, [closeWebview]);
-
-  useEffect(() => {
-    if (!isTauri) return;
-
-    const OVERLAY_SELECTOR = '.modal-overlay, .canvas-mission-control';
-    let hiddenByOverlay = false;
-
-    const checkOverlays = () => {
-      const hasOverlay = document.querySelector(OVERLAY_SELECTOR) !== null;
-      if (hasOverlay && !hiddenByOverlay) {
-        hiddenByOverlay = true;
-        void webviewRef.current?.hide().catch(() => {});
-      } else if (!hasOverlay && hiddenByOverlay) {
-        hiddenByOverlay = false;
-        if (isActive) {
-          void syncWebviewBounds()
-            .then(() => webviewRef.current?.show())
-            .catch(() => {});
-        }
-      }
-    };
-
-    const observer = new MutationObserver(checkOverlays);
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    const handleToolbarActivating = () => {
-      void webviewRef.current?.hide().catch(() => {});
-    };
-    window.addEventListener('toolbar-mode-activating', handleToolbarActivating);
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('toolbar-mode-activating', handleToolbarActivating);
-    };
-  }, [isActive, isTauri, syncWebviewBounds]);
+  const browser = useEmbeddedBrowserWebview({
+    defaultUrl: DEFAULT_URL,
+    isVisible: isActive,
+    labelPrefix: 'embedded-browser-view',
+    log,
+  });
 
   const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    void loadUrl(inputValue);
-  }, [inputValue, loadUrl]);
-
-  const handleGoBack = useCallback(() => {
-    if (!isTauri || !webviewLabelRef.current) return;
-    void evalWebview(webviewLabelRef.current, 'history.back()').catch(() => {});
-  }, [isTauri]);
-
-  const handleGoForward = useCallback(() => {
-    if (!isTauri || !webviewLabelRef.current) return;
-    void evalWebview(webviewLabelRef.current, 'history.forward()').catch(() => {});
-  }, [isTauri]);
-
-  const handleRefresh = useCallback(() => {
-    if (!isTauri || !webviewLabelRef.current) return;
-    void evalWebview(webviewLabelRef.current, 'location.reload()').catch(() => {});
-  }, [isTauri]);
+    void browser.loadUrl(browser.inputValue);
+  }, [browser]);
 
   return (
     <div className="browser-scene" data-testid="browser-panel">
@@ -466,7 +33,7 @@ const BrowserScene: React.FC = () => {
           type="button"
           variant="ghost"
           size="small"
-          onClick={handleGoBack}
+          onClick={browser.goBack}
           aria-label={t('nav.back')}
           data-testid="browser-back-button"
         >
@@ -476,7 +43,7 @@ const BrowserScene: React.FC = () => {
           type="button"
           variant="ghost"
           size="small"
-          onClick={handleGoForward}
+          onClick={browser.goForward}
           aria-label={t('nav.forward')}
           data-testid="browser-forward-button"
         >
@@ -486,23 +53,23 @@ const BrowserScene: React.FC = () => {
           type="button"
           variant="ghost"
           size="small"
-          onClick={handleRefresh}
-          disabled={isLoading}
+          onClick={browser.reload}
+          disabled={browser.isLoading}
           aria-label={t('actions.refresh')}
           data-testid="browser-refresh-button"
         >
           <RefreshCw
             size={14}
-            className={isLoading ? 'browser-scene__spinning' : undefined}
-            data-testid={isLoading ? 'browser-loading-indicator' : undefined}
+            className={browser.isLoading ? 'browser-scene__spinning' : undefined}
+            data-testid={browser.isLoading ? 'browser-loading-indicator' : undefined}
           />
         </IconButton>
         <div className="browser-scene__address">
           <Globe size={16} />
           <input
             type="text"
-            value={inputValue}
-            onChange={(event) => setInputValue(event.target.value)}
+            value={browser.inputValue}
+            onChange={(event) => browser.setInputValue(event.target.value)}
             placeholder={t('browserView.addressPlaceholder', { exampleUrl: 'https://example.com' })}
             spellCheck={false}
             data-testid="browser-url-input"
@@ -510,26 +77,30 @@ const BrowserScene: React.FC = () => {
         </div>
       </form>
 
-      {error ? (
+      {browser.error ? (
         <div className="browser-scene__error" data-testid="browser-error-message">
           <AlertTriangle size={16} />
-          <span>{error}</span>
+          <span>{browser.error}</span>
         </div>
       ) : null}
 
       <div className="browser-scene__content" data-testid="browser-page-frame">
-        {!isTauri ? (
+        {!browser.isTauri ? (
           <iframe
             className="browser-scene__iframe"
-            src={currentUrl}
+            src={browser.currentUrl}
             title="Embedded Browser"
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
           />
         ) : (
-          <div ref={viewportRef} className="browser-scene__webview-host">
+          <div
+            ref={browser.viewportRef}
+            className="browser-scene__webview-host"
+            data-webview-label={browser.webviewLabel}
+          >
             <div className="browser-scene__webview-placeholder">
               <Globe size={20} />
-              <span data-testid="browser-current-url">{currentUrl}</span>
+              <span data-testid="browser-current-url">{browser.currentUrl}</span>
             </div>
           </div>
         )}

--- a/src/web-ui/src/app/scenes/browser/browserStreamPerformanceScript.ts
+++ b/src/web-ui/src/app/scenes/browser/browserStreamPerformanceScript.ts
@@ -1,0 +1,145 @@
+/**
+ * Injected into browser webviews to reduce composition cost for realtime
+ * canvas/video preview pages. It is intentionally conservative and only
+ * activates for pages that look like BitFun's Harmony device preview stream.
+ */
+export const STREAM_RENDER_OPTIMIZATION_SCRIPT = /* js */ `(function(){
+  if(window.__bitfun_stream_render_optimized){return;}
+
+  // #region agent log
+  function installStreamDiagnostics(){
+    if(location.hostname!=='127.0.0.1'||location.port!=='41953'||window.__bitfun_stream_diagnostics){return;}
+    window.__bitfun_stream_diagnostics=true;
+
+    var endpoint='http://127.0.0.1:7469/log';
+    var drawCount=0;
+    var drawDuration=0;
+    var drawMax=0;
+    var rafCount=0;
+    var lastReport=performance.now();
+    var canvasPrototype=window.CanvasRenderingContext2D&&window.CanvasRenderingContext2D.prototype;
+    var originalDrawImage=canvasPrototype&&canvasPrototype.drawImage;
+
+    function post(message,data){
+      void fetch(endpoint,{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({
+          hypothesis:'A/B/C',
+          location:'browserStreamPerformanceScript.streamDiagnostics',
+          message:message,
+          data:data,
+          timestamp:new Date().toISOString()
+        })
+      }).catch(function(){});
+    }
+
+    function gpuInfo(){
+      try{
+        var probe=document.createElement('canvas');
+        var gl=probe.getContext('webgl')||probe.getContext('experimental-webgl');
+        var extension=gl&&gl.getExtension('WEBGL_debug_renderer_info');
+        return {
+          vendor:extension?gl.getParameter(extension.UNMASKED_VENDOR_WEBGL):null,
+          renderer:extension?gl.getParameter(extension.UNMASKED_RENDERER_WEBGL):null
+        };
+      }catch(error){
+        return {error:String(error)};
+      }
+    }
+
+    if(canvasPrototype&&originalDrawImage){
+      canvasPrototype.drawImage=function(){
+        var started=performance.now();
+        try{return originalDrawImage.apply(this,arguments);}
+        finally{
+          var elapsed=performance.now()-started;
+          drawCount+=1;
+          drawDuration+=elapsed;
+          drawMax=Math.max(drawMax,elapsed);
+        }
+      };
+    }
+
+    function sampleRaf(){
+      rafCount+=1;
+      requestAnimationFrame(sampleRaf);
+    }
+    requestAnimationFrame(sampleRaf);
+
+    post('stream diagnostics initialized',{
+      userAgent:navigator.userAgent,
+      hardwareConcurrency:navigator.hardwareConcurrency,
+      deviceMemory:navigator.deviceMemory||null,
+      visibility:document.visibilityState,
+      devicePixelRatio:window.devicePixelRatio,
+      gpu:gpuInfo(),
+      videoDecoder:typeof window.VideoDecoder,
+      screen:{width:screen.width,height:screen.height,colorDepth:screen.colorDepth}
+    });
+
+    setInterval(function(){
+      var now=performance.now();
+      var span=Math.max(1,now-lastReport);
+      var canvas=document.getElementById('screen');
+      post('stream render interval',{
+        spanMs:Math.round(span),
+        drawFps:Number((drawCount*1000/span).toFixed(2)),
+        drawAvgMs:drawCount?Number((drawDuration/drawCount).toFixed(3)):null,
+        drawMaxMs:Number(drawMax.toFixed(3)),
+        rafFps:Number((rafCount*1000/span).toFixed(2)),
+        visibility:document.visibilityState,
+        hasFocus:document.hasFocus(),
+        canvas:canvas?{
+          width:canvas.width,
+          height:canvas.height,
+          cssWidth:Math.round(canvas.getBoundingClientRect().width),
+          cssHeight:Math.round(canvas.getBoundingClientRect().height)
+        }:null
+      });
+      drawCount=0;
+      drawDuration=0;
+      drawMax=0;
+      rafCount=0;
+      lastReport=now;
+    },1000);
+  }
+  // #endregion
+
+  function looksLikeDeviceStream(){
+    if(document.getElementById('screen')&&document.getElementById('stage')){return true;}
+    if(document.title&&/harmony.*preview|device.*preview/i.test(document.title)){return true;}
+    return false;
+  }
+
+  function optimize(){
+    if(!looksLikeDeviceStream()){return;}
+    window.__bitfun_stream_render_optimized=true;
+    installStreamDiagnostics();
+
+    var style=document.getElementById('bitfun-stream-render-optimization');
+    if(!style){
+      style=document.createElement('style');
+      style.id='bitfun-stream-render-optimization';
+      style.textContent=[
+        'header{backdrop-filter:none!important;-webkit-backdrop-filter:none!important;box-shadow:none!important;}',
+        '#screenFrame{box-shadow:none!important;}',
+        '#screen{box-shadow:none!important;outline:none!important;transform:translateZ(0);will-change:transform;contain:paint;}'
+      ].join('\\n');
+      document.documentElement.appendChild(style);
+    }
+
+    var screen=document.getElementById('screen');
+    if(screen){
+      screen.style.transform='translateZ(0)';
+      screen.style.willChange='transform';
+      screen.style.contain='paint';
+    }
+  }
+
+  optimize();
+  if(document.readyState==='loading'){
+    document.addEventListener('DOMContentLoaded',optimize,{once:true});
+  }
+  window.addEventListener('load',optimize,{once:true});
+})()`;

--- a/src/web-ui/src/app/scenes/browser/browserUrlCheck.ts
+++ b/src/web-ui/src/app/scenes/browser/browserUrlCheck.ts
@@ -11,19 +11,3 @@ export function validateUrl(url: string): void {
     throw new Error(`Invalid URL: ${url}${e instanceof Error ? ` (${e.message})` : ''}`);
   }
 }
-
-export async function checkConnectivity(url: string): Promise<void> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5000);
-  try {
-    await fetch(url, {
-      method: 'HEAD',
-      mode: 'no-cors',
-      signal: controller.signal,
-    });
-  } catch {
-    throw new Error(`Connection failed: ${new URL(url).hostname} is not reachable`);
-  } finally {
-    clearTimeout(timeout);
-  }
-}

--- a/src/web-ui/src/app/scenes/browser/useEmbeddedBrowserWebview.ts
+++ b/src/web-ui/src/app/scenes/browser/useEmbeddedBrowserWebview.ts
@@ -1,0 +1,618 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BLANK_TARGET_INTERCEPT_SCRIPT } from './browserInspectorScript';
+import { STREAM_RENDER_OPTIMIZATION_SCRIPT } from './browserStreamPerformanceScript';
+import { validateUrl } from './browserUrlCheck';
+
+const WEBVIEW_RESIZE_DEBOUNCE_MS = 160;
+const WEBVIEW_BOUNDS_EPSILON = 1;
+const DEFAULT_WEBVIEW_BOUNDS: WebviewBounds = { left: 0, top: 0, width: 960, height: 640 };
+const OVERLAY_SELECTOR = '.modal-overlay, .canvas-mission-control';
+const BROWSER_WEBVIEW_PAGE_LOAD_EVENT = 'browser-webview-page-load';
+const WEBVIEW_CREATE_RETRY_DELAYS_MS = [0, 250, 750];
+
+// #region agent log
+function writeBrowserWebviewDiagnostic(
+  hypothesis: string,
+  location: string,
+  message: string,
+  data: Record<string, unknown>,
+): void {
+  void fetch('http://127.0.0.1:7469/log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      hypothesis,
+      location,
+      message,
+      data,
+      timestamp: new Date().toISOString(),
+    }),
+  }).catch(() => {});
+}
+// #endregion
+
+type BrowserLogger = {
+  warn: (message: string, ...args: unknown[]) => void;
+  error: (message: string, ...args: unknown[]) => void;
+};
+
+type BrowserWebviewHandle = {
+  close: () => Promise<void>;
+  hide: () => Promise<void>;
+  label: string;
+  setFocus: () => Promise<void>;
+  show: () => Promise<void>;
+};
+
+type WebviewBounds = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type BrowserWebviewPageLoadPayload = {
+  label: string;
+  event: 'started' | 'finished';
+  url: string;
+};
+
+export interface UseEmbeddedBrowserWebviewOptions {
+  defaultUrl: string;
+  initialUrl?: string;
+  isVisible: boolean;
+  labelPrefix: string;
+  log: BrowserLogger;
+}
+
+function isTauriEnvironment(): boolean {
+  return typeof window !== 'undefined' && '__TAURI__' in window;
+}
+
+function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>;
+    const payload = 'payload' in record ? record.payload : undefined;
+    const message =
+      (typeof record.message === 'string' && record.message) ||
+      (payload && typeof payload === 'object' && typeof (payload as Record<string, unknown>).message === 'string'
+        ? String((payload as Record<string, unknown>).message)
+        : null);
+    if (message) return message;
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+}
+
+function isWebviewNotFoundError(error: unknown): boolean {
+  return formatUnknownError(error).toLowerCase().includes('webview not found');
+}
+
+function isTransientWebviewCreationError(error: unknown): boolean {
+  const message = formatUnknownError(error).toLowerCase();
+  return message.includes('0x80070057')
+    || message.includes('0x8007139f')
+    || message.includes('failed to create webview');
+}
+
+function normalizeUrl(raw: string, defaultUrl: string): string {
+  const value = raw.trim();
+  if (!value) return defaultUrl;
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value)) return value;
+  return `https://${value}`;
+}
+
+async function evalWebview(label: string, script: string): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('browser_webview_eval', { request: { label, script } });
+}
+
+async function injectBrowserPageScripts(label: string): Promise<void> {
+  await evalWebview(label, `${BLANK_TARGET_INTERCEPT_SCRIPT};\n${STREAM_RENDER_OPTIMIZATION_SCRIPT};`);
+}
+
+async function navigateWebview(label: string, url: string): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('browser_webview_navigate', { request: { label, url } });
+}
+
+async function reloadWebview(label: string): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('browser_webview_reload', { request: { label } });
+}
+
+async function setWebviewBounds(label: string, bounds: WebviewBounds): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('browser_webview_set_bounds', {
+    request: {
+      label,
+      x: bounds.left,
+      y: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+    },
+  });
+}
+
+async function createBrowserWebview(label: string, url: string, bounds: WebviewBounds): Promise<BrowserWebviewHandle> {
+  const [{ invoke }, { Webview }] = await Promise.all([
+    import('@tauri-apps/api/core'),
+    import('@tauri-apps/api/webview'),
+  ]);
+  await invoke('browser_webview_create', {
+    request: {
+      label,
+      url,
+      x: bounds.left,
+      y: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+    },
+  });
+  const handle = await Webview.getByLabel(label) as unknown as BrowserWebviewHandle | null;
+  if (!handle) {
+    throw new Error(`Webview not found after creation: ${label}`);
+  }
+  return handle;
+}
+
+export function useEmbeddedBrowserWebview(options: UseEmbeddedBrowserWebviewOptions) {
+  const { defaultUrl, initialUrl, isVisible, labelPrefix, log } = options;
+  const isTauri = useMemo(() => isTauriEnvironment(), []);
+  const startUrl = initialUrl ?? defaultUrl;
+
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const webviewRef = useRef<BrowserWebviewHandle | null>(null);
+  const webviewSequenceRef = useRef(0);
+  const currentUrlRef = useRef<string>(startUrl);
+  const resizeTimerRef = useRef<number | null>(null);
+  const lastBoundsRef = useRef<WebviewBounds | null>(null);
+  const webviewLabelRef = useRef<string>('');
+  const pageLoadUnlistenRef = useRef<(() => void) | null>(null);
+
+  const [inputValue, setInputValue] = useState(startUrl);
+  const [currentUrl, setCurrentUrl] = useState(startUrl);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [webviewLabel, setWebviewLabel] = useState('');
+
+  const readViewportBounds = useCallback((): WebviewBounds | null => {
+    if (!viewportRef.current) return null;
+
+    const rect = viewportRef.current.getBoundingClientRect();
+    if (rect.width <= 1 || rect.height <= 1) return null;
+
+    return {
+      left: Math.round(rect.left),
+      top: Math.round(rect.top),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    };
+  }, []);
+
+  const syncWebviewBounds = useCallback(async (handle?: BrowserWebviewHandle | null) => {
+    const target = handle ?? webviewRef.current;
+    if (!isTauri || !target || !viewportRef.current) return;
+
+    const nextBounds = readViewportBounds();
+    if (!nextBounds) {
+      // #region agent log
+      const viewport = viewportRef.current;
+      const viewportRect = viewport?.getBoundingClientRect();
+      const ancestors: Array<Record<string, unknown>> = [];
+      let ancestor = viewport?.parentElement ?? null;
+      for (let index = 0; ancestor && index < 6; index += 1, ancestor = ancestor.parentElement) {
+        const style = window.getComputedStyle(ancestor);
+        const rect = ancestor.getBoundingClientRect();
+        ancestors.push({
+          tagName: ancestor.tagName,
+          className: ancestor.className,
+          display: style.display,
+          visibility: style.visibility,
+          width: rect.width,
+          height: rect.height,
+        });
+      }
+      writeBrowserWebviewDiagnostic('F', 'useEmbeddedBrowserWebview.syncWebviewBounds', isVisible
+        ? 'keeping active webview at its last valid bounds while viewport is transiently unavailable'
+        : 'hiding inactive webview because viewport has no usable bounds', {
+        label: target.label,
+        isVisible,
+        hasViewport: Boolean(viewport),
+        isConnected: viewport?.isConnected ?? false,
+        viewportRect: viewportRect ? {
+          left: viewportRect.left,
+          top: viewportRect.top,
+          width: viewportRect.width,
+          height: viewportRect.height,
+        } : null,
+        windowSize: { width: window.innerWidth, height: window.innerHeight },
+        ancestors,
+      });
+      // #endregion
+      if (!isVisible) {
+        await target.hide().catch(() => {});
+      }
+      return;
+    }
+
+    const previous = lastBoundsRef.current;
+    const boundsChanged =
+      !previous ||
+      Math.abs(previous.left - nextBounds.left) > WEBVIEW_BOUNDS_EPSILON ||
+      Math.abs(previous.top - nextBounds.top) > WEBVIEW_BOUNDS_EPSILON ||
+      Math.abs(previous.width - nextBounds.width) > WEBVIEW_BOUNDS_EPSILON ||
+      Math.abs(previous.height - nextBounds.height) > WEBVIEW_BOUNDS_EPSILON;
+
+    if (boundsChanged) {
+      await setWebviewBounds(target.label, nextBounds);
+      lastBoundsRef.current = nextBounds;
+    }
+    if (isVisible) {
+      // #region agent log
+      writeBrowserWebviewDiagnostic('F', 'useEmbeddedBrowserWebview.syncWebviewBounds', 'showing webview after bounds sync', {
+        label: target.label,
+        bounds: nextBounds,
+      });
+      // #endregion
+      await target.show().catch(() => {});
+    }
+  }, [isTauri, isVisible, readViewportBounds]);
+
+  const closeWebview = useCallback(async (handle?: BrowserWebviewHandle | null) => {
+    const target = handle ?? webviewRef.current;
+    if (!target) return;
+
+    try {
+      await target.close();
+    } catch (closeError) {
+      if (!isWebviewNotFoundError(closeError)) {
+        log.warn('Close browser webview failed', closeError);
+      }
+    } finally {
+      if (!handle || target === webviewRef.current) {
+        webviewRef.current = null;
+        webviewLabelRef.current = '';
+        setWebviewLabel('');
+        lastBoundsRef.current = null;
+        pageLoadUnlistenRef.current?.();
+        pageLoadUnlistenRef.current = null;
+      }
+    }
+  }, [log]);
+
+  const startPageLoadListener = useCallback(async (label: string) => {
+    pageLoadUnlistenRef.current?.();
+    pageLoadUnlistenRef.current = null;
+
+    const { listen } = await import('@tauri-apps/api/event');
+    pageLoadUnlistenRef.current = await listen<BrowserWebviewPageLoadPayload>(
+      BROWSER_WEBVIEW_PAGE_LOAD_EVENT,
+      ({ payload }) => {
+        if (!payload || payload.label !== label) return;
+        if (payload.event === 'started') {
+          setIsLoading(true);
+        } else {
+          setIsLoading(false);
+        }
+        if (payload.url && payload.url !== currentUrlRef.current) {
+          currentUrlRef.current = payload.url;
+          setInputValue(payload.url);
+          setCurrentUrl(payload.url);
+          setError(null);
+          injectBrowserPageScripts(label).catch(() => {});
+        }
+      },
+    );
+  }, []);
+
+  const createWebview = useCallback(async (url: string) => {
+    const previous = webviewRef.current;
+    if (previous) await closeWebview(previous);
+
+    const { Webview } = await import('@tauri-apps/api/webview');
+    const initialBounds = readViewportBounds() ?? DEFAULT_WEBVIEW_BOUNDS;
+    let lastError: unknown = null;
+
+    for (let attempt = 0; attempt < WEBVIEW_CREATE_RETRY_DELAYS_MS.length; attempt += 1) {
+      const delay = WEBVIEW_CREATE_RETRY_DELAYS_MS[attempt];
+      if (delay > 0) {
+        await new Promise((resolve) => window.setTimeout(resolve, delay));
+      }
+
+      const label = `${labelPrefix}-${webviewSequenceRef.current++}`;
+      webviewLabelRef.current = label;
+      setWebviewLabel(label);
+      try {
+        const handle = await createBrowserWebview(label, url, initialBounds);
+        webviewRef.current = handle;
+        lastBoundsRef.current = initialBounds;
+        await injectBrowserPageScripts(label);
+        await startPageLoadListener(label);
+        return handle;
+      } catch (creationError) {
+        lastError = creationError;
+        const staleHandle = await Webview.getByLabel(label).catch(() => null);
+        await staleHandle?.close().catch(() => {});
+        if (!isTransientWebviewCreationError(creationError)
+          || attempt === WEBVIEW_CREATE_RETRY_DELAYS_MS.length - 1) {
+          throw creationError;
+        }
+        log.warn('Retry browser webview creation after transient WebView2 error', {
+          attempt: attempt + 1,
+          error: formatUnknownError(creationError),
+        });
+      }
+    }
+
+    throw lastError;
+  }, [closeWebview, labelPrefix, log, readViewportBounds, startPageLoadListener]);
+
+  const navigateExistingWebview = useCallback(async (url: string): Promise<boolean> => {
+    const label = webviewLabelRef.current;
+    if (!label || !webviewRef.current) return false;
+
+    try {
+      await navigateWebview(label, url);
+      window.setTimeout(() => {
+        if (webviewLabelRef.current === label) {
+          void injectBrowserPageScripts(label).catch(() => {});
+        }
+      }, 1000);
+      window.setTimeout(() => {
+        if (webviewLabelRef.current === label) {
+          void injectBrowserPageScripts(label).catch(() => {});
+        }
+      }, 2500);
+      return true;
+    } catch (navigationError) {
+      log.warn('Navigate browser webview via existing instance failed', navigationError);
+      return false;
+    }
+  }, [log]);
+
+  const loadUrl = useCallback(async (rawUrl: string) => {
+    const nextUrl = normalizeUrl(rawUrl, defaultUrl);
+    setInputValue(nextUrl);
+    setCurrentUrl(nextUrl);
+    currentUrlRef.current = nextUrl;
+    setError(null);
+    setIsLoading(true);
+
+    if (!isTauri) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      validateUrl(nextUrl);
+      let handle = webviewRef.current;
+      if (!handle) {
+        handle = await createWebview(nextUrl);
+      } else {
+        const navigated = await navigateExistingWebview(nextUrl);
+        if (!navigated) {
+          handle = await createWebview(nextUrl);
+        }
+      }
+      await syncWebviewBounds(handle);
+      if (isVisible) {
+        await handle.show();
+        await handle.setFocus();
+      }
+    } catch (loadError) {
+      const message = formatUnknownError(loadError);
+      log.error('Load browser url failed', loadError);
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [createWebview, defaultUrl, isTauri, isVisible, log, navigateExistingWebview, syncWebviewBounds]);
+
+  const queueSync = useCallback(() => {
+    if (resizeTimerRef.current !== null) window.clearTimeout(resizeTimerRef.current);
+    resizeTimerRef.current = window.setTimeout(() => {
+      resizeTimerRef.current = null;
+      void syncWebviewBounds().catch((syncError) => {
+        log.warn('Sync browser webview bounds failed', syncError);
+      });
+    }, WEBVIEW_RESIZE_DEBOUNCE_MS);
+  }, [log, syncWebviewBounds]);
+
+  useEffect(() => {
+    if (!isTauri) return;
+
+    if (isVisible) {
+      // #region agent log
+      writeBrowserWebviewDiagnostic('G', 'useEmbeddedBrowserWebview.visibilityEffect', 'browser surface activated', {
+        label: webviewRef.current?.label ?? null,
+      });
+      // #endregion
+      if (!webviewRef.current) {
+        void loadUrl(currentUrlRef.current).catch((loadError) => {
+          log.warn('Restore browser webview failed', loadError);
+        });
+        return;
+      }
+
+      void syncWebviewBounds()
+        .then(() => webviewRef.current?.show())
+        .then(() => webviewRef.current?.setFocus())
+        .catch((syncError) => {
+          log.warn('Activate browser webview failed', syncError);
+        });
+      return;
+    }
+
+    if (webviewRef.current) {
+      // #region agent log
+      writeBrowserWebviewDiagnostic('G', 'useEmbeddedBrowserWebview.visibilityEffect', 'hiding webview because browser surface deactivated', {
+        label: webviewRef.current.label,
+      });
+      // #endregion
+      void webviewRef.current.hide().catch((hideError) => {
+        log.warn('Hide browser webview on deactivate failed', hideError);
+      });
+    }
+  }, [isTauri, isVisible, loadUrl, log, syncWebviewBounds]);
+
+  useEffect(() => {
+    if (!isTauri) return;
+
+    const observer = new ResizeObserver(() => {
+      if (isVisible) queueSync();
+    });
+
+    if (viewportRef.current) observer.observe(viewportRef.current);
+
+    const handleResize = () => {
+      if (isVisible) queueSync();
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', handleResize);
+      if (resizeTimerRef.current !== null) {
+        window.clearTimeout(resizeTimerRef.current);
+        resizeTimerRef.current = null;
+      }
+    };
+  }, [isTauri, isVisible, queueSync]);
+
+  useEffect(() => () => {
+    pageLoadUnlistenRef.current?.();
+    pageLoadUnlistenRef.current = null;
+    if (resizeTimerRef.current !== null) {
+      window.clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = null;
+    }
+    void closeWebview();
+  }, [closeWebview]);
+
+  useEffect(() => {
+    if (!isTauri) return;
+
+    let hiddenByOverlay = false;
+    const checkOverlays = () => {
+      const overlay = document.querySelector<HTMLElement>(OVERLAY_SELECTOR);
+      const hasOverlay = overlay !== null;
+      // #region agent log
+      if (overlay) {
+        const style = window.getComputedStyle(overlay);
+        const rect = overlay.getBoundingClientRect();
+        writeBrowserWebviewDiagnostic('E', 'useEmbeddedBrowserWebview.checkOverlays', 'overlay selector matched', {
+          label: webviewRef.current?.label ?? null,
+          className: overlay.className,
+          display: style.display,
+          visibility: style.visibility,
+          opacity: style.opacity,
+          width: rect.width,
+          height: rect.height,
+          hiddenByOverlay,
+        });
+      }
+      // #endregion
+      if (hasOverlay && !hiddenByOverlay) {
+        hiddenByOverlay = true;
+        // #region agent log
+        writeBrowserWebviewDiagnostic('E', 'useEmbeddedBrowserWebview.checkOverlays', 'hiding webview because overlay selector exists', {
+          label: webviewRef.current?.label ?? null,
+          className: overlay?.className ?? null,
+        });
+        // #endregion
+        void webviewRef.current?.hide().catch(() => {});
+      } else if (!hasOverlay && hiddenByOverlay) {
+        hiddenByOverlay = false;
+        if (isVisible) {
+          // #region agent log
+          writeBrowserWebviewDiagnostic('E', 'useEmbeddedBrowserWebview.checkOverlays', 'showing webview because overlay selector disappeared', {
+            label: webviewRef.current?.label ?? null,
+          });
+          // #endregion
+          void syncWebviewBounds()
+            .then(() => webviewRef.current?.show())
+            .catch(() => {});
+        }
+      }
+    };
+
+    const observer = new MutationObserver(checkOverlays);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    const handleToolbarActivating = () => {
+      void webviewRef.current?.hide().catch(() => {});
+    };
+    window.addEventListener('toolbar-mode-activating', handleToolbarActivating);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('toolbar-mode-activating', handleToolbarActivating);
+    };
+  }, [isTauri, isVisible, syncWebviewBounds]);
+
+  const evalInWebview = useCallback(async (script: string) => {
+    const label = webviewLabelRef.current;
+    if (!isTauri || !label) return;
+    await evalWebview(label, script);
+  }, [isTauri]);
+
+  const goBack = useCallback(() => {
+    void evalInWebview('history.back()').catch(() => {});
+  }, [evalInWebview]);
+
+  const goForward = useCallback(() => {
+    void evalInWebview('history.forward()').catch(() => {});
+  }, [evalInWebview]);
+
+  const reload = useCallback(() => {
+    const label = webviewLabelRef.current;
+    if (!isTauri || !label) return;
+    void reloadWebview(label).catch(() => {});
+  }, [isTauri]);
+
+  const getWebviewLabel = useCallback(() => webviewLabelRef.current, []);
+  const getCurrentUrl = useCallback(() => currentUrlRef.current, []);
+  const hasWebview = useCallback(() => webviewRef.current !== null, []);
+
+  return useMemo(() => ({
+    currentUrl,
+    error,
+    evalInWebview,
+    getCurrentUrl,
+    getWebviewLabel,
+    goBack,
+    goForward,
+    hasWebview,
+    inputValue,
+    isLoading,
+    isTauri,
+    loadUrl,
+    reload,
+    setInputValue,
+    viewportRef,
+    webviewLabel,
+  }), [
+    currentUrl,
+    error,
+    evalInWebview,
+    getCurrentUrl,
+    getWebviewLabel,
+    goBack,
+    goForward,
+    hasWebview,
+    inputValue,
+    isLoading,
+    isTauri,
+    loadUrl,
+    reload,
+    viewportRef,
+    webviewLabel,
+  ]);
+}

--- a/tests/e2e/fixtures/browser-video-stream.html
+++ b/tests/e2e/fixtures/browser-video-stream.html
@@ -1,0 +1,307 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Embedded Browser Video Stream Fixture</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: #f6f7f9;
+      background: #111418;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      overflow: hidden;
+    }
+
+    main {
+      display: grid;
+      grid-template-columns: minmax(280px, 1fr) 280px;
+      gap: 16px;
+      width: 100vw;
+      height: 100vh;
+      padding: 16px;
+    }
+
+    .stage {
+      position: relative;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+      border: 1px solid #3b424e;
+      border-radius: 8px;
+      background: #07090c;
+    }
+
+    video {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      background: #000;
+    }
+
+    .phone-frame {
+      position: absolute;
+      top: 8%;
+      left: 50%;
+      width: min(42vw, 360px);
+      aspect-ratio: 9 / 19.5;
+      transform: translateX(-50%);
+      border: 8px solid rgba(255, 255, 255, 0.22);
+      border-radius: 28px;
+      pointer-events: none;
+    }
+
+    aside {
+      display: flex;
+      min-width: 0;
+      flex-direction: column;
+      gap: 10px;
+      padding: 14px;
+      border: 1px solid #3b424e;
+      border-radius: 8px;
+      background: #191f27;
+    }
+
+    h1 {
+      margin: 0 0 6px;
+      font-size: 18px;
+      font-weight: 650;
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 8px 12px;
+      margin: 0;
+      font-size: 13px;
+    }
+
+    dt {
+      color: #aeb7c4;
+    }
+
+    dd {
+      margin: 0;
+      font-variant-numeric: tabular-nums;
+    }
+
+    button {
+      height: 32px;
+      border: 1px solid #677080;
+      border-radius: 6px;
+      color: #f6f7f9;
+      background: #26303d;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    button:hover {
+      background: #303b4b;
+    }
+
+    .status {
+      min-height: 24px;
+      padding: 6px 8px;
+      border-radius: 6px;
+      color: #102015;
+      background: #8ee6a4;
+      font-size: 12px;
+      font-weight: 650;
+    }
+
+    @media (max-width: 720px) {
+      main {
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr auto;
+      }
+
+      aside {
+        max-height: 38vh;
+        overflow: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="stage">
+      <video id="preview" autoplay muted playsinline></video>
+      <div class="phone-frame" aria-hidden="true"></div>
+    </section>
+    <aside>
+      <h1>Video stream fixture</h1>
+      <div id="status" class="status">Starting stream</div>
+      <dl>
+        <dt>Frames</dt><dd id="frames">0</dd>
+        <dt>Approx FPS</dt><dd id="fps">0</dd>
+        <dt>Long gaps</dt><dd id="gaps">0</dd>
+        <dt>Green samples</dt><dd id="green">0</dd>
+        <dt>Resolution</dt><dd id="resolution">0 x 0</dd>
+      </dl>
+      <button id="size">Toggle stage size</button>
+      <button id="stress">Toggle stress motion</button>
+    </aside>
+  </main>
+
+  <script>
+    const width = 1280;
+    const height = 720;
+    const canvas = document.createElement('canvas');
+    const sample = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const sampleCtx = sample.getContext('2d', { willReadFrequently: true });
+    const video = document.getElementById('preview');
+    const status = document.getElementById('status');
+    const framesEl = document.getElementById('frames');
+    const fpsEl = document.getElementById('fps');
+    const gapsEl = document.getElementById('gaps');
+    const greenEl = document.getElementById('green');
+    const resolutionEl = document.getElementById('resolution');
+    const stage = document.querySelector('.stage');
+
+    canvas.width = width;
+    canvas.height = height;
+    sample.width = 96;
+    sample.height = 54;
+
+    let stressMotion = true;
+    let compact = false;
+    let startedAt = performance.now();
+    let lastVideoFrameAt = 0;
+    let frames = 0;
+    let longGaps = 0;
+    let greenSamples = 0;
+    let tick = 0;
+
+    function drawPhoneFrame(now) {
+      const swipe = Math.sin(now / 260);
+      const scroll = (now / 18) % 560;
+
+      ctx.fillStyle = '#10141b';
+      ctx.fillRect(0, 0, width, height);
+
+      const hue = (now / 38) % 360;
+      const gradient = ctx.createLinearGradient(0, 0, width, height);
+      gradient.addColorStop(0, `hsl(${hue}, 84%, 58%)`);
+      gradient.addColorStop(0.45, `hsl(${(hue + 96) % 360}, 76%, 46%)`);
+      gradient.addColorStop(1, `hsl(${(hue + 190) % 360}, 72%, 52%)`);
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.save();
+      ctx.translate(width / 2 - 170 + swipe * 34, 38);
+      ctx.fillStyle = 'rgba(9, 14, 22, 0.88)';
+      ctx.roundRect(0, 0, 340, 644, 28);
+      ctx.fill();
+      ctx.clip();
+
+      ctx.fillStyle = '#f8fafc';
+      ctx.fillRect(18, 24, 304, 596);
+
+      for (let i = 0; i < 16; i += 1) {
+        const y = 42 + ((i * 76 - scroll) % 640 + 640) % 640;
+        ctx.fillStyle = i % 2 ? '#e8eef8' : '#dfe8f4';
+        ctx.roundRect(34, y, 272, 54, 12);
+        ctx.fill();
+        ctx.fillStyle = `hsl(${(hue + i * 27) % 360}, 68%, 48%)`;
+        ctx.roundRect(48, y + 10, 36, 34, 10);
+        ctx.fill();
+        ctx.fillStyle = '#223044';
+        ctx.fillRect(100, y + 14, 168, 8);
+        ctx.fillRect(100, y + 32, 118, 7);
+      }
+
+      ctx.fillStyle = '#0f1724';
+      ctx.roundRect(122, 8, 96, 18, 9);
+      ctx.fill();
+
+      if (stressMotion) {
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.26)';
+        ctx.beginPath();
+        ctx.arc(170 + swipe * 112, 530 + Math.cos(now / 170) * 38, 28, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      ctx.restore();
+
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+      ctx.fillRect(0, 0, width, 34);
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '16px ui-monospace, Menlo, monospace';
+      ctx.fillText(`dynamic stream frame ${tick++}`, 18, 23);
+    }
+
+    function render(now) {
+      drawPhoneFrame(now);
+      requestAnimationFrame(render);
+    }
+
+    function sampleVideoFrame() {
+      if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+      sampleCtx.drawImage(video, 0, 0, sample.width, sample.height);
+      const pixels = sampleCtx.getImageData(0, 0, sample.width, sample.height).data;
+      let greenish = 0;
+      for (let i = 0; i < pixels.length; i += 16) {
+        const r = pixels[i];
+        const g = pixels[i + 1];
+        const b = pixels[i + 2];
+        if (g > 120 && g > r * 1.8 && g > b * 1.8) greenish += 1;
+      }
+      if (greenish > pixels.length / 16 * 0.58) greenSamples += 1;
+    }
+
+    function updateStats() {
+      const elapsed = Math.max(1, performance.now() - startedAt);
+      framesEl.textContent = String(frames);
+      fpsEl.textContent = String(Math.round(frames / elapsed * 1000));
+      gapsEl.textContent = String(longGaps);
+      greenEl.textContent = String(greenSamples);
+      resolutionEl.textContent = `${video.videoWidth || 0} x ${video.videoHeight || 0}`;
+      status.textContent = longGaps === 0 && greenSamples === 0 ? 'Stream healthy' : 'Inspect stream visually';
+    }
+
+    function onVideoFrame(now, metadata) {
+      frames += 1;
+      if (lastVideoFrameAt && metadata.mediaTime - lastVideoFrameAt > 0.18) {
+        longGaps += 1;
+      }
+      lastVideoFrameAt = metadata.mediaTime;
+      sampleVideoFrame();
+      video.requestVideoFrameCallback(onVideoFrame);
+    }
+
+    document.getElementById('size').addEventListener('click', () => {
+      compact = !compact;
+      stage.style.margin = compact ? '8vh 8vw' : '0';
+    });
+
+    document.getElementById('stress').addEventListener('click', () => {
+      stressMotion = !stressMotion;
+    });
+
+    const stream = canvas.captureStream(60);
+    video.srcObject = stream;
+    video.play().catch((error) => {
+      status.textContent = `Play failed: ${error && error.message ? error.message : error}`;
+    });
+
+    if ('requestVideoFrameCallback' in HTMLVideoElement.prototype) {
+      video.requestVideoFrameCallback(onVideoFrame);
+    } else {
+      setInterval(() => {
+        frames += 1;
+        sampleVideoFrame();
+      }, 16);
+    }
+
+    setInterval(updateStats, 500);
+    requestAnimationFrame(render);
+  </script>
+</body>
+</html>

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -29,6 +29,7 @@
     "test:l1:session": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-session.spec.ts\"",
     "test:l1:dialog": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-dialog.spec.ts\"",
     "test:l1:chat-flow": "wdio run ./config/wdio.conf.ts --spec \"./specs/l1-chat.spec.ts\"",
+    "test:l1:browser-video": "wdio run ./config/wdio.conf.ts --spec \"../specs/l1-browser-video-stream.spec.ts\"",
     "test:perf": "wdio run ./config/wdio.conf.ts --spec \"./specs/performance/startup-session-perf.spec.ts\"",
     "fixture:long-session": "node ./scripts/generate-long-session-fixture.mjs",
     "test:smoke": "wdio run ./config/wdio.conf.ts --spec \"./specs/startup/*.spec.ts\"",

--- a/tests/e2e/specs/l1-browser-real-stream-diagnostic.spec.ts
+++ b/tests/e2e/specs/l1-browser-real-stream-diagnostic.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Diagnostic-only spec for comparing the real local stream inside BitFun's
+ * embedded browser. Run with BITFUN_BROWSER_STREAM_URL=http://127.0.0.1:41953/
+ */
+
+import { browser, $ } from '@wdio/globals';
+
+const streamUrl = process.env.BITFUN_BROWSER_STREAM_URL || 'http://127.0.0.1:41953/';
+const describeRealStream = process.env.BITFUN_BROWSER_STREAM_URL ? describe : describe.skip;
+
+async function fetchClientStatus() {
+  const response = await fetch(`${streamUrl.replace(/\/$/, '')}/api/client-status`, {
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`client-status failed: ${response.status} ${await response.text()}`);
+  }
+  return response.json() as Promise<Record<string, any>>;
+}
+
+async function runLongDrag() {
+  const baseUrl = streamUrl.replace(/\/$/, '');
+  const send = async (payload: Record<string, unknown>) => {
+    const response = await fetch(`${baseUrl}/api/input`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error(`input failed: ${response.status} ${await response.text()}`);
+    }
+  };
+
+  const x = 1200;
+  const startY = 1750;
+  const endY = 450;
+  await send({ kind: 'touchDown', x, y: startY });
+  let previousY = startY;
+  for (let index = 1; index <= 180; index += 1) {
+    const phase = (index % 90) / 90;
+    const nextY = Math.round(index <= 90
+      ? startY + (endY - startY) * phase
+      : endY + (startY - endY) * phase);
+    await send({
+      kind: 'touchMove',
+      x1: x,
+      y1: previousY,
+      x2: x,
+      y2: nextY,
+      duration: 16,
+    });
+    previousY = nextY;
+    await new Promise((resolve) => setTimeout(resolve, 16));
+  }
+  await send({ kind: 'touchUp', x, y: previousY });
+}
+
+function summarizeStatus(status: Record<string, any>) {
+  const stream = status.stream || {};
+  const browserTelemetry = status.browser || {};
+  const selfTest = status.browserSelfTest || {};
+  return {
+    streamRecentFps: stream.recentFps,
+    streamLastFrameAgoMs: stream.lastFrameAgoMs,
+    avccClients: stream.avccClients,
+    browserDecodedFps: browserTelemetry.decodedFps,
+    frameIntervalAvgMs: browserTelemetry.frameIntervalAvgMs,
+    frameIntervalP95Ms: browserTelemetry.frameIntervalP95Ms,
+    frameIntervalMaxMs: browserTelemetry.frameIntervalMaxMs,
+    jankFrames: browserTelemetry.jankFrames,
+    jankRatio: browserTelemetry.jankRatio,
+    canvasWidth: browserTelemetry.canvasWidth,
+    canvasHeight: browserTelemetry.canvasHeight,
+    visibility: browserTelemetry.visibility,
+    pageUrl: browserTelemetry.pageUrl,
+    inputAckAvgMs: browserTelemetry.inputAckAvgMs,
+    inputAckMaxMs: browserTelemetry.inputAckMaxMs,
+    selfTestLastResult: selfTest.lastResult,
+  };
+}
+
+describeRealStream('L1 Built-in browser real stream diagnostic', () => {
+  it('opens the real local stream and prints browser telemetry', async () => {
+    await browser.execute(async () => {
+      const invoke = window.__TAURI__?.core?.invoke;
+      if (typeof invoke === 'function') {
+        await invoke('plugin:window|maximize', { label: 'main' });
+      }
+    });
+    await browser.pause(500);
+
+    const entry = await $('[data-testid="browser-panel-entry"]');
+    await entry.waitForClickable({ timeout: 15000 });
+    await entry.click();
+
+    const input = await $('[data-testid="browser-url-input"]');
+    await input.waitForDisplayed({ timeout: 15000 });
+    await browser.execute((url: string) => {
+      const inputElement = document.querySelector<HTMLInputElement>('[data-testid="browser-url-input"]');
+      if (!inputElement) throw new Error('Browser URL input not found');
+
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      valueSetter?.call(inputElement, url);
+      inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+      inputElement.form?.requestSubmit();
+    }, streamUrl);
+
+    await browser.waitUntil(async () => {
+      const current = await $('[data-testid="browser-current-url"]');
+      if (!(await current.isExisting())) return false;
+      return (await current.getText()).includes('127.0.0.1:41953');
+    }, {
+      timeout: 15000,
+      interval: 250,
+      timeoutMsg: 'Browser UI did not reflect the real stream URL',
+    });
+
+    const webviewLabel = await browser.waitUntil(async () => {
+      const label = await browser.execute(() => {
+        const host = document.querySelector('[data-webview-label]');
+        return host?.getAttribute('data-webview-label') || '';
+      });
+      return label || false;
+    }, {
+      timeout: 15000,
+      interval: 250,
+      timeoutMsg: 'Browser WebView label was not exposed',
+    }) as string;
+
+    await browser.waitUntil(async () => {
+      return browser.execute(async (label: string, expectedUrl: string) => {
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (typeof invoke !== 'function') return false;
+        const url = await invoke('browser_get_url', { request: { label } });
+        return url === expectedUrl;
+      }, webviewLabel, streamUrl);
+    }, {
+      timeout: 15000,
+      interval: 250,
+      timeoutMsg: 'Native browser WebView did not navigate to the real stream URL',
+    });
+
+    await browser.pause(5000);
+
+    for (let index = 0; index < 8; index += 1) {
+      const status = await fetchClientStatus();
+      console.log(`[real-stream-before-${index}] ${JSON.stringify(summarizeStatus(status))}`);
+      await browser.pause(1000);
+    }
+
+    if (process.env.BITFUN_BROWSER_LONG_DRAG === '1') {
+      await runLongDrag();
+    } else {
+      await fetch(`${streamUrl.replace(/\/$/, '')}/api/browser/self-test`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ kind: 'drag' }),
+      });
+    }
+
+    await browser.pause(7000);
+
+    for (let index = 0; index < 8; index += 1) {
+      const status = await fetchClientStatus();
+      console.log(`[real-stream-after-${index}] ${JSON.stringify(summarizeStatus(status))}`);
+      await browser.pause(1000);
+    }
+  });
+});

--- a/tests/e2e/specs/l1-browser-video-stream.spec.ts
+++ b/tests/e2e/specs/l1-browser-video-stream.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * L1 browser video stream spec: verifies the built-in browser can navigate a
+ * native child WebView to a dynamic video stream fixture without breaking the
+ * surrounding browser toolbar interactions.
+ */
+
+import { browser, expect, $ } from '@wdio/globals';
+import { createServer, type Server } from 'http';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentFile = fileURLToPath(import.meta.url);
+const currentDir = path.dirname(currentFile);
+const fixturePath = path.resolve(currentDir, '..', 'fixtures', 'browser-video-stream.html');
+
+async function startFixtureServer(): Promise<{ server: Server; url: string }> {
+  const html = await readFile(fixturePath);
+  const server = createServer((request, response) => {
+    if (request.url === '/' || request.url === '/browser-video-stream.html') {
+      response.writeHead(200, {
+        'content-length': html.length,
+        'content-type': 'text/html; charset=utf-8',
+      });
+      response.end(html);
+      return;
+    }
+
+    response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end('Not found');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Fixture server did not expose a TCP port');
+  }
+
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}/browser-video-stream.html`,
+  };
+}
+
+describe('L1 Built-in browser video stream', () => {
+  let fixtureServer: Server | null = null;
+  let fixtureUrl = '';
+
+  before(async () => {
+    const fixture = await startFixtureServer();
+    fixtureServer = fixture.server;
+    fixtureUrl = fixture.url;
+  });
+
+  after(async () => {
+    if (fixtureServer) {
+      fixtureServer.closeAllConnections?.();
+      fixtureServer.closeIdleConnections?.();
+      await new Promise<void>((resolve) => fixtureServer?.close(() => resolve()));
+      fixtureServer = null;
+    }
+  });
+
+  it('navigates the native WebView to the video stream fixture and keeps toolbar controls clickable', async () => {
+    const entry = await $('[data-testid="browser-panel-entry"]');
+    await entry.waitForClickable({ timeout: 15000 });
+    await entry.click();
+
+    const input = await $('[data-testid="browser-url-input"]');
+    await input.waitForDisplayed({ timeout: 15000 });
+    await browser.execute((url: string) => {
+      const inputElement = document.querySelector<HTMLInputElement>('[data-testid="browser-url-input"]');
+      if (!inputElement) throw new Error('Browser URL input not found');
+
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+      valueSetter?.call(inputElement, url);
+      inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+      inputElement.form?.requestSubmit();
+    }, fixtureUrl);
+
+    await browser.waitUntil(async () => {
+      const current = await $('[data-testid="browser-current-url"]');
+      if (!(await current.isExisting())) return false;
+      return (await current.getText()).includes('/browser-video-stream.html');
+    }, {
+      timeout: 15000,
+      interval: 250,
+      timeoutMsg: 'Browser UI did not reflect the video stream fixture URL',
+    });
+
+    const webviewLabel = await browser.waitUntil(async () => {
+      const label = await browser.execute(() => {
+        const host = document.querySelector('[data-webview-label]');
+        return host?.getAttribute('data-webview-label') || '';
+      });
+      return label || false;
+    }, {
+      timeout: 15000,
+      interval: 250,
+      timeoutMsg: 'Browser WebView label was not exposed',
+    }) as string;
+
+    await browser.waitUntil(async () => {
+      return browser.execute(async (label: string, expectedUrl: string) => {
+        const invoke = window.__TAURI__?.core?.invoke;
+        if (typeof invoke !== 'function') return false;
+        const url = await invoke('browser_get_url', { request: { label } });
+        return url === expectedUrl;
+      }, webviewLabel, fixtureUrl);
+    }, {
+      timeout: 15000,
+      interval: 250,
+      timeoutMsg: 'Native browser WebView did not navigate to the video stream fixture',
+    });
+
+    const refresh = await $('[data-testid="browser-refresh-button"]');
+    await refresh.waitForClickable({ timeout: 5000 });
+    await refresh.click();
+
+    await browser.pause(500);
+
+    const urlAfterRefresh = await browser.execute(async (label: string) => {
+      const invoke = window.__TAURI__?.core?.invoke;
+      if (typeof invoke !== 'function') return '';
+      return invoke('browser_get_url', { request: { label } });
+    }, webviewLabel);
+
+    expect(urlAfterRefresh).toBe(fixtureUrl);
+  });
+});


### PR DESCRIPTION
- create embedded browser webviews through the native desktop adapter
- prefer software decoding for WebCodecs H.264 streams on WebView2
- preserve active webview bounds during transient layout collapse
- reuse webviews for navigation, reload, and bounds updates
- retain overlay and toolbar interaction protections
- remove the experimental performance window path
- add embedded video stream and real-stream diagnostic coverage

## Summary

<!-- Briefly describe what changed. -->

Fixes #

## Type and Areas

Type:

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas:

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

## Checklist

- [ ] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [ ] Relevant verification is recorded above, or skipped checks are explained.
- [ ] User-facing strings, docs, and locales are updated where applicable.
