### PR TITLE
chore: bump version to 0.2.13

### DIFF
--- a/BitFun-Installer/package-lock.json
+++ b/BitFun-Installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-installer",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "type": "module",
   "description": "BitFun Custom Installer - Modern branded installation experience",

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-installer"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Custom Installer - Modern branded installation experience"

--- a/BitFun-Installer/src/pages/LanguageSelect.tsx
+++ b/BitFun-Installer/src/pages/LanguageSelect.tsx
@@ -72,7 +72,7 @@ export function LanguageSelect({ onSelect }: LanguageSelectProps) {
             opacity: 0.6,
             letterSpacing: '0.5px',
           }}>
-            Version 0.2.12
+            Version 0.2.13
           </div>
         </div>
       </div>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ resolver = "2"
 
 # Shared package metadata — single source of truth for version
 [workspace.package]
-version = "0.2.12" # x-release-please-version
+version = "0.2.13" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "BitFun",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "BitFun",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "hasInstallScript": true,
       "dependencies": {
         "pnpm": "^10.32.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BitFun",
   "private": true,
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-server"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Relay Server - WebSocket relay for Remote Connect"

--- a/src/crates/services/services-integrations/tests/announcement_contracts.rs
+++ b/src/crates/services/services-integrations/tests/announcement_contracts.rs
@@ -165,14 +165,14 @@ async fn announcement_state_store_round_trips_state_and_defaults_missing_file() 
 fn announcement_remote_fetch_request_preserves_legacy_query_shape() {
     let request = AnnouncementRemoteFetchRequest {
         endpoint_url: "https://announcements.example.com/cards".to_string(),
-        app_version: "0.2.12".to_string(),
+        app_version: "0.2.13".to_string(),
         locale: "zh-CN".to_string(),
         platform: "desktop".to_string(),
     };
 
     assert_eq!(
         request.request_url(),
-        "https://announcements.example.com/cards?app_version=0.2.12&locale=zh-CN&platform=desktop"
+        "https://announcements.example.com/cards?app_version=0.2.13&locale=zh-CN&platform=desktop"
     );
 }
 

--- a/src/mobile-web/package-lock.json
+++ b/src/mobile-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-mobile-web",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfun/web-ui",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "description": "BitFun Web UI - 支持 Desktop 和 Server 两种部署方式",
   "type": "module",

--- a/src/web-ui/src/component-library/preview/PreviewApp.tsx
+++ b/src/web-ui/src/component-library/preview/PreviewApp.tsx
@@ -48,7 +48,7 @@ export const PreviewApp: React.FC = () => {
       <header className="preview-header">
         <div className="preview-logo">
           <h1>{t('componentLibrary.previewApp.title')}</h1>
-          <span className="preview-version">v0.2.12</span>
+          <span className="preview-version">v0.2.13</span>
         </div>
         <div className="preview-header-actions">
           <label className="preview-theme-selector">

--- a/src/web-ui/src/shared/utils/version.ts
+++ b/src/web-ui/src/shared/utils/version.ts
@@ -6,7 +6,7 @@ import { i18nService } from '@/infrastructure/i18n';
  
 const DEFAULT_VERSION_INFO: VersionInfo = {
   name: 'BitFun',
-  version: '0.2.12',
+  version: '0.2.13',
   buildDate: new Date().toISOString(),
   buildTimestamp: Date.now(),
   isDev: import.meta.env.DEV,


### PR DESCRIPTION
## Summary

- bump BitFun product versions from 0.2.12 to 0.2.13
- keep desktop, web, mobile web, relay server, and installer version metadata aligned
- update version display fallbacks and the announcement request contract fixture

## Verification

- pnpm run type-check:web
- pnpm --dir src/mobile-web run type-check
- pnpm --dir BitFun-Installer run type-check
- cargo check --workspace
- cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml
- cargo test -p bitfun-services-integrations --features announcement --test announcement_contracts announcement_remote_fetch_request_preserves_legacy_query_shape -- --exact
- pnpm run check:repo-hygiene
- pnpm run check:github-config
- git diff --check

AI-assisted: Yes (Codex)
Testing level: Fully tested for the changed scope.