### PR TITLE
fix(ci): stabilize Linux arm64 desktop packaging

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -98,7 +98,8 @@ jobs:
           - os: ubuntu-24.04-arm
             name: linux-arm64
             target: aarch64-unknown-linux-gnu
-            build_command: pnpm run desktop:build:linux -- --target aarch64-unknown-linux-gnu --bundles deb,rpm,appimage
+            # Fat LTO exhausts the hosted ARM runner while linking bitfun-desktop.
+            build_command: CARGO_PROFILE_RELEASE_LTO=thin pnpm run desktop:build:linux -- --target aarch64-unknown-linux-gnu --bundles deb,rpm,appimage
           - os: macos-15
             name: macos-arm64
             target: aarch64-apple-darwin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,8 @@ jobs:
           - os: ubuntu-24.04-arm
             name: linux-arm64
             target: aarch64-unknown-linux-gnu
-            build_command: pnpm run desktop:build:linux -- --target aarch64-unknown-linux-gnu --bundles deb,rpm,appimage
+            # Fat LTO exhausts the hosted ARM runner while linking bitfun-desktop.
+            build_command: CARGO_PROFILE_RELEASE_LTO=thin pnpm run desktop:build:linux -- --target aarch64-unknown-linux-gnu --bundles deb,rpm,appimage
           - os: macos-15
             name: macos-arm64
             target: aarch64-apple-darwin

--- a/src/apps/desktop/src/api/computer_use_api.rs
+++ b/src/apps/desktop/src/api/computer_use_api.rs
@@ -4,6 +4,7 @@ use crate::api::app_state::AppState;
 use crate::computer_use::DesktopComputerUseHost;
 use bitfun_core::agentic::tools::computer_use_host::ComputerUseHost;
 use bitfun_core::service::config::types::AIConfig;
+#[cfg(target_os = "windows")]
 use bitfun_core::util::process_manager;
 use serde::{Deserialize, Serialize};
 use tauri::State;

--- a/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
@@ -12,21 +12,30 @@
 use super::macos;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use super::resolve_pid;
+use super::DesktopComputerUseHost;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use super::LINUX_LEGACY_AX_UNAVAILABLE;
 #[cfg(target_os = "macos")]
 use super::{require_macos_background_input, resolve_pid_macos};
-use super::{CachedInteractiveView, CachedVisualMarkView, DesktopComputerUseHost};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use super::{CachedInteractiveView, CachedVisualMarkView};
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
+use bitfun_core::agentic::tools::computer_use_host::ComputerScreenshot;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use bitfun_core::agentic::tools::computer_use_host::VisualMark;
 use bitfun_core::agentic::tools::computer_use_host::{
-    AppClickParams, AppSelector, AppStateSnapshot, AppWaitPredicate, ClickTarget,
-    ComputerScreenshot, ComputerUseHost, InteractiveActionResult, InteractiveClickParams,
-    InteractiveScrollParams, InteractiveTypeTextParams, InteractiveView, InteractiveViewOpts,
-    VisualActionResult, VisualClickParams, VisualMark, VisualMarkView, VisualMarkViewOpts,
+    AppClickParams, AppSelector, AppStateSnapshot, AppWaitPredicate, InteractiveActionResult,
+    InteractiveClickParams, InteractiveScrollParams, InteractiveTypeTextParams, InteractiveView,
+    InteractiveViewOpts, VisualActionResult, VisualClickParams, VisualMarkView, VisualMarkViewOpts,
 };
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use bitfun_core::agentic::tools::computer_use_host::{ClickTarget, ComputerUseHost};
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
 #[cfg(target_os = "macos")]
 use log::debug;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use log::warn;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::time::{Duration, Instant};
 
 impl DesktopComputerUseHost {
@@ -1422,6 +1431,7 @@ impl DesktopComputerUseHost {
 /// view either. The digest is meant to detect *structural* changes
 /// (elements appeared, disappeared, or moved noticeably), not cosmetic
 /// noise.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn compute_interactive_view_digest(
     elements: &[bitfun_core::agentic::tools::computer_use_host::InteractiveElement],
 ) -> String {
@@ -1449,6 +1459,7 @@ fn compute_interactive_view_digest(
     out
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn compute_visual_mark_view_digest(marks: &[VisualMark], screenshot_id: Option<&str>) -> String {
     use sha1::{Digest, Sha1};
     let mut hasher = Sha1::new();
@@ -1470,6 +1481,7 @@ fn compute_visual_mark_view_digest(marks: &[VisualMark], screenshot_id: Option<&
     out
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn build_regular_visual_marks(
     shot: &ComputerScreenshot,
     opts: &VisualMarkViewOpts,
@@ -1541,6 +1553,7 @@ fn build_regular_visual_marks(
     Ok(marks)
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn visual_marks_to_overlay_elements(
     marks: &[VisualMark],
 ) -> Vec<bitfun_core::agentic::tools::computer_use_host::InteractiveElement> {
@@ -1563,6 +1576,7 @@ fn visual_marks_to_overlay_elements(
         .collect()
 }
 
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
 pub(super) fn detect_regular_grid_rect_from_screenshot(
     shot: &ComputerScreenshot,
     rows: u32,
@@ -1613,6 +1627,7 @@ pub(super) fn detect_regular_grid_rect_from_screenshot(
     Ok((x0 as i32, y0 as i32, w, h))
 }
 
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
 fn projection_darkness(
     img: &image::RgbImage,
     left: u32,
@@ -1647,6 +1662,7 @@ fn projection_darkness(
     smooth_projection(&out, 2)
 }
 
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
 fn smooth_projection(values: &[f64], radius: usize) -> Vec<f64> {
     if values.is_empty() {
         return Vec::new();
@@ -1661,6 +1677,7 @@ fn smooth_projection(values: &[f64], radius: usize) -> Vec<f64> {
     out
 }
 
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
 fn detect_regular_line_sequence(
     projection: &[f64],
     count: u32,
@@ -1789,6 +1806,7 @@ fn detect_regular_line_sequence(
         })
 }
 
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
 fn top_regular_positions(
     scores: &[f64],
     count: u32,
@@ -1832,10 +1850,12 @@ fn top_regular_positions(
 /// error text rather than introducing a typed error enum because every
 /// `BitFunError::tool` is already string-based throughout the host
 /// surface; adding a new variant would ripple through ~40 callers.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn is_stale_interactive_view_error(err: &BitFunError) -> bool {
     err.to_string().contains("STALE_INTERACTIVE_VIEW")
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn is_stale_visual_mark_view_error(err: &BitFunError) -> bool {
     err.to_string().contains("STALE_VISUAL_MARK_VIEW")
 }

--- a/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
@@ -22,14 +22,15 @@ use super::{CachedInteractiveView, CachedVisualMarkView};
 #[cfg(any(test, target_os = "macos", target_os = "windows"))]
 use bitfun_core::agentic::tools::computer_use_host::ComputerScreenshot;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
+use bitfun_core::agentic::tools::computer_use_host::ComputerUseHost;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use bitfun_core::agentic::tools::computer_use_host::VisualMark;
 use bitfun_core::agentic::tools::computer_use_host::{
-    AppClickParams, AppSelector, AppStateSnapshot, AppWaitPredicate, InteractiveActionResult,
-    InteractiveClickParams, InteractiveScrollParams, InteractiveTypeTextParams, InteractiveView,
-    InteractiveViewOpts, VisualActionResult, VisualClickParams, VisualMarkView, VisualMarkViewOpts,
+    AppClickParams, AppSelector, AppStateSnapshot, AppWaitPredicate, ClickTarget,
+    InteractiveActionResult, InteractiveClickParams, InteractiveScrollParams,
+    InteractiveTypeTextParams, InteractiveView, InteractiveViewOpts, VisualActionResult,
+    VisualClickParams, VisualMarkView, VisualMarkViewOpts,
 };
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-use bitfun_core::agentic::tools::computer_use_host::{ClickTarget, ComputerUseHost};
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
 #[cfg(target_os = "macos")]
 use log::debug;

--- a/src/apps/desktop/src/computer_use/desktop_host/mod.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/mod.rs
@@ -4,6 +4,8 @@ mod screenshot;
 use screenshot::{ComputerUseNavFocus, PointerMap, ScreenshotCacheEntry};
 
 use async_trait::async_trait;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use bitfun_core::agentic::tools::computer_use_host::VisualMark;
 use bitfun_core::agentic::tools::computer_use_host::{
     ActionRecord, AppClickParams, AppInfo, AppSelector, AppShortcutsSnapshot, AppStateSnapshot,
     AppWaitPredicate, ClickTarget, ComputerScreenshot, ComputerUseDisplayInfo, ComputerUseHost,
@@ -12,7 +14,7 @@ use bitfun_core::agentic::tools::computer_use_host::{
     ComputerUseSessionSnapshot, InteractiveActionResult, InteractiveClickParams,
     InteractiveScrollParams, InteractiveTypeTextParams, InteractiveView, InteractiveViewOpts,
     LoopDetectionResult, UiElementLocateQuery, UiElementLocateResult, VisualActionResult,
-    VisualClickParams, VisualMark, VisualMarkView, VisualMarkViewOpts,
+    VisualClickParams, VisualMarkView, VisualMarkViewOpts,
 };
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use bitfun_core::agentic::tools::computer_use_host::{
@@ -144,12 +146,15 @@ struct ComputerUseSessionMutableState {
     /// Most-recent Set-of-Mark interactive view per pid. Used to resolve
     /// `interactive_*` numeric `i` indices back to AX node indices and to
     /// detect stale-view usage via `before_view_digest`.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     interactive_view_cache: std::collections::HashMap<i32, CachedInteractiveView>,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     visual_mark_cache: std::collections::HashMap<i32, CachedVisualMarkView>,
     /// Most-recent focused-window screenshot coordinate map per application
     /// pid. `app_click(target: image_xy | image_grid)` must use the same
     /// image basis the model saw from `get_app_state`, not whichever global
     /// computer-use screenshot happened to run last.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     app_pointer_maps: std::collections::HashMap<i32, PointerMap>,
     /// Exact screenshot-id keyed coordinate maps. This is the strongest
     /// addressing basis for arbitrary visual targets because it survives
@@ -158,6 +163,7 @@ struct ComputerUseSessionMutableState {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 struct CachedInteractiveView {
     digest: String,
     /// `i` → `node_idx` map (dense, indexed by `i`).
@@ -165,6 +171,7 @@ struct CachedInteractiveView {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 struct CachedVisualMarkView {
     digest: String,
     marks: Vec<VisualMark>,
@@ -185,8 +192,11 @@ impl ComputerUseSessionMutableState {
             optimizer: ComputerUseOptimizer::new(),
             last_mutation_kind: None,
             preferred_display_id: None,
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             interactive_view_cache: std::collections::HashMap::new(),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             visual_mark_cache: std::collections::HashMap::new(),
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             app_pointer_maps: std::collections::HashMap::new(),
             screenshot_pointer_maps: std::collections::HashMap::new(),
         }
@@ -1738,6 +1748,7 @@ async fn resolve_pid_macos(host: &DesktopComputerUseHost, app: &AppSelector) -> 
 /// matching entry (e.g. it exited between resolution and this lookup) —
 /// `get_app_shortcuts` should never fail just because the display name
 /// couldn't be resolved.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 async fn app_info_for_pid(host: &DesktopComputerUseHost, pid: i32) -> AppInfo {
     host.list_apps(true)
         .await

--- a/src/apps/desktop/src/computer_use/desktop_host/mod.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/mod.rs
@@ -22,6 +22,7 @@ use bitfun_core::agentic::tools::computer_use_host::{
 };
 use bitfun_core::agentic::tools::computer_use_optimizer::ComputerUseOptimizer;
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use log::debug;
 use screenshots::display_info::DisplayInfo;
 use screenshots::Screen;

--- a/src/apps/desktop/src/computer_use/desktop_host/pointer_input.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/pointer_input.rs
@@ -13,8 +13,10 @@ use super::macos;
 use super::DesktopComputerUseHost;
 #[cfg(target_os = "windows")]
 use bitfun_core::agentic::tools::computer_use_host::AppSelector;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use bitfun_core::agentic::tools::computer_use_host::ClickTarget;
 use bitfun_core::agentic::tools::computer_use_host::{
-    ClickTarget, ComputerUseHost, ComputerUseLastMutationKind,
+    ComputerUseHost, ComputerUseLastMutationKind,
 };
 use bitfun_core::util::errors::{BitFunError, BitFunResult};
 use enigo::{Axis, Button, Coordinate, Direction, Enigo, Key, Keyboard, Mouse, Settings};
@@ -265,6 +267,7 @@ impl DesktopComputerUseHost {
         Ok(())
     }
 
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     pub(super) fn map_app_image_coords_to_pointer_f64(
         &self,
         pid: i32,
@@ -290,6 +293,7 @@ impl DesktopComputerUseHost {
         map.map_image_to_global_f64(x, y)
     }
 
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     pub(super) fn image_grid_target_to_xy(
         target: &ClickTarget,
     ) -> BitFunResult<Option<(i32, i32)>> {

--- a/src/apps/desktop/src/computer_use/linux_ax_ui.rs
+++ b/src/apps/desktop/src/computer_use/linux_ax_ui.rs
@@ -29,7 +29,7 @@ async fn role_match_string(acc: &AccessibleProxy<'_>) -> String {
 }
 
 /// Registry application roots → BFS until first match with non-empty screen extents.
-pub async fn locate_ui_element_center(
+pub(super) async fn locate_ui_element_center(
     query: UiElementLocateQuery,
 ) -> BitFunResult<UiElementLocateResult> {
     ui_locate_common::validate_query(&query)?;


### PR DESCRIPTION
## Summary

- use thin LTO for Linux arm64 desktop packages to reduce release-link memory pressure
- keep AX-first Computer Use caches and helpers out of Linux legacy builds
- tighten the Linux AT-SPI helper visibility

## Root cause

The Linux arm64 hosted runner lost communication during the release link in six consecutive nightly runs. The warning block at the end of the captured log was not fatal; GitHub annotated the job as runner CPU/memory starvation. The Linux x64 and other platform jobs completed on the same commit.

## Verification

- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop visual_grid_tests`
- `pnpm run check:github-config`
- `pnpm run fmt:rs`
- `git diff --check`

The final Linux arm64 release link requires CI because the local host is macOS.