### PR TITLE
feat(plugins): add managed activation candidate projection

### DIFF
--- a/docs/architecture/cli-product-line-design.md
+++ b/docs/architecture/cli-product-line-design.md
@@ -15,8 +15,8 @@ CLI 产品入口、配置兼容、TUI Blueprint 消费和 CLI Agent 体验，不
 
 | CLI 阶段 | 可消费的插件里程碑 | 边界 |
 |---|---|---|
-| CLI-P0 / CLI-P1 | P0-C.1 | 仅受管来源、审核和只读诊断，不激活或执行插件。 |
-| CLI-P2 激活 | P0-C.2 | 建立独立 Host trust，并消费经过权限门禁的最小候选。 |
+| CLI-P0 / CLI-P1 | P0-C.1；插件管理命令可消费 P0-C.2 | 提供受管来源、审核、显式激活和候选预览；不把候选注册为可执行工具。 |
+| CLI-P2 候选消费 | P0-C.2 | 将已激活且经过权限门禁的候选接入 CLI Agent 工具快照。 |
 | CLI-P2 隔离执行/分发 | P0+ | worker、资源预算、可写 Hook、更新/撤销和组织策略分别完成设计与安全验收后接入。 |
 
 ## 1. 目标与边界
@@ -172,7 +172,7 @@ CLI-P1 应统一以下命令的文本和结构化只读视图：
 
 CLI-P2 在 CLI-P0/CLI-P1 契约稳定后进入：
 
-- OpenCode-compatible 受管包的显式激活、隔离执行、更新/卸载和组织策略。
+- OpenCode-compatible 受管包候选进入工具快照；隔离执行、更新/卸载和组织策略分别验收。
 - 受控命令、Skill、Tool、事件订阅、权限候选和只读 TUI contribution；可写 Hook 单独评审。
 - 扩展 OpenCode、Codex、Claude Code 的资产覆盖和批量预览/选择体验，不改变 CLI-P1 已冻结的资产分类与写入边界。
 - 消费完整 TUI Blueprint、产品内置扩展投影和多品牌 CLI 发布事实；通用 Bundle 构建、品牌资源、签名和

--- a/docs/architecture/opencode-plugin-surface-audit.md
+++ b/docs/architecture/opencode-plugin-surface-audit.md
@@ -57,19 +57,19 @@
 |---|---|---|
 | `runtime-ports` plugin contract | 已有主机 ABI、只读视图、候选项、权限提示、诊断和隔离类型；公开符号较多但已受脚本预算约束 | 不继续新增泛描述符；公开符号必须声明接口切面、消费方和验证目标 |
 | `plugin-runtime-host` | 已有受控 host 边界、deadline、幂等、隔离和 restart 清理路径 | 继续保持窄方法集；P0-C.1 来源接口不得直接泄漏主机 ABI |
-| `product-domains/plugin_source` | 定义生态无关的版本 1 包清单、来源标识、工作区信任记录和 epoch 规则 | `adapter` 仅为不透明标识；不得加入生态入口规则、文件系统、安装或主机行为 |
-| `services-integrations/plugin_source` | 校验用户级和项目级 BitFun 目录中的全部声明文件，安全替换工作区信任记录，并为选定包生成固定内容输入 | 不解释 `.opencode` 布局，不扫描外部生态目录，不执行插件，不增加通用 registry/manager 接口 |
+| `product-domains/plugin_source` | 定义生态无关的包清单、来源审核记录、激活记录和独立代次 | `adapter` 仅为不透明标识；不得加入生态入口规则、文件系统、安装或主机行为 |
+| `services-integrations/plugin_source` | 校验受管目录、持久化来源审核与激活状态、生成固定输入，并复核实时激活授权 | 不解释 `.opencode` 布局，不扫描外部生态目录，不执行插件，不增加通用 registry/manager 接口 |
 | `bitfun-core/plugin_source` | 注入产品目录并向 CLI 保留来源与诊断兼容接口 | 不实现文件扫描、锁、持久化或生态解析 |
-| `bitfun-cli plugins` | 当前来源审核接口的产品消费方，支持 `list/approve-source/deny/revoke`；`doctor` 汇总严重来源错误 | `SourceApproved` 不得宣称能力已批准、包已启用或可执行，不承担安装复制和卸载 |
-| `opencode-adapter` | 消费固定内容的受管包输入，提供诊断只读视图和 custom tool 映射；未激活或暂不支持的能力返回诊断或 `unsupported` 状态 | 不拥有目录发现；生产组装和激活接入须独立评审 |
+| `bitfun-cli plugins` | 消费来源审核与激活接口，支持预览、精确哈希确认和停用；`doctor` 汇总严重来源错误 | 不承担安装复制、卸载、最终工具注册或执行 |
+| `opencode-adapter` | 普通输入只返回诊断；激活输入将受支持 custom tool 映射为权限候选 | 不拥有目录发现、激活持久化或最终工具执行 |
 | `events` | 已有产品事件清单 | 需要在真实插件事件消费前定义可订阅子集，不新增插件专用事件模型 |
 | `tool-contracts` | 已有动态工具提供方和工具快照 | custom tool 映射必须复用它，不新增插件专用工具 ABI |
 
 `opencode-adapter` 当前规则：
 
-- 唯一产品组装根调用公开工厂并把返回的适配器注入 Plugin Runtime Host；工厂只接收来源服务生成的受管包输入。
+- `bitfun-core/plugin_runtime` 是唯一生产组装点；它只把来源服务生成的固定输入和可选激活授权信息交给适配器，并把适配器注入 Plugin Runtime Host。
 - `SourceApproved` 仅表示包内容已经用户审核，适配器必须保持未激活状态，不得生成受信任候选。
-- GUI、TUI/CLI、Web 等产品入口只消费能力服务接口、插件只读视图、诊断和稳定状态词。
+- GUI、TUI/CLI、Web 等产品入口只消费产品级来源、激活、候选和诊断接口，不接触适配器或 Host ABI。
 - 适配器不执行 JS/TS、不安装 npm、不依赖用户本机 `opencode`。
 - 当前源码探测只识别测试覆盖的 `export const` 和同一行 `name: tool({` 声明形式，不提供完整 JS/TS 语法兼容；没有可识别入口的包和已识别但不支持的 hook 必须返回诊断，其他语法不属于本阶段兼容范围。
 
@@ -78,8 +78,8 @@
 - 包清单文件为 `bitfun.plugin.json`；版本 1 的 `adapter` 是小写不透明标识。只有清单声明并通过哈希校验的文件进入来源标识和后续适配器访问范围。
 - `.opencode/plugins/*.js|ts` 只在 OpenCode 适配层中解释；文件必须先进入受管包清单并通过来源服务校验，不得由公开适配入口直接扫描用户 OpenCode 配置目录。
 - 包内容变化后旧来源审核失效，新来源标识回到 `Unknown`；损坏的信任文件按失败处理且不自动覆盖。
-- P0-C.2 不得把 `SourceApproved` 直接映射为 Host 的 `Trusted`；首次激活需展示适配器、入口、能力和副作用并重新确认。
-- P0-C.1 没有生产 Host 绑定和 JS/TS 执行能力。
+- `SourceApproved` 不直接映射为 Host 的 `Trusted`；首次激活必须使用预览返回的精确内容哈希确认。无受支持 custom tool 的包不得进入激活状态。
+- 激活只允许产生需要权限的候选，不执行 JS/TS，不注册或执行最终工具。
 
 ## 5. PR 审查问题
 

--- a/docs/architecture/plugin-runtime-host-design.md
+++ b/docs/architecture/plugin-runtime-host-design.md
@@ -73,7 +73,7 @@ flowchart LR
 |---|---|---|
 | P0-B | 主机内部 ABI、产品形态保护、read/dispatch 校验、deadline、epoch、幂等、隔离、诊断、`HostRestarted` 清除路径 | Desktop/CLI 插件消费、来源发现、激活、副作用执行、用户可执行恢复动作、界面贡献载荷 |
 | P0-C.1 | BitFun 受管插件包发现、完整性校验、工作区信任和 CLI 诊断 | 插件执行、生产主机绑定、安装复制、随产品携带包和外部 OpenCode 目录导入 |
-| P0-C.2 | OpenCode-compatible 最小映射和一个真实候选项消费路径 | 完整 OpenCode 运行时、外部 OpenCode CLI 前置依赖、全入口界面扩展矩阵、任意可写 hook |
+| P0-C.2 | 工作区激活、生产组装和 OpenCode custom tool 候选读取 | 最终工具注册或执行、完整 OpenCode 运行时、外部 OpenCode CLI 前置依赖、界面扩展矩阵、可写 hook |
 | P0+ | Server/Remote/ACP/SDK 受控运行、更多 OpenCode hook、界面贡献、跨生态兼容 | 让外部生态接口成为 BitFun 内部归属接口 |
 
 P0-B 的完成标准只能证明主机边界安全，不能宣称 OpenCode-compatible 产品体验完成。
@@ -174,29 +174,39 @@ P0-C.1 只读取两个 BitFun 受管目录：用户数据目录的 `plugins` 和
 - 单文件、包总量、一次来源刷新或审核操作的总读取字节、总扫描时间和信任文件均有固定上限；校验失败或部分失败的读取同样计入操作预算，二次稳定性扫描不得重置预算。符号链接、Windows reparse point 和越出受管根目录的路径按错误处理。
 - 工作区包存在时，用户级同 ID 包及其诊断归一化为 `shadowed_package`；工作区包无效时也不得回退。
 - 本地项目 ID、工作区 ID 和来源标识基于平台原生路径摘要生成，避免非 UTF-8 或非法 UTF-16 路径经有损转换后共享信任；Remote、Server 或组织项目必须提供自己的身份来源。
-- 信任文件按平台原生工作区路径摘要隔离并存放在用户运行数据目录。BitFun 进程的完整读改写使用同一文件锁；锁等待受操作期限约束，阻塞写入任务持锁直至替换与同步完成，调用 future 取消不能提前释放锁。写入使用同目录临时文件、大小上限、Windows 备份恢复和平台原子替换；提交前复核文件身份，替换完成但目录同步失败时明确报告“状态已写入但持久性不确定”。该锁只协调遵守同一锁文件的 BitFun 进程，不承诺阻止其他进程直接篡改用户信任文件；外部修改在后续读取时按文件身份或内容校验结果处理。文件重建时使用新的随机初始 epoch；扫描不完整时保留原记录但不返回 `SourceApproved`，也不允许写入新决定。
+- 信任文件按平台原生工作区路径摘要隔离并存放在用户运行数据目录。BitFun 进程的完整读改写使用同一文件锁；锁等待受操作期限约束，阻塞写入任务持锁直至替换与同步完成，调用 future 取消不能提前释放锁。写入使用同目录临时文件、大小上限、Windows 备份恢复和平台原子替换；提交前复核文件身份。激活后目录同步失败时返回持久性警告；停用后目录同步失败时返回错误，不能向用户声明已确定停用。该锁只协调遵守同一锁文件的 BitFun 进程，不承诺阻止其他进程直接篡改用户信任文件；外部修改在后续读取时按文件身份或内容校验结果处理。文件重建时使用新的随机初始 epoch；扫描不完整时保留原记录但不返回 `SourceApproved`，也不允许写入新决定。
 - 具体文件系统校验和信任持久化归 `services-integrations/plugin_source`，`bitfun-core/plugin_source` 只注入产品目录并保留兼容接口。
 - 产品路径初始化失败或全局路径管理器已降级到临时目录时，来源列表、审核和 `doctor` 必须返回错误，不得在临时目录中创建信任记录。
-- 产品域的 `SourceApproved` 只确认来源内容，不依赖 Host ABI，也不得直接映射为 Host 的 `Trusted`。P0-C.2 首次激活必须展示适配器、入口、能力和副作用并重新确认。
+- 产品域的 `SourceApproved` 只确认来源内容。CLI 激活预览展示适配器、入口、静态候选名称、高风险标记、权限要求和内容哈希；确认命令必须提交相同哈希。
 - 来源服务按包重新校验清单、声明文件和哈希，并返回固定内容的包输入。OpenCode 适配器不得根据包路径再次访问文件系统，也不得直接扫描工作区或用户 OpenCode 目录。
-- 来源服务只为当前 `SourceApproved` 的包返回固定内容输入；输入不携带来源审核状态或审核 epoch。适配器始终按未激活状态处理，当前只读 Host 链路不得产生 custom tool 候选。后续激活流程必须重新确认入口、能力和副作用，并独立定义 Host 信任及其 epoch。
+- 来源服务维护精确来源激活记录，并为每条新记录保存签发代次。内容变化、拒绝、撤销或停用会清除对应记录；重复写入相同状态不推进代次，其他包的状态变化不使当前记录失效。
+- 普通固定输入保持未激活，只返回来源和诊断。激活授权信息只包含项目、工作区、精确来源和激活代次，不复制包内容；产品组装点在 read 前以及 dispatch 前后向来源服务复核授权。
+- 当前只读取声明，无法判断 custom tool 的实际副作用，因此候选统一采用高风险级别；适配器不得根据工具名称降低风险。
+- 当前 Binding 使用 `PluginRuntimeEpochs.trust_epoch` 传递激活代次，适配器只用它校验激活作用域。来源审核代次不进入 Host；当前候选投影不消费项目状态和产品策略，因此 `project_epoch`、`policy_epoch` 为 `0`，`tool_registry_epoch` 为空。具体适配器工厂只允许由 `bitfun-core/plugin_runtime` 调用。
 - 单个来源服务实例串行生成固定内容输入；扫描和稳定性复核共享同一字节与时间预算，返回前再次确认信任 epoch、目标来源身份和 `SourceApproved` 状态。固定输入构造同时限制文件数量、单文件大小、包总量和声明文件集合。
+- OpenCode 声明解析限制单个来源最多 128 个 custom tool、单个受管包最多 256 个、单个工具标识 64 字节；`opencode.json` 最多声明 128 个 npm 插件且名称与元数据总量受限。超限包不进入候选构造。
 
 ```mermaid
 sequenceDiagram
-  participant Assembly as 产品组装
+  participant CLI as CLI
+  participant Assembly as 核心激活接口
   participant Source as 受管包来源服务
   participant Adapter as OpenCode 适配器
   participant Host as 插件运行时主机
 
-  Assembly->>Source: 读取指定包
-  Source->>Source: 重新校验清单、文件边界与哈希
-  Source-->>Assembly: 固定内容的包输入
-  Assembly->>Adapter: 创建只读适配器
+  CLI->>Assembly: 预览指定包
+  Assembly->>Source: 读取并重新校验固定内容
+  Assembly->>Adapter: 创建未激活适配器
   Assembly->>Host: PluginRuntimeHost::new(adapter)
-  Host->>Adapter: read / dispatch
-  Adapter-->>Host: 来源、诊断和未激活状态
-  Note over Adapter,Host: 不执行 JS/TS，不产生工具候选
+  Host-->>Assembly: 入口、诊断和支持状态
+  Assembly-->>CLI: 内容哈希与激活预览
+  CLI->>Assembly: 使用精确内容哈希确认
+  Assembly->>Source: 原子校验并写入激活记录
+  Source-->>Assembly: 固定内容与激活授权信息
+  Assembly->>Adapter: 创建激活适配器
+  Assembly->>Host: read / dispatch
+  Host-->>Assembly: 需要权限的 custom tool 候选
+  Note over Adapter,Host: 不执行 JS/TS，不注册或执行工具
 ```
 
 ## 7. 验证要求
@@ -208,10 +218,9 @@ sequenceDiagram
 - `cargo test -p bitfun-plugin-runtime-host`
 - `cargo test -p bitfun-product-domains --test plugin_source_contracts --features plugin-source`
 - `cargo test -p bitfun-services-integrations --no-default-features --features plugin-source plugin_source --lib`
-- `cargo test -p bitfun-cli --test plugin_source_cli`，在隔离用户目录和临时工作区验证真实 `list/approve-source/deny/revoke/doctor` 生命周期与退出码。
-- `cargo test -p bitfun-opencode-adapter --test opencode_source_adapter`，证明 OpenCode 输入可通过 Host adapter 转换为 BitFun 来源只读视图和诊断只读视图；未建立信任的来源只返回诊断和只读状态，不进入工具候选链路。
-- `cargo test -p bitfun-opencode-adapter p0_c2_fixture` 保护可信源 custom tool 到 `PluginEffectCandidatePayload::ProviderCandidate` 的候选映射、权限提示和工具 ABI 标识。
-- `cargo test -p bitfun-opencode-adapter host_path_projects_trusted_custom_tool_candidate_with_permission_prompt` 保护可信 custom tool 候选在 `PluginRuntimeHost` dispatch 路径下仍通过权限门禁和响应契约校验。
+- `cargo test -p bitfun-cli --test plugin_source_cli`，验证 `list/approve-source/activate/deactivate/deny/revoke/doctor`，以及过期内容哈希不得激活。
+- `cargo test -p bitfun-opencode-adapter --test opencode_source_adapter`，验证普通输入仅返回只读状态，激活输入产生权限候选，错误作用域或旧代次不触发永久隔离。
+- `cargo test -p bitfun-core plugin_runtime::tests --lib`，验证唯一产品组装点、无支持能力时不写入激活，以及停用或内容变化使既有 Binding 失效。
 - `node scripts/check-core-boundaries.mjs`
 
 PR 审查重点：

--- a/docs/architecture/product-architecture.md
+++ b/docs/architecture/product-architecture.md
@@ -130,30 +130,30 @@ flowchart TB
 
 P0 的目标不是复制完整 OpenCode 运行时，也不是导入用户已有 OpenCode 安装。P0 只验证一条 BitFun 主导的 OpenCode-compatible 插件路径。
 
-P0-C.1 已建立包识别、完整性校验、工作区信任和 CLI 诊断，不执行插件：
+P0-C.1 已建立包识别、完整性校验、工作区来源审核和 CLI 诊断。P0-C.2 在此基础上增加工作区激活与 custom tool 候选读取：
 
 1. 用户级包和项目级包只从 BitFun 受管目录发现；工作区同 ID 来源优先且不得回退到用户级包。
 2. `bitfun.plugin.json` 只定义生态无关的包来源标识、适配器标识和文件哈希；具体生态入口由对应适配器解释。
-3. `bitfun-cli plugins` 提供来源审核和诊断；`SourceApproved` 只确认当前来源内容，不表示能力已批准、已启用或可执行，完整性错误由 `bitfun-cli doctor` 返回失败。
-4. 来源接口尚未绑定生产插件主机，不执行 JS/TS，不注册最终工具。目录、清单和持久化规则见 [`plugin-runtime-host-design.md`](plugin-runtime-host-design.md#6-目录与来源原则)。
+3. `SourceApproved` 只确认当前来源内容。`plugins activate` 先展示适配器、入口、静态候选名称、高风险标记、权限要求和内容哈希；激活命令必须提交该哈希，内容变化时拒绝激活。
+4. 产品组装根按工作区和包临时组合 OpenCode 适配器、插件运行时主机与 `PluginRuntimeBinding`，只读取受权限保护的 custom tool 候选。不执行 JS/TS，不注册或执行最终工具。
 
-归属边界：`product-domains/plugin_source` 定义纯数据和信任规则，`services-integrations/plugin_source` 负责文件系统校验、锁和持久化，`bitfun-core/plugin_source` 仅注入产品目录并保留 CLI 兼容接口。
+归属边界：`product-domains/plugin_source` 定义来源审核与激活规则，`services-integrations/plugin_source` 负责校验、锁、持久化和实时激活校验，`bitfun-core/plugin_runtime` 是唯一生态适配组装点。CLI 只消费核心提供的激活视图。
 
 ```mermaid
 flowchart LR
   UserRoot["用户级 BitFun 插件目录"] --> Discovery["包发现与完整性校验"]
   WorkspaceRoot["项目级 .bitfun/plugins"] --> Discovery
   Manifest["bitfun.plugin.json"] --> Discovery
-  Discovery --> SourceView["来源与诊断接口"]
-  Trust["工作区信任存储"] --> SourceView
-  CLI["CLI 插件管理与 doctor"] --> SourceView
-  CLI --> Trust
-  SourceView -->|按包重新校验| PackageInput["不可变包输入"]
-  PackageInput --> Adapter["OpenCode 适配器"]
-  Assembly["产品组装根"] -->|创建| Adapter
-  Adapter -->|注入| Host["插件运行时主机"]
-  Host -->|封装 client| RuntimeBinding["PluginRuntimeBinding"]
-  RuntimeBinding --> AgentRuntime["Agent Runtime"]
+  Discovery --> SourceService["来源与激活服务"]
+  State["工作区审核与激活存储"] --> SourceService
+  CLI["CLI 插件管理与 doctor"] --> ProductAPI["核心激活接口"]
+  ProductAPI --> SourceService
+  SourceService -->|固定内容与激活授权信息| Assembly["plugin_runtime 组装点"]
+  Assembly --> Adapter["OpenCode 适配器"]
+  Adapter --> Host["插件运行时主机"]
+  Host --> Binding["PluginRuntimeBinding"]
+  Binding --> CandidateView["候选与诊断视图"]
+  CandidateView --> ProductAPI
 ```
 
 当前实现与后续能力边界：
@@ -163,19 +163,21 @@ flowchart LR
 | 用户级、项目级包 | 从两个 BitFun 受管目录发现并校验 | 安装复制、更新、卸载和组织策略 |
 | 随产品携带包 | 未建立独立扫描根 | 由构建配置、安装器和产品组装提供来源后接入同一校验接口 |
 | OpenCode 兼容内容 | 包清单可声明 `opencode_compatible`；来源模块重新校验并固定声明文件，适配器只解释该输入 | 外部目录需经独立导入流程转换为受管包 |
-| 来源审核 | 工作区 `SourceApproved`、`Denied`、`Revoked`；内容变化使旧审核失效，新来源标识回到 `Unknown` | 首次激活能力审核、组织策略、签名和撤销列表 |
-| 插件运行 | 不执行 JS/TS，不注册最终工具 | 产品组装创建适配器和 Host，再通过 `PluginRuntimeBinding` 注入 Agent Runtime |
+| 来源审核 | 工作区 `SourceApproved`、`Denied`、`Revoked`；内容变化使旧审核与激活失效 | 组织策略、签名和撤销列表 |
+| 激活 | 预览后按精确内容哈希确认；激活代次与来源审核代次独立；停用或内容变化立即使既有 Binding 失效 | GUI/Web 管理入口、组织策略，以及包缺失或损坏后的显式记录清理体验 |
+| 插件运行 | 只通过 Host 读取 custom tool 候选；候选始终需要权限；不执行 JS/TS，不注册最终工具 | 接入工具快照、权限裁决和最终工具提供方 |
 
 OpenCode 适配接入规则：
 
 - OpenCode 适配器的公开入口只接收来源服务重新校验并固定的受管包输入，不直接扫描工作区或用户 OpenCode 目录。
-- 来源服务只为当前 `SourceApproved` 的包生成固定内容输入；输入只包含来源标识、清单和声明文件内容，不把来源审核状态或审核 epoch 传入 Host。
+- 来源服务只为当前 `SourceApproved` 的包生成固定内容输入。每条激活记录保存自己的签发代次；激活授权信息只包含项目、工作区、精确来源和该代次，包内容不在授权信息中重复保存，其他包的状态变化不会使当前授权失效。
 - 固定内容输入只保证结构、大小和哈希自洽，不作为审核凭据。生产组装必须从来源服务取得输入；即使其他进程内调用方构造了有效输入，适配器仍只能返回未激活状态。
 - Host 来源 URI 使用来源模块生成的路径摘要区分用户级包、项目级包和后续其他来源，不暴露原始本地路径。
-- OpenCode 适配器始终按未激活状态处理该输入，只能暴露来源只读视图和诊断；激活确认产生独立的 Host 信任后，才允许映射 custom tool 候选。
-- 当前源码探测只识别经过测试的单行声明形式，不是完整 JS/TS 解析器；空包或没有任何受支持入口的包必须返回诊断，其他 JS/TS 语法不属于本阶段兼容范围。
+- 普通包输入只能产生来源与诊断视图。只有产品组装点持有来源服务生成的当前激活授权信息时，适配器才将受支持 custom tool 映射为权限候选。
+- 当前源码探测只识别经过测试的单行声明形式，不是完整 JS/TS 解析器；注释中的声明不参与识别，重复工具 id 按歧义输入拒绝。空包或没有任何受支持入口的包必须返回诊断，其他 JS/TS 语法不属于本阶段兼容范围。
+- 声明读取不能推断工具的文件、网络、进程或凭据副作用，因此当前 custom tool 候选统一标记为高风险；精确风险只能由后续真实工具接口和权限策略确定。
 - 未支持或信任不足的能力必须返回诊断或 `unsupported` 状态，不得因外部插件内容导致运行时崩溃。
-- 后续生产接入由唯一的产品组装根调用具体适配器工厂，将适配器注入 Host，再把 Host client 封装为 `PluginRuntimeBinding`；同一变更必须同步边界脚本、主机路径测试和启用/降级策略。
+- `bitfun-core/plugin_runtime` 是唯一允许调用具体适配器工厂的生产组装点。它在 read 前以及 dispatch 前后重新校验激活授权，产品入口不得直接构造适配器或 Host。
 - GUI、TUI/CLI、Web 等产品入口只消费能力服务接口、插件只读视图、诊断和稳定状态词，不直接依赖 OpenCode 适配器内部类型或插件主机内部 ABI。
 
 信任 epoch 与生命周期：
@@ -183,7 +185,8 @@ OpenCode 适配接入规则：
 - 来源审核 epoch 由 BitFun 来源与信任模块维护。审核、拒绝、撤销、已有记录的来源标识或哈希变化都会推进 epoch；重复写入相同决定不推进 epoch。信任文件重建时使用新的随机初始值，避免旧 epoch 被重复使用。
 - 发现的新来源默认为 `Unknown`；CLI 只允许对当前工作区已发现且 id 唯一的包写入 `SourceApproved`、`Denied` 或 `Revoked`。
 - 损坏、版本未知或记录冲突的信任文件按失败处理；适配器和主机不得写信任状态。
-- `SourceApproved` 不得直接映射为 Host 的 `Trusted`。来源审核 epoch 只属于来源存储；P0-C.2 首次激活必须展示适配器、入口、能力和副作用，并由激活归属模块定义独立的 Host 信任及其 epoch。
+- `SourceApproved` 不直接映射为 Host 的 `Trusted`。来源审核代次只用于来源存储；每条激活记录的签发代次写入当前 Binding 的 `trust_epoch` 字段，只用于校验该包的激活有效性。该字段不承载来源审核代次。
+- 当前链路只读取声明并生成权限候选，不消费项目状态或产品策略快照，因此 `project_epoch`、`policy_epoch` 固定为 `0`，`tool_registry_epoch` 为空。后续只有在接入相应状态时，才由其归属模块提供实际代次。
 - `ProjectionOnly` 在候选路径中表示插件代码没有被执行、最终效果没有提交；它允许主机返回受权限门禁保护的候选项和诊断，不表示插件运行时已经可执行。
 
 OpenCode 能力映射：
@@ -245,8 +248,8 @@ Product Profile、Delivery Profile、Runtime Configuration 和 Capability Availa
 
 | 产品形态 | P0 插件策略 | 入口行为 |
 |---|---|---|
-| Desktop / product-full | 当前仅保留插件主机基础边界，尚未绑定受管包来源 | 生产绑定完成前不得把来源审核通过的包显示为已启用或可执行 |
-| CLI | 提供受管包来源审核和诊断入口，不启动插件主机 | `plugins list` 显示两个扫描根、适配器、来源、hash、审核状态和执行不可用；`doctor` 对完整性错误返回失败 |
+| Desktop / product-full | 提供受管包来源、激活和候选投影的组装能力 | 当前没有插件管理界面，也不把候选显示为已注册或可执行工具 |
+| CLI | 提供来源审核、激活预览、精确哈希确认和停用；按需组装仅用于候选投影的 Host/Binding | 不执行插件代码、不注册最终工具；`doctor` 对完整性错误返回失败 |
 | ACP | `status-only`、`projection-only`、`unsupported`、`policy-denied` 或 `quarantined` | 不把插件失败解释为 agent 失败，不接入 P0 副作用闭环 |
 | Server / Remote | `projection-only`、`temporarily-unavailable`、`unsupported` 或 `policy-denied` | 不自动启动本地 JS/TS 运行时；远端执行域需 P0+ 单独设计 |
 | Web / Mobile Web | 只消费后端能力服务接口和只读视图 | 不持有插件执行单元，不直接加载插件代码 |

--- a/docs/plans/core-decomposition-plan.md
+++ b/docs/plans/core-decomposition-plan.md
@@ -23,8 +23,8 @@
 - 工具 ABI、事件清单、运行时服务、智能体运行时、产品能力和插件 `disabled` / `projection-only` 基础边界已存在。
 - `runtime-ports` 的插件主机 ABI 已有公开接口预算脚本；后续不能绕过预算新增插件、hook、event、UI 或生态兼容对象。
 - `opencode-adapter` 当前解释固定内容的受管包，提供诊断只读视图和 custom tool 候选映射；来源发现归 `services-integrations/plugin_source`。
-- `services-integrations/plugin_source` 已提供受管包发现、完整性校验和工作区信任持久化；`bitfun-core/plugin_source` 仅保留路径注入与 CLI 兼容接口。该接口尚未绑定生产 Plugin Runtime Host。
-- 当前阶段先完成受管包到 Plugin Runtime Host 的只读链路；后续再完成激活确认和工具 ABI 消费，不执行无约束 JS/TS，也不依赖外部 OpenCode CLI。
+- `services-integrations/plugin_source` 提供受管包发现、完整性校验、来源审核、激活持久化和实时凭证复核；`bitfun-core/plugin_runtime` 是唯一 OpenCode 生产组装点。
+- CLI 已能预览、按精确内容哈希激活和停用包。激活路径只通过 Plugin Runtime Host 返回需要权限的 custom tool 候选，不执行 JS/TS，也不依赖外部 OpenCode CLI。
 
 ## 3. 当前差距
 
@@ -32,7 +32,8 @@
 |---|---|---|
 | 接口切面仍易混用 | 前后端线缆、插件扩展、host ABI 和生态适配容易互相穿透 | 以主架构文档的四个接口切面作为唯一口径，详细设计只补充归属和验证 |
 | 公开接口预算只覆盖部分源码 | 可以继续在文档或代码中声明无消费方对象 | 扩展公开接口预算元数据，要求每个插件公开符号声明接口切面、消费方和退场条件 |
-| 来源与主机仍未生产组装 | 受信任包仍不能形成可执行 custom tool | P0-C.2 只接入一个真实候选消费路径，并复用现有工具 ABI 和权限门禁 |
+| 候选尚未进入最终工具快照 | 已激活包只能检查候选，不能形成可调用工具 | 后续 PR 复用现有工具 ABI 和权限门禁接入一个最终工具提供方，不扩展插件专用 ABI |
+| 激活写入在跨进程锁内执行稳定性复核 | 操作受统一期限约束，超时后失败关闭；慢文件系统可能延长同一工作区的授权检查等待 | 后续 PR 采用锁外扫描、锁内代次与来源身份复核的两阶段事务，并以并发变更测试证明不引入 TOCTOU |
 | OpenCode 适配容易反向定义 BitFun | 可能形成 OpenCode 专用产品入口或内部模型 | OpenCode 只作为兼容适配输入，输出 BitFun 来源、诊断、候选项或 unsupported |
 | 部分 core / product-full 路径仍偏宽 | 新入口可能继续依赖旧大门面 | 只迁移与插件主线或关键产品路径直接相关的归属模块，并同步删除或显著简化旧路径 |
 
@@ -93,18 +94,17 @@
 - `cargo test -p bitfun-cli --test plugin_source_cli`
 - 不要求用户安装 OpenCode CLI。
 - 不扫描或回写用户 OpenCode 配置目录，不执行 JS/TS。
-- `SourceApproved` 不得直接映射为 Host 的 `Trusted`；P0-C.2 首次激活需展示适配器、入口、能力和副作用并重新确认。
+- `SourceApproved` 不得直接映射为 Host 的 `Trusted`；首次激活需展示入口、支持状态、权限要求和内容哈希，并使用该哈希确认。
 
 未包含在 P0-C.1 的工作：安装复制、更新、卸载、随产品携带包、组织或 registry 来源、签名、外部 OpenCode 目录导入、生产 Host 绑定。以上能力必须由对应产品流程提供真实消费方后分别接入。
 
 ### 阶段 P0-C.2：OpenCode custom tool 最小候选链路
 
+状态：本 PR 完成。
+
 目标：证明一个 OpenCode-compatible custom tool 可以映射为 BitFun 工具候选；是否进入最终工具链路，仍由工具 ABI、权限门禁和归属模块决定。
 
-执行顺序：
-
-1. 先完成受管包到 OpenCode 适配器的固定输入链路。来源服务按包重新校验声明文件，适配器公开入口不再扫描工作区目录；`SourceApproved` 只返回未激活状态和诊断。
-2. 再由独立 PR 完成激活确认、Host 信任和产品组装。该步骤完成前不得生成 custom tool 候选或宣称插件可执行。
+实现路径：来源服务重新校验固定输入；CLI 预览后以精确内容哈希确认；来源服务原子写入独立激活记录；唯一产品组装点创建适配器、Host 与 Binding，并在 read 前以及 dispatch 前后复核激活授权。
 
 范围：
 
@@ -119,7 +119,7 @@
 - 生成最终工具或执行任何工具前，必须继续经过工具快照、权限门禁和归属模块；OpenCode adapter 内不得执行工具。
 - 不新增插件专用工具 ABI。
 - Desktop / CLI 产品入口只消费能力服务接口、插件只读视图、诊断和稳定状态词，不直接依赖 OpenCode adapter。
-- 后续生产接入由唯一产品组装根创建适配器和插件运行时主机，再将 Host client 封装为 `PluginRuntimeBinding`，并同步边界脚本、主机路径测试和启用/降级策略。
+- 唯一产品组装根创建适配器和插件运行时主机，再将 Host client 封装为 `PluginRuntimeBinding`；边界脚本禁止其他生产模块直接依赖 OpenCode adapter。
 
 ## 5. 后端复杂度整改清单
 
@@ -150,7 +150,7 @@
 | 插件公开接口预算 | `node --test scripts/check-core-boundaries.test.mjs`，`node scripts/check-core-boundaries.mjs` |
 | 插件运行时主机 ABI | `cargo test -p bitfun-runtime-ports --test plugin_runtime_contracts`，`cargo test -p bitfun-runtime-ports --test plugin_runtime_host_contracts`，`cargo test -p bitfun-plugin-runtime-host` |
 | OpenCode P0-C.1 受管包来源与信任 | `cargo test -p bitfun-product-domains --test plugin_source_contracts --features plugin-source`，`cargo test -p bitfun-services-integrations --no-default-features --features plugin-source plugin_source --lib`，`cargo test -p bitfun-cli --test plugin_source_cli` |
-| OpenCode P0-C.2 custom tool 候选映射 | `cargo test -p bitfun-opencode-adapter p0_c2_fixture`，`cargo test -p bitfun-opencode-adapter host_path_projects_trusted_custom_tool_candidate_with_permission_prompt` |
+| OpenCode P0-C.2 激活与 custom tool 候选 | `cargo test -p bitfun-opencode-adapter --test opencode_source_adapter`，`cargo test -p bitfun-core plugin_runtime::tests --lib`，`cargo test -p bitfun-cli --test plugin_source_cli` |
 | 产品形态 / SDK 最小可用性 | `cargo test -p bitfun-product-capabilities --test plugin_product_shape`，`cargo test -p bitfun-product-capabilities --test product_sdk_assembly`，`cargo metadata --no-deps --format-version 1` |
 | 大范围归属迁移 | `cargo check --workspace`，必要时补 focused test |
 

--- a/scripts/core-boundaries/rules/crate-rules.mjs
+++ b/scripts/core-boundaries/rules/crate-rules.mjs
@@ -29,11 +29,14 @@ export const forbiddenManifestDependencyRules = [
     dependencyNames: ['bitfun-opencode-adapter'],
     scanRoots: ['src/apps', 'src/crates', 'BitFun-Installer/src-tauri'],
     workspaceManifestPath: 'Cargo.toml',
-    allowManifestPaths: ['src/crates/adapters/opencode-adapter/Cargo.toml'],
+    allowManifestPaths: [
+      'src/crates/adapters/opencode-adapter/Cargo.toml',
+      'src/crates/assembly/core/Cargo.toml',
+    ],
     reason:
-      'OpenCode adapter must not become a production dependency before reviewed product source wiring',
+      'OpenCode adapter production dependencies are limited to the reviewed product composition root',
     message:
-      'production manifests must not depend on bitfun-opencode-adapter; integrate OpenCode through the Plugin Runtime Host boundary',
+      'only bitfun-core product-full assembly may inject bitfun-opencode-adapter through the Plugin Runtime Host boundary',
   },
 ];
 

--- a/scripts/core-boundaries/rules/source/forbidden-rules.mjs
+++ b/scripts/core-boundaries/rules/source/forbidden-rules.mjs
@@ -28,11 +28,11 @@ export const forbiddenContentRules = [
   {
     path: 'src/crates/services/services-integrations/src/plugin_source.rs',
     reason:
-      'managed plugin source service method surface must stay limited to construction, refresh, trust review, and one selected-package read',
+      'managed plugin source service method surface must stay limited to source review and activation authority',
     patterns: [
       {
         regex:
-          /\bpub\s+(?:async\s+)?fn\s+(?!(?:new|refresh|set_trust|load_package)\b)[A-Za-z_][A-Za-z0-9_]*\b/,
+          /\bpub\s+(?:async\s+)?fn\s+(?!(?:new|refresh|set_trust|load_package|set_activation|load_activated_package|has_activation_authority)\b)[A-Za-z_][A-Za-z0-9_]*\b/,
         message:
           'unexpected public ManagedPluginSourceService method; update the reviewed method budget before exposing more API',
       },
@@ -41,11 +41,11 @@ export const forbiddenContentRules = [
   {
     path: 'src/crates/contracts/product-domains/src/plugin_source.rs',
     reason:
-      'plugin source contract methods must stay limited to manifest validation and source review transitions',
+      'plugin source contract methods must stay limited to manifest validation, source review, and activation authority',
     patterns: [
       {
         regex:
-          /\bpub\s+(?:const\s+)?fn\s+(?!(?:parse_json|validate|content_hash|new|into_parts|epoch|trust_level_for|apply_decision|reconcile_sources)\b)[A-Za-z_][A-Za-z0-9_]*\b/,
+          /\bpub\s+(?:const\s+)?fn\s+(?!(?:parse_json|validate|content_hash|new|into_parts|epoch|activation_epoch|trust_level_for|apply_decision|reconcile_sources|is_activated|activation_authority|is_activation_current|set_activation)\b)[A-Za-z_][A-Za-z0-9_]*\b/,
         message:
           'unexpected public plugin source contract method; update the reviewed method budget before exposing more API',
       },
@@ -4123,12 +4123,15 @@ export const forbiddenContentUnderRules = [
   {
     path: 'src',
     reason:
-      'OpenCode adapter must not become a production dependency before reviewed composition-root wiring',
+      'OpenCode adapter production imports are limited to the reviewed composition root',
     patterns: [
       {
         regex:
           /\b(?:use\s+bitfun_opencode_adapter\b|extern\s+crate\s+bitfun_opencode_adapter\b|bitfun_opencode_adapter::)/,
-        allowPaths: ['src/crates/adapters/opencode-adapter/tests/opencode_source_adapter.rs'],
+        allowPaths: [
+          'src/crates/adapters/opencode-adapter/tests/opencode_source_adapter.rs',
+          'src/crates/assembly/core/src/plugin_runtime.rs',
+        ],
         message:
           'only a reviewed product composition root may import bitfun-opencode-adapter and inject it into Plugin Runtime Host',
       },
@@ -4137,7 +4140,7 @@ export const forbiddenContentUnderRules = [
   {
     path: 'BitFun-Installer/src-tauri',
     reason:
-      'OpenCode adapter must not become a production dependency before reviewed composition-root wiring',
+      'OpenCode adapter production imports are limited to the reviewed composition root',
     patterns: [
       {
         regex:

--- a/scripts/core-boundaries/rules/source/public-api-rules.mjs
+++ b/scripts/core-boundaries/rules/source/public-api-rules.mjs
@@ -170,7 +170,7 @@ function opencodeAdapterEntry(symbol, consumer) {
 export const opencodeAdapterPublicApiEntries = [
   opencodeAdapterEntry(
     'load_opencode_package_adapter',
-    'managed package source service to PluginRuntimeHost integration tests; production Product Assembly binding is out of scope for this PR',
+    'bitfun-core managed plugin composition root and PluginRuntimeHost integration tests',
   ),
 ];
 
@@ -199,6 +199,7 @@ export const pluginSourceContractPublicApiEntries = [
   'PluginTrustDecision',
   'PluginTrustStore',
   'PluginSourceContractError',
+  'PluginActivationAuthority',
 ].map((symbol) =>
   pluginSourceEntry(
     symbol,
@@ -224,6 +225,21 @@ export const managedPluginSourcePublicApiEntries = [
     'bitfun-core managed plugin source compatibility facade',
     'bitfun-cli plugins and doctor commands',
     'services-integrations plugin_source tests, core boundary checks, and bitfun-cli plugin command tests',
+    false,
+  ),
+);
+
+export const managedPluginActivationPublicApiEntries = [
+  'ManagedPluginCandidateView',
+  'ManagedPluginActivationView',
+  'preview_managed_plugin_activation',
+  'set_managed_plugin_activation',
+].map((symbol) =>
+  pluginSourceEntry(
+    symbol,
+    'bitfun-core managed plugin composition root',
+    'bitfun-cli plugin activation commands',
+    'bitfun-core plugin_runtime tests, bitfun-cli plugin source tests, and core boundary checks',
     false,
   ),
 );
@@ -288,5 +304,11 @@ export const publicApiAllowlistRules = [
     reason:
       'core managed plugin source compatibility API must stay limited to the current CLI consumer surface',
     allowedSymbolEntries: managedPluginSourcePublicApiEntries,
+  },
+  {
+    path: 'src/crates/assembly/core/src/plugin_runtime.rs',
+    reason:
+      'core managed plugin activation API must stay limited to product status projection and one state transition',
+    allowedSymbolEntries: managedPluginActivationPublicApiEntries,
   },
 ];

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -858,6 +858,9 @@ export function runManifestParserSelfTest({
   const opencodeAdapterPublicApiRule = publicApiAllowlistRules.find(
     (rule) => rule.path === 'src/crates/adapters/opencode-adapter/src/lib.rs',
   );
+  const managedPluginActivationPublicApiRule = publicApiAllowlistRules.find(
+    (rule) => rule.path === 'src/crates/assembly/core/src/plugin_runtime.rs',
+  );
   const parsedPluginReexports = collectPluginRootReexports(`
     pub use plugin::{PluginDispatchEnvelope, PluginResponseEnvelope};
     pub use self::plugin::{
@@ -958,7 +961,7 @@ export function runManifestParserSelfTest({
     opencodeAdapterPublicApiSymbols.join(',') !==
     'load_opencode_package_adapter'
   ) {
-    throw new Error('OpenCode adapter public API budget must stay limited to source adapter loading');
+    throw new Error('OpenCode adapter public API budget must stay limited to one reviewed factory');
   }
   for (const entry of opencodeAdapterPublicApiRule.allowedSymbolEntries) {
     for (const field of ['owner', 'consumer', 'verification', 'p0', 'contractSlice', 'rationale', 'exit']) {
@@ -972,6 +975,14 @@ export function runManifestParserSelfTest({
     if (entry.wireImpact !== false) {
       throw new Error(`OpenCode adapter public API entry must not claim wire impact: ${entry.symbol}`);
     }
+  }
+  if (
+    (managedPluginActivationPublicApiRule?.allowedSymbolEntries || [])
+      .map((entry) => entry.symbol)
+      .join(',') !==
+    'ManagedPluginCandidateView,ManagedPluginActivationView,preview_managed_plugin_activation,set_managed_plugin_activation'
+  ) {
+    throw new Error('managed plugin activation API budget must stay limited to four product-facing symbols');
   }
   const appHostAbiRule = forbiddenContentUnderRules.find((rule) => rule.path === 'src/apps');
   if (!appHostAbiRule) {
@@ -1011,8 +1022,15 @@ export function runManifestParserSelfTest({
   ) {
     throw new Error('OpenCode adapter manifest guard must allow its own manifest');
   }
+  if (
+    !opencodeManifestRule.allowManifestPaths?.includes(
+      'src/crates/assembly/core/Cargo.toml',
+    )
+  ) {
+    throw new Error('OpenCode adapter manifest guard must allow the reviewed core composition root');
+  }
   const opencodeSourceRules = forbiddenContentUnderRules.filter((rule) =>
-    rule.reason.includes('OpenCode adapter must not become a production dependency'),
+    rule.reason.includes('OpenCode adapter production imports are limited'),
   );
   for (const scanRoot of ['src', 'BitFun-Installer/src-tauri']) {
     if (!opencodeSourceRules.some((rule) => rule.path === scanRoot)) {
@@ -1026,6 +1044,13 @@ export function runManifestParserSelfTest({
     !opencodeSourceRegex?.test('bitfun_opencode_adapter::OpenCodePluginAdapter')
   ) {
     throw new Error('OpenCode adapter source guard must catch direct, alias, and extern imports');
+  }
+  if (
+    !opencodeSourceRules
+      .find((rule) => rule.path === 'src')
+      ?.patterns?.[0]?.allowPaths?.includes('src/crates/assembly/core/src/plugin_runtime.rs')
+  ) {
+    throw new Error('OpenCode adapter source guard must allow only the reviewed core composition file');
   }
   const runtimeServicesRule = lightweightBoundaryRules.find(
     (rule) => rule.crateName === 'runtime-services',

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -220,6 +220,15 @@ enum PluginAction {
     Deny { package_id: String },
     /// Revoke the current package approval for this workspace
     Revoke { package_id: String },
+    /// Preview or confirm activation of one source-approved package
+    Activate {
+        package_id: String,
+        /// Confirm the exact content hash displayed by the activation preview
+        #[arg(long, value_name = "CONTENT_HASH")]
+        confirm: Option<String>,
+    },
+    /// Deactivate one package for this workspace
+    Deactivate { package_id: String },
 }
 
 #[derive(Subcommand)]
@@ -667,6 +676,15 @@ async fn run_cli() -> Result<()> {
                 )
                 .await?;
             }
+            Some(PluginAction::Activate {
+                package_id,
+                confirm,
+            }) => {
+                management::activate_plugin(&package_id, confirm.as_deref()).await?;
+            }
+            Some(PluginAction::Deactivate { package_id }) => {
+                management::deactivate_plugin(&package_id).await?;
+            }
         },
 
         Some(Commands::Usage { session_id }) => {
@@ -847,6 +865,46 @@ mod plugin_command_tests {
             revoke.command,
             Some(Commands::Plugins {
                 action: Some(PluginAction::Revoke { package_id })
+            }) if package_id == "acme.demo"
+        ));
+
+        let preview = Cli::try_parse_from(["bitfun-cli", "plugins", "activate", "acme.demo"])
+            .expect("parse plugin activation preview");
+        assert!(matches!(
+            preview.command,
+            Some(Commands::Plugins {
+                action: Some(PluginAction::Activate {
+                    package_id,
+                    confirm: None,
+                })
+            }) if package_id == "acme.demo"
+        ));
+
+        let confirm = Cli::try_parse_from([
+            "bitfun-cli",
+            "plugins",
+            "activate",
+            "acme.demo",
+            "--confirm",
+            "sha256:previewed",
+        ])
+        .expect("parse confirmed plugin activation");
+        assert!(matches!(
+            confirm.command,
+            Some(Commands::Plugins {
+                action: Some(PluginAction::Activate {
+                    package_id,
+                    confirm: Some(content_hash),
+                })
+            }) if package_id == "acme.demo" && content_hash == "sha256:previewed"
+        ));
+
+        let deactivate = Cli::try_parse_from(["bitfun-cli", "plugins", "deactivate", "acme.demo"])
+            .expect("parse plugin deactivation");
+        assert!(matches!(
+            deactivate.command,
+            Some(Commands::Plugins {
+                action: Some(PluginAction::Deactivate { package_id })
             }) if package_id == "acme.demo"
         ));
     }

--- a/src/apps/cli/src/management.rs
+++ b/src/apps/cli/src/management.rs
@@ -5,6 +5,9 @@ use std::time::Duration;
 use bitfun_core::agentic::get_agent_registry;
 use bitfun_core::agentic::persistence::PersistenceManager;
 use bitfun_core::infrastructure::try_get_path_manager_arc;
+use bitfun_core::plugin_runtime::{
+    preview_managed_plugin_activation, set_managed_plugin_activation, ManagedPluginActivationView,
+};
 use bitfun_core::plugin_source::{
     refresh_managed_plugin_sources, set_managed_plugin_trust, ManagedPluginSourceSnapshot,
     ManagedPluginTrustDecision, ManagedPluginTrustLevel,
@@ -322,6 +325,126 @@ pub(crate) async fn set_plugin_trust(
     Ok(())
 }
 
+pub(crate) async fn activate_plugin(package_id: &str, confirm: Option<&str>) -> Result<()> {
+    let workspace = std::env::current_dir().context("Failed to resolve current directory")?;
+    let view = if let Some(content_hash) = confirm {
+        set_managed_plugin_activation(&workspace, package_id, true, Some(content_hash)).await
+    } else {
+        preview_managed_plugin_activation(&workspace, package_id).await
+    }
+    .map_err(|error| {
+        let diagnostic = crate::plugin_diagnostics::escape_terminal_text(&error.to_string());
+        if confirm.is_some() {
+            anyhow!(
+                "{}\nRe-run `bitfun-cli plugins activate {}` to preview the current content, then confirm with the new content hash.",
+                diagnostic,
+                crate::plugin_diagnostics::escape_terminal_text(package_id)
+            )
+        } else {
+            anyhow!(diagnostic)
+        }
+    })?;
+
+    print_plugin_activation(&view, confirm.is_none());
+    if confirm.is_none() {
+        println!();
+        println!(
+            "No activation state changed. Re-run `bitfun-cli plugins activate {} --confirm {}` to confirm this exact package content.",
+            crate::plugin_diagnostics::escape_terminal_text(package_id),
+            crate::plugin_diagnostics::escape_terminal_text(&view.content_hash)
+        );
+    }
+    Ok(())
+}
+
+pub(crate) async fn deactivate_plugin(package_id: &str) -> Result<()> {
+    let workspace = std::env::current_dir().context("Failed to resolve current directory")?;
+    let view = set_managed_plugin_activation(&workspace, package_id, false, None)
+        .await
+        .map_err(|error| {
+            anyhow!(crate::plugin_diagnostics::escape_terminal_text(
+                &error.to_string()
+            ))
+        })?;
+    println!(
+        "Plugin package {} is inactive.",
+        crate::plugin_diagnostics::escape_terminal_text(&view.package_id)
+    );
+    for diagnostic in &view.diagnostics {
+        println!(
+            "- [warning] {}",
+            crate::plugin_diagnostics::escape_terminal_text(diagnostic)
+        );
+    }
+    println!("No plugin code or candidate effect was executed.");
+    Ok(())
+}
+
+fn print_plugin_activation(view: &ManagedPluginActivationView, preview: bool) {
+    println!(
+        "Plugin activation {}",
+        if preview { "preview" } else { "result" }
+    );
+    println!();
+    println!(
+        "Package: {} {}",
+        crate::plugin_diagnostics::escape_terminal_text(&view.package_id),
+        crate::plugin_diagnostics::escape_terminal_text(&view.version)
+    );
+    println!(
+        "Adapter: {}",
+        crate::plugin_diagnostics::escape_terminal_text(&view.adapter)
+    );
+    println!("Content hash: {}", view.content_hash);
+    println!(
+        "Custom tool candidates: {}",
+        if view.provider_candidates_supported {
+            "supported"
+        } else {
+            "not found"
+        }
+    );
+    println!(
+        "Permission required before use: {}",
+        if view.permission_required {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+    println!("Entries: {}", view.entry_ids.len());
+    for entry_id in &view.entry_ids {
+        println!(
+            "- {}",
+            crate::plugin_diagnostics::escape_terminal_text(entry_id)
+        );
+    }
+    println!(
+        "{}: {}",
+        if preview {
+            "Declared candidates requiring permission"
+        } else {
+            "Candidates requiring permission"
+        },
+        view.candidates.len()
+    );
+    for candidate in &view.candidates {
+        println!(
+            "- {} -> {} (risk: {})",
+            crate::plugin_diagnostics::escape_terminal_text(&candidate.entry_id),
+            crate::plugin_diagnostics::escape_terminal_text(&candidate.target),
+            candidate.risk_level
+        );
+    }
+    for diagnostic in &view.diagnostics {
+        println!(
+            "- [diagnostic] {}",
+            crate::plugin_diagnostics::escape_terminal_text(diagnostic)
+        );
+    }
+    println!("Plugin code was not executed and no tool was registered.");
+}
+
 fn print_plugin_snapshot(snapshot: &ManagedPluginSourceSnapshot) {
     let approved_count = snapshot
         .packages
@@ -366,7 +489,14 @@ fn print_plugin_snapshot(snapshot: &ManagedPluginSourceSnapshot) {
             crate::plugin_diagnostics::escape_terminal_text(&package.adapter)
         );
         println!("  Content hash: {}", package.content_hash);
-        println!("  Execution: unavailable; source review does not enable this package");
+        println!(
+            "  Activation: {}",
+            if package.activated {
+                "active for candidate projection; plugin code is not executed"
+            } else {
+                "inactive; source review does not activate this package"
+            }
+        );
     }
     for issue in &snapshot.issues {
         println!(
@@ -380,6 +510,13 @@ fn print_plugin_snapshot(snapshot: &ManagedPluginSourceSnapshot) {
     println!(
         "{}",
         crate::plugin_diagnostics::render_source_review_epoch(snapshot.trust_epoch)
+    );
+    println!(
+        "Activation epoch: {}",
+        snapshot
+            .activation_epoch
+            .map(|epoch| epoch.to_string())
+            .unwrap_or_else(|| "unavailable".to_string())
     );
 }
 
@@ -430,6 +567,11 @@ pub(crate) async fn print_doctor() -> Result<bool> {
         .iter()
         .filter(|package| package.trust_level == ManagedPluginTrustLevel::SourceApproved)
         .count();
+    let active_plugin_count = plugin_sources
+        .packages
+        .iter()
+        .filter(|package| package.activated)
+        .count();
     let plugin_warning_count = plugin_sources
         .issues
         .iter()
@@ -463,6 +605,10 @@ pub(crate) async fn print_doctor() -> Result<bool> {
             plugin_warning_count,
             plugin_error_count,
         )
+    );
+    println!(
+        "[ok] Managed plugin source integrity checked; {} active. Candidate projection was not probed.",
+        active_plugin_count
     );
     for issue in plugin_sources.issues.iter().take(10) {
         println!(

--- a/src/apps/cli/tests/plugin_source_cli.rs
+++ b/src/apps/cli/tests/plugin_source_cli.rs
@@ -2,21 +2,34 @@ use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+const PLUGIN_SOURCE: &[u8] = br#"
+import { type Plugin, tool } from "@opencode-ai/plugin"
+export const DemoPlugin: Plugin = async () => ({
+  tool: {
+    ping: tool({
+      description: "Ping the workspace",
+      args: { topic: tool.schema.string() },
+      async execute(args) { return args.topic },
+    }),
+  },
+})
+"#;
+
 fn sha256(bytes: &[u8]) -> String {
     format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
 }
 
 fn write_package(workspace: &Path, source: &[u8], declared_hash: &str) {
     let package = workspace.join(".bitfun/plugins/acme.demo");
-    std::fs::create_dir_all(package.join("plugin")).expect("create package directories");
-    std::fs::write(package.join("plugin/demo.ts"), source).expect("write plugin source");
+    std::fs::create_dir_all(package.join(".opencode/plugins")).expect("create package directories");
+    std::fs::write(package.join(".opencode/plugins/demo.ts"), source).expect("write plugin source");
     let manifest = serde_json::json!({
         "schemaVersion": 1,
         "id": "acme.demo",
         "version": "1.0.0",
         "adapter": "opencode_compatible",
         "files": [{
-            "path": "plugin/demo.ts",
+            "path": ".opencode/plugins/demo.ts",
             "sha256": declared_hash,
         }],
     });
@@ -50,6 +63,14 @@ fn stdout(output: &Output) -> String {
 
 fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn activation_content_hash(output: &Output) -> String {
+    stdout(output)
+        .lines()
+        .find_map(|line| line.strip_prefix("Content hash: "))
+        .expect("activation preview content hash")
+        .to_string()
 }
 
 fn find_trust_file(root: &Path) -> Option<PathBuf> {
@@ -100,13 +121,13 @@ fn plugin_source_cli_lifecycle_and_doctor_exit_codes() {
     let user_root = temp.path().join("user-root");
     let home_root = temp.path().join("home-root");
     std::fs::create_dir_all(&workspace).expect("create workspace");
-    let first_source = b"export const Demo = true;";
+    let first_source = PLUGIN_SOURCE;
     write_package(&workspace, first_source, &sha256(first_source));
 
     let list = run_cli(&workspace, &user_root, &home_root, &["plugins", "list"]);
     assert!(list.status.success(), "{}", stderr(&list));
     assert!(stdout(&list).contains("acme.demo 1.0.0 (workspace, unreviewed)"));
-    assert!(stdout(&list).contains("Execution: unavailable; source review does not enable"));
+    assert!(stdout(&list).contains("Activation: inactive"));
 
     let approve = run_cli(
         &workspace,
@@ -118,8 +139,76 @@ fn plugin_source_cli_lifecycle_and_doctor_exit_codes() {
     assert!(stdout(&approve).contains("source-approved"));
     assert!(find_trust_file(&home_root).is_some());
 
+    let preview = run_cli(
+        &workspace,
+        &user_root,
+        &home_root,
+        &["plugins", "activate", "acme.demo"],
+    );
+    assert!(preview.status.success(), "{}", stderr(&preview));
+    assert!(stdout(&preview).contains("Plugin activation preview"));
+    assert!(stdout(&preview).contains("No activation state changed"));
+    assert!(stdout(&preview).contains("to confirm this exact package content"));
+    assert!(stdout(&preview).contains("Custom tool candidates: supported"));
+    assert!(stdout(&preview).contains("Declared candidates requiring permission: 1"));
+    let preview_stdout = stdout(&preview);
+    assert!(
+        preview_stdout.contains("-> ping (risk: high)"),
+        "{preview_stdout}"
+    );
+
+    let rejected = run_cli(
+        &workspace,
+        &user_root,
+        &home_root,
+        &[
+            "plugins",
+            "activate",
+            "acme.demo",
+            "--confirm",
+            "sha256:stale",
+        ],
+    );
+    assert!(!rejected.status.success());
+    assert!(stderr(&rejected).contains("does not match"));
+    assert!(stderr(&rejected)
+        .contains("Re-run `bitfun-cli plugins activate acme.demo` to preview the current content"));
+
+    let content_hash = activation_content_hash(&preview);
+
+    let activate = run_cli(
+        &workspace,
+        &user_root,
+        &home_root,
+        &[
+            "plugins",
+            "activate",
+            "acme.demo",
+            "--confirm",
+            &content_hash,
+        ],
+    );
+    assert!(activate.status.success(), "{}", stderr(&activate));
+    assert!(stdout(&activate).contains("Plugin activation result"));
+    assert!(stdout(&activate).contains("Candidates requiring permission: 1"));
+    assert!(stdout(&activate).contains("no tool was registered"));
+
+    let active_list = run_cli(&workspace, &user_root, &home_root, &["plugins", "list"]);
+    assert!(active_list.status.success(), "{}", stderr(&active_list));
+    assert!(stdout(&active_list).contains("Activation: active for candidate projection"));
+
+    let deactivate = run_cli(
+        &workspace,
+        &user_root,
+        &home_root,
+        &["plugins", "deactivate", "acme.demo"],
+    );
+    assert!(deactivate.status.success(), "{}", stderr(&deactivate));
+    assert!(stdout(&deactivate).contains("is inactive"));
+
     let healthy = run_cli(&workspace, &user_root, &home_root, &["doctor"]);
     assert!(healthy.status.success(), "{}", stderr(&healthy));
+    assert!(stdout(&healthy).contains("Candidate projection was not probed"));
 
     let revoke = run_cli(
         &workspace,
@@ -139,14 +228,14 @@ fn plugin_source_cli_lifecycle_and_doctor_exit_codes() {
     assert!(deny.status.success(), "{}", stderr(&deny));
     assert!(stdout(&deny).contains("denied"));
 
-    let second_source = b"export const Demo = false;";
+    let second_source = b"export const DemoPlugin = async () => ({})";
     write_package(&workspace, second_source, &sha256(second_source));
     let changed = run_cli(&workspace, &user_root, &home_root, &["plugins", "list"]);
     assert!(changed.status.success(), "{}", stderr(&changed));
     assert!(stdout(&changed).contains("acme.demo 1.0.0 (workspace, unreviewed)"));
 
     std::fs::write(
-        workspace.join(".bitfun/plugins/acme.demo/plugin/demo.ts"),
+        workspace.join(".bitfun/plugins/acme.demo/.opencode/plugins/demo.ts"),
         b"tampered",
     )
     .expect("tamper package");
@@ -159,8 +248,8 @@ fn plugin_source_cli_lifecycle_and_doctor_exit_codes() {
     assert!(!invalid_approval.status.success());
     assert!(stderr(&invalid_approval).contains("hash_mismatch"));
     assert!(
-        stderr(&invalid_approval).contains("plugin\\demo.ts")
-            || stderr(&invalid_approval).contains("plugin/demo.ts")
+        stderr(&invalid_approval).contains(".opencode\\plugins\\demo.ts")
+            || stderr(&invalid_approval).contains(".opencode/plugins/demo.ts")
     );
 
     let unhealthy = run_cli(&workspace, &user_root, &home_root, &["doctor"]);

--- a/src/crates/adapters/opencode-adapter/AGENTS-CN.md
+++ b/src/crates/adapters/opencode-adapter/AGENTS-CN.md
@@ -14,7 +14,7 @@
 - 导入 `opencode.json`、`.opencode/plugins/*.js|ts` 或未来 OpenCode 全局插件目录时，必须先生成类型化
   导入事实、候选 BitFun 插件来源记录、清单、哈希、诊断和信任状态，
   这些结果才能交给产品侧启用或执行链路；适配器自身不直接启用或执行。
-- `load_opencode_package_adapter` 只接收固定内容的受管包输入。`SourceApproved` 在 Host 边界仍为未激活状态，没有独立评审的激活路径时不得产生候选项。
+- `load_opencode_package_adapter` 接收固定内容的受管包输入和可选的来源服务激活授权信息。没有当前激活授权时，`SourceApproved` 在 Host 边界仍为未激活状态，不得产生候选项。
 - 受信任 custom tool 声明只能映射为提供方候选；生成最终工具、权限结果和审计事实仍由工具 ABI、
   权限控制和产品归属路径完成。
 - 用户本机是否安装 `opencode` CLI 与加载 OpenCode-compatible 插件无关。与已安装 OpenCode 可执行文件
@@ -34,8 +34,7 @@
   当前消费方和聚焦主机路径测试。
 - 本 crate 可以提供私有 OpenCode 兼容导入映射器和验证样例用于适配器验证；
   公开入口仍限制为 `load_opencode_package_adapter`，由经过评审的产品组装根调用，再把返回的适配器注入 Plugin Runtime Host。
-- 本 PR 不包含生产产品组装接入。后续唯一产品组装根可以依赖本 crate 创建适配器，
-  但必须在同一变更中同步边界脚本和聚焦主机路径测试。
+- 生产组装仅允许位于 `bitfun-core/plugin_runtime`；增加其他消费方时必须同步边界脚本和聚焦主机路径测试。
 - 生产 crate 不得直接依赖 `bitfun_opencode_adapter` 内部类型。未支持能力必须诊断化，
   不得因外部插件内容导致运行时崩溃。
 

--- a/src/crates/adapters/opencode-adapter/AGENTS.md
+++ b/src/crates/adapters/opencode-adapter/AGENTS.md
@@ -19,9 +19,10 @@ Product-source boundary:
   plugin source records, manifests, hashes, diagnostics, and trust state before
   those facts can enter the product-side enablement or execution path. The
   adapter itself must not enable or execute plugins.
-- `load_opencode_package_adapter` receives only fixed managed package content.
-  `SourceApproved` remains untrusted at the Host boundary and must not produce
-  candidates without a separately reviewed activation path.
+- `load_opencode_package_adapter` receives fixed managed package content and an
+  optional source-service activation authority. Without that authority,
+  `SourceApproved` remains untrusted at the Host boundary and produces no
+  candidates.
 - Trusted custom tool declarations may only be mapped as provider candidates;
   final tool creation, permission decisions, and audit facts must stay in the
   tool ABI, permission, and product owner path.
@@ -51,9 +52,8 @@ Product-source boundary:
   fixtures for adapter verification. The public entry remains limited to
   `load_opencode_package_adapter`, called by the reviewed product composition
   root before the returned adapter is injected into Plugin Runtime Host.
-- This PR keeps production Product Assembly wiring out of scope. A future
-  reviewed composition root may depend on this crate to create the adapter, but
-  must update boundary guards and focused host-path tests in the same change.
+- Production assembly is limited to `bitfun-core/plugin_runtime`; boundary
+  guards and focused host-path tests must change with any additional consumer.
 - Production crates must not depend on `bitfun_opencode_adapter` internals.
   Unsupported capabilities must return diagnostics or typed unsupported states
   instead of failing at runtime on external plugin content.

--- a/src/crates/adapters/opencode-adapter/src/lib.rs
+++ b/src/crates/adapters/opencode-adapter/src/lib.rs
@@ -1,11 +1,9 @@
 //! OpenCode-compatible plugin adapter.
 //!
 //! The production surface is intentionally small: load OpenCode-compatible
-//! managed package content as a Plugin Runtime Host adapter that exposes source
-//! facts, diagnostics, and an unactivated status. Candidate mapping remains
-//! private until a separately reviewed Host activation path exists. The adapter
-//! does not execute JavaScript, install npm packages, or depend on a user-local
-//! `opencode` CLI.
+//! managed package content and optional activation authority as a Plugin Runtime
+//! Host adapter plus typed dispatch targets. The adapter does not execute
+//! JavaScript, install npm packages, or depend on a user-local `opencode` CLI.
 
 mod source_adapter;
 

--- a/src/crates/adapters/opencode-adapter/src/source_adapter.rs
+++ b/src/crates/adapters/opencode-adapter/src/source_adapter.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use bitfun_plugin_runtime_host::PluginHostAdapter;
-use bitfun_product_domains::plugin_source::PluginPackageInput;
+use bitfun_product_domains::plugin_source::{PluginActivationAuthority, PluginPackageInput};
 use bitfun_runtime_ports::{
     PermissionPromptDenyState, PermissionPromptDescriptor, PermissionPromptEffectKind,
     PluginArtifactRef, PluginCapabilityRef, PluginDataClassification, PluginEffectCandidatePayload,
@@ -35,6 +35,12 @@ const CUSTOM_TOOL_CAPABILITY_ID: &str = "opencode.custom_tool";
 const CUSTOM_TOOL_CAPABILITY_OWNER_ID: &str = "opencode.custom-tools";
 const CUSTOM_TOOL_EXTENSION_POINT: &str = "tool";
 const MAX_PLUGIN_ID_COMPONENT_LEN: usize = 40;
+const MAX_CUSTOM_TOOLS_PER_SOURCE: usize = 128;
+const MAX_CUSTOM_TOOLS_PER_PACKAGE: usize = 256;
+const MAX_CUSTOM_TOOL_ID_BYTES: usize = 64;
+const MAX_NPM_PLUGINS: usize = 128;
+const MAX_NPM_PLUGIN_NAME_BYTES: usize = 256;
+const MAX_NPM_PLUGIN_METADATA_BYTES: usize = 16 * 1024;
 
 const UNSUPPORTED_HOOK_EVENTS: &[&str] = &[
     "command.executed",
@@ -75,6 +81,13 @@ impl OpenCodeAdapterError {
 struct OpenCodePluginHostAdapter {
     projections: Vec<OpenCodeProjection>,
     observed_at_ms: u64,
+    activation: Option<OpenCodeActivationContext>,
+}
+
+struct OpenCodeActivationContext {
+    project_domain_id: String,
+    workspace_id: String,
+    activation_epoch: u64,
 }
 
 impl OpenCodePluginHostAdapter {
@@ -137,6 +150,7 @@ impl OpenCodePluginHostAdapter {
             None => OpenCodeConfig::empty(config_uri.clone()),
         };
 
+        let mut package_custom_tool_count = 0usize;
         for (relative_path, bytes) in files.iter().filter(|(path, _)| {
             path.starts_with(".opencode/plugins/")
                 && (path.ends_with(".js") || path.ends_with(".ts"))
@@ -177,7 +191,19 @@ impl OpenCodePluginHostAdapter {
                 projection.source.content_hash = source.content_hash.clone();
                 projection.without_config_package_diagnostics()
             }) {
-                Ok(projection) => projections.push(OpenCodeProjection::Local(projection)),
+                Ok(projection) => {
+                    package_custom_tool_count = package_custom_tool_count
+                        .checked_add(projection.local_plugin.custom_tools.len())
+                        .ok_or_else(|| {
+                            adapter_port_error("custom tool count overflow".to_string())
+                        })?;
+                    if package_custom_tool_count > MAX_CUSTOM_TOOLS_PER_PACKAGE {
+                        return Err(adapter_port_error(format!(
+                            "managed package declares more than {MAX_CUSTOM_TOOLS_PER_PACKAGE} custom tools"
+                        )));
+                    }
+                    projections.push(OpenCodeProjection::Local(projection));
+                }
                 Err(error) => projections.push(OpenCodeProjection::Invalid(
                     OpenCodeInvalidProjection::local_source(
                         Path::new(&plugin_path),
@@ -222,6 +248,83 @@ impl OpenCodePluginHostAdapter {
         Ok(Self {
             projections,
             observed_at_ms,
+            activation: None,
+        })
+    }
+
+    fn from_activated_package(
+        input: PluginPackageInput,
+        authority: PluginActivationAuthority,
+        observed_at_ms: u64,
+    ) -> PortResult<Self> {
+        let (project_domain_id, workspace_id, authority_source, activation_epoch) =
+            authority.into_parts();
+        let (manifest, source, files) = input.into_parts();
+        if source != authority_source {
+            return Err(PortError::new(
+                PortErrorKind::InvalidRequest,
+                "OpenCode package input does not match its activation authority",
+            ));
+        }
+        let input = PluginPackageInput::new(manifest, source, files)
+            .map_err(|error| PortError::new(PortErrorKind::InvalidRequest, error.to_string()))?;
+        let mut adapter = Self::from_package(input, observed_at_ms)?;
+        for projection in &mut adapter.projections {
+            projection.activate_supported_source();
+        }
+        adapter.activation = Some(OpenCodeActivationContext {
+            project_domain_id,
+            workspace_id,
+            activation_epoch,
+        });
+        Ok(adapter)
+    }
+
+    fn custom_tool_dispatch_targets(
+        &self,
+    ) -> Vec<(
+        PluginSourceRef,
+        String,
+        PluginCapabilityRef,
+        Vec<(PluginTargetRef, PluginRiskLevel)>,
+    )> {
+        self.projections
+            .iter()
+            .filter_map(OpenCodeProjection::custom_tool_dispatch_target)
+            .collect()
+    }
+
+    fn validate_activation_scope(
+        &self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        epochs: &PluginRuntimeEpochs,
+    ) -> PortResult<()> {
+        let Some(activation) = &self.activation else {
+            return Ok(());
+        };
+        if activation.project_domain_id != project_domain_id
+            || activation.workspace_id != workspace_id
+            || activation.activation_epoch != epochs.trust_epoch
+        {
+            return Err(PortError::new(
+                PortErrorKind::NotAvailable,
+                "OpenCode package activation scope or epoch is stale",
+            ));
+        }
+        Ok(())
+    }
+
+    fn activation_matches(
+        &self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        epochs: &PluginRuntimeEpochs,
+    ) -> bool {
+        self.activation.as_ref().is_none_or(|activation| {
+            activation.project_domain_id == project_domain_id
+                && activation.workspace_id == workspace_id
+                && activation.activation_epoch == epochs.trust_epoch
         })
     }
 
@@ -232,21 +335,48 @@ impl OpenCodePluginHostAdapter {
     }
 
     fn source_mismatch_response(&self, envelope: PluginDispatchEnvelope) -> PluginResponseEnvelope {
+        self.unavailable_response(
+            envelope,
+            "opencode.source_mismatch",
+            "OpenCode dispatch source does not match a loaded source snapshot",
+            false,
+        )
+    }
+
+    fn activation_stale_response(
+        &self,
+        envelope: PluginDispatchEnvelope,
+    ) -> PluginResponseEnvelope {
+        self.unavailable_response(
+            envelope,
+            "opencode.activation_stale",
+            "OpenCode package activation scope or epoch is stale",
+            true,
+        )
+    }
+
+    fn unavailable_response(
+        &self,
+        envelope: PluginDispatchEnvelope,
+        code: &str,
+        message: &str,
+        retryable: bool,
+    ) -> PluginResponseEnvelope {
         let diagnostic_id = format!(
-            "diag:{}:dispatch:{}:source_mismatch",
-            envelope.source.plugin_id, envelope.event_id
+            "diag:{}:dispatch:{}:{}",
+            envelope.source.plugin_id, envelope.event_id, code
         );
         let diagnostic = PluginDiagnostic {
             diagnostic_id: diagnostic_id.clone(),
             severity: PluginDiagnosticSeverity::Warning,
             source: envelope.source.clone(),
-            code: "opencode.source_mismatch".to_string(),
-            message: "OpenCode dispatch source does not match a loaded source snapshot".to_string(),
+            code: code.to_string(),
+            message: message.to_string(),
             detail: PluginDiagnosticDetail::Adapter {
                 adapter_id: OPENCODE_ADAPTER_ID.to_string(),
             },
             audit: audit_ref(&envelope),
-            retryable: false,
+            retryable,
         };
 
         PluginResponseEnvelope {
@@ -286,6 +416,11 @@ impl PluginHostAdapter for OpenCodePluginHostAdapter {
         &self,
         request: PluginRuntimeReadRequest,
     ) -> PortResult<PluginRuntimeReadResponse> {
+        self.validate_activation_scope(
+            &request.project_domain_id,
+            &request.workspace_id,
+            &request.epochs,
+        )?;
         let mut sources = Vec::new();
         let mut plugin_statuses = Vec::new();
         let mut diagnostics = Vec::new();
@@ -326,6 +461,13 @@ impl PluginHostAdapter for OpenCodePluginHostAdapter {
         &self,
         envelope: PluginDispatchEnvelope,
     ) -> PortResult<PluginResponseEnvelope> {
+        if !self.activation_matches(
+            &envelope.project_domain_id,
+            &envelope.workspace_id,
+            &envelope.epochs,
+        ) {
+            return Ok(self.activation_stale_response(envelope));
+        }
         match self.projection_for_source(&envelope.source) {
             Some(projection) => projection.project_dispatch_response(envelope),
             None => Ok(self.source_mismatch_response(envelope)),
@@ -335,12 +477,25 @@ impl PluginHostAdapter for OpenCodePluginHostAdapter {
 
 pub fn load_opencode_package_adapter(
     input: PluginPackageInput,
+    activation: Option<PluginActivationAuthority>,
     observed_at_ms: u64,
-) -> PortResult<Arc<dyn PluginHostAdapter>> {
-    Ok(Arc::new(OpenCodePluginHostAdapter::from_package(
-        input,
-        observed_at_ms,
-    )?))
+) -> PortResult<(
+    Arc<dyn PluginHostAdapter>,
+    Vec<(
+        PluginSourceRef,
+        String,
+        PluginCapabilityRef,
+        Vec<(PluginTargetRef, PluginRiskLevel)>,
+    )>,
+)> {
+    let adapter = match activation {
+        Some(authority) => {
+            OpenCodePluginHostAdapter::from_activated_package(input, authority, observed_at_ms)?
+        }
+        None => OpenCodePluginHostAdapter::from_package(input, observed_at_ms)?,
+    };
+    let targets = adapter.custom_tool_dispatch_targets();
+    Ok((Arc::new(adapter), targets))
 }
 
 fn source_identity_matches(left: &PluginSourceRef, right: &PluginSourceRef) -> bool {
@@ -367,12 +522,52 @@ enum OpenCodeProjection {
 }
 
 impl OpenCodeProjection {
+    fn activate_supported_source(&mut self) {
+        if let Self::Local(projection) = self {
+            projection.source.trust_level = PluginTrustLevel::Trusted;
+        }
+    }
+
     fn source_ref(&self) -> &PluginSourceRef {
         match self {
             Self::Local(projection) => projection.source_ref(),
             Self::Package(projection) => projection.source_ref(),
             Self::Invalid(projection) => projection.source_ref(),
         }
+    }
+
+    fn custom_tool_dispatch_target(
+        &self,
+    ) -> Option<(
+        PluginSourceRef,
+        String,
+        PluginCapabilityRef,
+        Vec<(PluginTargetRef, PluginRiskLevel)>,
+    )> {
+        let Self::Local(projection) = self else {
+            return None;
+        };
+        let capability = projection
+            .local_plugin
+            .custom_tools
+            .first()
+            .map(OpenCodeCustomTool::capability_ref)?;
+        Some((
+            projection.source_ref().clone(),
+            CUSTOM_TOOL_EXTENSION_POINT.to_string(),
+            capability,
+            projection
+                .local_plugin
+                .custom_tools
+                .iter()
+                .map(|tool| {
+                    (
+                        tool.target_ref(&projection.source.plugin_id),
+                        PluginRiskLevel::High,
+                    )
+                })
+                .collect(),
+        ))
     }
 
     fn source_ref_for_epochs(&self, epochs: &PluginRuntimeEpochs) -> PluginSourceRef {
@@ -1196,7 +1391,7 @@ impl OpenCodeSourceProjection {
             declared_capability: tool.capability_ref(),
             target_ref: target,
             data_classification: PluginDataClassification::Workspace,
-            risk_level: PluginRiskLevel::Medium,
+            risk_level: PluginRiskLevel::High,
             permission,
             source_ref: envelope.source.clone(),
             payload: PluginEffectCandidatePayload::ProviderCandidate {
@@ -1223,7 +1418,7 @@ impl OpenCodeSourceProjection {
             requested_capability: tool.capability_ref(),
             requested_effect: PermissionPromptEffectKind::ProviderCandidate,
             target,
-            risk_level: PluginRiskLevel::Medium,
+            risk_level: PluginRiskLevel::High,
             owner: tool.capability_ref().owner,
             rollback: PluginRollbackPolicy {
                 mode: PluginRollbackMode::DisablePlugin,
@@ -1383,14 +1578,44 @@ impl OpenCodeConfig {
             });
         }
 
+        if doc.plugin.len() > MAX_NPM_PLUGINS {
+            return Err(OpenCodeAdapterError::InvalidConfig {
+                field: "plugin",
+                message: format!("at most {MAX_NPM_PLUGINS} npm plugins may be declared"),
+            });
+        }
+
         let mut npm_plugins = Vec::new();
         let mut seen_packages = HashSet::new();
+        let mut metadata_bytes = 0usize;
         for package in doc.plugin {
             let package = package.trim().to_string();
             if package.is_empty() {
                 return Err(OpenCodeAdapterError::InvalidConfig {
                     field: "plugin",
                     message: "package names must not be empty".to_string(),
+                });
+            }
+            if package.len() > MAX_NPM_PLUGIN_NAME_BYTES {
+                return Err(OpenCodeAdapterError::InvalidConfig {
+                    field: "plugin",
+                    message: format!(
+                        "npm plugin names may contain at most {MAX_NPM_PLUGIN_NAME_BYTES} bytes"
+                    ),
+                });
+            }
+            metadata_bytes = metadata_bytes.checked_add(package.len()).ok_or_else(|| {
+                OpenCodeAdapterError::InvalidConfig {
+                    field: "plugin",
+                    message: "npm plugin metadata size overflow".to_string(),
+                }
+            })?;
+            if metadata_bytes > MAX_NPM_PLUGIN_METADATA_BYTES {
+                return Err(OpenCodeAdapterError::InvalidConfig {
+                    field: "plugin",
+                    message: format!(
+                        "npm plugin metadata may contain at most {MAX_NPM_PLUGIN_METADATA_BYTES} bytes"
+                    ),
                 });
             }
             if seen_packages.insert(package.clone()) {
@@ -1423,13 +1648,14 @@ struct OpenCodeLocalPlugin {
 
 impl OpenCodeLocalPlugin {
     fn from_source(path: &str, source: &str) -> Result<Self, OpenCodeAdapterError> {
+        let source = strip_js_comments(source)?;
         let export_name =
-            exported_plugin_name(source).ok_or(OpenCodeAdapterError::InvalidPluginSource {
+            exported_plugin_name(&source).ok_or(OpenCodeAdapterError::InvalidPluginSource {
                 field: "plugin.export",
                 message: "expected an exported OpenCode plugin function".to_string(),
             })?;
-        let custom_tools = discover_custom_tools(source);
-        let unsupported_hooks = discover_unsupported_hooks(source);
+        let custom_tools = discover_custom_tools(&source)?;
+        let unsupported_hooks = discover_unsupported_hooks(&source);
         if custom_tools.is_empty() && unsupported_hooks.is_empty() {
             return Err(OpenCodeAdapterError::InvalidPluginSource {
                 field: "plugin.contributions",
@@ -1493,8 +1719,9 @@ fn exported_plugin_name(source: &str) -> Option<String> {
     })
 }
 
-fn discover_custom_tools(source: &str) -> Vec<OpenCodeCustomTool> {
-    source
+fn discover_custom_tools(source: &str) -> Result<Vec<OpenCodeCustomTool>, OpenCodeAdapterError> {
+    let mut ids = HashSet::new();
+    let tools = source
         .lines()
         .filter_map(|line| {
             let (name, rest) = line.trim().split_once(':')?;
@@ -1502,12 +1729,103 @@ fn discover_custom_tools(source: &str) -> Vec<OpenCodeCustomTool> {
                 .starts_with("tool({")
                 .then(|| name.trim())
                 .filter(|candidate| is_identifier(candidate))
-                .map(|id| OpenCodeCustomTool {
-                    id: id.to_string(),
-                    tool_contract_id: CUSTOM_TOOL_CONTRACT_ID.to_string(),
-                })
         })
-        .collect()
+        .map(|id| {
+            if id.len() > MAX_CUSTOM_TOOL_ID_BYTES {
+                return Err(OpenCodeAdapterError::InvalidPluginSource {
+                    field: "plugin.custom_tools",
+                    message: format!(
+                        "custom tool identifiers may contain at most {MAX_CUSTOM_TOOL_ID_BYTES} bytes"
+                    ),
+                });
+            }
+            if !ids.insert(id) {
+                return Err(OpenCodeAdapterError::InvalidPluginSource {
+                    field: "plugin.custom_tools",
+                    message: format!("duplicate custom tool declaration: {id}"),
+                });
+            }
+            Ok(OpenCodeCustomTool {
+                id: id.to_string(),
+                tool_contract_id: CUSTOM_TOOL_CONTRACT_ID.to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if tools.len() > MAX_CUSTOM_TOOLS_PER_SOURCE {
+        return Err(OpenCodeAdapterError::InvalidPluginSource {
+            field: "plugin.custom_tools",
+            message: format!(
+                "a plugin source may declare at most {MAX_CUSTOM_TOOLS_PER_SOURCE} custom tools"
+            ),
+        });
+    }
+    Ok(tools)
+}
+
+fn strip_js_comments(source: &str) -> Result<String, OpenCodeAdapterError> {
+    let mut output = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut block_comment = false;
+
+    while let Some(ch) = chars.next() {
+        if line_comment {
+            if ch == '\n' {
+                line_comment = false;
+                output.push(ch);
+            } else {
+                output.push(' ');
+            }
+            continue;
+        }
+        if block_comment {
+            if ch == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                output.push_str("  ");
+                block_comment = false;
+            } else if ch == '\n' {
+                output.push(ch);
+            } else {
+                output.push(' ');
+            }
+            continue;
+        }
+        if let Some(delimiter) = quote {
+            output.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+        if matches!(ch, '\'' | '"' | '`') {
+            quote = Some(ch);
+            output.push(ch);
+        } else if ch == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            output.push_str("  ");
+            line_comment = true;
+        } else if ch == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            output.push_str("  ");
+            block_comment = true;
+        } else {
+            output.push(ch);
+        }
+    }
+
+    if block_comment {
+        return Err(OpenCodeAdapterError::InvalidPluginSource {
+            field: "plugin.comments",
+            message: "unterminated block comment".to_string(),
+        });
+    }
+    Ok(output)
 }
 
 fn discover_unsupported_hooks(source: &str) -> Vec<String> {
@@ -1655,6 +1973,92 @@ mod opencode_projection_contracts {
     const LOCAL_PLUGIN_PATH: &str = ".opencode/plugins/workspace-tools.ts";
     const LOCAL_PLUGIN_SOURCE: &str =
         include_str!("../tests/fixtures/opencode-example/.opencode/plugins/workspace-tools.ts");
+
+    #[test]
+    fn commented_custom_tool_declarations_are_not_discovered() {
+        let source = r#"
+export const DemoPlugin = async () => ({
+  /*
+  ghost: tool({
+  */
+  // lineGhost: tool({
+})
+"#;
+
+        let error = OpenCodeLocalPlugin::from_source(LOCAL_PLUGIN_PATH, source)
+            .expect_err("comments must not create contributions");
+        assert!(error.to_string().contains("expected a custom tool or hook"));
+    }
+
+    #[test]
+    fn duplicate_custom_tool_declarations_are_rejected() {
+        let source = r#"
+export const DemoPlugin = async () => ({
+  tool: {
+    duplicate: tool({
+    duplicate: tool({
+  }
+})
+"#;
+
+        let error = OpenCodeLocalPlugin::from_source(LOCAL_PLUGIN_PATH, source)
+            .expect_err("duplicate declarations must be ambiguous");
+        assert!(error
+            .to_string()
+            .contains("duplicate custom tool declaration"));
+    }
+
+    #[test]
+    fn custom_tool_declaration_limit_accepts_boundary_and_rejects_overflow() {
+        let source = |count| {
+            let declarations = (0..count)
+                .map(|index| format!("  tool{index}: tool({{"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("export const DemoPlugin = async () => ({{\n{declarations}\n}})")
+        };
+
+        let boundary = source(MAX_CUSTOM_TOOLS_PER_SOURCE);
+        let plugin = OpenCodeLocalPlugin::from_source(LOCAL_PLUGIN_PATH, &boundary)
+            .expect("boundary declaration count");
+        assert_eq!(plugin.custom_tools.len(), MAX_CUSTOM_TOOLS_PER_SOURCE);
+
+        let overflow = source(MAX_CUSTOM_TOOLS_PER_SOURCE + 1);
+        let error = OpenCodeLocalPlugin::from_source(LOCAL_PLUGIN_PATH, &overflow)
+            .expect_err("overflow declaration count");
+        assert!(error.to_string().contains("may declare at most"));
+
+        let long_id = "a".repeat(MAX_CUSTOM_TOOL_ID_BYTES + 1);
+        let long_source =
+            format!("export const DemoPlugin = async () => ({{\n  {long_id}: tool({{\n}})");
+        let error = OpenCodeLocalPlugin::from_source(LOCAL_PLUGIN_PATH, &long_source)
+            .expect_err("long custom tool identifier");
+        assert!(error
+            .to_string()
+            .contains("identifiers may contain at most"));
+    }
+
+    #[test]
+    fn npm_plugin_declaration_limits_reject_count_and_metadata_amplification() {
+        let doc = |plugin| OpenCodeConfigDoc {
+            schema: Some(OPENCODE_CONFIG_SCHEMA.to_string()),
+            plugin,
+        };
+
+        let count_error = OpenCodeConfig::try_from_doc(doc((0..=MAX_NPM_PLUGINS)
+            .map(|index| format!("package-{index}"))
+            .collect()))
+        .expect_err("npm plugin count overflow");
+        assert!(count_error.to_string().contains("at most 128 npm plugins"));
+
+        let metadata_error = OpenCodeConfig::try_from_doc(doc((0..65)
+            .map(|index| format!("{index:03}{}", "a".repeat(253)))
+            .collect()))
+        .expect_err("npm plugin metadata overflow");
+        assert!(metadata_error
+            .to_string()
+            .contains("metadata may contain at most"));
+    }
 
     fn adapter(trust_level: PluginTrustLevel) -> OpenCodeSourceProjection {
         OpenCodeSourceProjection::from_opencode_sources(
@@ -1858,6 +2262,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter)],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -1913,6 +2318,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter)],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -1947,6 +2353,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter.clone())],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -1982,6 +2389,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter.clone())],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -2015,6 +2423,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter)],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -2043,6 +2452,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter.clone())],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -2074,6 +2484,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter.clone())],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 
@@ -2106,6 +2517,7 @@ mod opencode_projection_contracts {
         let host_adapter: Arc<dyn PluginHostAdapter> = Arc::new(OpenCodePluginHostAdapter {
             projections: vec![OpenCodeProjection::Local(adapter.clone())],
             observed_at_ms: 1_720_000_001,
+            activation: None,
         });
         let host = PluginRuntimeHost::new(host_adapter);
 

--- a/src/crates/adapters/opencode-adapter/tests/opencode_source_adapter.rs
+++ b/src/crates/adapters/opencode-adapter/tests/opencode_source_adapter.rs
@@ -1,10 +1,11 @@
 use bitfun_opencode_adapter::load_opencode_package_adapter;
 use bitfun_plugin_runtime_host::PluginRuntimeHost;
-use bitfun_product_domains::plugin_source::PluginPackageInput;
+use bitfun_product_domains::plugin_source::{PluginActivationAuthority, PluginPackageInput};
 use bitfun_runtime_ports::{
     PluginCapabilityRef, PluginDataClassification, PluginDispatchEnvelope, PluginOwnerKind,
-    PluginOwnerRef, PluginPayloadRedaction, PluginPayloadRef, PluginRuntimeClient,
-    PluginRuntimeEpochs, PluginRuntimeReadRequest, PluginStatusKind, PluginTrustLevel,
+    PluginOwnerRef, PluginPayloadRedaction, PluginPayloadRef, PluginPermissionGate,
+    PluginRuntimeClient, PluginRuntimeEpochs, PluginRuntimeReadRequest, PluginStatusKind,
+    PluginTrustLevel,
 };
 use bitfun_services_integrations::plugin_source::{
     ManagedPluginSourceService, ManagedPluginTrustDecision,
@@ -14,6 +15,14 @@ use std::{fs, path::PathBuf, process, time::SystemTime};
 
 const PLUGIN_SOURCE: &str =
     include_str!("fixtures/opencode-example/.opencode/plugins/workspace-tools.ts");
+
+fn custom_tool_source(prefix: &str, count: usize) -> String {
+    let declarations = (0..count)
+        .map(|index| format!("  {prefix}{index}: tool({{"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("export const DemoPlugin = async () => ({{\n{declarations}\n}})")
+}
 
 struct ManagedPackageFixture {
     root: PathBuf,
@@ -123,6 +132,25 @@ impl ManagedPackageFixture {
             .await
             .expect("load fixed package input")
     }
+
+    async fn activated_input(&self) -> (PluginPackageInput, PluginActivationAuthority) {
+        let input = self.approved_input().await;
+        let content_hash = input.clone().into_parts().1.content_hash;
+        self.service
+            .set_activation(
+                &self.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("activate package");
+        self.service
+            .load_activated_package(&self.workspace, "acme.demo")
+            .await
+            .expect("load activated package input")
+    }
 }
 
 impl Drop for ManagedPackageFixture {
@@ -135,8 +163,9 @@ impl Drop for ManagedPackageFixture {
 async fn managed_package_is_read_through_plugin_runtime_host() {
     let fixture = ManagedPackageFixture::new("read", PLUGIN_SOURCE);
     let input = fixture.approved_input().await;
-    let adapter = load_opencode_package_adapter(input, 1_720_000_001)
-        .expect("create OpenCode package adapter");
+    let adapter = load_opencode_package_adapter(input, None, 1_720_000_001)
+        .expect("create OpenCode package adapter")
+        .0;
     let host = PluginRuntimeHost::new(adapter);
 
     let response = host
@@ -163,8 +192,9 @@ async fn managed_package_is_read_through_plugin_runtime_host() {
 async fn source_approval_does_not_create_custom_tool_candidate() {
     let fixture = ManagedPackageFixture::new("approval", PLUGIN_SOURCE);
     let input = fixture.approved_input().await;
-    let adapter = load_opencode_package_adapter(input, 1_720_000_001)
-        .expect("create OpenCode package adapter");
+    let adapter = load_opencode_package_adapter(input, None, 1_720_000_001)
+        .expect("create OpenCode package adapter")
+        .0;
     let host = PluginRuntimeHost::new(adapter);
     let source = host
         .read_plugins(read_request())
@@ -188,6 +218,116 @@ async fn source_approval_does_not_create_custom_tool_candidate() {
 }
 
 #[tokio::test]
+async fn activated_package_projects_permission_required_candidate_through_host() {
+    let fixture = ManagedPackageFixture::new("activated", PLUGIN_SOURCE);
+    let (input, authority) = fixture.activated_input().await;
+    let (project_domain_id, workspace_id, _, activation_epoch) = authority.clone().into_parts();
+    let (adapter, dispatch_targets) =
+        load_opencode_package_adapter(input, Some(authority), 1_720_000_001)
+            .expect("create activated OpenCode package adapter");
+    assert!(!dispatch_targets.is_empty());
+    let host = PluginRuntimeHost::new(adapter);
+    let request = read_request_for(&project_domain_id, &workspace_id, activation_epoch);
+    let source = host
+        .read_plugins(request)
+        .await
+        .expect("read activated package")
+        .sources
+        .into_iter()
+        .next()
+        .expect("activated source");
+
+    assert_eq!(source.trust_level, PluginTrustLevel::Trusted);
+    let response = host
+        .dispatch(dispatch_envelope_for(
+            source,
+            &project_domain_id,
+            &workspace_id,
+            activation_epoch,
+        ))
+        .await
+        .expect("dispatch activated package");
+
+    assert!(!response.effects.is_empty());
+    assert!(response.effects.iter().all(|effect| matches!(
+        effect.permission,
+        PluginPermissionGate::PermissionRequired { .. }
+    )));
+    assert!(response
+        .effects
+        .iter()
+        .all(|effect| effect.risk_level == bitfun_runtime_ports::PluginRiskLevel::High));
+}
+
+#[tokio::test]
+async fn activated_adapter_rejects_wrong_scope_and_epoch() {
+    let fixture = ManagedPackageFixture::new("activation-scope", PLUGIN_SOURCE);
+    let (input, authority) = fixture.activated_input().await;
+    let (project_domain_id, workspace_id, _, activation_epoch) = authority.clone().into_parts();
+    let host = PluginRuntimeHost::new(
+        load_opencode_package_adapter(input, Some(authority), 1_720_000_001)
+            .expect("create activated adapter")
+            .0,
+    );
+
+    assert!(host
+        .read_plugins(read_request_for(
+            "wrong-project",
+            &workspace_id,
+            activation_epoch,
+        ))
+        .await
+        .is_err());
+    assert!(host
+        .read_plugins(read_request_for(
+            &project_domain_id,
+            &workspace_id,
+            activation_epoch + 1,
+        ))
+        .await
+        .is_err());
+
+    let source = host
+        .read_plugins(read_request_for(
+            &project_domain_id,
+            &workspace_id,
+            activation_epoch,
+        ))
+        .await
+        .expect("read current activation")
+        .sources
+        .into_iter()
+        .next()
+        .expect("activated source");
+    let stale = host
+        .dispatch(dispatch_envelope_for(
+            source.clone(),
+            &project_domain_id,
+            &workspace_id,
+            activation_epoch + 1,
+        ))
+        .await
+        .expect("stale activation returns a typed unavailable response");
+    assert!(stale.effects.is_empty());
+    assert!(stale.quarantine.is_none());
+    assert!(stale
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == "opencode.activation_stale"));
+
+    let current = host
+        .dispatch(dispatch_envelope_for(
+            source,
+            &project_domain_id,
+            &workspace_id,
+            activation_epoch,
+        ))
+        .await
+        .expect("stale request does not quarantine the current activation");
+    assert!(!current.effects.is_empty());
+}
+
+#[tokio::test]
 async fn fixed_package_input_is_not_re_read_or_executed() {
     let fixture = ManagedPackageFixture::new(
         "immutable",
@@ -200,8 +340,9 @@ async fn fixed_package_input_is_not_re_read_or_executed() {
     )
     .expect("replace package file after fixed input was created");
 
-    let adapter = load_opencode_package_adapter(input, 1_720_000_001)
-        .expect("adapter reads only fixed input");
+    let adapter = load_opencode_package_adapter(input, None, 1_720_000_001)
+        .expect("adapter reads only fixed input")
+        .0;
     let host = PluginRuntimeHost::new(adapter);
     let response = host
         .read_plugins(read_request())
@@ -299,8 +440,9 @@ async fn invalid_plugin_diagnostic_keeps_managed_package_identity() {
     let expected_version = source.version.clone();
     let expected_hash = source.content_hash.clone();
     let input = PluginPackageInput::new(manifest, source, files).expect("rebuild package input");
-    let adapter = load_opencode_package_adapter(input, 1_720_000_001)
-        .expect("create adapter for invalid plugin");
+    let adapter = load_opencode_package_adapter(input, None, 1_720_000_001)
+        .expect("create adapter for invalid plugin")
+        .0;
     let host = PluginRuntimeHost::new(adapter);
 
     let response = host
@@ -330,8 +472,9 @@ async fn invalid_config_diagnostics_are_isolated_by_managed_source() {
     let mut diagnostic_ids = Vec::new();
     for fixture in [&first, &second] {
         let host = PluginRuntimeHost::new(
-            load_opencode_package_adapter(fixture.approved_input().await, 1_720_000_001)
-                .expect("create adapter"),
+            load_opencode_package_adapter(fixture.approved_input().await, None, 1_720_000_001)
+                .expect("create adapter")
+                .0,
         );
         let response = host
             .read_plugins(read_request())
@@ -355,12 +498,14 @@ async fn host_source_identity_distinguishes_managed_package_origins() {
     let first = ManagedPackageFixture::new("origin-a", PLUGIN_SOURCE);
     let second = ManagedPackageFixture::new("origin-b", PLUGIN_SOURCE);
     let first_host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(first.approved_input().await, 1_720_000_001)
-            .expect("create first adapter"),
+        load_opencode_package_adapter(first.approved_input().await, None, 1_720_000_001)
+            .expect("create first adapter")
+            .0,
     );
     let second_host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(second.approved_input().await, 1_720_000_001)
-            .expect("create second adapter"),
+        load_opencode_package_adapter(second.approved_input().await, None, 1_720_000_001)
+            .expect("create second adapter")
+            .0,
     );
 
     let first_source = first_host
@@ -389,8 +534,9 @@ async fn managed_source_uri_encodes_reserved_path_characters() {
         ".opencode/plugins/nested #dir/workspace-tools.ts",
     );
     let host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(fixture.approved_input().await, 1_720_000_001)
-            .expect("create adapter"),
+        load_opencode_package_adapter(fixture.approved_input().await, None, 1_720_000_001)
+            .expect("create adapter")
+            .0,
     );
 
     let source = host
@@ -414,12 +560,14 @@ async fn npm_projection_identity_distinguishes_managed_package_origins() {
     first.add_opencode_config(config);
     second.add_opencode_config(config);
     let first_host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(first.approved_input().await, 1_720_000_001)
-            .expect("create first adapter"),
+        load_opencode_package_adapter(first.approved_input().await, None, 1_720_000_001)
+            .expect("create first adapter")
+            .0,
     );
     let second_host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(second.approved_input().await, 1_720_000_001)
-            .expect("create second adapter"),
+        load_opencode_package_adapter(second.approved_input().await, None, 1_720_000_001)
+            .expect("create second adapter")
+            .0,
     );
 
     let first_source = first_host
@@ -452,8 +600,9 @@ async fn npm_projection_identity_distinguishes_managed_package_origins() {
     assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()));
 
     let repeated_host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(first.approved_input().await, 1_720_000_001)
-            .expect("create repeated adapter"),
+        load_opencode_package_adapter(first.approved_input().await, None, 1_720_000_001)
+            .expect("create repeated adapter")
+            .0,
     );
     let repeated_source = repeated_host
         .read_plugins(read_request())
@@ -476,8 +625,9 @@ async fn managed_local_plugin_ids_distinguish_nested_and_dotted_paths() {
     fixture.add_declared_file(".opencode/plugins/b/foo.ts", PLUGIN_SOURCE.as_bytes());
     fixture.add_declared_file(".opencode/plugins/foo.test.ts", PLUGIN_SOURCE.as_bytes());
     let host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(fixture.approved_input().await, 1_720_000_001)
-            .expect("create adapter"),
+        load_opencode_package_adapter(fixture.approved_input().await, None, 1_720_000_001)
+            .expect("create adapter")
+            .0,
     );
 
     let response = host
@@ -497,15 +647,16 @@ async fn managed_local_plugin_ids_distinguish_nested_and_dotted_paths() {
 #[tokio::test]
 async fn npm_projection_ids_distinguish_collisions_and_deduplicate_exact_entries() {
     let fixture = ManagedPackageFixture::new("unique-npm-ids", PLUGIN_SOURCE);
-    let long_name = "a".repeat(512);
+    let long_name = "a".repeat(256);
     let config = serde_json::json!({
         "$schema": "https://opencode.ai/config.json",
         "plugin": ["foo-bar", "foo_bar", "foo-bar", long_name]
     });
     fixture.add_opencode_config(&serde_json::to_string(&config).expect("serialize config"));
     let host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(fixture.approved_input().await, 1_720_000_001)
-            .expect("create adapter"),
+        load_opencode_package_adapter(fixture.approved_input().await, None, 1_720_000_001)
+            .expect("create adapter")
+            .0,
     );
 
     let response = host
@@ -527,8 +678,9 @@ async fn npm_projection_ids_distinguish_collisions_and_deduplicate_exact_entries
 async fn package_without_recognized_opencode_entries_reports_diagnostic() {
     let fixture = ManagedPackageFixture::new_with_path("unsupported-layout", "notes", "README.md");
     let host = PluginRuntimeHost::new(
-        load_opencode_package_adapter(fixture.approved_input().await, 1_720_000_001)
-            .expect("create adapter"),
+        load_opencode_package_adapter(fixture.approved_input().await, None, 1_720_000_001)
+            .expect("create adapter")
+            .0,
     );
 
     let response = host
@@ -543,23 +695,63 @@ async fn package_without_recognized_opencode_entries_reports_diagnostic() {
         .any(|diagnostic| { diagnostic.code == "opencode.package_no_supported_entry" }));
 }
 
+#[tokio::test]
+async fn managed_package_custom_tool_limit_is_cumulative() {
+    let first = custom_tool_source("first", 128);
+    let fixture = ManagedPackageFixture::new("custom-tool-budget", &first);
+    let second = custom_tool_source("second", 128);
+    fixture.add_declared_file(".opencode/plugins/second.ts", second.as_bytes());
+
+    let boundary = fixture.approved_input().await;
+    load_opencode_package_adapter(boundary, None, 1).expect("package boundary count");
+
+    let overflow = custom_tool_source("overflow", 1);
+    fixture.add_declared_file(".opencode/plugins/overflow.ts", overflow.as_bytes());
+    let input = fixture.approved_input().await;
+    let error = match load_opencode_package_adapter(input, None, 1) {
+        Ok(_) => panic!("package cumulative declaration overflow"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("more than 256 custom tools"));
+}
+
 fn read_request() -> PluginRuntimeReadRequest {
+    read_request_for("project-1", "workspace-1", 20)
+}
+
+fn read_request_for(
+    project_domain_id: &str,
+    workspace_id: &str,
+    trust_epoch: u64,
+) -> PluginRuntimeReadRequest {
     PluginRuntimeReadRequest {
         request_id: "read-managed-package".to_string(),
-        project_domain_id: "project-1".to_string(),
-        workspace_id: "workspace-1".to_string(),
+        project_domain_id: project_domain_id.to_string(),
+        workspace_id: workspace_id.to_string(),
         plugin_ids: Vec::new(),
         include_config_validation: true,
-        epochs: epochs(),
+        epochs: PluginRuntimeEpochs {
+            trust_epoch,
+            ..epochs()
+        },
     }
 }
 
 fn dispatch_envelope(source: bitfun_runtime_ports::PluginSourceRef) -> PluginDispatchEnvelope {
+    dispatch_envelope_for(source, "project-1", "workspace-1", 20)
+}
+
+fn dispatch_envelope_for(
+    source: bitfun_runtime_ports::PluginSourceRef,
+    project_domain_id: &str,
+    workspace_id: &str,
+    trust_epoch: u64,
+) -> PluginDispatchEnvelope {
     PluginDispatchEnvelope {
         envelope_version: 1,
         event_id: "event-1".to_string(),
-        project_domain_id: "project-1".to_string(),
-        workspace_id: "workspace-1".to_string(),
+        project_domain_id: project_domain_id.to_string(),
+        workspace_id: workspace_id.to_string(),
         source,
         event_type: "agent.turn.completed".to_string(),
         event_version: "2026-07-07".to_string(),
@@ -582,7 +774,10 @@ fn dispatch_envelope(source: bitfun_runtime_ports::PluginSourceRef) -> PluginDis
             redaction: PluginPayloadRedaction::Partial,
             uri: Some("bitfun://payloads/payload-1".to_string()),
         }),
-        epochs: epochs(),
+        epochs: PluginRuntimeEpochs {
+            trust_epoch,
+            ..epochs()
+        },
     }
 }
 

--- a/src/crates/assembly/core/AGENTS-CN.md
+++ b/src/crates/assembly/core/AGENTS-CN.md
@@ -45,6 +45,7 @@ SessionManager -> Session -> DialogTurn -> ModelRound
 - Product-domain 改动可以在有等价保护时迁移纯产品领域计划；filesystem writes、worker/host side effect、
   Git/AI concrete calls、marker IO 和 path-manager integration 仍留在 core，除非有经过评审的 owner 设计。
 - `plugin_source` 只注入产品目录并保留兼容接口；受管插件包发现与信任持久化归 `services-integrations`，生态适配解析与 Plugin Runtime Host 行为分别归对应的适配器层和执行层。
+- `plugin_runtime` 是 `product-full` 唯一允许选择生态适配器并注入 Plugin Runtime Host 的组装文件。产品入口只消费其产品级激活视图，不得导入适配器或 Host ABI 类型。
 - Remote/service 改动必须保持 external protocol lifecycle、workspace projection、scheduler/session restore、
   terminal pre-warm 和 product execution 边界清晰。
 - Feature 改动必须保持 `product-full` 作为兼容产品组装边界；默认能力选择只有在单独的 product matrix review 后才能变化。

--- a/src/crates/assembly/core/AGENTS.md
+++ b/src/crates/assembly/core/AGENTS.md
@@ -64,6 +64,10 @@ SessionManager -> Session -> DialogTurn -> ModelRound
   concrete managed-package discovery and trust persistence stay in
   `services-integrations`, while ecosystem parsing and Plugin Runtime Host
   behavior remain in their adapter and execution owners.
+- `plugin_runtime` is the only product-full composition file allowed to select
+  an ecosystem adapter and inject it into Plugin Runtime Host. Product surfaces
+  consume its product-level activation view and must not import adapter or Host
+  ABI types.
 - Remote/service changes must keep external protocol lifecycle, workspace
   projection, scheduler/session restore, terminal pre-warm, and product
   execution boundaries explicit.

--- a/src/crates/assembly/core/Cargo.toml
+++ b/src/crates/assembly/core/Cargo.toml
@@ -138,6 +138,10 @@ bitfun-events = { path = "../../contracts/events" }
 bitfun-runtime-ports = { path = "../../contracts/runtime-ports" }
 bitfun-runtime-services = { path = "../../execution/runtime-services" }
 
+# Reviewed product-full plugin composition root.
+bitfun-opencode-adapter = { path = "../../adapters/opencode-adapter", optional = true }
+bitfun-plugin-runtime-host = { path = "../../execution/plugin-runtime-host", optional = true }
+
 # Transport layer dependency
 bitfun-transport = { path = "../../adapters/transport" }
 
@@ -171,6 +175,8 @@ product-full = [
     "dep:glob",
     "dep:globset",
     "dep:include_dir",
+    "dep:bitfun-opencode-adapter",
+    "dep:bitfun-plugin-runtime-host",
     "dep:indexmap",
     "dep:md5",
     "dep:similar",

--- a/src/crates/assembly/core/src/lib.rs
+++ b/src/crates/assembly/core/src/lib.rs
@@ -12,6 +12,8 @@ pub mod function_agents; // Function-based agents
 pub mod infrastructure; // AI clients, storage, logging, events
 #[cfg(feature = "product-domains")]
 pub mod miniapp; // AI-generated instant apps (Zero-Dialect Runtime)
+#[cfg(feature = "product-full")]
+pub mod plugin_runtime;
 #[cfg(any(feature = "plugin-source", feature = "product-domains"))]
 pub mod plugin_source;
 #[cfg(feature = "product-full")]

--- a/src/crates/assembly/core/src/plugin_runtime.rs
+++ b/src/crates/assembly/core/src/plugin_runtime.rs
@@ -1,0 +1,921 @@
+//! Workspace-scoped managed plugin composition.
+//!
+//! This is the only product-full root that selects the OpenCode-compatible
+//! adapter and Plugin Runtime Host. It projects candidates for product
+//! surfaces; it does not register tools or execute plugin code.
+
+use async_trait::async_trait;
+use bitfun_opencode_adapter::load_opencode_package_adapter;
+use bitfun_plugin_runtime_host::PluginRuntimeHost;
+use bitfun_product_domains::plugin_source::{
+    PluginActivationAuthority, PluginPackageInput, PluginPackageSourceIdentity,
+};
+use bitfun_runtime_ports::{
+    PluginCapabilityRef, PluginDispatchEnvelope, PluginEffectCandidatePayload,
+    PluginPermissionGate, PluginResponseEnvelope, PluginRiskLevel, PluginRuntimeAvailability,
+    PluginRuntimeBinding, PluginRuntimeClient, PluginRuntimeEpochs, PluginRuntimeReadRequest,
+    PluginRuntimeReadResponse, PluginSourceRef, PluginTargetRef, PortError, PortErrorKind,
+    PortResult,
+};
+use bitfun_services_integrations::plugin_source::{
+    ManagedPluginSourceError, ManagedPluginSourceService,
+};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const PREVIEW_PROJECT_ID: &str = "managed-plugin-preview";
+const PREVIEW_WORKSPACE_ID: &str = "managed-plugin-preview";
+type PluginDispatchTarget = (
+    PluginSourceRef,
+    String,
+    PluginCapabilityRef,
+    Vec<(PluginTargetRef, PluginRiskLevel)>,
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedPluginCandidateView {
+    pub entry_id: String,
+    pub target: String,
+    pub risk_level: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedPluginActivationView {
+    pub package_id: String,
+    pub version: String,
+    pub adapter: String,
+    pub content_hash: String,
+    pub activated: bool,
+    pub activation_epoch: Option<u64>,
+    pub entry_ids: Vec<String>,
+    pub provider_candidates_supported: bool,
+    pub permission_required: bool,
+    pub candidates: Vec<ManagedPluginCandidateView>,
+    pub diagnostics: Vec<String>,
+}
+
+pub async fn preview_managed_plugin_activation(
+    workspace: &Path,
+    package_id: &str,
+) -> Result<ManagedPluginActivationView, ManagedPluginSourceError> {
+    let service = Arc::new(crate::plugin_source::managed_plugin_source_service(
+        workspace,
+    )?);
+    preview_with_service(service, workspace, package_id).await
+}
+
+pub async fn set_managed_plugin_activation(
+    workspace: &Path,
+    package_id: &str,
+    activated: bool,
+    expected_content_hash: Option<&str>,
+) -> Result<ManagedPluginActivationView, ManagedPluginSourceError> {
+    let service = Arc::new(crate::plugin_source::managed_plugin_source_service(
+        workspace,
+    )?);
+    set_activation_with_service(
+        service,
+        workspace,
+        package_id,
+        activated,
+        expected_content_hash,
+    )
+    .await
+}
+
+async fn preview_with_service(
+    service: Arc<ManagedPluginSourceService>,
+    workspace: &Path,
+    package_id: &str,
+) -> Result<ManagedPluginActivationView, ManagedPluginSourceError> {
+    let input = service.load_package(workspace, package_id).await?;
+    let source = input.clone().into_parts().1;
+    let (adapter, dispatch_targets) = load_opencode_package_adapter(input, None, current_time_ms())
+        .map_err(|error| invalid_package(package_id, error.to_string()))?;
+    let binding = PluginRuntimeBinding::client(Arc::new(PluginRuntimeHost::new(adapter)));
+    let response = binding
+        .as_client()
+        .read_plugins(read_request(PREVIEW_PROJECT_ID, PREVIEW_WORKSPACE_ID, 1))
+        .await
+        .map_err(|error| unavailable(package_id, error.to_string()))?;
+    let candidates = preview_candidates(&dispatch_targets);
+    Ok(project_view(
+        source,
+        false,
+        None,
+        !dispatch_targets.is_empty(),
+        response,
+        candidates,
+    ))
+}
+
+async fn set_activation_with_service(
+    service: Arc<ManagedPluginSourceService>,
+    workspace: &Path,
+    package_id: &str,
+    activated: bool,
+    expected_content_hash: Option<&str>,
+) -> Result<ManagedPluginActivationView, ManagedPluginSourceError> {
+    if !activated {
+        let (snapshot, _) = service
+            .set_activation(workspace, package_id, false, None, None)
+            .await?;
+        let package = snapshot
+            .packages
+            .into_iter()
+            .find(|package| package.package_id == package_id)
+            .ok_or_else(|| ManagedPluginSourceError::PackageNotFound(package_id.to_string()))?;
+        return Ok(ManagedPluginActivationView {
+            package_id: package.package_id,
+            version: package.version,
+            adapter: package.adapter,
+            content_hash: package.content_hash,
+            activated: false,
+            activation_epoch: None,
+            entry_ids: Vec::new(),
+            provider_candidates_supported: false,
+            permission_required: false,
+            candidates: Vec::new(),
+            diagnostics: snapshot
+                .issues
+                .into_iter()
+                .map(|issue| issue.message)
+                .collect(),
+        });
+    }
+
+    let expected_content_hash = expected_content_hash.ok_or_else(|| {
+        invalid_package(
+            package_id,
+            "activation requires the exact content hash from the preview".to_string(),
+        )
+    })?;
+    let preview = preview_with_service(Arc::clone(&service), workspace, package_id).await?;
+    if preview.content_hash != expected_content_hash {
+        return Err(invalid_package(
+            package_id,
+            "activation confirmation does not match the current package content".to_string(),
+        ));
+    }
+    if !preview.provider_candidates_supported {
+        return Err(invalid_package(
+            package_id,
+            "the package contains no supported OpenCode custom tool declaration".to_string(),
+        ));
+    }
+
+    let (activation, activation_changed) = service
+        .set_activation(
+            workspace,
+            package_id,
+            true,
+            Some(expected_content_hash),
+            None,
+        )
+        .await?;
+    let activation_epoch = activation.activation_epoch.ok_or_else(|| {
+        unavailable(
+            package_id,
+            "activation state did not provide a generation".to_string(),
+        )
+    })?;
+    let activation_diagnostics = activation
+        .issues
+        .into_iter()
+        .map(|issue| issue.message)
+        .collect::<Vec<_>>();
+
+    let projection = async {
+        let (input, authority) = service
+            .load_activated_package(workspace, package_id)
+            .await?;
+        project_activated(
+            Arc::clone(&service),
+            workspace,
+            package_id,
+            input,
+            authority,
+            activation_diagnostics,
+        )
+        .await
+    }
+    .await;
+    match projection {
+        Ok(view) => Ok(view),
+        Err(error) if activation_changed => {
+            let rollback = service
+                .set_activation(workspace, package_id, false, None, Some(activation_epoch))
+                .await;
+            match rollback {
+                Ok((snapshot, _))
+                    if snapshot
+                        .packages
+                        .iter()
+                        .any(|package| package.package_id == package_id && !package.activated) =>
+                {
+                    Err(error)
+                }
+                Ok(_) => Err(unavailable(
+                    package_id,
+                    format!("{error}; activation changed concurrently and was not rolled back"),
+                )),
+                Err(rollback_error) => Err(unavailable(
+                    package_id,
+                    format!("{error}; activation rollback failed: {rollback_error}"),
+                )),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn project_activated(
+    service: Arc<ManagedPluginSourceService>,
+    workspace: &Path,
+    package_id: &str,
+    input: PluginPackageInput,
+    authority: PluginActivationAuthority,
+    initial_diagnostics: Vec<String>,
+) -> Result<ManagedPluginActivationView, ManagedPluginSourceError> {
+    let (project_domain_id, workspace_id, source, activation_epoch) =
+        authority.clone().into_parts();
+    let (binding, dispatch_targets) =
+        activated_binding(service, workspace, package_id, input, authority)?;
+    let client = binding.as_client();
+    let read = client
+        .read_plugins(read_request(
+            &project_domain_id,
+            &workspace_id,
+            activation_epoch,
+        ))
+        .await
+        .map_err(|error| unavailable(package_id, error.to_string()))?;
+    let mut diagnostics = initial_diagnostics;
+    diagnostics.extend(
+        read.diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.clone()),
+    );
+    let mut candidates = Vec::new();
+    for (index, (plugin_source, extension_point_id, declared_capability, _)) in
+        dispatch_targets.into_iter().enumerate()
+    {
+        let response = client
+            .dispatch(dispatch_envelope(
+                plugin_source,
+                extension_point_id,
+                declared_capability,
+                &project_domain_id,
+                &workspace_id,
+                activation_epoch,
+                index,
+            ))
+            .await
+            .map_err(|error| unavailable(package_id, error.to_string()))?;
+        diagnostics.extend(
+            response
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message.clone()),
+        );
+        candidates.extend(response.effects.iter().filter_map(project_candidate));
+    }
+    diagnostics.sort();
+    diagnostics.dedup();
+    Ok(
+        project_view(source, true, Some(activation_epoch), true, read, candidates)
+            .with_diagnostics(diagnostics),
+    )
+}
+
+fn preview_candidates(
+    dispatch_targets: &[PluginDispatchTarget],
+) -> Vec<ManagedPluginCandidateView> {
+    dispatch_targets
+        .iter()
+        .flat_map(|(source, _, _, targets)| {
+            targets
+                .iter()
+                .map(|(target, risk_level)| ManagedPluginCandidateView {
+                    entry_id: source.plugin_id.clone(),
+                    target: target.display_name.clone(),
+                    risk_level: risk_level_name(*risk_level).to_string(),
+                })
+        })
+        .collect()
+}
+
+fn activated_binding(
+    service: Arc<ManagedPluginSourceService>,
+    workspace: &Path,
+    package_id: &str,
+    input: PluginPackageInput,
+    authority: PluginActivationAuthority,
+) -> Result<(PluginRuntimeBinding, Vec<PluginDispatchTarget>), ManagedPluginSourceError> {
+    let (adapter, dispatch_targets) =
+        load_opencode_package_adapter(input, Some(authority.clone()), current_time_ms())
+            .map_err(|error| invalid_package(package_id, error.to_string()))?;
+    let host: Arc<dyn PluginRuntimeClient> = Arc::new(PluginRuntimeHost::new(adapter));
+    Ok((
+        PluginRuntimeBinding::client(Arc::new(ActivationGatedPluginRuntimeClient {
+            inner: host,
+            service,
+            workspace: workspace.to_path_buf(),
+            package_id: package_id.to_string(),
+            authority,
+        })),
+        dispatch_targets,
+    ))
+}
+
+fn project_view(
+    source: PluginPackageSourceIdentity,
+    activated: bool,
+    activation_epoch: Option<u64>,
+    provider_candidates_supported: bool,
+    response: PluginRuntimeReadResponse,
+    candidates: Vec<ManagedPluginCandidateView>,
+) -> ManagedPluginActivationView {
+    ManagedPluginActivationView {
+        package_id: source.package_id,
+        version: source.version,
+        adapter: source.adapter,
+        content_hash: source.content_hash,
+        activated,
+        activation_epoch,
+        entry_ids: response
+            .sources
+            .iter()
+            .map(|source| source.plugin_id.clone())
+            .collect(),
+        provider_candidates_supported,
+        permission_required: provider_candidates_supported,
+        candidates,
+        diagnostics: response
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.clone())
+            .collect(),
+    }
+}
+
+impl ManagedPluginActivationView {
+    fn with_diagnostics(mut self, diagnostics: Vec<String>) -> Self {
+        self.diagnostics = diagnostics;
+        self
+    }
+}
+
+fn project_candidate(
+    effect: &bitfun_runtime_ports::PluginEffectCandidate,
+) -> Option<ManagedPluginCandidateView> {
+    let PluginPermissionGate::PermissionRequired { .. } = &effect.permission else {
+        return None;
+    };
+    let PluginEffectCandidatePayload::ProviderCandidate { .. } = &effect.payload else {
+        return None;
+    };
+    Some(ManagedPluginCandidateView {
+        entry_id: effect.source_ref.plugin_id.clone(),
+        target: effect.target_ref.display_name.clone(),
+        risk_level: risk_level_name(effect.risk_level).to_string(),
+    })
+}
+
+fn read_request(
+    project_domain_id: &str,
+    workspace_id: &str,
+    trust_epoch: u64,
+) -> PluginRuntimeReadRequest {
+    PluginRuntimeReadRequest {
+        request_id: "managed-plugin-read".to_string(),
+        project_domain_id: project_domain_id.to_string(),
+        workspace_id: workspace_id.to_string(),
+        plugin_ids: Vec::new(),
+        include_config_validation: true,
+        epochs: runtime_epochs(trust_epoch),
+    }
+}
+
+fn dispatch_envelope(
+    source: PluginSourceRef,
+    extension_point_id: String,
+    declared_capability: PluginCapabilityRef,
+    project_domain_id: &str,
+    workspace_id: &str,
+    trust_epoch: u64,
+    index: usize,
+) -> PluginDispatchEnvelope {
+    PluginDispatchEnvelope {
+        envelope_version: 1,
+        event_id: format!("managed-plugin-candidate-{index}"),
+        event_type: "plugin.activation.candidates.requested".to_string(),
+        event_version: "v1".to_string(),
+        project_domain_id: project_domain_id.to_string(),
+        workspace_id: workspace_id.to_string(),
+        extension_point_id,
+        source,
+        declared_capability,
+        correlation_id: "managed-plugin-activation".to_string(),
+        causation_id: None,
+        idempotency_key: format!("managed-plugin-candidate-{index}"),
+        deadline_ms: 30_000,
+        epochs: runtime_epochs(trust_epoch),
+        payload_ref: None,
+    }
+}
+
+fn runtime_epochs(trust_epoch: u64) -> PluginRuntimeEpochs {
+    PluginRuntimeEpochs {
+        project_epoch: 0,
+        trust_epoch,
+        policy_epoch: 0,
+        tool_registry_epoch: None,
+    }
+}
+
+fn risk_level_name(risk: PluginRiskLevel) -> &'static str {
+    match risk {
+        PluginRiskLevel::Low => "low",
+        PluginRiskLevel::Medium => "medium",
+        PluginRiskLevel::High => "high",
+        _ => "unknown",
+    }
+}
+
+fn invalid_package(package_id: &str, diagnostic: String) -> ManagedPluginSourceError {
+    ManagedPluginSourceError::PackageInvalid {
+        package_id: package_id.to_string(),
+        diagnostic,
+    }
+}
+
+fn unavailable(package_id: &str, diagnostic: String) -> ManagedPluginSourceError {
+    ManagedPluginSourceError::TemporarilyUnavailable {
+        package_id: package_id.to_string(),
+        diagnostic,
+    }
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u64::MAX as u128) as u64
+}
+
+struct ActivationGatedPluginRuntimeClient {
+    inner: Arc<dyn PluginRuntimeClient>,
+    service: Arc<ManagedPluginSourceService>,
+    workspace: PathBuf,
+    package_id: String,
+    authority: PluginActivationAuthority,
+}
+
+impl ActivationGatedPluginRuntimeClient {
+    async fn check_authority(&self) -> PortResult<()> {
+        match self
+            .service
+            .has_activation_authority(&self.workspace, &self.package_id, &self.authority)
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(PortError::new(
+                PortErrorKind::NotAvailable,
+                "managed plugin activation is no longer current",
+            )),
+            Err(error) => Err(PortError::new(
+                PortErrorKind::NotAvailable,
+                error.to_string(),
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl PluginRuntimeClient for ActivationGatedPluginRuntimeClient {
+    fn availability(&self) -> PluginRuntimeAvailability {
+        self.inner.availability()
+    }
+
+    async fn read_plugins(
+        &self,
+        request: PluginRuntimeReadRequest,
+    ) -> PortResult<PluginRuntimeReadResponse> {
+        self.check_authority().await?;
+        self.inner.read_plugins(request).await
+    }
+
+    async fn dispatch(
+        &self,
+        envelope: PluginDispatchEnvelope,
+    ) -> PortResult<PluginResponseEnvelope> {
+        let deadline = Duration::from_millis(envelope.deadline_ms);
+        tokio::time::timeout(deadline, async {
+            self.check_authority().await?;
+            let response = self.inner.dispatch(envelope).await?;
+            self.check_authority().await?;
+            Ok(response)
+        })
+        .await
+        .map_err(|_| {
+            PortError::new(
+                PortErrorKind::Timeout,
+                "managed plugin dispatch exceeded its end-to-end deadline",
+            )
+        })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitfun_services_integrations::plugin_source::ManagedPluginTrustDecision;
+    use sha2::{Digest, Sha256};
+    use std::fs;
+    use tokio::sync::Notify;
+
+    const PLUGIN_SOURCE: &str = r#"
+import { type Plugin, tool } from "@opencode-ai/plugin"
+export const WorkspaceToolsPlugin: Plugin = async () => ({
+  tool: {
+    workspaceSummary: tool({
+      description: "Summarize the workspace",
+      args: { topic: tool.schema.string() },
+      async execute(args, context) { return `${context.directory}: ${args.topic}` },
+    }),
+  },
+})
+"#;
+
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        workspace: PathBuf,
+        source_path: PathBuf,
+        service: Arc<ManagedPluginSourceService>,
+    }
+
+    struct BlockingDispatchClient {
+        inner: Arc<dyn PluginRuntimeClient>,
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl PluginRuntimeClient for BlockingDispatchClient {
+        fn availability(&self) -> PluginRuntimeAvailability {
+            self.inner.availability()
+        }
+
+        async fn read_plugins(
+            &self,
+            request: PluginRuntimeReadRequest,
+        ) -> PortResult<PluginRuntimeReadResponse> {
+            self.inner.read_plugins(request).await
+        }
+
+        async fn dispatch(
+            &self,
+            envelope: PluginDispatchEnvelope,
+        ) -> PortResult<PluginResponseEnvelope> {
+            self.started.notify_one();
+            self.release.notified().await;
+            self.inner.dispatch(envelope).await
+        }
+    }
+
+    impl Fixture {
+        async fn new() -> Self {
+            Self::with_source(PLUGIN_SOURCE).await
+        }
+
+        async fn with_source(plugin_source: &str) -> Self {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("workspace");
+            let user = temp.path().join("user");
+            let package = workspace.join(".bitfun/plugins/acme.demo");
+            let source_path = package.join(".opencode/plugins/workspace-tools.ts");
+            fs::create_dir_all(source_path.parent().expect("source parent"))
+                .expect("create package");
+            fs::create_dir_all(user.join("plugins")).expect("create user plugins");
+            fs::write(&source_path, plugin_source).expect("write plugin source");
+            let file_hash = format!(
+                "sha256:{}",
+                hex::encode(Sha256::digest(plugin_source.as_bytes()))
+            );
+            fs::write(
+                package.join("bitfun.plugin.json"),
+                serde_json::to_vec_pretty(&serde_json::json!({
+                    "schemaVersion": 1,
+                    "id": "acme.demo",
+                    "version": "1.0.0",
+                    "adapter": "opencode_compatible",
+                    "files": [{
+                        "path": ".opencode/plugins/workspace-tools.ts",
+                        "sha256": file_hash
+                    }]
+                }))
+                .expect("serialize manifest"),
+            )
+            .expect("write manifest");
+            let service = Arc::new(ManagedPluginSourceService::new(
+                user.join("plugins"),
+                user.clone(),
+                workspace.join(".bitfun/plugins"),
+                workspace.clone(),
+                user.join("runtime/plugin-trust.json"),
+            ));
+            service
+                .set_trust(
+                    &workspace,
+                    "acme.demo",
+                    ManagedPluginTrustDecision::ApproveSource,
+                )
+                .await
+                .expect("approve package source");
+            Self {
+                _temp: temp,
+                workspace,
+                source_path,
+                service,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn preview_and_activation_project_only_permission_required_candidates() {
+        let fixture = Fixture::new().await;
+        let preview = preview_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+        )
+        .await
+        .expect("preview package");
+        assert!(!preview.activated);
+        assert!(!preview.candidates.is_empty());
+        assert!(preview
+            .candidates
+            .iter()
+            .all(|candidate| candidate.risk_level == "high"));
+        assert!(preview.provider_candidates_supported);
+        assert!(preview.permission_required);
+
+        let activated = set_activation_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+            true,
+            Some(&preview.content_hash),
+        )
+        .await
+        .expect("activate package");
+        assert!(activated.activated);
+        assert!(!activated.entry_ids.is_empty());
+        assert!(!activated.candidates.is_empty());
+        assert!(activated.permission_required);
+
+        let deactivated = set_activation_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+            false,
+            None,
+        )
+        .await
+        .expect("deactivate package");
+        assert!(!deactivated.activated);
+        assert_eq!(deactivated.activation_epoch, None);
+    }
+
+    #[tokio::test]
+    async fn activation_without_supported_custom_tools_does_not_persist_state() {
+        let fixture = Fixture::with_source(
+            r#"export const MetadataPlugin = async () => ({ config: async () => {} })"#,
+        )
+        .await;
+        let preview = preview_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+        )
+        .await
+        .expect("preview unsupported package");
+        assert!(!preview.provider_candidates_supported);
+
+        let error = set_activation_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+            true,
+            Some(&preview.content_hash),
+        )
+        .await
+        .expect_err("unsupported package must not activate");
+        assert!(matches!(
+            error,
+            ManagedPluginSourceError::PackageInvalid { .. }
+        ));
+        let snapshot = fixture.service.refresh(&fixture.workspace).await;
+        assert!(!snapshot.packages[0].activated);
+
+        let inactive = set_activation_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+            false,
+            None,
+        )
+        .await
+        .expect("keep package inactive");
+        assert_eq!(inactive.activation_epoch, None);
+    }
+
+    #[tokio::test]
+    async fn existing_binding_fails_after_deactivation_or_source_change() {
+        let fixture = Fixture::new().await;
+        let first_content_hash = preview_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+        )
+        .await
+        .expect("preview package")
+        .content_hash;
+        fixture
+            .service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&first_content_hash),
+                None,
+            )
+            .await
+            .expect("activate package");
+        let (input, authority) = fixture
+            .service
+            .load_activated_package(&fixture.workspace, "acme.demo")
+            .await
+            .expect("load activation authority");
+        let (project_domain_id, workspace_id, _, activation_epoch) = authority.clone().into_parts();
+        let (binding, _) = activated_binding(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+            input,
+            authority,
+        )
+        .expect("create binding");
+        binding
+            .as_client()
+            .read_plugins(read_request(
+                &project_domain_id,
+                &workspace_id,
+                activation_epoch,
+            ))
+            .await
+            .expect("binding is initially current");
+
+        fixture
+            .service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect("deactivate package");
+        assert!(binding
+            .as_client()
+            .read_plugins(read_request(
+                &project_domain_id,
+                &workspace_id,
+                activation_epoch,
+            ))
+            .await
+            .is_err());
+
+        let current_content_hash = preview_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+        )
+        .await
+        .expect("preview package")
+        .content_hash;
+        fixture
+            .service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&current_content_hash),
+                None,
+            )
+            .await
+            .expect("reactivate package");
+        let (current_input, current_authority) = fixture
+            .service
+            .load_activated_package(&fixture.workspace, "acme.demo")
+            .await
+            .expect("load current activation authority");
+        let (project_domain_id, workspace_id, _, activation_epoch) =
+            current_authority.clone().into_parts();
+        let (current_binding, _) = activated_binding(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+            current_input,
+            current_authority,
+        )
+        .expect("create current binding");
+        fs::write(&fixture.source_path, "changed without manifest update")
+            .expect("change package source");
+        assert!(current_binding
+            .as_client()
+            .read_plugins(read_request(
+                &project_domain_id,
+                &workspace_id,
+                activation_epoch,
+            ))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn dispatch_rechecks_activation_after_adapter_returns() {
+        let fixture = Fixture::new().await;
+        let preview = preview_with_service(
+            Arc::clone(&fixture.service),
+            &fixture.workspace,
+            "acme.demo",
+        )
+        .await
+        .expect("preview package");
+        fixture
+            .service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&preview.content_hash),
+                None,
+            )
+            .await
+            .expect("activate package");
+        let (input, authority) = fixture
+            .service
+            .load_activated_package(&fixture.workspace, "acme.demo")
+            .await
+            .expect("load activation authority");
+        let (project_domain_id, workspace_id, _, activation_epoch) = authority.clone().into_parts();
+        let (adapter, mut targets) =
+            load_opencode_package_adapter(input, Some(authority.clone()), current_time_ms())
+                .expect("create activated adapter");
+        let (source, extension_point_id, capability, _) =
+            targets.pop().expect("custom tool dispatch target");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let inner: Arc<dyn PluginRuntimeClient> = Arc::new(BlockingDispatchClient {
+            inner: Arc::new(PluginRuntimeHost::new(adapter)),
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        });
+        let client: Arc<dyn PluginRuntimeClient> = Arc::new(ActivationGatedPluginRuntimeClient {
+            inner,
+            service: Arc::clone(&fixture.service),
+            workspace: fixture.workspace.clone(),
+            package_id: "acme.demo".to_string(),
+            authority,
+        });
+        let dispatch = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move {
+                client
+                    .dispatch(dispatch_envelope(
+                        source,
+                        extension_point_id,
+                        capability,
+                        &project_domain_id,
+                        &workspace_id,
+                        activation_epoch,
+                        0,
+                    ))
+                    .await
+            }
+        });
+
+        started.notified().await;
+        fixture
+            .service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect("deactivate while dispatch is in flight");
+        release.notify_one();
+
+        let error = dispatch
+            .await
+            .expect("dispatch task")
+            .expect_err("revoked dispatch result must be discarded");
+        assert_eq!(error.kind, PortErrorKind::NotAvailable);
+    }
+}

--- a/src/crates/assembly/core/src/plugin_source.rs
+++ b/src/crates/assembly/core/src/plugin_source.rs
@@ -39,7 +39,7 @@ pub async fn set_managed_plugin_trust(
         .await
 }
 
-fn managed_plugin_source_service(
+pub(crate) fn managed_plugin_source_service(
     workspace: &Path,
 ) -> Result<ManagedPluginSourceService, ManagedPluginSourceError> {
     let path_manager = crate::infrastructure::try_get_path_manager_arc().map_err(|error| {

--- a/src/crates/contracts/product-domains/src/plugin_source.rs
+++ b/src/crates/contracts/product-domains/src/plugin_source.rs
@@ -4,13 +4,14 @@
 //! adapter or Plugin Runtime Host is selected. Filesystem discovery and trust
 //! persistence are concrete service integration responsibilities.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt;
 
 const PLUGIN_PACKAGE_MANIFEST_SCHEMA_VERSION: u16 = 1;
-const PLUGIN_TRUST_STORE_SCHEMA_VERSION: u16 = 1;
+const PLUGIN_TRUST_STORE_SCHEMA_VERSION: u16 = 2;
+const LEGACY_PLUGIN_TRUST_STORE_SCHEMA_VERSION: u16 = 1;
 
 const MAX_PACKAGE_ID_LEN: usize = 128;
 const MAX_ADAPTER_ID_LEN: usize = 64;
@@ -22,6 +23,7 @@ const MAX_PACKAGE_FILES: usize = 64;
 const MAX_PACKAGE_FILE_BYTES: usize = 1024 * 1024;
 const MAX_PACKAGE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_TRUST_RECORDS: usize = 1024;
+const MAX_ACTIVATION_RECORDS: usize = 1024;
 const SHA256_PREFIX: &str = "sha256:";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -234,10 +236,119 @@ struct PluginTrustRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PluginActivationRecord {
+    project_domain_id: String,
+    workspace_id: String,
+    source: PluginPackageSourceIdentity,
+    activation_epoch: u64,
+    updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PluginTrustStore {
     schema_version: u16,
     epoch: u64,
     records: Vec<PluginTrustRecord>,
+    activation_epoch: u64,
+    activation_records: Vec<PluginActivationRecord>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PersistedPluginTrustStore {
+    V2(PersistedPluginTrustStoreV2),
+    V1(PersistedPluginTrustStoreV1),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PersistedPluginTrustStoreV1 {
+    schema_version: u16,
+    epoch: u64,
+    records: Vec<PluginTrustRecord>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PersistedPluginTrustStoreV2 {
+    schema_version: u16,
+    epoch: u64,
+    records: Vec<PluginTrustRecord>,
+    activation_epoch: u64,
+    activation_records: Vec<PluginActivationRecord>,
+}
+
+impl<'de> Deserialize<'de> for PluginTrustStore {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match PersistedPluginTrustStore::deserialize(deserializer)? {
+            PersistedPluginTrustStore::V1(persisted)
+                if persisted.schema_version == LEGACY_PLUGIN_TRUST_STORE_SCHEMA_VERSION =>
+            {
+                Ok(Self {
+                    schema_version: PLUGIN_TRUST_STORE_SCHEMA_VERSION,
+                    epoch: persisted.epoch,
+                    records: persisted.records,
+                    activation_epoch: persisted.epoch,
+                    activation_records: Vec::new(),
+                })
+            }
+            PersistedPluginTrustStore::V1(persisted)
+                if persisted.schema_version == PLUGIN_TRUST_STORE_SCHEMA_VERSION =>
+            {
+                Err(serde::de::Error::custom(
+                    "schema-v2 plugin trust store requires activation fields",
+                ))
+            }
+            PersistedPluginTrustStore::V1(persisted) => Ok(Self {
+                schema_version: persisted.schema_version,
+                epoch: persisted.epoch,
+                records: persisted.records,
+                activation_epoch: 0,
+                activation_records: Vec::new(),
+            }),
+            PersistedPluginTrustStore::V2(persisted)
+                if persisted.schema_version == LEGACY_PLUGIN_TRUST_STORE_SCHEMA_VERSION =>
+            {
+                Err(serde::de::Error::custom(
+                    "schema-v1 plugin trust store cannot contain activation fields",
+                ))
+            }
+            PersistedPluginTrustStore::V2(persisted) => Ok(Self {
+                schema_version: persisted.schema_version,
+                epoch: persisted.epoch,
+                records: persisted.records,
+                activation_epoch: persisted.activation_epoch,
+                activation_records: persisted.activation_records,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginActivationAuthority {
+    project_domain_id: String,
+    workspace_id: String,
+    source: PluginPackageSourceIdentity,
+    activation_epoch: u64,
+}
+
+impl PluginActivationAuthority {
+    pub const fn activation_epoch(&self) -> u64 {
+        self.activation_epoch
+    }
+
+    pub fn into_parts(self) -> (String, String, PluginPackageSourceIdentity, u64) {
+        (
+            self.project_domain_id,
+            self.workspace_id,
+            self.source,
+            self.activation_epoch,
+        )
+    }
 }
 
 impl PluginTrustStore {
@@ -246,11 +357,17 @@ impl PluginTrustStore {
             schema_version: PLUGIN_TRUST_STORE_SCHEMA_VERSION,
             epoch: initial_epoch,
             records: Vec::new(),
+            activation_epoch: initial_epoch,
+            activation_records: Vec::new(),
         }
     }
 
     pub const fn epoch(&self) -> u64 {
         self.epoch
+    }
+
+    pub const fn activation_epoch(&self) -> u64 {
+        self.activation_epoch
     }
 
     pub fn validate(&self) -> Result<(), PluginSourceContractError> {
@@ -262,8 +379,14 @@ impl PluginTrustStore {
         if self.epoch == 0 {
             return Err(PluginSourceContractError::InvalidTrustEpoch);
         }
+        if self.activation_epoch == 0 {
+            return Err(PluginSourceContractError::InvalidActivationEpoch);
+        }
         if self.records.len() > MAX_TRUST_RECORDS {
             return Err(PluginSourceContractError::TooManyTrustRecords);
+        }
+        if self.activation_records.len() > MAX_ACTIVATION_RECORDS {
+            return Err(PluginSourceContractError::TooManyActivationRecords);
         }
 
         let mut package_scopes = HashSet::new();
@@ -280,6 +403,35 @@ impl PluginTrustStore {
             );
             if !package_scopes.insert(key) {
                 return Err(PluginSourceContractError::DuplicateTrustRecord);
+            }
+        }
+
+        let mut activation_scopes = HashSet::new();
+        for record in &self.activation_records {
+            validate_scope(&record.project_domain_id, &record.workspace_id)?;
+            record.source.validate()?;
+            if record.activation_epoch == 0 || record.activation_epoch > self.activation_epoch {
+                return Err(PluginSourceContractError::InvalidActivationEpoch);
+            }
+            let key = (
+                record.project_domain_id.as_str(),
+                record.workspace_id.as_str(),
+                &record.source,
+            );
+            if !activation_scopes.insert(key) {
+                return Err(PluginSourceContractError::DuplicateActivationRecord);
+            }
+            let Some(trust_record) = self.records.iter().find(|trust_record| {
+                trust_record.project_domain_id == record.project_domain_id
+                    && trust_record.workspace_id == record.workspace_id
+                    && trust_record.source.package_id == record.source.package_id
+            }) else {
+                return Err(PluginSourceContractError::UnknownActivationRecord);
+            };
+            if trust_record.source != record.source
+                || trust_record.trust_level != PluginPackageTrustLevel::SourceApproved
+            {
+                return Err(PluginSourceContractError::StaleActivationRecord);
             }
         }
         Ok(())
@@ -300,6 +452,117 @@ impl PluginTrustStore {
             })
             .map(|record| record.trust_level)
             .unwrap_or(PluginPackageTrustLevel::Unknown)
+    }
+
+    pub fn is_activated(
+        &self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        source: &PluginPackageSourceIdentity,
+    ) -> bool {
+        self.trust_level_for(project_domain_id, workspace_id, source)
+            == PluginPackageTrustLevel::SourceApproved
+            && self
+                .activation_record(project_domain_id, workspace_id, source)
+                .is_some()
+    }
+
+    pub fn activation_authority(
+        &self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        source: &PluginPackageSourceIdentity,
+    ) -> Result<PluginActivationAuthority, PluginSourceContractError> {
+        validate_scope(project_domain_id, workspace_id)?;
+        if self.trust_level_for(project_domain_id, workspace_id, source)
+            != PluginPackageTrustLevel::SourceApproved
+        {
+            return Err(PluginSourceContractError::PluginPackageNotActivated);
+        }
+        let record = self
+            .activation_record(project_domain_id, workspace_id, source)
+            .ok_or(PluginSourceContractError::PluginPackageNotActivated)?;
+        Ok(PluginActivationAuthority {
+            project_domain_id: project_domain_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            source: source.clone(),
+            activation_epoch: record.activation_epoch,
+        })
+    }
+
+    pub fn is_activation_current(&self, authority: &PluginActivationAuthority) -> bool {
+        self.trust_level_for(
+            &authority.project_domain_id,
+            &authority.workspace_id,
+            &authority.source,
+        ) == PluginPackageTrustLevel::SourceApproved
+            && self
+                .activation_record(
+                    &authority.project_domain_id,
+                    &authority.workspace_id,
+                    &authority.source,
+                )
+                .is_some_and(|record| record.activation_epoch == authority.activation_epoch)
+    }
+
+    pub fn set_activation(
+        &mut self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        source: PluginPackageSourceIdentity,
+        activated: bool,
+        updated_at_ms: u64,
+    ) -> Result<bool, PluginSourceContractError> {
+        validate_scope(project_domain_id, workspace_id)?;
+        source.validate()?;
+        if activated
+            && self.trust_level_for(project_domain_id, workspace_id, &source)
+                != PluginPackageTrustLevel::SourceApproved
+        {
+            return Err(PluginSourceContractError::ActivationRequiresSourceApproval);
+        }
+
+        let existing_index = self.activation_records.iter().position(|record| {
+            record.project_domain_id == project_domain_id
+                && record.workspace_id == workspace_id
+                && record.source == source
+        });
+        if activated == existing_index.is_some() {
+            return Ok(false);
+        }
+
+        let mut next = self.clone();
+        if activated {
+            if next.activation_records.len() >= MAX_ACTIVATION_RECORDS {
+                return Err(PluginSourceContractError::TooManyActivationRecords);
+            }
+            next.advance_activation_epoch()?;
+            next.activation_records.push(PluginActivationRecord {
+                project_domain_id: project_domain_id.to_string(),
+                workspace_id: workspace_id.to_string(),
+                source,
+                activation_epoch: next.activation_epoch,
+                updated_at_ms,
+            });
+        } else if let Some(index) = existing_index {
+            next.activation_records.remove(index);
+            next.advance_activation_epoch()?;
+        }
+        *self = next;
+        Ok(true)
+    }
+
+    fn activation_record(
+        &self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        source: &PluginPackageSourceIdentity,
+    ) -> Option<&PluginActivationRecord> {
+        self.activation_records.iter().find(|record| {
+            record.project_domain_id == project_domain_id
+                && record.workspace_id == workspace_id
+                && record.source == *source
+        })
     }
 
     pub fn apply_decision(
@@ -336,7 +599,7 @@ impl PluginTrustStore {
                     *record = PluginTrustRecord {
                         project_domain_id: project_domain_id.to_string(),
                         workspace_id: workspace_id.to_string(),
-                        source,
+                        source: source.clone(),
                         trust_level,
                         updated_at_ms,
                     };
@@ -347,7 +610,7 @@ impl PluginTrustStore {
                 next.records.push(PluginTrustRecord {
                     project_domain_id: project_domain_id.to_string(),
                     workspace_id: workspace_id.to_string(),
-                    source,
+                    source: source.clone(),
                     trust_level,
                     updated_at_ms,
                 });
@@ -358,7 +621,19 @@ impl PluginTrustStore {
         if !changed {
             return Ok(false);
         }
+        let previous_activation_len = next.activation_records.len();
+        next.activation_records.retain(|record| {
+            record.project_domain_id != project_domain_id
+                || record.workspace_id != workspace_id
+                || record.source.package_id != source.package_id
+                || (record.source == source
+                    && trust_level == PluginPackageTrustLevel::SourceApproved)
+        });
+        let activation_changed = next.activation_records.len() != previous_activation_len;
         next.advance_epoch()?;
+        if activation_changed {
+            next.advance_activation_epoch()?;
+        }
         *self = next;
         Ok(true)
     }
@@ -386,7 +661,17 @@ impl PluginTrustStore {
         if !changed {
             return Ok(false);
         }
+        let previous_activation_len = next.activation_records.len();
+        next.activation_records.retain(|record| {
+            record.project_domain_id != project_domain_id
+                || record.workspace_id != workspace_id
+                || current.contains(&record.source)
+        });
+        let activation_changed = next.activation_records.len() != previous_activation_len;
         next.advance_epoch()?;
+        if activation_changed {
+            next.advance_activation_epoch()?;
+        }
         *self = next;
         Ok(true)
     }
@@ -396,6 +681,14 @@ impl PluginTrustStore {
             .epoch
             .checked_add(1)
             .ok_or(PluginSourceContractError::TrustEpochExhausted)?;
+        Ok(())
+    }
+
+    fn advance_activation_epoch(&mut self) -> Result<(), PluginSourceContractError> {
+        self.activation_epoch = self
+            .activation_epoch
+            .checked_add(1)
+            .ok_or(PluginSourceContractError::ActivationEpochExhausted)?;
         Ok(())
     }
 }
@@ -421,11 +714,19 @@ pub enum PluginSourceContractError {
     EmptyScope,
     InvalidScope,
     InvalidTrustEpoch,
+    InvalidActivationEpoch,
     TooManyTrustRecords,
+    TooManyActivationRecords,
     UnknownTrustRecord,
+    UnknownActivationRecord,
+    StaleActivationRecord,
     DuplicateTrustRecord,
+    DuplicateActivationRecord,
     InvalidTrustTransition,
+    ActivationRequiresSourceApproval,
+    PluginPackageNotActivated,
     TrustEpochExhausted,
+    ActivationEpochExhausted,
 }
 
 impl fmt::Display for PluginSourceContractError {
@@ -483,18 +784,54 @@ impl fmt::Display for PluginSourceContractError {
             Self::EmptyScope => write!(formatter, "plugin trust scope is empty"),
             Self::InvalidScope => write!(formatter, "invalid plugin trust scope"),
             Self::InvalidTrustEpoch => write!(formatter, "plugin trust epoch must be positive"),
+            Self::InvalidActivationEpoch => {
+                write!(formatter, "plugin activation epoch must be positive")
+            }
             Self::TooManyTrustRecords => write!(formatter, "too many plugin trust records"),
+            Self::TooManyActivationRecords => {
+                write!(formatter, "too many plugin activation records")
+            }
             Self::UnknownTrustRecord => {
                 write!(formatter, "persisted plugin trust record cannot be unknown")
             }
+            Self::UnknownActivationRecord => {
+                write!(
+                    formatter,
+                    "persisted plugin activation record has no trust record"
+                )
+            }
+            Self::StaleActivationRecord => {
+                write!(
+                    formatter,
+                    "persisted plugin activation record is not source-approved"
+                )
+            }
             Self::DuplicateTrustRecord => write!(formatter, "duplicate plugin trust record"),
+            Self::DuplicateActivationRecord => {
+                write!(formatter, "duplicate plugin activation record")
+            }
             Self::InvalidTrustTransition => {
                 write!(
                     formatter,
                     "only a source-approved plugin package can be revoked"
                 )
             }
+            Self::ActivationRequiresSourceApproval => {
+                write!(
+                    formatter,
+                    "only a source-approved plugin package can be activated"
+                )
+            }
+            Self::PluginPackageNotActivated => {
+                write!(
+                    formatter,
+                    "plugin package input is not activated in this scope"
+                )
+            }
             Self::TrustEpochExhausted => write!(formatter, "plugin trust epoch exhausted"),
+            Self::ActivationEpochExhausted => {
+                write!(formatter, "plugin activation epoch exhausted")
+            }
         }
     }
 }

--- a/src/crates/contracts/product-domains/tests/plugin_source_contracts.rs
+++ b/src/crates/contracts/product-domains/tests/plugin_source_contracts.rs
@@ -7,6 +7,9 @@ use std::collections::BTreeMap;
 
 const HASH_A: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const HASH_B: &str = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PROJECT: &str = "project-1";
+const WORKSPACE: &str = "workspace-1";
+const SOURCE_PATH: &str = "file:///workspace/.bitfun/plugins/acme.demo";
 
 fn source(content_hash: &str, source_path: &str) -> PluginPackageSourceIdentity {
     PluginPackageSourceIdentity {
@@ -16,6 +19,80 @@ fn source(content_hash: &str, source_path: &str) -> PluginPackageSourceIdentity 
         source_path: source_path.to_string(),
         content_hash: content_hash.to_string(),
     }
+}
+
+fn approve_source(store: &mut PluginTrustStore, package: &PluginPackageSourceIdentity) {
+    store
+        .apply_decision(
+            PROJECT,
+            WORKSPACE,
+            package.clone(),
+            PluginTrustDecision::ApproveSource,
+            100,
+        )
+        .expect("approve source");
+}
+
+fn activate_source(store: &mut PluginTrustStore, package: &PluginPackageSourceIdentity) {
+    store
+        .set_activation(PROJECT, WORKSPACE, package.clone(), true, 101)
+        .expect("activate source");
+}
+
+fn fixed_package_input(source_path: &str) -> (PluginPackageInput, PluginPackageSourceIdentity) {
+    let bytes = b"export const Demo = async () => ({})".to_vec();
+    let file_hash = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
+    let manifest = PluginPackageManifest::parse_json(&format!(
+        r#"{{"schemaVersion":1,"id":"acme.demo","version":"1.0.0","adapter":"test_adapter","files":[{{"path":"plugin/main.ts","sha256":"{file_hash}"}}]}}"#
+    ))
+    .expect("valid manifest");
+    let package = source(
+        &manifest.content_hash().expect("manifest hash"),
+        source_path,
+    );
+    let input = PluginPackageInput::new(
+        manifest,
+        package.clone(),
+        BTreeMap::from([("plugin/main.ts".to_string(), bytes)]),
+    )
+    .expect("valid fixed package input");
+    (input, package)
+}
+
+fn trust_record(
+    package: &PluginPackageSourceIdentity,
+    trust_level: PluginPackageTrustLevel,
+) -> serde_json::Value {
+    serde_json::json!({
+        "projectDomainId": PROJECT,
+        "workspaceId": WORKSPACE,
+        "source": package,
+        "trustLevel": trust_level,
+        "updatedAtMs": 100
+    })
+}
+
+fn activation_record(package: &PluginPackageSourceIdentity) -> serde_json::Value {
+    serde_json::json!({
+        "projectDomainId": PROJECT,
+        "workspaceId": WORKSPACE,
+        "source": package,
+        "activationEpoch": 2,
+        "updatedAtMs": 101
+    })
+}
+
+fn schema_v2_store(
+    records: Vec<serde_json::Value>,
+    activation_records: Vec<serde_json::Value>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": 2,
+        "epoch": 2,
+        "records": records,
+        "activationEpoch": 2,
+        "activationRecords": activation_records
+    })
 }
 
 #[test]
@@ -240,9 +317,11 @@ fn revoke_requires_an_existing_source_approval() {
 #[test]
 fn trust_store_rejects_unknown_schema_and_duplicate_identity_records() {
     let unknown_schema = r#"{
-      "schemaVersion": 2,
+      "schemaVersion": 3,
       "epoch": 1,
-      "records": []
+      "records": [],
+      "activationEpoch": 1,
+      "activationRecords": []
     }"#;
     let unknown_schema: PluginTrustStore =
         serde_json::from_str(unknown_schema).expect("deserialize unknown schema");
@@ -283,4 +362,225 @@ fn trust_store_rejects_unknown_schema_and_duplicate_identity_records() {
     let duplicate_records: PluginTrustStore =
         serde_json::from_value(duplicate_records).expect("deserialize duplicate records");
     assert!(duplicate_records.validate().is_err());
+}
+
+#[test]
+fn activation_lifecycle_is_exact_independent_and_idempotent() {
+    let package = source(HASH_A, SOURCE_PATH);
+    let mut store = PluginTrustStore::new(7);
+    assert_eq!(store.activation_epoch(), 7);
+    assert_eq!(
+        store
+            .set_activation(PROJECT, WORKSPACE, package.clone(), true, 100)
+            .expect_err("unapproved source must not activate")
+            .to_string(),
+        "only a source-approved plugin package can be activated"
+    );
+
+    approve_source(&mut store, &package);
+    let trust_epoch = store.epoch();
+    activate_source(&mut store, &package);
+    assert_eq!((store.epoch(), store.activation_epoch()), (trust_epoch, 8));
+    assert!(store.is_activated(PROJECT, WORKSPACE, &package));
+    assert!(!store.is_activated(PROJECT, "workspace-2", &package));
+    assert!(!store.is_activated(PROJECT, WORKSPACE, &source(HASH_B, SOURCE_PATH)));
+    assert!(!store
+        .set_activation(PROJECT, WORKSPACE, package.clone(), true, 102)
+        .expect("repeat activation"));
+
+    assert!(store
+        .set_activation(PROJECT, WORKSPACE, package.clone(), false, 103)
+        .expect("deactivate source"));
+    assert_eq!((store.epoch(), store.activation_epoch()), (trust_epoch, 9));
+    assert!(!store
+        .set_activation(PROJECT, WORKSPACE, package, false, 104)
+        .expect("repeat deactivation"));
+    assert_eq!((store.epoch(), store.activation_epoch()), (trust_epoch, 9));
+}
+
+#[test]
+fn source_changes_deny_and_revoke_invalidate_activation_atomically() {
+    let original = source(HASH_A, SOURCE_PATH);
+    let changed = source(HASH_B, SOURCE_PATH);
+    let mut store = PluginTrustStore::new(1);
+    approve_source(&mut store, &original);
+    activate_source(&mut store, &original);
+    let epochs = (store.epoch(), store.activation_epoch());
+    assert!(store
+        .reconcile_sources(PROJECT, WORKSPACE, std::slice::from_ref(&changed))
+        .expect("reconcile changed source"));
+    assert_eq!(
+        (store.epoch(), store.activation_epoch()),
+        (epochs.0 + 1, epochs.1 + 1)
+    );
+    assert!(!store.is_activated(PROJECT, WORKSPACE, &original));
+    assert!(!store
+        .reconcile_sources(PROJECT, WORKSPACE, &[changed])
+        .expect("repeat reconciliation"));
+
+    for decision in [PluginTrustDecision::Denied, PluginTrustDecision::Revoked] {
+        let mut store = PluginTrustStore::new(1);
+        approve_source(&mut store, &original);
+        activate_source(&mut store, &original);
+        let epochs = (store.epoch(), store.activation_epoch());
+        store
+            .apply_decision(PROJECT, WORKSPACE, original.clone(), decision, 102)
+            .expect("replace source approval");
+        assert_eq!(
+            (store.epoch(), store.activation_epoch()),
+            (epochs.0 + 1, epochs.1 + 1)
+        );
+        assert!(!store.is_activated(PROJECT, WORKSPACE, &original));
+    }
+}
+
+#[test]
+fn schema_v1_migrates_inactive_and_recreated_stores_do_not_reuse_generation() {
+    let package = source(HASH_A, SOURCE_PATH);
+    let schema_v1 = serde_json::json!({
+        "schemaVersion": 1,
+        "epoch": 7,
+        "records": [trust_record(&package, PluginPackageTrustLevel::SourceApproved)]
+    });
+    let store: PluginTrustStore =
+        serde_json::from_value(schema_v1).expect("deserialize schema-v1 store");
+    store.validate().expect("validate migrated schema-v1 store");
+    assert_eq!(store.activation_epoch(), 7);
+    assert!(!store.is_activated(PROJECT, WORKSPACE, &package));
+    let migrated = serde_json::to_value(&store).expect("serialize migrated store");
+    assert_eq!(migrated["schemaVersion"], 2);
+    assert_eq!(migrated["activationRecords"], serde_json::json!([]));
+
+    let mut recreated = PluginTrustStore::new(store.activation_epoch());
+    approve_source(&mut recreated, &package);
+    activate_source(&mut recreated, &package);
+    assert!(recreated.activation_epoch() > store.activation_epoch());
+}
+
+#[test]
+fn invalid_persisted_activation_records_fail_closed() {
+    let package = source(HASH_A, SOURCE_PATH);
+    let activation = activation_record(&package);
+    let approved = trust_record(&package, PluginPackageTrustLevel::SourceApproved);
+
+    let duplicate: PluginTrustStore = serde_json::from_value(schema_v2_store(
+        vec![approved],
+        vec![activation.clone(), activation.clone()],
+    ))
+    .expect("deserialize duplicate activations");
+    assert_eq!(
+        duplicate
+            .validate()
+            .expect_err("reject duplicate")
+            .to_string(),
+        "duplicate plugin activation record"
+    );
+
+    let unknown: PluginTrustStore =
+        serde_json::from_value(schema_v2_store(vec![], vec![activation.clone()]))
+            .expect("deserialize unknown activation");
+    assert_eq!(
+        unknown.validate().expect_err("reject unknown").to_string(),
+        "persisted plugin activation record has no trust record"
+    );
+
+    let stale: PluginTrustStore = serde_json::from_value(schema_v2_store(
+        vec![trust_record(&package, PluginPackageTrustLevel::Denied)],
+        vec![activation.clone()],
+    ))
+    .expect("deserialize stale activation");
+    assert_eq!(
+        stale.validate().expect_err("reject stale").to_string(),
+        "persisted plugin activation record is not source-approved"
+    );
+
+    let excessive: PluginTrustStore =
+        serde_json::from_value(schema_v2_store(vec![], vec![activation; 1025]))
+            .expect("deserialize excessive activations");
+    assert_eq!(
+        excessive
+            .validate()
+            .expect_err("reject excessive")
+            .to_string(),
+        "too many plugin activation records"
+    );
+}
+
+#[test]
+fn activation_authority_requires_the_exact_activated_package() {
+    let (_, package) = fixed_package_input(SOURCE_PATH);
+    let mut store = PluginTrustStore::new(1);
+    assert_eq!(
+        store
+            .activation_authority(PROJECT, WORKSPACE, &package)
+            .expect_err("inactive package must not create authority")
+            .to_string(),
+        "plugin package input is not activated in this scope"
+    );
+
+    approve_source(&mut store, &package);
+    activate_source(&mut store, &package);
+    let (_, mismatched) = fixed_package_input("file:///workspace/other/acme.demo");
+    assert!(store
+        .activation_authority(PROJECT, WORKSPACE, &mismatched)
+        .is_err());
+
+    let authority = store
+        .activation_authority(PROJECT, WORKSPACE, &package)
+        .expect("create exact activation authority");
+    let issued_epoch = authority.activation_epoch();
+    assert_eq!(issued_epoch, store.activation_epoch());
+    assert!(store.is_activation_current(&authority));
+    let mut other = source(HASH_B, "file:///workspace/.bitfun/plugins/acme.other");
+    other.package_id = "acme.other".to_string();
+    approve_source(&mut store, &other);
+    activate_source(&mut store, &other);
+    assert!(store.activation_epoch() > issued_epoch);
+    assert!(store.is_activation_current(&authority));
+    let cross_scope = store
+        .activation_authority(PROJECT, "workspace-2", &package)
+        .expect_err("activation authority must stay in its exact scope");
+    assert_eq!(
+        cross_scope.to_string(),
+        "plugin package input is not activated in this scope"
+    );
+
+    let retained = authority.clone();
+    store
+        .set_activation(PROJECT, WORKSPACE, package.clone(), false, 102)
+        .expect("deactivate source");
+    assert!(!store.is_activation_current(&retained));
+
+    let (project, workspace, authority_source, activation_epoch) = authority.into_parts();
+    assert_eq!(activation_epoch, issued_epoch);
+    assert_ne!(activation_epoch, store.activation_epoch());
+    assert_eq!((project.as_str(), workspace.as_str()), (PROJECT, WORKSPACE));
+    assert_eq!(authority_source, package);
+}
+
+#[test]
+fn trust_store_schema_versions_reject_missing_null_and_cross_version_fields() {
+    let missing_v2 = r#"{
+      "schemaVersion": 2,
+      "epoch": 1,
+      "records": [],
+      "activationEpoch": 1
+    }"#;
+    assert!(serde_json::from_str::<PluginTrustStore>(missing_v2).is_err());
+
+    for invalid_v1 in [
+        r#"{"schemaVersion":1,"epoch":1,"records":[],"activationEpoch":null}"#,
+        r#"{"schemaVersion":1,"epoch":1,"records":[],"activationRecords":null}"#,
+    ] {
+        assert!(serde_json::from_str::<PluginTrustStore>(invalid_v1).is_err());
+    }
+
+    let null_v2 = r#"{
+      "schemaVersion": 2,
+      "epoch": 1,
+      "records": [],
+      "activationEpoch": 1,
+      "activationRecords": null
+    }"#;
+    assert!(serde_json::from_str::<PluginTrustStore>(null_v2).is_err());
 }

--- a/src/crates/services/services-integrations/src/plugin_source.rs
+++ b/src/crates/services/services-integrations/src/plugin_source.rs
@@ -4,8 +4,9 @@
 //! file interpretation remains in the corresponding adapter.
 
 use bitfun_product_domains::plugin_source::{
-    PluginPackageInput, PluginPackageManifest, PluginPackageSourceIdentity,
-    PluginPackageTrustLevel, PluginSourceContractError, PluginTrustStore,
+    PluginActivationAuthority, PluginPackageInput, PluginPackageManifest,
+    PluginPackageSourceIdentity, PluginPackageTrustLevel, PluginSourceContractError,
+    PluginTrustStore,
 };
 pub use bitfun_product_domains::plugin_source::{
     PluginPackageTrustLevel as ManagedPluginTrustLevel,
@@ -42,6 +43,7 @@ pub struct ManagedPluginPackageView {
     pub source_path: String,
     pub content_hash: String,
     pub trust_level: PluginPackageTrustLevel,
+    pub activated: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +59,7 @@ pub struct ManagedPluginSourceSnapshot {
     pub packages: Vec<ManagedPluginPackageView>,
     pub issues: Vec<ManagedPluginSourceIssue>,
     pub trust_epoch: Option<u64>,
+    pub activation_epoch: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -110,6 +113,32 @@ fn map_load_store_error(
         }
     } else {
         error.into()
+    }
+}
+
+fn map_activation_store_error(
+    package_id: &str,
+    error: PluginSourceStoreError,
+) -> ManagedPluginSourceError {
+    match error {
+        PluginSourceStoreError::Contract(
+            error @ (PluginSourceContractError::ActivationRequiresSourceApproval
+            | PluginSourceContractError::PluginPackageNotActivated),
+        ) => ManagedPluginSourceError::PackageInvalid {
+            package_id: package_id.to_string(),
+            diagnostic: error.to_string(),
+        },
+        PluginSourceStoreError::ActivationContentMismatch => {
+            ManagedPluginSourceError::PackageInvalid {
+                package_id: package_id.to_string(),
+                diagnostic: "activation confirmation does not match the current package content"
+                    .to_string(),
+            }
+        }
+        PluginSourceStoreError::Contract(error) => {
+            ManagedPluginSourceError::TrustStore(error.to_string())
+        }
+        error => error.into(),
     }
 }
 
@@ -187,12 +216,168 @@ impl ManagedPluginSourceService {
         Ok(build_snapshot(discovery, Some(trust_store), None, &scope))
     }
 
+    /// Activate or deactivate one exact managed package without changing source approval.
+    pub async fn set_activation(
+        &self,
+        workspace: &Path,
+        package_id: &str,
+        activated: bool,
+        expected_content_hash: Option<&str>,
+        expected_activation_epoch: Option<u64>,
+    ) -> Result<(ManagedPluginSourceSnapshot, bool), ManagedPluginSourceError> {
+        let scope = workspace_scope(workspace);
+        let result = self
+            .store
+            .apply_activation(
+                &scope.project_domain_id,
+                &scope.workspace_id,
+                package_id,
+                activated,
+                expected_content_hash,
+                expected_activation_epoch,
+                current_time_ms(),
+            )
+            .await;
+        match result {
+            Ok(outcome) => {
+                let mut snapshot =
+                    build_snapshot(outcome.discovery, Some(outcome.trust_store), None, &scope);
+                if let Some(error) = outcome.durability_warning {
+                    snapshot.issues.push(ManagedPluginSourceIssue {
+                        code: "activation_durability_uncertain".to_string(),
+                        source_path: self.store.trust_path.display().to_string(),
+                        message: error.to_string(),
+                        is_error: false,
+                    });
+                }
+                Ok((snapshot, outcome.changed))
+            }
+            Err(error) => Err(map_activation_store_error(package_id, error)),
+        }
+    }
+
     /// Load one selected package as fixed content for an ecosystem adapter.
     pub async fn load_package(
         &self,
         workspace: &Path,
         package_id: &str,
     ) -> Result<PluginPackageInput, ManagedPluginSourceError> {
+        Ok(self.load_approved_package(workspace, package_id).await?.0)
+    }
+
+    /// Load fixed package content with evidence for the current activation generation.
+    pub async fn load_activated_package(
+        &self,
+        workspace: &Path,
+        package_id: &str,
+    ) -> Result<(PluginPackageInput, PluginActivationAuthority), ManagedPluginSourceError> {
+        let (input, trust_store, budget) =
+            self.load_approved_package(workspace, package_id).await?;
+        let (manifest, source, files) = input.into_parts();
+        let scope = workspace_scope(workspace);
+        let authority = trust_store
+            .activation_authority(&scope.project_domain_id, &scope.workspace_id, &source)
+            .map_err(|error| ManagedPluginSourceError::PackageInvalid {
+                package_id: package_id.to_string(),
+                diagnostic: error.to_string(),
+            })?;
+        if !self
+            .store
+            .activation_authority_matches(&authority, &budget)
+            .await?
+        {
+            return Err(ManagedPluginSourceError::TemporarilyUnavailable {
+                package_id: package_id.to_string(),
+                diagnostic: "managed plugin activation changed while loading; retry the operation"
+                    .to_string(),
+            });
+        }
+        let input = PluginPackageInput::new(manifest, source, files).map_err(|error| {
+            ManagedPluginSourceError::PackageInvalid {
+                package_id: package_id.to_string(),
+                diagnostic: error.to_string(),
+            }
+        })?;
+        Ok((input, authority))
+    }
+
+    /// Check the selected package identity and its persisted activation generation.
+    pub async fn has_activation_authority(
+        &self,
+        workspace: &Path,
+        package_id: &str,
+        authority: &PluginActivationAuthority,
+    ) -> Result<bool, ManagedPluginSourceError> {
+        let (input, budget) = match self.read_selected_package(package_id).await {
+            Ok(loaded) => loaded,
+            Err(
+                ManagedPluginSourceError::PackageNotFound(_)
+                | ManagedPluginSourceError::PackageInvalid { .. },
+            ) => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        let source = input.into_parts().1;
+        let (project_domain_id, workspace_id, authority_source, _) = authority.clone().into_parts();
+        let scope = workspace_scope(workspace);
+        if project_domain_id != scope.project_domain_id
+            || workspace_id != scope.workspace_id
+            || authority_source != source
+        {
+            return Ok(false);
+        }
+        self.store
+            .activation_authority_matches(authority, &budget)
+            .await
+            .map_err(|error| map_load_store_error(package_id, error))
+    }
+
+    async fn load_approved_package(
+        &self,
+        workspace: &Path,
+        package_id: &str,
+    ) -> Result<(PluginPackageInput, PluginTrustStore, OperationScanBudget), ManagedPluginSourceError>
+    {
+        let (input, budget) = self.read_selected_package(package_id).await?;
+        let input_source = input.clone().into_parts().1;
+        let scope = workspace_scope(workspace);
+        let trust_store = self
+            .store
+            .load_trust_store_with_budget(&budget)
+            .await
+            .map_err(|error| map_load_store_error(package_id, error))?;
+        if trust_store.trust_level_for(&scope.project_domain_id, &scope.workspace_id, &input_source)
+            != PluginPackageTrustLevel::SourceApproved
+        {
+            return Err(ManagedPluginSourceError::PackageInvalid {
+                package_id: package_id.to_string(),
+                diagnostic: "managed plugin package source is not approved".to_string(),
+            });
+        }
+        if !self
+            .store
+            .trust_approval_matches(
+                trust_store.epoch(),
+                &scope.project_domain_id,
+                &scope.workspace_id,
+                &input_source,
+                &budget,
+            )
+            .await
+            .map_err(|error| map_load_store_error(package_id, error))?
+        {
+            return Err(ManagedPluginSourceError::TemporarilyUnavailable {
+                package_id: package_id.to_string(),
+                diagnostic: "managed plugin trust changed while loading; retry the operation"
+                    .to_string(),
+            });
+        }
+        Ok((input, trust_store, budget))
+    }
+
+    async fn read_selected_package(
+        &self,
+        package_id: &str,
+    ) -> Result<(PluginPackageInput, OperationScanBudget), ManagedPluginSourceError> {
         let mut budget = OperationScanBudget::new();
         let _load_permit = tokio::time::timeout(budget.remaining_time(), self.load_gate.acquire())
             .await
@@ -204,7 +389,6 @@ impl ManagedPluginSourceService {
                 package_id: package_id.to_string(),
                 diagnostic: "load capacity is unavailable; retry the operation".to_string(),
             })?;
-        let scope = workspace_scope(workspace);
         let mut discovery = self
             .store
             .discover_with_budget_for(&mut budget, Some(package_id))
@@ -240,11 +424,6 @@ impl ManagedPluginSourceService {
                 },
             );
         }
-        let trust_store = self
-            .store
-            .load_trust_store_with_budget(&budget)
-            .await
-            .map_err(|error| map_load_store_error(package_id, error))?;
         let index = discovery
             .packages
             .iter()
@@ -265,18 +444,6 @@ impl ManagedPluginSourceService {
                     )
             })?;
         let package = discovery.packages.swap_remove(index);
-        let source_trust_level = trust_store.trust_level_for(
-            &scope.project_domain_id,
-            &scope.workspace_id,
-            &package.identity,
-        );
-        if source_trust_level != PluginPackageTrustLevel::SourceApproved {
-            return Err(ManagedPluginSourceError::PackageInvalid {
-                package_id: package_id.to_string(),
-                diagnostic: "managed plugin package source is not approved".to_string(),
-            });
-        }
-        let input_source = package.identity.clone();
         let input = PluginPackageInput::new(
             package.manifest,
             package.identity,
@@ -288,25 +455,7 @@ impl ManagedPluginSourceService {
             package_id: package_id.to_string(),
             diagnostic: error.to_string(),
         })?;
-        if !self
-            .store
-            .trust_approval_matches(
-                trust_store.epoch(),
-                &scope.project_domain_id,
-                &scope.workspace_id,
-                &input_source,
-                &budget,
-            )
-            .await
-            .map_err(|error| map_load_store_error(package_id, error))?
-        {
-            return Err(ManagedPluginSourceError::TemporarilyUnavailable {
-                package_id: package_id.to_string(),
-                diagnostic: "managed plugin trust changed while loading; retry the operation"
-                    .to_string(),
-            });
-        }
-        Ok(input)
+        Ok((input, budget))
     }
 }
 
@@ -348,6 +497,14 @@ fn build_snapshot(
             } else {
                 PluginPackageTrustLevel::Unknown
             },
+            activated: discovery_complete
+                && trust_store.as_ref().is_some_and(|trust_store| {
+                    trust_store.is_activated(
+                        &scope.project_domain_id,
+                        &scope.workspace_id,
+                        &package.identity,
+                    )
+                }),
         })
         .collect::<Vec<_>>();
     packages.sort_by(|left, right| left.package_id.cmp(&right.package_id));
@@ -361,6 +518,7 @@ fn build_snapshot(
         packages,
         issues,
         trust_epoch: trust_store.as_ref().map(PluginTrustStore::epoch),
+        activation_epoch: trust_store.as_ref().map(PluginTrustStore::activation_epoch),
     }
 }
 
@@ -916,11 +1074,19 @@ fn operation_scan_timeout(path: &Path) -> PluginSourceIssue {
 struct ProductPluginSourceStore {
     roots: Vec<PluginPackageRoot>,
     trust_path: PathBuf,
+    parent_sync: fn(&Path) -> io::Result<()>,
 }
 
 struct LoadedTrustStore {
     store: PluginTrustStore,
     identity: Option<TrustFileIdentity>,
+}
+
+struct ActivationStoreOutcome {
+    discovery: PluginSourceDiscovery,
+    trust_store: PluginTrustStore,
+    changed: bool,
+    durability_warning: Option<PluginSourceStoreError>,
 }
 
 #[derive(Debug)]
@@ -977,7 +1143,11 @@ struct TrustFileIdentity {
 
 impl ProductPluginSourceStore {
     fn new(roots: Vec<PluginPackageRoot>, trust_path: PathBuf) -> Self {
-        Self { roots, trust_path }
+        Self {
+            roots,
+            trust_path,
+            parent_sync: sync_parent_directory,
+        }
     }
 
     #[cfg(test)]
@@ -1329,13 +1499,42 @@ impl ProductPluginSourceStore {
                 });
             }
         };
-        let store = serde_json::from_slice::<PluginTrustStore>(&bytes).map_err(|source| {
+        let persisted = serde_json::from_slice::<serde_json::Value>(&bytes).map_err(|source| {
+            PluginSourceStoreError::TrustDeserialize {
+                path: self.trust_path.clone(),
+                source,
+            }
+        })?;
+        let migrated_from_v1 = persisted
+            .get("schemaVersion")
+            .and_then(serde_json::Value::as_u64)
+            == Some(1);
+        let store = serde_json::from_value::<PluginTrustStore>(persisted).map_err(|source| {
             PluginSourceStoreError::TrustDeserialize {
                 path: self.trust_path.clone(),
                 source,
             }
         })?;
         store.validate()?;
+        if migrated_from_v1 {
+            self.persist_trust_store_locked(
+                &store,
+                file_guard,
+                TrustFileExpectation::Identity(identity),
+            )
+            .await?;
+            let (_, migrated_identity) =
+                read_trust_file(&self.trust_path).await.map_err(|source| {
+                    PluginSourceStoreError::TrustRead {
+                        path: self.trust_path.clone(),
+                        source,
+                    }
+                })?;
+            return Ok(LoadedTrustStore {
+                store,
+                identity: Some(migrated_identity),
+            });
+        }
         Ok(LoadedTrustStore {
             store,
             identity: Some(identity),
@@ -1436,6 +1635,101 @@ impl ProductPluginSourceStore {
             .await?;
         }
         Ok((verified, store))
+    }
+
+    async fn apply_activation(
+        &self,
+        project_domain_id: &str,
+        workspace_id: &str,
+        package_id: &str,
+        activated: bool,
+        expected_content_hash: Option<&str>,
+        expected_activation_epoch: Option<u64>,
+        updated_at_ms: u64,
+    ) -> Result<ActivationStoreOutcome, PluginSourceStoreError> {
+        let mut scan_budget = OperationScanBudget::new();
+        let discovery = self.discover_with_budget(&mut scan_budget).await;
+        if !discovery.is_complete() {
+            return Err(PluginSourceStoreError::IncompleteDiscovery);
+        }
+        let source = discovery
+            .packages
+            .iter()
+            .find(|package| package.identity.package_id == package_id)
+            .map(|package| package.identity.clone())
+            .ok_or_else(|| PluginSourceStoreError::PackageNotFound(package_id.to_string()))?;
+        if activated && expected_content_hash.is_none_or(|expected| expected != source.content_hash)
+        {
+            return Err(PluginSourceStoreError::ActivationContentMismatch);
+        }
+        let mut file_guard = self.acquire_trust_file_lock(&scan_budget).await?;
+        let loaded = self
+            .load_trust_store_generation_locked(&mut file_guard, false)
+            .await?;
+        let mut store = loaded.store;
+        let before = store.clone();
+        if !activated {
+            if let Some(expected) = expected_activation_epoch {
+                let current = store
+                    .activation_authority(project_domain_id, workspace_id, &source)
+                    .ok()
+                    .map(|authority| authority.activation_epoch());
+                if current != Some(expected) {
+                    return Ok(ActivationStoreOutcome {
+                        discovery,
+                        trust_store: store,
+                        changed: false,
+                        durability_warning: None,
+                    });
+                }
+            }
+        }
+        store.reconcile_sources(project_domain_id, workspace_id, &discovery.identities())?;
+        let changed = store.set_activation(
+            project_domain_id,
+            workspace_id,
+            source,
+            activated,
+            updated_at_ms,
+        )?;
+        let verified = self.discover_with_budget(&mut scan_budget).await;
+        if !verified.is_complete()
+            || discovery.identities() != verified.identities()
+            || discovery.workspace_package_ids != verified.workspace_package_ids
+        {
+            return Err(PluginSourceStoreError::SourceChanged);
+        }
+        let durability_warning = if store != before {
+            match self
+                .persist_trust_store_locked(
+                    &store,
+                    &mut file_guard,
+                    loaded
+                        .identity
+                        .map(TrustFileExpectation::Identity)
+                        .unwrap_or(TrustFileExpectation::Missing),
+                )
+                .await
+            {
+                Ok(()) => None,
+                Err(error @ PluginSourceStoreError::TrustDurabilityUncertain { .. }) => {
+                    if activated {
+                        Some(error)
+                    } else {
+                        return Err(error);
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        } else {
+            None
+        };
+        Ok(ActivationStoreOutcome {
+            discovery: verified,
+            trust_store: store,
+            changed,
+            durability_warning,
+        })
     }
 
     async fn reconcile_trust(
@@ -1554,6 +1848,16 @@ impl ProductPluginSourceStore {
                 == PluginPackageTrustLevel::SourceApproved)
     }
 
+    async fn activation_authority_matches(
+        &self,
+        authority: &PluginActivationAuthority,
+        operation_budget: &OperationScanBudget,
+    ) -> Result<bool, PluginSourceStoreError> {
+        let mut file_guard = self.acquire_trust_file_lock(operation_budget).await?;
+        let current = self.load_trust_store_locked(&mut file_guard).await?;
+        Ok(current.is_activation_current(authority))
+    }
+
     async fn load_trust_store_with_budget(
         &self,
         operation_budget: &OperationScanBudget,
@@ -1635,12 +1939,13 @@ impl ProductPluginSourceStore {
             return Err(PluginSourceStoreError::TrustStoreTooLarge(bytes.len()));
         }
         let trust_path = self.trust_path.clone();
+        let parent_sync = self.parent_sync;
         file_guard
             .run_blocking(move || {
                 if !trust_file_expectation_matches(&trust_path, expected)? {
                     return Err(PluginSourceStoreError::TrustGenerationChanged);
                 }
-                persist_trust_bytes(&trust_path, &bytes)
+                persist_trust_bytes_with_parent_sync(&trust_path, &bytes, parent_sync)
             })
             .await
     }
@@ -1732,12 +2037,10 @@ enum PluginSourceStoreError {
     IncompleteDiscovery,
     #[error("managed plugin sources changed during trust validation; retry the operation")]
     SourceChanged,
+    #[error("managed plugin activation confirmation does not match the current content hash")]
+    ActivationContentMismatch,
     #[error("plugin trust store generation changed during the operation; retry the operation")]
     TrustGenerationChanged,
-}
-
-fn persist_trust_bytes(path: &Path, bytes: &[u8]) -> Result<(), PluginSourceStoreError> {
-    persist_trust_bytes_with_parent_sync(path, bytes, sync_parent_directory)
 }
 
 fn persist_trust_bytes_with_parent_sync(
@@ -2627,16 +2930,18 @@ fn declared_parent_metadata_issue_code(kind: ErrorKind) -> PluginSourceIssueCode
 mod tests {
     use super::{
         build_snapshot, charge_scanned_read, declared_parent_metadata_issue_code,
-        map_load_store_error, native_path_identity, persist_trust_bytes_with_parent_sync,
-        read_bounded_reader, read_scanned_file, replace_file_atomically, trust_file_identity,
-        trust_store_issue_code, workspace_scope, ManagedPluginSourceError,
-        ManagedPluginSourceService, OperationScanBudget, PluginPackageManifest, PluginPackageRoot,
-        PluginPackageScope, PluginSourceDiscovery, PluginSourceIssue, PluginSourceIssueCode,
-        PluginSourceStoreError, PluginTrustScope, ProductPluginSourceStore, ScannedFileReadError,
-        SecureManagedRoot, MAX_OPERATION_READ_BYTES, MAX_PACKAGE_FILE_BYTES, MAX_TRUST_STORE_BYTES,
+        map_activation_store_error, map_load_store_error, native_path_identity,
+        persist_trust_bytes_with_parent_sync, read_bounded_reader, read_scanned_file,
+        replace_file_atomically, trust_file_identity, trust_store_issue_code, workspace_scope,
+        ManagedPluginSourceError, ManagedPluginSourceService, OperationScanBudget,
+        PluginPackageManifest, PluginPackageRoot, PluginPackageScope, PluginSourceDiscovery,
+        PluginSourceIssue, PluginSourceIssueCode, PluginSourceStoreError, PluginTrustScope,
+        ProductPluginSourceStore, ScannedFileReadError, SecureManagedRoot,
+        MAX_OPERATION_READ_BYTES, MAX_PACKAGE_FILE_BYTES, MAX_TRUST_STORE_BYTES,
     };
-    use bitfun_product_domains::plugin_source::PluginPackageTrustLevel;
-    use bitfun_product_domains::plugin_source::PluginTrustDecision;
+    use bitfun_product_domains::plugin_source::{
+        PluginPackageTrustLevel, PluginSourceContractError, PluginTrustDecision,
+    };
     use sha2::{Digest, Sha256};
     use std::io::{self, ErrorKind, Read};
     use std::path::{Path, PathBuf};
@@ -2860,6 +3165,453 @@ mod tests {
         )
         .await
         .expect("write manifest");
+    }
+
+    struct ManagedPluginFixture {
+        _temp: tempfile::TempDir,
+        workspace: PathBuf,
+        workspace_root: PathBuf,
+        trust_path: PathBuf,
+    }
+
+    impl ManagedPluginFixture {
+        async fn new() -> Self {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let workspace = temp.path().join("workspace");
+            let fixture = Self {
+                workspace_root: workspace.join(".bitfun/plugins"),
+                trust_path: temp.path().join("state/trust.json"),
+                workspace,
+                _temp: temp,
+            };
+            tokio::fs::create_dir_all(fixture._temp.path().join("user/plugins"))
+                .await
+                .expect("create user root");
+            fixture
+                .write("acme.demo", b"export const Version = 1;")
+                .await;
+            fixture
+        }
+
+        fn service(&self) -> ManagedPluginSourceService {
+            ManagedPluginSourceService::new(
+                self._temp.path().join("user/plugins"),
+                self._temp.path().join("user"),
+                self.workspace_root.clone(),
+                self.workspace.clone(),
+                self.trust_path.clone(),
+            )
+        }
+
+        async fn write(&self, id: &str, source: &[u8]) {
+            write_package(&self.workspace_root, id, source, &sha256(source)).await;
+        }
+
+        async fn activate(
+            &self,
+            service: &ManagedPluginSourceService,
+            id: &str,
+        ) -> super::PluginActivationAuthority {
+            service
+                .set_trust(&self.workspace, id, PluginTrustDecision::ApproveSource)
+                .await
+                .expect("approve source");
+            let content_hash = self.content_hash(service, id).await;
+            service
+                .set_activation(&self.workspace, id, true, Some(&content_hash), None)
+                .await
+                .expect("activate package");
+            service
+                .load_activated_package(&self.workspace, id)
+                .await
+                .expect("load activated package")
+                .1
+        }
+
+        async fn content_hash(&self, service: &ManagedPluginSourceService, id: &str) -> String {
+            service
+                .load_package(&self.workspace, id)
+                .await
+                .expect("load package")
+                .into_parts()
+                .1
+                .content_hash
+        }
+
+        async fn authority(
+            &self,
+            service: &ManagedPluginSourceService,
+            authority: &super::PluginActivationAuthority,
+        ) -> bool {
+            service
+                .has_activation_authority(&self.workspace, "acme.demo", authority)
+                .await
+                .expect("check activation authority")
+        }
+    }
+
+    #[tokio::test]
+    async fn activation_requires_source_approval_without_persisting_partial_state() {
+        let fixture = ManagedPluginFixture::new().await;
+        let service = fixture.service();
+
+        let content_hash = service.store.discover().await.packages[0]
+            .identity
+            .content_hash
+            .clone();
+        let error = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect_err("unapproved source must not activate");
+
+        assert!(matches!(
+            error,
+            ManagedPluginSourceError::PackageInvalid { .. }
+        ));
+        assert!(!fixture.trust_path.exists());
+    }
+
+    #[tokio::test]
+    async fn activation_rejects_missing_or_stale_content_confirmation() {
+        let fixture = ManagedPluginFixture::new().await;
+        let service = fixture.service();
+        service
+            .set_trust(
+                &fixture.workspace,
+                "acme.demo",
+                PluginTrustDecision::ApproveSource,
+            )
+            .await
+            .expect("approve source");
+
+        for expected in [None, Some("sha256:stale")] {
+            let error = service
+                .set_activation(&fixture.workspace, "acme.demo", true, expected, None)
+                .await
+                .expect_err("confirmation must match the selected package");
+            assert!(matches!(
+                error,
+                ManagedPluginSourceError::PackageInvalid { .. }
+            ));
+        }
+        assert!(!service.refresh(&fixture.workspace).await.packages[0].activated);
+    }
+
+    #[test]
+    fn activation_contract_errors_distinguish_package_state_from_store_failures() {
+        let package_error = map_activation_store_error(
+            "acme.demo",
+            PluginSourceStoreError::Contract(
+                PluginSourceContractError::ActivationRequiresSourceApproval,
+            ),
+        );
+        let store_error = map_activation_store_error(
+            "acme.demo",
+            PluginSourceStoreError::Contract(PluginSourceContractError::ActivationEpochExhausted),
+        );
+
+        assert!(matches!(
+            package_error,
+            ManagedPluginSourceError::PackageInvalid { .. }
+        ));
+        assert!(matches!(
+            store_error,
+            ManagedPluginSourceError::TrustStore(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn schema_v1_store_is_persisted_as_v2_on_first_successful_read() {
+        let fixture = ManagedPluginFixture::new().await;
+        tokio::fs::create_dir_all(fixture.trust_path.parent().expect("trust state directory"))
+            .await
+            .expect("create trust state directory");
+        tokio::fs::write(
+            &fixture.trust_path,
+            br#"{"schemaVersion":1,"epoch":7,"records":[]}"#,
+        )
+        .await
+        .expect("write schema-v1 trust store");
+
+        let snapshot = fixture.service().refresh(&fixture.workspace).await;
+        let persisted: serde_json::Value = serde_json::from_slice(
+            &tokio::fs::read(&fixture.trust_path)
+                .await
+                .expect("read migrated trust store"),
+        )
+        .expect("parse migrated trust store");
+
+        assert!(snapshot.issues.is_empty());
+        assert_eq!(persisted["schemaVersion"], 2);
+        assert_eq!(persisted["activationEpoch"], 7);
+        assert_eq!(persisted["activationRecords"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn activation_and_deactivation_are_exact_persisted_idempotent_state() {
+        let fixture = ManagedPluginFixture::new().await;
+        let service = fixture.service();
+        service
+            .set_trust(
+                &fixture.workspace,
+                "acme.demo",
+                PluginTrustDecision::ApproveSource,
+            )
+            .await
+            .expect("approve source");
+
+        let content_hash = fixture.content_hash(&service, "acme.demo").await;
+        let (activated, activated_changed) = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("activate package");
+        let (activated_again, activated_again_changed) = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("repeat activation");
+        assert!(activated.packages[0].activated);
+        assert!(activated_changed);
+        assert!(!activated_again_changed);
+        assert_eq!(activated.activation_epoch, activated_again.activation_epoch);
+
+        let recreated = fixture.service().refresh(&fixture.workspace).await;
+        assert!(recreated.packages[0].activated);
+        assert_eq!(activated.activation_epoch, recreated.activation_epoch);
+
+        let (deactivated, deactivated_changed) = service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect("deactivate package");
+        let (deactivated_again, deactivated_again_changed) = service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect("repeat deactivation");
+        assert!(!deactivated.packages[0].activated);
+        assert!(deactivated_changed);
+        assert!(!deactivated_again_changed);
+        assert_eq!(
+            deactivated.activation_epoch,
+            deactivated_again.activation_epoch
+        );
+        assert!(!fixture.service().refresh(&fixture.workspace).await.packages[0].activated);
+    }
+
+    #[tokio::test]
+    async fn stale_rollback_cannot_clear_a_newer_activation() {
+        let fixture = ManagedPluginFixture::new().await;
+        let service = fixture.service();
+        service
+            .set_trust(
+                &fixture.workspace,
+                "acme.demo",
+                PluginTrustDecision::ApproveSource,
+            )
+            .await
+            .expect("approve source");
+        let content_hash = fixture.content_hash(&service, "acme.demo").await;
+        let (first, _) = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("activate package");
+        let first_epoch = first.activation_epoch.expect("first activation epoch");
+
+        service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect("deactivate package");
+        let (current, _) = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("reactivate package");
+        let current_epoch = current.activation_epoch.expect("current activation epoch");
+
+        let (rollback, rollback_changed) = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                false,
+                None,
+                Some(first_epoch),
+            )
+            .await
+            .expect("stale rollback is a no-op");
+        assert!(rollback.packages[0].activated);
+        assert!(!rollback_changed);
+        assert_eq!(rollback.activation_epoch, Some(current_epoch));
+    }
+
+    #[tokio::test]
+    async fn committed_activation_with_uncertain_directory_sync_returns_warning() {
+        fn fail_parent_sync(_parent: &Path) -> io::Result<()> {
+            Err(io::Error::other("injected directory sync failure"))
+        }
+
+        let fixture = ManagedPluginFixture::new().await;
+        let mut service = fixture.service();
+        service
+            .set_trust(
+                &fixture.workspace,
+                "acme.demo",
+                PluginTrustDecision::ApproveSource,
+            )
+            .await
+            .expect("approve source");
+        let content_hash = fixture.content_hash(&service, "acme.demo").await;
+        service.store.parent_sync = fail_parent_sync;
+
+        let (snapshot, changed) = service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("committed activation remains successful");
+
+        assert!(snapshot.packages[0].activated);
+        assert!(changed);
+        assert!(snapshot
+            .issues
+            .iter()
+            .any(|issue| { issue.code == "activation_durability_uncertain" && !issue.is_error }));
+    }
+
+    #[tokio::test]
+    async fn uncertain_deactivation_does_not_report_success() {
+        fn fail_parent_sync(_parent: &Path) -> io::Result<()> {
+            Err(io::Error::other("injected directory sync failure"))
+        }
+
+        let fixture = ManagedPluginFixture::new().await;
+        let mut service = fixture.service();
+        fixture.activate(&service, "acme.demo").await;
+        service.store.parent_sync = fail_parent_sync;
+
+        let error = service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect_err("uncertain deactivation must not report success");
+
+        assert!(matches!(error, ManagedPluginSourceError::TrustStore(_)));
+        assert!(error.to_string().contains("may not survive a system crash"));
+    }
+
+    #[tokio::test]
+    async fn activated_load_returns_authority_only_for_current_exact_identity() {
+        let fixture = ManagedPluginFixture::new().await;
+        let service = fixture.service();
+        let evidence = fixture.activate(&service, "acme.demo").await;
+        assert!(fixture.authority(&service, &evidence).await);
+
+        fixture
+            .write("acme.demo", b"export const Version = 2;")
+            .await;
+        assert!(service
+            .load_activated_package(&fixture.workspace, "acme.demo")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn source_change_deny_and_revoke_atomically_remove_activation_authority() {
+        let changed = ManagedPluginFixture::new().await;
+        let changed_service = changed.service();
+        let changed_evidence = changed.activate(&changed_service, "acme.demo").await;
+        changed
+            .write("acme.demo", b"export const Version = 2;")
+            .await;
+        assert!(!changed.authority(&changed_service, &changed_evidence).await);
+        let changed_snapshot = changed_service.refresh(&changed.workspace).await;
+        assert!(!changed_snapshot.packages[0].activated);
+
+        for decision in [PluginTrustDecision::Denied, PluginTrustDecision::Revoked] {
+            let fixture = ManagedPluginFixture::new().await;
+            let service = fixture.service();
+            let evidence = fixture.activate(&service, "acme.demo").await;
+
+            let snapshot = service
+                .set_trust(&fixture.workspace, "acme.demo", decision)
+                .await
+                .expect("invalidate source approval");
+            assert!(!snapshot.packages[0].activated);
+            assert!(!fixture.authority(&service, &evidence).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn unrelated_activation_does_not_invalidate_existing_authority() {
+        let fixture = ManagedPluginFixture::new().await;
+        fixture
+            .write("acme.other", b"export const Other = 1;")
+            .await;
+        let service = fixture.service();
+        let retained = fixture.activate(&service, "acme.demo").await;
+        fixture.activate(&service, "acme.other").await;
+        assert!(fixture.authority(&service, &retained).await);
+    }
+
+    #[tokio::test]
+    async fn recreated_activation_uses_a_different_generation() {
+        let fixture = ManagedPluginFixture::new().await;
+        let service = fixture.service();
+        let first = fixture.activate(&service, "acme.demo").await;
+
+        service
+            .set_activation(&fixture.workspace, "acme.demo", false, None, None)
+            .await
+            .expect("deactivate package");
+        let content_hash = fixture.content_hash(&service, "acme.demo").await;
+        service
+            .set_activation(
+                &fixture.workspace,
+                "acme.demo",
+                true,
+                Some(&content_hash),
+                None,
+            )
+            .await
+            .expect("recreate activation");
+        let second = service
+            .load_activated_package(&fixture.workspace, "acme.demo")
+            .await
+            .expect("load recreated activation")
+            .1;
+
+        assert_ne!(first.activation_epoch(), second.activation_epoch());
+        assert!(!fixture.authority(&service, &first).await);
+        assert!(fixture.authority(&service, &second).await);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add exact-content managed plugin activation with per-package generations, atomic persistence, CAS rollback, and runtime authority rechecks
- project OpenCode-compatible custom tool declarations as high-risk, permission-required candidates through the existing Plugin Runtime Host without executing JS/TS or registering tools
- add CLI preview, confirm, deactivate, list, and doctor behavior, with architecture and boundary-rule updates
- bound custom tool and npm declaration counts and metadata before candidate construction

## Scope

This PR completes the P0-C.2 managed activation and candidate-projection path only. It does not install or import OpenCode plugins, require an external OpenCode installation, execute plugin code, register final tools, inject candidates into the global Agent Runtime, or add GUI management.

Deferred work is recorded in the design plan: final tool-snapshot consumption, explicit cleanup for missing or corrupt activated packages, and a two-phase activation transaction that moves the stability scan outside the cross-process lock while preserving generation and source-identity checks.

## Safety and review

- source approval remains separate from activation
- activation binds the exact package hash and uses an independent per-package generation
- read and dispatch paths revalidate authority; dispatch checks both before and after adapter work
- uncertain activation durability is reported as a warning, while uncertain deactivation returns an error
- comments do not create declarations, duplicate tool IDs are rejected, and unsupported input remains diagnostic-only
- independent architecture, product, and security reviews were repeated after rebase; all P0/P1/P2 findings in the submitted scope were closed

## Verification

- `cargo +nightly test -p bitfun-product-domains --features plugin-source --test plugin_source_contracts` (13 passed)
- `cargo +nightly test -p bitfun-services-integrations --no-default-features --features plugin-source plugin_source --lib` (52 passed)
- `cargo +nightly test -p bitfun-opencode-adapter --lib opencode_projection_contracts` (19 passed)
- `cargo +nightly test -p bitfun-opencode-adapter --test opencode_source_adapter` (18 passed)
- `cargo +nightly test -p bitfun-core plugin_runtime::tests` (4 passed)
- `cargo +nightly test -p bitfun-cli --bin bitfun-cli` (38 passed)
- `cargo +nightly test -p bitfun-cli --test plugin_source_cli` (2 passed)
- `cargo +nightly check -p bitfun-core -p bitfun-cli`
- `node scripts/core-boundaries/self-test.mjs`
- `node scripts/core-boundaries/checker.mjs`
- `pnpm run check:repo-hygiene`

`cargo +nightly check --workspace` reaches the Desktop Tauri build script and stops because the generated `src/mobile-web/dist` directory is absent in this worktree. The directly affected core and CLI crates pass targeted checks.