### PR TITLE
fix(ci): retry transient macOS DMG bundling

### DIFF
--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -5,8 +5,15 @@
  */
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { basename, dirname, join, relative, sep } from 'path';
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
 import { ensureOpenSslWindows } from './ensure-openssl-windows.mjs';
 import { ensureFlashgrepBinary } from './prepare-flashgrep-resource.mjs';
 
@@ -45,12 +52,17 @@ async function main() {
     flashgrepBinary,
   });
   const tauriBin = join(ROOT, 'node_modules', '.bin', 'tauri');
-  const r = spawnSync(tauriBin, ['build', '--config', tauriConfig, ...forward], {
-    cwd: desktopDir,
-    env: process.env,
-    stdio: 'inherit',
-    shell: true,
-  });
+  const tauriArgs = ['build', '--config', tauriConfig, ...forward];
+  const buildStartedAtMs = Date.now();
+  let r = runTauriBuild(tauriBin, tauriArgs, desktopDir);
+
+  if (!r.error && shouldRetryMacDmgBuild(r, forward, desktopDir, buildStartedAtMs)) {
+    console.warn(
+      '[tauri-build] DMG bundling failed after the macOS app bundle was created; retrying once in 10 seconds.'
+    );
+    await new Promise((resolveRetry) => setTimeout(resolveRetry, 10_000));
+    r = runTauriBuild(tauriBin, tauriArgs, desktopDir);
+  }
 
   if (r.error) {
     console.error(r.error);
@@ -62,6 +74,80 @@ async function main() {
   }
 
   process.exit(r.status ?? 1);
+}
+
+function runTauriBuild(tauriBin, args, desktopDir) {
+  return spawnSync(tauriBin, args, {
+    cwd: desktopDir,
+    env: process.env,
+    stdio: 'inherit',
+    shell: true,
+  });
+}
+
+export function shouldRetryMacDmgBuild(
+  result,
+  args,
+  desktopDir,
+  buildStartedAtMs,
+  runtime = {}
+) {
+  const platform = runtime.platform ?? process.platform;
+  const githubActions = runtime.githubActions ?? process.env.GITHUB_ACTIONS;
+  if (
+    result.status === 0 ||
+    platform !== 'darwin' ||
+    githubActions !== 'true' ||
+    args.includes('--no-bundle') ||
+    !requestsDmgBundle(args)
+  ) {
+    return false;
+  }
+
+  const configuredTargetDir = runtime.cargoTargetDir ?? process.env.CARGO_TARGET_DIR;
+  const targetDir = configuredTargetDir
+    ? isAbsolute(configuredTargetDir)
+      ? configuredTargetDir
+      : resolve(desktopDir, configuredTargetDir)
+    : join(runtime.root ?? ROOT, 'target');
+  const target = optionValue(args, '--target');
+  const profile = args.includes('--debug') ? 'debug' : optionValue(args, '--profile') || 'release';
+  const bundleDir = join(
+    targetDir,
+    ...(target ? [target] : []),
+    profile,
+    'bundle',
+    'macos'
+  );
+
+  try {
+    return readdirSync(bundleDir, { withFileTypes: true }).some(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name.endsWith('.app') &&
+        statSync(join(bundleDir, entry.name)).mtimeMs >= buildStartedAtMs - 1_000
+    );
+  } catch {
+    return false;
+  }
+}
+
+function requestsDmgBundle(args) {
+  const bundles = optionValue(args, '--bundles');
+  return bundles === undefined || bundles.split(',').some((bundle) => bundle.trim() === 'dmg');
+}
+
+function optionValue(args, option) {
+  const inlinePrefix = `${option}=`;
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === option) {
+      return args[i + 1];
+    }
+    if (args[i].startsWith(inlinePrefix)) {
+      return args[i].slice(inlinePrefix.length);
+    }
+  }
+  return undefined;
 }
 
 function prepareTauriConfig(baseConfigPath, { desktopDir, flashgrepBinary }) {
@@ -194,7 +280,9 @@ function findDmgFiles(dir) {
   return results;
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/desktop-tauri-build.test.mjs
+++ b/scripts/desktop-tauri-build.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, rmSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { shouldRetryMacDmgBuild } from './desktop-tauri-build.mjs';
+
+const FAILED_BUILD = { status: 1 };
+const DMG_ARGS = ['--target', 'x86_64-apple-darwin', '--bundles', 'app,dmg'];
+
+function retryFixture() {
+  const root = join(tmpdir(), `bitfun-dmg-retry-${process.pid}-${Date.now()}`);
+  const desktopDir = join(root, 'src', 'apps', 'desktop');
+  const targetDir = join(root, 'target');
+  const appDir = join(
+    targetDir,
+    'x86_64-apple-darwin',
+    'release',
+    'bundle',
+    'macos',
+    'BitFun.app'
+  );
+  mkdirSync(desktopDir, { recursive: true });
+  mkdirSync(appDir, { recursive: true });
+
+  return {
+    appDir,
+    desktopDir,
+    runtime: {
+      cargoTargetDir: targetDir,
+      githubActions: 'true',
+      platform: 'darwin',
+      root,
+    },
+    cleanup: () => rmSync(root, { force: true, recursive: true }),
+  };
+}
+
+test('retries a failed GitHub Actions DMG bundle after a fresh app bundle', () => {
+  const fixture = retryFixture();
+  try {
+    assert.equal(
+      shouldRetryMacDmgBuild(
+        FAILED_BUILD,
+        DMG_ARGS,
+        fixture.desktopDir,
+        Date.now(),
+        fixture.runtime
+      ),
+      true
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('does not retry failures outside the narrow DMG bundling boundary', () => {
+  const fixture = retryFixture();
+  try {
+    const cases = [
+      [{ status: 0 }, DMG_ARGS, fixture.runtime],
+      [FAILED_BUILD, DMG_ARGS, { ...fixture.runtime, platform: 'linux' }],
+      [FAILED_BUILD, DMG_ARGS, { ...fixture.runtime, githubActions: 'false' }],
+      [FAILED_BUILD, ['--no-bundle'], fixture.runtime],
+      [FAILED_BUILD, ['--bundles=app'], fixture.runtime],
+      [
+        FAILED_BUILD,
+        DMG_ARGS,
+        { ...fixture.runtime, cargoTargetDir: join(fixture.runtime.root, 'missing') },
+      ],
+    ];
+    for (const [result, args, runtime] of cases) {
+      assert.equal(
+        shouldRetryMacDmgBuild(result, args, fixture.desktopDir, Date.now(), runtime),
+        false
+      );
+    }
+
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(fixture.appDir, staleTime, staleTime);
+    assert.equal(
+      shouldRetryMacDmgBuild(
+        FAILED_BUILD,
+        DMG_ARGS,
+        fixture.desktopDir,
+        Date.now(),
+        fixture.runtime
+      ),
+      false
+    );
+  } finally {
+    fixture.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- retry a failed macOS DMG build once on GitHub Actions when Tauri already produced a fresh `.app` bundle
- keep compile failures, local builds, non-macOS builds, `--no-bundle`, and non-DMG builds outside the retry path
- cover the retry boundary with focused Node tests

## Root cause

Nightly run 29238622886 completed the x86_64 Rust release build and generated `BitFun.app`, then Tauri 2.10 failed inside its bundled `bundle_dmg.sh`. The job left a `diskimages-help` process for runner cleanup. The same macOS x64 path succeeded earlier that day, and macOS arm64 succeeded in the failing matrix run, indicating a transient DiskImages/hdiutil failure rather than a source or warning failure.

Tauri create-dmg retries busy detaches, but not transient create/attach/convert failures. A second Tauri invocation reuses the completed Cargo output and retries only bundling.

## Verification

- `node --test scripts/desktop-tauri-build.test.mjs` (2 passed)
- `node --check scripts/desktop-tauri-build.mjs`
- `node --check scripts/desktop-tauri-build.test.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check`

A full x86_64 release build was not repeated locally because it takes about an hour and cannot force the hosted runner DiskImages fault. The next nightly run is the end-to-end verification.