### PR TITLE
fix(flow-chat): restore deferred long-session navigation

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -54,7 +54,7 @@ export interface FlowChatHeaderProps {
   sessionId?: string;
   /** Ordered turn summaries used by header navigation. */
   turns?: FlowChatHeaderTurnSummary[];
-  /** Jump to a specific turn. Return false when the selection is rejected or still pending. */
+  /** Jump to a specific turn. Return false only when the selection is rejected. */
   onJumpToTurn?: (turnId: string) => boolean | void;
   /** Jump to the currently displayed turn. */
   onJumpToCurrentTurn?: () => void;

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -1055,7 +1055,7 @@ describe('ModernFlowChatContainer historical empty state', () => {
     expect(virtualListMock.pinTurnToTopWithStatus.mock.calls.length).toBe(settledCallCount);
   });
 
-  it('leaves internally pending turn pins with the list instead of retrying from the container', async () => {
+  it('accepts list-owned pending turn pins without retrying from the container', async () => {
     stateMocks.activeSession = createSession({
       isHistorical: false,
       historyState: 'ready',
@@ -1080,12 +1080,12 @@ describe('ModernFlowChatContainer historical empty state', () => {
       root.render(<ModernFlowChatContainer />);
     });
 
-    let accepted = true;
+    let accepted = false;
     await act(async () => {
-      accepted = (headerPropsMock.latest?.onJumpToTurn as ((turnId: string) => boolean) | undefined)?.('turn-1') ?? true;
+      accepted = (headerPropsMock.latest?.onJumpToTurn as ((turnId: string) => boolean) | undefined)?.('turn-1') ?? false;
     });
 
-    expect(accepted).toBe(false);
+    expect(accepted).toBe(true);
     expect(virtualListMock.pinTurnToTopWithStatus).toHaveBeenLastCalledWith('turn-1', {
       behavior: 'smooth',
       pinMode: 'transient',

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -1028,7 +1028,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     if (pinStatus === 'pending') {
       setQueuedHeaderTurnPinId(null);
       setPendingHeaderTurnId(null);
-      return false;
+      return true;
     }
 
     setQueuedHeaderTurnPinId(turnId);

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -17,6 +17,10 @@ const stateMocks = vi.hoisted(() => ({
   visibleTurnInfo: null as unknown,
   setVisibleTurnInfo: vi.fn(),
 }));
+const virtuosoMocks = vi.hoisted(() => ({
+  renderedRange: null as { start: number; end: number } | null,
+  scrollToIndex: vi.fn(),
+}));
 const flowStoreMocks = vi.hoisted(() => ({
   hasPendingSessionHistoryCompletion: vi.fn(() => false),
   hasDeferredSessionHistoryProjection: vi.fn(() => false),
@@ -45,9 +49,18 @@ vi.mock('react-i18next', () => ({
 vi.mock('react-virtuoso', () => ({
   Virtuoso: React.forwardRef((props: any, ref) => {
     const scrollerRef = React.useRef<HTMLDivElement | null>(null);
+    const [, rerender] = React.useReducer((value: number) => value + 1, 0);
     React.useImperativeHandle(ref, () => ({
       scrollTo: vi.fn(),
-      scrollToIndex: vi.fn(),
+      scrollToIndex: vi.fn((options: { index: number }) => {
+        virtuosoMocks.scrollToIndex(options);
+        const localIndex = Math.max(0, options.index - (props.firstItemIndex ?? 0));
+        virtuosoMocks.renderedRange = {
+          start: localIndex,
+          end: Math.min(props.data?.length ?? 0, localIndex + 4),
+        };
+        rerender();
+      }),
     }));
 
     React.useLayoutEffect(() => {
@@ -76,11 +89,23 @@ vi.mock('react-virtuoso', () => ({
         tabIndex={0}
       >
         {props.components?.Header ? <props.components.Header /> : null}
-        {props.data?.map((item: VirtualItem, index: number) => (
-          <div key={item.turnId} className="virtual-item-wrapper" data-turn-id={item.turnId} data-virtual-index={index} data-item-type={item.type}>
-            {item.turnId}
-          </div>
-        ))}
+        {props.data
+          ?.map((item: VirtualItem, index: number) => ({ item, index }))
+          .filter(({ index }: { index: number }) => {
+            const range = virtuosoMocks.renderedRange;
+            return !range || (index >= range.start && index < range.end);
+          })
+          .map(({ item, index }: { item: VirtualItem; index: number }) => (
+            <div
+              key={`${item.type}:${item.turnId}`}
+              className="virtual-item-wrapper"
+              data-turn-id={item.turnId}
+              data-virtual-index={index}
+              data-item-type={item.type}
+            >
+              {item.turnId}
+            </div>
+          ))}
         {props.components?.Footer ? <props.components.Footer /> : null}
       </div>
     );
@@ -318,6 +343,8 @@ describe('VirtualMessageList session boundary', () => {
     root = createRoot(container);
     stateMocks.visibleTurnInfo = null;
     stateMocks.setVisibleTurnInfo.mockReset();
+    virtuosoMocks.renderedRange = null;
+    virtuosoMocks.scrollToIndex.mockReset();
     flowStoreMocks.hasPendingSessionHistoryCompletion.mockReset();
     flowStoreMocks.hasPendingSessionHistoryCompletion.mockReturnValue(false);
     flowStoreMocks.hasDeferredSessionHistoryProjection.mockReset();
@@ -419,6 +446,84 @@ describe('VirtualMessageList session boundary', () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  it('materializes an unrendered turn with an immediate auto index jump', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const turnIds = Array.from(
+      { length: 24 },
+      (_, index) => `turn-${String(index + 1).padStart(2, '0')}`,
+    );
+    const targetTurnId = 'turn-02';
+
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds);
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+    virtuosoMocks.renderedRange = { start: 40, end: 48 };
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    expect(
+      container.querySelector(
+        `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+      ),
+    ).toBeNull();
+    virtuosoMocks.scrollToIndex.mockClear();
+
+    let status: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
+    act(() => {
+      status = listRef.current?.pinTurnToTopWithStatus(targetTurnId, {
+        behavior: 'smooth',
+        pinMode: 'transient',
+      }) ?? 'rejected';
+    });
+
+    expect(status).toBe('pending');
+    expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledWith(expect.objectContaining({
+      align: 'start',
+      behavior: 'auto',
+    }));
+
+    const target = container.querySelector<HTMLElement>(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    );
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(target).not.toBeNull();
+    expect(scroller).not.toBeNull();
+    if (!target || !scroller) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 6_000,
+      clientHeight: 1_000,
+      scrollTop: 4_000,
+    });
+    vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 0,
+      bottom: 1_000,
+      height: 1_000,
+    }));
+    const targetDocumentTop = 4_500;
+    vi.spyOn(target, 'getBoundingClientRect').mockImplementation(() => {
+      const top = targetDocumentTop - scroller.scrollTop;
+      return createRect({
+        top,
+        bottom: top + 40,
+        height: 40,
+      });
+    });
+
+    flushAnimationFrame();
+    flushAnimationFrame();
+    flushAnimationFrame();
+    expect(scroller.scrollTop).toBe(4_443);
+    expect(target.getBoundingClientRect().top).toBe(57);
+    expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a static initial history turn pin from being pulled back to bottom by the initial guard', () => {
@@ -566,12 +671,15 @@ describe('VirtualMessageList session boundary', () => {
     expect(container.querySelector(`[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`)).toBeNull();
     expect(container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)).not.toBeNull();
 
-    let didPin = false;
+    let pinStatus: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
     act(() => {
-      didPin = listRef.current?.pinTurnToTop(targetTurnId, { behavior: 'auto' }) ?? false;
+      pinStatus = listRef.current?.pinTurnToTopWithStatus(targetTurnId, {
+        behavior: 'auto',
+      }) ?? 'rejected';
     });
 
-    expect(didPin).toBe(true);
+    expect(pinStatus).toBe('pending');
+    expect(scroller.scrollTop).toBeLessThan(11_000);
     expect(container.querySelector(`[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`)).not.toBeNull();
     expect(container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)).toBeNull();
     expect(container.querySelector('[data-history-initial-render-tail-spacer="true"]')).not.toBeNull();

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -1658,13 +1658,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
     const resolvedMetrics = resolveTurnPinMetrics(request.turnId, ignoredTailSpacePx);
     if (!resolvedMetrics) {
-      const fallbackBehavior: ScrollBehavior = request.pinMode === 'sticky-latest'
-        ? 'auto'
-        : targetItem.index === 0
-          ? 'auto'
-        : request.attempts === 0 && request.behavior === 'smooth'
-          ? 'smooth'
-          : 'auto';
+      // A far smooth scroll can leave the target virtualized long enough for the
+      // deferred pin to expire. Materialize it first, then let the existing live
+      // geometry pass perform the exact alignment and stabilization.
+      const fallbackBehavior: ScrollBehavior = 'auto';
       const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
       const provisionalPinPx = request.pinMode === 'sticky-latest'
         ? Math.max(maxScrollTop, currentPinReservation.px)

--- a/tests/e2e/specs/l1-chat-turn-navigation-release.spec.ts
+++ b/tests/e2e/specs/l1-chat-turn-navigation-release.spec.ts
@@ -440,6 +440,10 @@ describe('Release long-session turn navigation', () => {
     expect(before.maxScrollTop).toBeGreaterThan(300);
 
     const revealState = await revealHistoryUntilTurnListContains(targetTitle);
+    await closeHeaderTurnList();
+    const beforeDeferredSelection = await scrollToLatest(targetTurnId);
+    expect(beforeDeferredSelection.targetExists).toBe(false);
+
     const clickResult = await clickHeaderTurnListItemByTitle(targetTitle);
     expect(clickResult.itemCount).toBeGreaterThan(0);
     await browser.waitUntil(async () => {
@@ -468,6 +472,7 @@ describe('Release long-session turn navigation', () => {
         targetTurnId,
         targetTitle,
         revealState,
+        beforeDeferredSelection,
         clickResult,
         lastMetrics,
         shellState: await readSessionShellState(),
@@ -476,7 +481,16 @@ describe('Release long-session turn navigation', () => {
 
     await browser.pause(600);
     const after = await readTurnViewportMetrics(targetTurnId);
-    const diagnostics = { sessionId, targetTurnId, targetTitle, revealState, clickResult, before, after };
+    const diagnostics = {
+      sessionId,
+      targetTurnId,
+      targetTitle,
+      revealState,
+      before,
+      beforeDeferredSelection,
+      clickResult,
+      after,
+    };
     console.log('[ReleaseTurnNav] diagnostics:', JSON.stringify(diagnostics));
 
     expect(after.targetExists).toBe(true);


### PR DESCRIPTION
## Summary

- treat list-owned `pending` turn pins as accepted so the header chooser closes promptly without restoring Container-level retries
- materialize offscreen targets with an immediate non-animated index jump before the existing exact alignment and stabilization pass
- add 24-turn virtual-window coverage, strengthen static-history assertions, and require the release E2E to prove the target is unrendered before selection

## Root cause

PR #1413 correctly separated Container and `VirtualMessageList` scroll ownership, but `ModernFlowChatContainer` returned `false` to the Header for both `pending` and `rejected` outcomes. Short sessions usually settled immediately; long sessions more often returned `pending` because the selected turn was outside the rendered DOM. The Header therefore kept the chooser open, while a far smooth Virtuoso jump could leave the target unrendered until the internal request expired.

This change defines `pending` as accepted but incomplete. `VirtualMessageList` remains the sole owner after acceptance and performs a deterministic coarse materialization before its existing exact pin pass.

## Product impact and scope

- header list selections now close for both immediately settled and list-owned deferred requests
- previous/next/current-turn entry points share the same acceptance contract
- explicit user scroll, session switch, partial-history rejection, sticky-latest behavior, and return-to-latest behavior remain covered by the existing cancellation and ownership paths
- search-result navigation, `TurnHistoryPanel`, overscan, and the separate long-session flicker report in #1537 are intentionally unchanged

## Validation

| Check | Result |
| --- | --- |
| Focused Flow Chat Vitest suite | 4 files, 47 tests passed |
| Web UI TypeScript | `pnpm run type-check:web` passed |
| E2E coverage contract | 6 tests passed |
| Long-session interaction matrix | `--dry-run --profile scroll` passed; includes `turn-navigation` |
| Independent adversarial review | initial test-depth finding fixed; re-review found no Critical or Important issues |

The real release WDIO turn-navigation spec was not run locally because this isolated worktree does not have `E2E_TEST_WORKSPACE` or a release binary. The updated spec is included for CI/release-environment execution and now asserts that the target is absent from the DOM before selection.

Follow-up to #1381 and PR #1413.

Reported regression: https://github.com/GCWing/BitFun/issues/1381#issuecomment-4964376487

AI-assisted: yes. Testing level: focused automated regression tests, Web UI type-check, E2E source contract, and interaction-matrix dry-run.
