### PR TITLE
feat(cli): Peer Host HostInvoke parity, login TUI, and account sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ tests/e2e/reports/
 
 # Eval job artifacts
 .eval/
+.tmp/
+tmp/
 Cross.toml
 
 # BitFun sandbox data - auto managed

--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -2,7 +2,8 @@
 
 Peer Device Mode switches the desktop (and mobile control target) data plane
 onto another same-account online BitFun device. The React shell stays local;
-product invokes and agentic events come from the peer.
+product invokes and agentic events come from the peer. The peer may be Desktop
+or CLI: both speak the same HostInvoke / DeviceEvent protocol.
 
 ## Product goal
 
@@ -51,8 +52,12 @@ FS) and must not be mixed with Peer Device Mode.
   - editor disk sync poll slows to 15s (from 1s)
   - canvas snapshot poll slows to 15s (from 2s)
   - workspace search-index poll slows to 30s idle / 5s active
-- Peer: decrypt → allow/deny → webview bridge `peer-host-invoke://request` →
-  same Tauri handlers as local UI → `peer_host_invoke_complete`.
+- Peer: decrypt → allow/deny → execute on the peer host:
+  - Desktop: webview bridge `peer-host-invoke://request` → same Tauri handlers
+    as local UI → `peer_host_invoke_complete`
+  - CLI: Core HostInvoke registry (`WorkspaceService`, FS, config, session,
+    git, `DialogScheduler`) — no webview. Desktop-only surfaces (MiniApp /
+    cron / ACP list) return empty or no-op so hydrate does not fail.
 - Events: peer agentic projection (and other product events such as terminal /
   FS / MCP interaction) fan-out as `RemoteCommand::DeviceEvent` to attached
   controllers; controller re-emits the same event names locally.
@@ -80,6 +85,10 @@ Still use normal `openWorkspace` / create-workspace flows (not SSH
 
 - Desktop host invoke / fan-out: `src/apps/desktop/src/api/peer_host_invoke.rs`,
   `remote_connect_api.rs`
+- CLI host invoke / fan-out: `src/apps/cli/src/peer_host/` (Core registry; no
+  webview bridge). Device routing in `src/apps/cli/src/account.rs` special-cases
+  `HostInvoke` / `DeviceEvent`. Same machine Desktop+CLI share one `device_id`;
+  last `AuthConnect` wins.
 - Frontend mode + transport: `src/web-ui/src/infrastructure/peer-device/`,
   `adapters/peer-device-adapter.ts`
 - Peer directory picker: `pickWorkspaceDirectory.ts`, `PeerDirectoryBrowser.tsx`,

--- a/docs/superpowers/plans/2026-07-14-cli-login-tui.md
+++ b/docs/superpowers/plans/2026-07-14-cli-login-tui.md
@@ -1,0 +1,35 @@
+# CLI Login TUI Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace cooked-mode `/login` prompts with a dedicated ratatui Login page.
+
+**Architecture:** New `ui/login_form.rs` owns form state/render/keys. `account::login_with_credentials` performs Auth + persistence + Peer Host. Startup and Chat show the form and handle Submit/Cancel.
+
+**Tech Stack:** ratatui, crossterm, existing CLI account client
+
+---
+
+### Task 1: Account API without stdin
+
+- Modify: `src/apps/cli/src/account.rs`
+- [ ] Replace `login_interactive` + echo helpers with `login_with_credentials(relay_url, username, password)`
+
+### Task 2: Login form UI
+
+- Create: `src/apps/cli/src/ui/login_form.rs`
+- Modify: `src/apps/cli/src/ui/mod.rs`
+- [ ] Full-viewport form with three empty fields + Login button
+- [ ] Password masked as `*`
+- [ ] Up/Down/Tab focus; Enter advances or submits
+
+### Task 3: Wire startup + chat
+
+- Modify: `src/apps/cli/src/ui/startup.rs`, `src/apps/cli/src/ui/chat/*`, `src/apps/cli/src/modes/chat.rs`
+- [ ] `/login` and palette open the form; no raw-mode toggle
+- [ ] Submit calls `login_with_credentials`; errors stay on form
+
+### Task 4: Verify
+
+- [ ] `cargo check -p bitfun-cli`
+- [ ] Rebuild Ubuntu `~/bitfun-build/target/debug/bitfun-cli`

--- a/docs/superpowers/plans/2026-07-14-cli-peer-host.md
+++ b/docs/superpowers/plans/2026-07-14-cli-peer-host.md
@@ -1,0 +1,42 @@
+# CLI Peer Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make BitFun CLI a full Peer Device Mode host so Desktop A can control CLI B via HostInvoke / DeviceEvent.
+
+**Architecture:** CLI decrypts device RPC, special-cases HostInvoke to a Core command registry (no webview), fans out agentic DeviceEvents to attached controllers. Same device_id as Desktop; last AuthConnect wins.
+
+**Tech Stack:** Rust (`bitfun-cli`), `bitfun-core` services, existing account relay WS.
+
+---
+
+### Task 1: Spec + envelope routing — DONE
+
+- [x] Spec under `docs/superpowers/specs/2026-07-14-cli-peer-host.md`
+- [x] `account.rs` routes HostInvoke / DeviceEvent; reply target `"rpc"` for HTTP RPC
+
+### Task 2: Control plane + deny tables — DONE
+
+- [x] `peer_mode_ping` / attach / detach
+- [x] LOCAL_ONLY + CLI_UNSUPPORTED deny
+
+### Task 3: Bootstrap Core services — DONE
+
+- [x] WorkspaceService, FileSystemService, DialogScheduler, PersistenceManager
+- [x] Wire from `initialize_core_services`
+
+### Task 4: Must HostInvoke registry — DONE
+
+- [x] Workspace / FS / session / dialog / system HIGH_PRIORITY commands
+
+### Task 5: DeviceEvent fan-out — DONE
+
+- [x] EventQueue subscriber + sequential encrypt send
+
+### Task 6: Docs + verify — DONE
+
+- [x] `peer-device-mode.md`, CLI `AGENTS.md`
+- [x] `cargo check -p bitfun-cli` (clean)
+- [x] `cargo test -p bitfun-cli peer_host`
+- [x] Enter peer host via chat `/login` (same Auth Server / Username / Password
+  + `~/.bitfun` session/hint as Desktop). No separate `peer-host` CLI subcommand.

--- a/docs/superpowers/specs/2026-07-14-cli-account-sync-panel-design.md
+++ b/docs/superpowers/specs/2026-07-14-cli-account-sync-panel-design.md
@@ -1,0 +1,37 @@
+# CLI Account Sync & Status Panel Design
+
+## Goal
+
+Align CLI `/login` with Desktop Account Login after authentication:
+
+1. After credentials succeed, if cloud settings exist → choose **Use local** / **Use cloud**.
+2. Then run the same auto-sync flow (settings + session upload).
+3. If already logged in, `/login` opens an **account status** page (not the credential form) with account info and sync progress.
+
+## Views
+
+| Mode | When | UI |
+|---|---|---|
+| Login | Not logged in | Existing Auth Server / Username / Password / Login |
+| SyncChoice | Login succeeded and `has_cloud_settings` | Use local / Use cloud / Cancel (logout) |
+| Account | Logged in (or after sync choice / first login) | User id, relay, this device, devices list, sync status/progress, Logout |
+
+## Sync semantics (match Desktop)
+
+- No cloud settings → treat as first login: upload local config (`is_first_login=true`), then export sessions.
+- Use local → `is_first_login=true` (upload local settings).
+- Use cloud → `is_first_login=false` (download + import settings).
+- Cancel on SyncChoice → logout, return to Login.
+- Progress phases: uploading/downloading/applying settings → listing/exporting sessions → done/failed.
+- Sync runs in background; Account page reads shared progress state (Esc closes panel, sync continues).
+
+## Implementation
+
+- `account.rs`: structured `LoginResult` + `fetch_settings` for `has_cloud_settings`; `run_auto_sync` using `AccountClient`, `ConfigService`, `PersistenceManager`, `sync_state`.
+- `ui/account_panel.rs` (replaces single-purpose login form): multi-mode TUI.
+- `/login` entry: if logged in → Account; else → Login.
+
+## Non-goals (this change)
+
+- Continuous debounce push like Desktop `init_auto_sync` (follow-up).
+- Peer Device Mode controller entry from CLI Account page.

--- a/docs/superpowers/specs/2026-07-14-cli-login-tui-design.md
+++ b/docs/superpowers/specs/2026-07-14-cli-login-tui-design.md
@@ -1,0 +1,26 @@
+# CLI Login TUI Design
+
+## Problem
+
+`/login` temporarily disables raw mode and uses `print!` + echo-off stdin prompts. That fights the ratatui alternate screen and produces misaligned / overlapping characters.
+
+## Decision
+
+Dedicated full-viewport Login page (approach A), ratatui-native, no cooked-mode prompts.
+
+## Behavior
+
+- Entry: `/login` or palette Login from startup or chat.
+- Fields start empty (no credential-hint / default relay prefill).
+- Focus cycle (Up/Down, Tab/Shift+Tab): Auth Server → Username → Password → Login.
+- Password stores plaintext; display is `*` repeated by character count.
+- Enter on a text field moves focus down; Enter on Login submits.
+- Esc cancels and returns to the previous screen.
+- Validation / API errors stay on the form; success hides the form and shows a status/system message.
+- Persistence and Peer Host routing reuse existing `account` APIs after credentials are collected.
+
+## Non-goals
+
+- Changing Desktop login UI
+- Changing Auth Server protocol
+- Prefill / remembered credentials on the form fields

--- a/docs/superpowers/specs/2026-07-14-cli-peer-host.md
+++ b/docs/superpowers/specs/2026-07-14-cli-peer-host.md
@@ -1,0 +1,77 @@
+# CLI Peer Device Mode Host
+
+## Goal
+
+Desktop A can enter Peer Mode against a same-account CLI process on machine B
+using the same HostInvoke / DeviceEvent wire protocol as Desktop B. The CLI is
+a **host only** (not a Peer Mode controller).
+
+## Non-goals
+
+- CLI controlling other devices
+- Remote-desktop / raw input mirroring
+- Splitting same-machine Desktop + CLI into two device list entries
+- Full IDE parity (LSP UI, canvas, window chrome) — deny with clear English errors
+
+## Device identity and election
+
+- `device_id = hash(hostname + MAC)` (shared across Desktop and CLI on one machine)
+- Relay replaces the live connection for the same `(user_id, device_id)`
+- Last successful `AuthConnect` wins as the Peer Host process
+
+## Architecture
+
+1. CLI decrypts `IncomingDeviceMessage` and **special-cases** `HostInvoke` /
+   `DeviceEvent` (does not send HostInvoke through `RemoteServer::dispatch`).
+2. Control plane in Rust: `peer_mode_ping`, `peer_control_attach`,
+   `peer_control_detach`.
+3. Product data plane: CLI HostInvoke registry calls Core services
+   (`WorkspaceService`, `FileSystemService`, `PersistenceManager`,
+   `ConversationCoordinator`, `DialogScheduler`, `ConfigService`, `GitService`)
+   — same Tauri command names and `{ request: ... }` arg shape as Desktop.
+4. Agentic (and selected UI) events fan out as `RemoteCommand::DeviceEvent` to
+   attached controllers.
+5. Denied / unsupported commands return
+   `HostInvokeResult { ok: false, error }` — never fall back to the controller.
+
+## Must-support command surface
+
+Control: `peer_mode_ping`, `peer_control_attach`, `peer_control_detach`
+
+Hydrate / chat / FS:
+
+- Workspace: `initialize_workspace_startup_state`, `get_opened_workspaces`,
+  `get_recent_workspaces`, `get_current_workspace`, `open_workspace`,
+  `get_workspace_info`, `cleanup_invalid_workspaces`, `reload_config`
+- Config: `get_config`, `get_configs`, `set_config`, `get_agent_profile_config`,
+  `get_agent_profile_configs`
+- Sessions: `list_persisted_sessions*`, `load_session_turns`,
+  `restore_session_view`, `restore_session_with_turns`, `restore_session`,
+  `create_session`, `delete_session`, `rename_session`, `archive_session`,
+  `touch_session_activity`, `get_session_thread_goal`, `update_session_model`,
+  `ensure_coordinator_session`, `get_available_modes`, `get_session_stats`,
+  `save_session_turn`
+- Snapshot: `rollback_to_turn`, `get_session_files`
+- Dialog: `start_dialog_turn`, `cancel_dialog_turn`, `confirm_tool_execution`,
+  `reject_tool_execution`
+- FS / system: `get_directory_children`, `get_directory_children_paginated`,
+  `list_files`, `check_path_exists`, `create_directory`, `get_system_info`
+- Git (local): `git_is_repository`
+
+### Soft empty / no-op (Desktop-only subsystems)
+
+CLI does not run MiniApp runtime, Desktop cron host, or Peer-mounted ACP
+client service. These commands succeed with empty / null payloads so Desktop
+hydrate does not fail:
+
+- `list_miniapps` → `[]`
+- `miniapp_worker_list_running` → `[]`
+- `get_acp_clients` → `[]`
+- `notify_cron_host_ready` → null Ok
+- `list_background_command_activities` → `{ activities: [] }`
+
+## Ownership
+
+- Implementation: `src/apps/cli/src/peer_host/`
+- Routing: `src/apps/cli/src/account.rs`
+- Product doc: `docs/architecture/peer-device-mode.md`

--- a/src/apps/cli/AGENTS.md
+++ b/src/apps/cli/AGENTS.md
@@ -11,6 +11,11 @@ before Product Profile, TUI Blueprint, branding, packaging, runtime, or plugin a
 
 - This app owns Clap commands, TUI state and rendering, terminal input/lifecycle,
   CLI-local settings, structured output projection, and user-facing CLI diagnostics.
+- Peer Device Mode **host** support lives in `src/peer_host/`: after `/login`
+  (same Auth Server / Username / Password flow and `~/.bitfun` session/hint
+  files as Desktop), device routing stays up so Desktop controllers can
+  HostInvoke this process. CLI is not a Peer Mode controller. Same-machine
+  Desktop+CLI share one `device_id`; last AuthConnect wins.
 - Shared session, turn, task, tool, permission, context, checkpoint, Subagent,
   Harness, MCP, plugin, and capability facts belong to their runtime owners.
 - Existing `bitfun-core/product-full` compatibility paths may remain during a

--- a/src/apps/cli/src/account.rs
+++ b/src/apps/cli/src/account.rs
@@ -1,10 +1,11 @@
 //! CLI account login and device-routing (RPC control) support.
 //!
 //! This module lets the CLI log in to a BitFun relay account and then become
-//! RPC-controllable by other devices on the same account. The flow mirrors the
-//! desktop implementation but is kept minimal: a single global AccountSession,
-//! a background WS task that decrypts incoming device messages and dispatches
-//! them through the shared `RemoteServer`, and simple text-based listing.
+//! RPC-controllable by other devices on the same account.
+//!
+//! Incoming `HostInvoke` / `DeviceEvent` messages are handled by
+//! `crate::peer_host` (Peer Device Mode host). Other remote-connect commands
+//! still go through `RemoteServer`.
 //!
 //! The master key lives in memory only and is lost when the CLI exits.
 
@@ -50,7 +51,7 @@ fn device_relay_client() -> &'static RwLock<Option<Arc<RelayClient>>> {
 
 /// Read both the session and relay URL, returning owned clones to avoid holding
 /// locks across awaits.
-async fn read_account_context() -> Result<(AccountSession, String)> {
+pub(crate) async fn read_account_context() -> Result<(AccountSession, String)> {
     let session = account_session().read().await.clone();
     let relay_url = account_relay_url().read().await.clone();
     match (session, relay_url) {
@@ -60,13 +61,13 @@ async fn read_account_context() -> Result<(AccountSession, String)> {
 }
 
 /// Whether an account session is currently held.
-pub async fn is_logged_in() -> bool {
+pub(crate) async fn is_logged_in() -> bool {
     account_session().read().await.is_some()
 }
 
 /// Attempt to restore a persisted session from disk.  Called at startup.
 /// Returns `Some(user_id)` if a session was restored.
-pub async fn try_restore_session() -> Option<String> {
+pub(crate) async fn try_restore_session() -> Option<String> {
     match session_store::load_session() {
         Ok(Some((token, user_id, master_key, relay_url))) => {
             let session = AccountSession {
@@ -88,8 +89,9 @@ pub async fn try_restore_session() -> Option<String> {
 }
 
 /// Whether the relay has reported the account token as expired/invalid.
-/// The chat loop can call this to prompt the user to re-login.
-pub fn is_token_expired() -> bool {
+/// Intended for the TUI to prompt re-login when account pages open.
+#[allow(dead_code)]
+pub(crate) fn is_token_expired() -> bool {
     TOKEN_EXPIRED.load(Ordering::Relaxed)
 }
 
@@ -98,192 +100,104 @@ fn current_device_identity() -> Result<DeviceIdentity> {
     DeviceIdentity::from_current_machine().map_err(|e| anyhow!("detect device: {e}"))
 }
 
-/// Prompt for a line of input from stdin with the terminal in cooked mode.
+/// Structured result of a successful credential login.
+#[derive(Debug, Clone)]
+pub(crate) struct LoginResult {
+    pub user_id: String,
+    pub relay_url: String,
+    /// True when the relay already has a settings blob (Desktop overwrite prompt).
+    pub has_cloud_settings: bool,
+    pub status_message: String,
+}
+
+/// Log in with credentials collected by the Login TUI form.
 ///
-/// `secret=true` disables local echo (best-effort — used for passwords). The
-/// caller must have already left raw mode so that line editing works normally.
-fn prompt_line(prompt: &str, secret: bool) -> Result<String> {
-    use std::io::{self, Write};
-    print!("{}", prompt);
-    io::stdout().flush()?;
-
-    let value = if secret {
-        read_password()?
-    } else {
-        let mut buf = String::new();
-        io::stdin().read_line(&mut buf)?;
-        buf
-    };
-    Ok(value.trim_end_matches(['\r', '\n']).to_string())
-}
-
-/// Read a password from stdin with echo disabled. Falls back to plain
-/// `read_line` if terminal echo control is unavailable.
-fn read_password() -> Result<String> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::io::AsRawFd;
-        let stdin = std::io::stdin();
-        let fd = stdin.as_raw_fd();
-        // Attempt to disable ECHO; if it fails, fall back to normal read.
-        let disabled = disable_echo(fd).is_ok();
-        let result = (|| {
-            let mut buf = String::new();
-            std::io::stdin().read_line(&mut buf)?;
-            Ok(buf)
-        })();
-        if disabled {
-            let _ = restore_echo(fd);
-            // Print a newline so the next prompt starts on a fresh line.
-            println!();
-        }
-        return result;
+/// Same fields as Desktop Account Login: Auth Server (relay URL), Username,
+/// Password. Persists encrypted session + non-secret hint, then starts device
+/// routing so this CLI becomes a Peer Device Mode host.
+pub(crate) async fn login_with_credentials(
+    relay_url: &str,
+    username: &str,
+    password: &str,
+) -> Result<LoginResult> {
+    let relay_url = relay_url.trim();
+    let username = username.trim();
+    if relay_url.is_empty() {
+        return Err(anyhow!("Auth Server is required"));
     }
-    #[cfg(not(unix))]
-    {
-        let mut buf = String::new();
-        std::io::stdin().read_line(&mut buf)?;
-        Ok(buf)
-    }
-}
-
-#[cfg(unix)]
-fn disable_echo(fd: std::os::unix::io::RawFd) -> std::io::Result<()> {
-    // Minimal termios binding to avoid pulling in another crate. Only the
-    // fields needed to toggle ECHO are touched.
-    use std::mem::MaybeUninit;
-    extern "C" {
-        fn tcgetattr(fd: i32, termios: *mut Termios) -> i32;
-        fn tcsetattr(fd: i32, optional_actions: i32, termios: *const Termios) -> i32;
-    }
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    struct Termios {
-        c_iflag: u32,
-        c_oflag: u32,
-        c_cflag: u32,
-        c_lflag: u32,
-        c_line: u8,
-        c_cc: [u8; 32],
-        c_ispeed: u32,
-        c_ospeed: u32,
-    }
-    const ECHO: u32 = 0o000010;
-    const ECHONL: u32 = 0o000100;
-    const TCSANOW: i32 = 0;
-    unsafe {
-        let mut t: MaybeUninit<Termios> = MaybeUninit::uninit();
-        if tcgetattr(fd, t.as_mut_ptr()) != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let mut t = t.assume_init();
-        t.c_lflag &= !(ECHO);
-        t.c_lflag |= ECHONL;
-        if tcsetattr(fd, TCSANOW, &t) != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn restore_echo(fd: std::os::unix::io::RawFd) -> std::io::Result<()> {
-    use std::mem::MaybeUninit;
-    extern "C" {
-        fn tcgetattr(fd: i32, termios: *mut Termios) -> i32;
-        fn tcsetattr(fd: i32, optional_actions: i32, termios: *const Termios) -> i32;
-    }
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    struct Termios {
-        c_iflag: u32,
-        c_oflag: u32,
-        c_cflag: u32,
-        c_lflag: u32,
-        c_line: u8,
-        c_cc: [u8; 32],
-        c_ispeed: u32,
-        c_ospeed: u32,
-    }
-    const ECHO: u32 = 0o000010;
-    const ECHONL: u32 = 0o000100;
-    const TCSANOW: i32 = 0;
-    unsafe {
-        let mut t: MaybeUninit<Termios> = MaybeUninit::uninit();
-        if tcgetattr(fd, t.as_mut_ptr()) != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        let mut t = t.assume_init();
-        t.c_lflag |= ECHO;
-        t.c_lflag &= !ECHONL;
-        if tcsetattr(fd, TCSANOW, &t) != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-    }
-    Ok(())
-}
-
-/// Default relay URL used when the user presses Enter at the prompt.
-const DEFAULT_RELAY_URL: &str = "https://remote.openbitfun.com/relay";
-
-/// Run the interactive login flow.
-///
-/// `read_input` is called for each prompt while the terminal is in cooked
-/// mode. Returns a short status message for the chat view. The caller is
-/// responsible for leaving raw mode before calling this and re-enabling it
-/// afterwards.
-pub async fn login_interactive() -> Result<String> {
-    let relay_url = prompt_line(&format!("Relay URL [{}]: ", DEFAULT_RELAY_URL), false)?;
-    let relay_url = if relay_url.is_empty() {
-        DEFAULT_RELAY_URL.to_string()
-    } else {
-        relay_url
-    };
-    let username = prompt_line("Username: ", false)?;
     if username.is_empty() {
-        return Err(anyhow!("username is required"));
+        return Err(anyhow!("Username is required"));
     }
-    let password = prompt_line("Password: ", true)?;
     if password.is_empty() {
-        return Err(anyhow!("password is required"));
+        return Err(anyhow!("Password is required"));
     }
 
     let device = current_device_identity()?;
     let client = AccountClient::new();
     let session = client
-        .login(&relay_url, &username, &password, &device)
+        .login(relay_url, username, password, &device)
         .await
         .map_err(|e| anyhow!("login failed: {e}"))?;
+
+    let has_cloud_settings = client
+        .fetch_settings(relay_url, &session)
+        .await
+        .unwrap_or(None)
+        .is_some();
 
     let user_id = session.user_id.clone();
     let device_name = device.device_name.clone();
     let token = session.token.clone();
     let master_key = session.master_key;
     *account_session().write().await = Some(session);
-    *account_relay_url().write().await = Some(relay_url.clone());
+    *account_relay_url().write().await = Some(relay_url.to_string());
 
-    // Persist session for restart recovery.
-    if let Err(e) = session_store::save_session(&token, &user_id, &master_key, &relay_url) {
+    if let Err(e) = session_store::save_session(&token, &user_id, &master_key, relay_url) {
         tracing::warn!("Failed to persist session: {e}");
     }
+    session_store::save_credential_hint(username, relay_url);
 
     TOKEN_EXPIRED.store(false, Ordering::Relaxed);
 
-    // Establish device routing so the CLI becomes RPC-controllable.
-    let connect_result = spawn_device_routing(&relay_url, &device_name).await;
+    let connect_result = spawn_device_routing(relay_url, &device_name).await;
     let routing_msg = match connect_result {
-        Ok(()) => " Device routing connected.".to_string(),
+        Ok(()) => " Device routing connected (Peer Host ready).".to_string(),
         Err(e) => format!(" (Warning: device routing failed: {e})"),
     };
 
-    Ok(format!(
-        "Logged in as user {} on {}.{}",
-        user_id, relay_url, routing_msg
-    ))
+    Ok(LoginResult {
+        user_id: user_id.clone(),
+        relay_url: relay_url.to_string(),
+        has_cloud_settings,
+        status_message: format!(
+            "Logged in as user {} on {}.{}",
+            user_id, relay_url, routing_msg
+        ),
+    })
+}
+
+/// Snapshot of the logged-in account for the Account status page.
+#[derive(Debug, Clone)]
+pub(crate) struct AccountInfo {
+    pub user_id: String,
+    pub relay_url: String,
+    pub device_id: String,
+    pub device_name: String,
+}
+
+pub(crate) async fn account_info() -> Result<AccountInfo> {
+    let (session, relay_url) = read_account_context().await?;
+    let device = current_device_identity()?;
+    Ok(AccountInfo {
+        user_id: session.user_id,
+        relay_url,
+        device_id: device.device_id,
+        device_name: device.device_name,
+    })
 }
 
 /// Public wrapper for restoring device routing after session restore at startup.
-pub async fn restore_device_routing(device_name: &str) -> Result<()> {
+pub(crate) async fn restore_device_routing(device_name: &str) -> Result<()> {
     let relay_url = account_relay_url()
         .read()
         .await
@@ -334,14 +248,14 @@ async fn spawn_device_routing(relay_url: &str, device_name: &str) -> Result<()> 
 }
 
 /// Disconnect the device-routing connection (if any).
-pub async fn stop_device_routing() {
+pub(crate) async fn stop_device_routing() {
     if let Some(client) = device_relay_client().write().await.take() {
         client.disconnect().await;
     }
 }
 
 /// Log out: tear down routing, revoke the token (best-effort), clear state.
-pub async fn logout() -> Result<()> {
+pub(crate) async fn logout() -> Result<()> {
     stop_device_routing().await;
     let result = read_account_context().await;
     if let Ok((session, relay_url)) = result {
@@ -352,6 +266,7 @@ pub async fn logout() -> Result<()> {
     *account_session().write().await = None;
     *account_relay_url().write().await = None;
     session_store::clear_session();
+    session_store::clear_credential_hint();
     TOKEN_EXPIRED.store(false, Ordering::Relaxed);
     Ok(())
 }
@@ -392,7 +307,7 @@ async fn handle_relay_event(
                         return;
                     }
                 };
-            use remote_connect::remote_server::RemoteCommand;
+            use remote_connect::remote_server::{RemoteCommand, RemoteResponse};
             let cmd: RemoteCommand = match serde_json::from_str(&plaintext) {
                 Ok(c) => c,
                 Err(e) => {
@@ -402,18 +317,46 @@ async fn handle_relay_event(
             };
             tracing::info!("Device command from {source_device_id}: {cmd:?} corr={correlation_id}");
 
-            let server = RemoteServer::new(session.master_key);
-            let response = server.dispatch(&cmd).await;
-            match server.encrypt_response(&response, None) {
+            let response = match &cmd {
+                RemoteCommand::HostInvoke { command, args } => {
+                    crate::peer_host::handle_host_invoke(command, args.clone()).await
+                }
+                RemoteCommand::DeviceEvent { .. } => {
+                    crate::peer_host::handle_device_event_command()
+                }
+                other => {
+                    let server = RemoteServer::new(session.master_key);
+                    server.dispatch(other).await
+                }
+            };
+
+            let resp_json = match serde_json::to_string(&response) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("Failed to serialize RPC response: {e}");
+                    serde_json::to_string(&RemoteResponse::Error {
+                        message: format!("failed to serialize RPC response: {e}"),
+                    })
+                    .unwrap_or_else(|_| {
+                        r#"{"resp":"error","message":"serialize failed"}"#.to_string()
+                    })
+                }
+            };
+
+            match encryption::encrypt_to_base64(&session.master_key, &resp_json) {
                 Ok((enc_resp, resp_nonce)) => {
-                    let _ = relay_client
-                        .send_device_message(
-                            &source_device_id,
-                            &correlation_id,
-                            &enc_resp,
-                            &resp_nonce,
-                        )
-                        .await;
+                    // HTTP RPC bridge expects replies targeted at "rpc".
+                    let reply_target = if source_device_id == "rpc" {
+                        "rpc"
+                    } else {
+                        source_device_id.as_str()
+                    };
+                    if let Err(e) = relay_client
+                        .send_device_message(reply_target, &correlation_id, &enc_resp, &resp_nonce)
+                        .await
+                    {
+                        tracing::warn!("Failed to send RPC response: {e}");
+                    }
                 }
                 Err(e) => {
                     tracing::warn!("Failed to encrypt RPC response: {e}");
@@ -433,16 +376,30 @@ async fn handle_relay_event(
     }
 }
 
+/// Context needed by Peer Host DeviceEvent fan-out.
+pub(crate) async fn peer_fanout_context() -> Result<(AccountSession, Arc<RelayClient>)> {
+    let session = account_session()
+        .read()
+        .await
+        .clone()
+        .ok_or_else(|| anyhow!("not logged in"))?;
+    let client = device_relay_client()
+        .read()
+        .await
+        .clone()
+        .ok_or_else(|| anyhow!("device routing not connected"))?;
+    Ok((session, client))
+}
+
 /// A textual device listing entry for display.
-pub struct AccountDevice {
-    pub device_id: String,
-    pub device_name: String,
-    pub online: bool,
-    pub last_seen_at: Option<i64>,
+pub(crate) struct AccountDevice {
+    pub(crate) device_id: String,
+    pub(crate) device_name: String,
+    pub(crate) online: bool,
 }
 
 /// List all devices in the account.
-pub async fn list_devices() -> Result<Vec<AccountDevice>> {
+pub(crate) async fn list_devices() -> Result<Vec<AccountDevice>> {
     let (session, relay_url) = read_account_context().await?;
     let devices = AccountClient::new()
         .list_devices(&relay_url, &session)
@@ -453,36 +410,6 @@ pub async fn list_devices() -> Result<Vec<AccountDevice>> {
             device_id: d.device_id,
             device_name: d.device_name,
             online: d.online,
-            last_seen_at: d.last_seen_at,
         })
         .collect())
-}
-
-/// Build a simple text report of account devices.
-pub fn format_devices(devices: &[AccountDevice]) -> String {
-    if devices.is_empty() {
-        return "No devices found on this account.".to_string();
-    }
-    let mut lines = Vec::new();
-    lines.push(format!("Account devices ({}):", devices.len()));
-    for d in devices {
-        let status = if d.online { "online" } else { "offline" };
-        let last = match d.last_seen_at {
-            Some(ts) => format!(", last seen {}", format_ts(ts)),
-            None => String::new(),
-        };
-        lines.push(format!(
-            "  • {} — {} [{}]{}",
-            d.device_name, d.device_id, status, last
-        ));
-    }
-    lines.join("\n")
-}
-
-fn format_ts(ts: i64) -> String {
-    use chrono::{DateTime, Utc};
-    match DateTime::<Utc>::from_timestamp(ts, 0) {
-        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
-        None => ts.to_string(),
-    }
 }

--- a/src/apps/cli/src/account_sync.rs
+++ b/src/apps/cli/src/account_sync.rs
@@ -1,0 +1,369 @@
+//! CLI account auto-sync (settings + session upload), matching Desktop semantics.
+
+use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, OnceLock,
+};
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use bitfun_core::agentic::persistence::PersistenceManager;
+use bitfun_core::infrastructure::try_get_path_manager_arc;
+use bitfun_core::service::config::get_global_config_service;
+use bitfun_core::service::remote_connect::{sync_state, AccountClient};
+
+use crate::account::read_account_context;
+
+const UPLOAD_CONCURRENCY_CHUNK: usize = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncStatus {
+    Idle,
+    Syncing,
+    Done,
+    Failed,
+}
+
+impl Default for SyncStatus {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SyncProgress {
+    pub status: SyncStatus,
+    pub phase: String,
+    pub percent: u8,
+    pub current: Option<usize>,
+    pub total: Option<usize>,
+    pub detail: Option<String>,
+    pub error: Option<String>,
+    pub settings_synced: bool,
+    pub sessions_exported: usize,
+}
+
+impl Default for SyncProgress {
+    fn default() -> Self {
+        Self {
+            status: SyncStatus::Idle,
+            phase: String::new(),
+            percent: 0,
+            current: None,
+            total: None,
+            detail: None,
+            error: None,
+            settings_synced: false,
+            sessions_exported: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AutoSyncResult {
+    pub settings_synced: bool,
+    pub sessions_exported: usize,
+    #[allow(dead_code)]
+    pub sessions_imported: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SessionBundle {
+    session_id: String,
+    metadata: serde_json::Value,
+    turns: Vec<serde_json::Value>,
+    source_device_id: Option<String>,
+    source_device_name: Option<String>,
+}
+
+static SYNC_PROGRESS: OnceLock<Arc<RwLock<SyncProgress>>> = OnceLock::new();
+static AUTO_SYNC_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+fn sync_progress_store() -> &'static Arc<RwLock<SyncProgress>> {
+    SYNC_PROGRESS.get_or_init(|| Arc::new(RwLock::new(SyncProgress::default())))
+}
+
+pub(crate) async fn current_sync_progress() -> SyncProgress {
+    sync_progress_store().read().await.clone()
+}
+
+pub(crate) fn sync_in_flight() -> bool {
+    AUTO_SYNC_IN_FLIGHT.load(Ordering::SeqCst)
+}
+
+async fn set_progress(mut update: impl FnMut(&mut SyncProgress)) {
+    let mut guard = sync_progress_store().write().await;
+    update(&mut guard);
+}
+
+async fn emit_progress(
+    phase: &str,
+    percent: u8,
+    current: Option<usize>,
+    total: Option<usize>,
+    detail: Option<&str>,
+) {
+    set_progress(|p| {
+        p.status = SyncStatus::Syncing;
+        p.phase = phase.to_string();
+        p.percent = percent;
+        p.current = current;
+        p.total = total;
+        p.detail = detail.map(|s| s.to_string());
+        p.error = None;
+    })
+    .await;
+}
+
+/// Start auto-sync in the background. Returns immediately; progress is in
+/// [`current_sync_progress`].
+pub(crate) fn start_auto_sync_background(is_first_login: bool, workspace_path: PathBuf) {
+    if AUTO_SYNC_IN_FLIGHT.swap(true, Ordering::SeqCst) {
+        tracing::warn!("Account auto-sync already in flight; skipping duplicate start");
+        return;
+    }
+    tokio::spawn(async move {
+        let result = run_auto_sync(is_first_login, &workspace_path).await;
+        AUTO_SYNC_IN_FLIGHT.store(false, Ordering::SeqCst);
+        match result {
+            Ok(r) => {
+                set_progress(|p| {
+                    p.status = SyncStatus::Done;
+                    p.phase = "done".into();
+                    p.percent = 100;
+                    p.settings_synced = r.settings_synced;
+                    p.sessions_exported = r.sessions_exported;
+                    p.error = None;
+                })
+                .await;
+            }
+            Err(e) => {
+                set_progress(|p| {
+                    p.status = SyncStatus::Failed;
+                    p.error = Some(e.to_string());
+                })
+                .await;
+                tracing::warn!("Account auto-sync failed: {e}");
+            }
+        }
+    });
+}
+
+pub(crate) async fn run_auto_sync(
+    is_first_login: bool,
+    workspace_path: &Path,
+) -> Result<AutoSyncResult> {
+    set_progress(|p| {
+        *p = SyncProgress {
+            status: SyncStatus::Syncing,
+            phase: "starting".into(),
+            percent: 1,
+            ..SyncProgress::default()
+        };
+    })
+    .await;
+
+    let (acct_session, relay_url) = read_account_context().await?;
+    let client = AccountClient::new();
+
+    let settings_synced = if is_first_login {
+        emit_progress("uploading_settings", 5, None, None, None).await;
+        let config_service = get_global_config_service()
+            .await
+            .map_err(|e| anyhow!("config service: {e}"))?;
+        let exported = config_service
+            .export_config()
+            .await
+            .map_err(|e| anyhow!("export config: {e}"))?;
+        let config_json =
+            serde_json::to_string(&exported).map_err(|e| anyhow!("serialize config: {e}"))?;
+        client
+            .upload_settings(&relay_url, &acct_session, &config_json)
+            .await
+            .map_err(|e| anyhow!("upload settings: {e}"))?;
+        emit_progress("settings_done", 15, None, None, None).await;
+        true
+    } else {
+        emit_progress("downloading_settings", 5, None, None, None).await;
+        let cloud = client
+            .fetch_settings_with_version(&relay_url, &acct_session)
+            .await
+            .map_err(|e| anyhow!("fetch settings: {e}"))?;
+        if let Some(blob) = cloud {
+            emit_progress("applying_settings", 10, None, None, None).await;
+            let config_value: serde_json::Value = serde_json::from_str(&blob.plaintext)
+                .map_err(|e| anyhow!("parse cloud config: {e}"))?;
+            let inner_config = config_value.get("config").cloned().unwrap_or(config_value);
+            let config_service = get_global_config_service()
+                .await
+                .map_err(|e| anyhow!("config service: {e}"))?;
+            let import_result = config_service
+                .import_config_data(inner_config)
+                .await
+                .map_err(|e| anyhow!("import cloud config: {e}"))?;
+            if !import_result.success {
+                return Err(anyhow!(
+                    "import cloud config failed: {}",
+                    import_result.errors.join("; ")
+                ));
+            }
+            if let Err(e) = config_service.reload().await {
+                tracing::warn!("reload after cloud config import failed: {e}");
+            }
+            emit_progress("settings_done", 15, None, None, None).await;
+            true
+        } else {
+            emit_progress("settings_done", 15, None, None, None).await;
+            false
+        }
+    };
+
+    emit_progress("listing_sessions", 18, None, None, None).await;
+    let path_manager = try_get_path_manager_arc().map_err(|e| anyhow!(e.to_string()))?;
+    let manager =
+        PersistenceManager::new(path_manager).map_err(|e| anyhow!("persistence manager: {e}"))?;
+
+    // PersistenceManager APIs take the workspace root and resolve the sessions
+    // directory internally (same path family as CLI session listing).
+    let storage_path = workspace_path.to_path_buf();
+
+    let local_sessions = manager
+        .list_session_metadata(&storage_path)
+        .await
+        .map_err(|e| anyhow!("list sessions: {e}"))?;
+
+    emit_progress(
+        "exporting_sessions",
+        20,
+        Some(0),
+        Some(local_sessions.len()),
+        None,
+    )
+    .await;
+
+    let mut sync_state_local = sync_state::load(&acct_session.user_id);
+    let mut pending_uploads: Vec<(String, String, String)> = Vec::new();
+    for meta in local_sessions.iter() {
+        let turns = manager
+            .load_session_turns(&storage_path, &meta.session_id)
+            .await
+            .map_err(|e| anyhow!("load turns: {e}"))?;
+        let metadata_json =
+            serde_json::to_value(meta).map_err(|e| anyhow!("serialize metadata: {e}"))?;
+        let turns_json: Vec<serde_json::Value> = turns
+            .iter()
+            .map(|t| serde_json::to_value(t).unwrap_or(serde_json::Value::Null))
+            .collect();
+        let bundle = SessionBundle {
+            session_id: meta.session_id.clone(),
+            metadata: metadata_json,
+            turns: turns_json,
+            source_device_id: None,
+            source_device_name: None,
+        };
+        let bundle_json =
+            serde_json::to_string(&bundle).map_err(|e| anyhow!("serialize bundle: {e}"))?;
+        let hash = sync_state::content_hash(&bundle_json);
+        if sync_state_local.uploaded_hash(&meta.session_id) == Some(hash.as_str()) {
+            continue;
+        }
+        pending_uploads.push((meta.session_id.clone(), bundle_json, hash));
+    }
+
+    let upload_total = pending_uploads.len();
+    emit_progress("exporting_sessions", 20, Some(0), Some(upload_total), None).await;
+
+    let mut uploaded: Vec<(String, String, i64)> = Vec::new();
+    for (chunk_idx, chunk) in pending_uploads.chunks(UPLOAD_CONCURRENCY_CHUNK).enumerate() {
+        let mut handles = Vec::new();
+        for (session_id, bundle_json, hash) in chunk {
+            let client = AccountClient::new();
+            let relay_url = relay_url.clone();
+            let acct_session = acct_session.clone();
+            let session_id = session_id.clone();
+            let bundle_json = bundle_json.clone();
+            let hash = hash.clone();
+            handles.push(tokio::spawn(async move {
+                let result = client
+                    .upload_session(&relay_url, &acct_session, &session_id, &bundle_json)
+                    .await;
+                (session_id, hash, result)
+            }));
+        }
+        for handle in handles {
+            let done_base = chunk_idx * UPLOAD_CONCURRENCY_CHUNK;
+            match handle.await {
+                Ok((session_id, hash, Ok(version))) => {
+                    uploaded.push((session_id.clone(), hash, version));
+                    let done = uploaded.len();
+                    let percent = if upload_total == 0 {
+                        95u8
+                    } else {
+                        20 + ((75 * done) / upload_total) as u8
+                    };
+                    emit_progress(
+                        "exporting_sessions",
+                        percent.min(95),
+                        Some(done),
+                        Some(upload_total),
+                        Some(&session_id),
+                    )
+                    .await;
+                }
+                Ok((session_id, _, Err(e))) => {
+                    tracing::warn!("Auto-sync upload {session_id} failed: {e}");
+                    let _ = done_base;
+                }
+                Err(e) => {
+                    tracing::warn!("Auto-sync upload task join failed: {e}");
+                }
+            }
+        }
+    }
+
+    let exported = uploaded.len();
+    let mut max_uploaded_version = sync_state_local.last_session_since;
+    for (session_id, hash, version) in uploaded {
+        sync_state_local.set_uploaded_hash(&session_id, hash);
+        if version > max_uploaded_version {
+            max_uploaded_version = version;
+        }
+    }
+    if max_uploaded_version > sync_state_local.last_session_since {
+        sync_state_local.last_session_since = max_uploaded_version;
+    }
+    let _ = sync_state::save(&acct_session.user_id, &sync_state_local);
+
+    tracing::info!("Auto-sync: settings={settings_synced} exported={exported} imported=0");
+    emit_progress("done", 100, Some(exported), Some(0), None).await;
+
+    Ok(AutoSyncResult {
+        settings_synced,
+        sessions_exported: exported,
+        sessions_imported: 0,
+    })
+}
+
+pub(crate) fn sync_phase_label(progress: &SyncProgress) -> String {
+    match progress.phase.as_str() {
+        "uploading_settings" => "Uploading settings…".into(),
+        "downloading_settings" => "Downloading settings…".into(),
+        "applying_settings" => "Applying cloud settings…".into(),
+        "settings_done" => "Settings sync done".into(),
+        "listing_sessions" => "Listing local sessions…".into(),
+        "exporting_sessions" => {
+            if let (Some(c), Some(t)) = (progress.current, progress.total) {
+                format!("Uploading sessions ({c}/{t})…")
+            } else {
+                "Uploading sessions…".into()
+            }
+        }
+        "done" => format!("Sync complete (exported {})", progress.sessions_exported),
+        "starting" => "Starting sync…".into(),
+        other if other.is_empty() => "Sync".into(),
+        other => other.to_string(),
+    }
+}

--- a/src/apps/cli/src/commands.rs
+++ b/src/apps/cli/src/commands.rs
@@ -78,15 +78,11 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
     },
     CommandSpec {
         name: "/login",
-        description: "Log in to BitFun account for multi-device sync",
+        description: "Account login / status (sync progress when signed in)",
     },
     CommandSpec {
         name: "/logout",
         description: "Log out of BitFun account",
-    },
-    CommandSpec {
-        name: "/devices",
-        description: "List devices on this account",
     },
 ];
 
@@ -131,6 +127,14 @@ pub(crate) const STARTUP_COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         name: "/acp",
         description: "Show ACP server setup",
+    },
+    CommandSpec {
+        name: "/login",
+        description: "Account login / status (sync progress when signed in)",
+    },
+    CommandSpec {
+        name: "/logout",
+        description: "Log out of BitFun account",
     },
     CommandSpec {
         name: "/init",

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -5,6 +5,7 @@
 /// - Single command execution
 /// - Batch task processing
 mod account;
+mod account_sync;
 mod acp_cli;
 mod agent;
 #[allow(dead_code)]
@@ -15,6 +16,7 @@ mod diagnostics;
 mod logging;
 mod management;
 mod modes;
+mod peer_host;
 mod plugin_diagnostics;
 mod prompts;
 mod root_handlers;
@@ -450,6 +452,12 @@ async fn initialize_core_services(
         .expect("Failed to initialize agentic system");
     tracing::info!("Agentic system initialized");
 
+    if let Err(e) = peer_host::ensure_peer_host_ready(&agentic_system).await {
+        tracing::warn!("Failed to initialize CLI peer host services: {e}");
+    } else {
+        tracing::info!("CLI peer host services initialized");
+    }
+
     // Initialize MCP service in background (non-blocking)
     if let Some(ref cfg_svc) = config_service {
         match bitfun_core::service::mcp::MCPService::new(cfg_svc.clone()) {
@@ -527,8 +535,8 @@ async fn run_interactive(
     if let Some(user_id) = account::try_restore_session().await {
         tracing::info!("Restored account session for user {user_id}");
         // Re-establish device routing so the CLI becomes RPC-controllable.
-        let device = DeviceIdentity::from_current_machine()
-            .map_err(|e| anyhow!("detect device: {e}"))?;
+        let device =
+            DeviceIdentity::from_current_machine().map_err(|e| anyhow!("detect device: {e}"))?;
         if let Err(e) = account::restore_device_routing(&device.device_name).await {
             tracing::warn!("Failed to restore device routing: {e}");
         }

--- a/src/apps/cli/src/modes/chat.rs
+++ b/src/apps/cli/src/modes/chat.rs
@@ -23,6 +23,7 @@ use crate::config::CliConfig;
 use crate::ui::agent_selector::AgentItem;
 use crate::ui::chat::{ChatView, MouseGestureOutcome};
 use crate::ui::command_palette::PaletteAction;
+use crate::ui::login_form::LoginFormAction;
 use crate::ui::mcp_add_dialog::McpAddAction;
 use crate::ui::mcp_selector::McpItem;
 use crate::ui::model_config_form::{ModelFormAction, ModelFormResult};
@@ -191,6 +192,152 @@ impl ChatMode {
         self
     }
 
+    fn workspace_path_for_sync(&self, chat_state: &ChatState) -> std::path::PathBuf {
+        chat_state
+            .workspace
+            .as_ref()
+            .map(std::path::PathBuf::from)
+            .or_else(|| self.workspace.clone().map(std::path::PathBuf::from))
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+    }
+
+    fn open_login_or_account_panel(
+        &self,
+        chat_view: &mut ChatView,
+        chat_state: &ChatState,
+        rt_handle: &tokio::runtime::Handle,
+    ) {
+        let logged_in =
+            tokio::task::block_in_place(|| rt_handle.block_on(crate::account::is_logged_in()));
+        if logged_in {
+            self.open_account_panel(chat_view, rt_handle);
+        } else {
+            chat_view.show_login_form();
+        }
+        let _ = chat_state;
+    }
+
+    fn open_account_panel(&self, chat_view: &mut ChatView, rt_handle: &tokio::runtime::Handle) {
+        let (info, devices, progress) = tokio::task::block_in_place(|| {
+            rt_handle.block_on(async {
+                let info = crate::account::account_info().await;
+                let devices = crate::account::list_devices().await.unwrap_or_default();
+                let progress = crate::account_sync::current_sync_progress().await;
+                (info, devices, progress)
+            })
+        });
+        match info {
+            Ok(info) => chat_view.show_account_panel(info, devices, progress),
+            Err(e) => {
+                chat_view.set_status(Some(format!("Failed to load account: {e}")));
+                chat_view.show_login_form();
+            }
+        }
+    }
+
+    fn refresh_account_panel_live(&self, chat_view: &mut ChatView) {
+        if !chat_view.login_form_visible() {
+            return;
+        }
+        let progress = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(crate::account_sync::current_sync_progress())
+        });
+        let devices = if matches!(
+            progress.status,
+            crate::account_sync::SyncStatus::Syncing | crate::account_sync::SyncStatus::Done
+        ) {
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current()
+                    .block_on(crate::account::list_devices())
+                    .ok()
+            })
+        } else {
+            None
+        };
+        chat_view.update_account_panel_progress(devices, progress);
+    }
+
+    fn start_sync_and_show_account(
+        &self,
+        is_first_login: bool,
+        chat_view: &mut ChatView,
+        chat_state: &mut ChatState,
+        rt_handle: &tokio::runtime::Handle,
+    ) {
+        let workspace = self.workspace_path_for_sync(chat_state);
+        crate::account_sync::start_auto_sync_background(is_first_login, workspace);
+        self.open_account_panel(chat_view, rt_handle);
+        chat_state.add_system_message(if is_first_login {
+            "Sync started (use local / upload settings).".to_string()
+        } else {
+            "Sync started (use cloud / download settings).".to_string()
+        });
+    }
+
+    fn handle_login_form_action(
+        &self,
+        action: LoginFormAction,
+        chat_view: &mut ChatView,
+        chat_state: &mut ChatState,
+        rt_handle: &tokio::runtime::Handle,
+    ) -> Result<Option<ChatExitReason>> {
+        match action {
+            LoginFormAction::Submit(creds) => {
+                let result = tokio::task::block_in_place(|| {
+                    rt_handle.block_on(crate::account::login_with_credentials(
+                        &creds.relay_url,
+                        &creds.username,
+                        &creds.password,
+                    ))
+                });
+                match result {
+                    Ok(login) => {
+                        chat_state.add_system_message(login.status_message.clone());
+                        if login.has_cloud_settings {
+                            chat_view.show_sync_choice_panel(&login.user_id, &login.relay_url);
+                        } else {
+                            self.start_sync_and_show_account(
+                                true, chat_view, chat_state, rt_handle,
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        chat_view.login_form_set_error(format!("Login failed: {e}"));
+                    }
+                }
+            }
+            LoginFormAction::SyncUseLocal => {
+                self.start_sync_and_show_account(true, chat_view, chat_state, rt_handle);
+            }
+            LoginFormAction::SyncUseCloud => {
+                self.start_sync_and_show_account(false, chat_view, chat_state, rt_handle);
+            }
+            LoginFormAction::SyncCancel => {
+                let _ =
+                    tokio::task::block_in_place(|| rt_handle.block_on(crate::account::logout()));
+                chat_view.show_login_form();
+                chat_state.add_system_message("Sync cancelled; logged out.".to_string());
+            }
+            LoginFormAction::Logout => {
+                match tokio::task::block_in_place(|| rt_handle.block_on(crate::account::logout())) {
+                    Ok(()) => {
+                        chat_view.show_login_form();
+                        chat_state.add_system_message("Logged out.".to_string());
+                    }
+                    Err(e) => {
+                        chat_view.login_form_set_error(format!("Logout failed: {e}"));
+                    }
+                }
+            }
+            LoginFormAction::Cancel => {
+                chat_view.set_status(Some("Account panel closed".to_string()));
+            }
+            LoginFormAction::None => {}
+        }
+        Ok(None)
+    }
+
     /// Check if any popup is currently visible
     fn any_popup_visible(&self, chat_view: &ChatView) -> bool {
         chat_view.command_palette_visible()
@@ -203,6 +350,7 @@ impl ChatMode {
             || chat_view.mcp_add_dialog_visible()
             || chat_view.provider_selector_visible()
             || chat_view.model_config_form_visible()
+            || chat_view.login_form_visible()
             || chat_view.theme_selector_visible()
             || chat_view.info_popup_visible()
     }
@@ -223,6 +371,7 @@ impl ChatMode {
         chat_view.hide_mcp_add_dialog();
         chat_view.hide_provider_selector();
         chat_view.hide_model_config_form();
+        chat_view.hide_login_form();
         chat_view.hide_theme_selector();
         chat_view.dismiss_info_popup();
         chat_view.popup_stack.clear();
@@ -244,6 +393,7 @@ impl ChatMode {
                 crate::ui::chat::PopupType::McpAddDialog => chat_view.hide_mcp_add_dialog(),
                 crate::ui::chat::PopupType::ProviderSelector => chat_view.hide_provider_selector(),
                 crate::ui::chat::PopupType::ModelConfigForm => chat_view.hide_model_config_form(),
+                crate::ui::chat::PopupType::LoginForm => chat_view.hide_login_form(),
                 crate::ui::chat::PopupType::ThemeSelector => {
                     chat_view.hide_theme_selector();
                     chat_view.cancel_theme_preview();
@@ -274,6 +424,7 @@ impl ChatMode {
                     crate::ui::chat::PopupType::ModelConfigForm => {
                         chat_view.reshow_model_config_form()
                     }
+                    crate::ui::chat::PopupType::LoginForm => chat_view.reshow_login_form(),
                     crate::ui::chat::PopupType::ThemeSelector => chat_view.reshow_theme_selector(),
                     crate::ui::chat::PopupType::InfoPopup => {}
                 }
@@ -456,6 +607,13 @@ impl ChatMode {
             // Poll completion of non-blocking MCP operations before rendering.
             if self.poll_mcp_task_completion(&mut chat_view, &mut chat_state, &rt_handle) {
                 needs_redraw = true;
+            }
+
+            if chat_view.login_form_visible() {
+                self.refresh_account_panel_live(&mut chat_view);
+                if crate::account_sync::sync_in_flight() {
+                    needs_redraw = true;
+                }
             }
 
             let mut did_render_this_loop = false;
@@ -737,8 +895,12 @@ impl ChatMode {
                         }
                         if !paste_buf.is_empty() {
                             let normalized = paste_buf.replace("\r\n", "\n").replace('\r', "\n");
-                            for c in normalized.chars() {
-                                chat_view.handle_char(c);
+                            if chat_view.login_form_visible() {
+                                chat_view.login_form_insert_paste(&normalized);
+                            } else {
+                                for c in normalized.chars() {
+                                    chat_view.handle_char(c);
+                                }
                             }
                             needs_redraw = true;
                         }
@@ -1157,6 +1319,12 @@ impl ChatMode {
             return Ok(None);
         }
 
+        if chat_view.login_form_visible() {
+            self.refresh_account_panel_live(chat_view);
+            let action = chat_view.login_form_handle_key(key);
+            return self.handle_login_form_action(action, chat_view, chat_state, rt_handle);
+        }
+
         match (key.code, key.modifiers) {
             // Ctrl+V: read clipboard directly (reliable paste on Windows where
             // bracketed paste is broken — crossterm issue #962)
@@ -1571,6 +1739,8 @@ impl ChatMode {
             Event::Paste(text) => {
                 if context.chat_view.mcp_add_dialog_visible() {
                     context.chat_view.mcp_add_dialog_handle_paste(&text);
+                } else if context.chat_view.login_form_visible() {
+                    context.chat_view.login_form_insert_paste(&text);
                 } else {
                     let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
                     for c in normalized.chars() {
@@ -1648,6 +1818,13 @@ impl ChatMode {
             // MCP group
             "mcp_servers" => {
                 self.show_mcp_selector(chat_view, chat_state, rt_handle);
+            }
+            // Account group
+            "login" => {
+                return self.handle_command("/login", chat_view, chat_state, rt_handle);
+            }
+            "logout" => {
+                return self.handle_command("/logout", chat_view, chat_state, rt_handle);
             }
             // System group
             "help" => {
@@ -1813,26 +1990,8 @@ impl ChatMode {
                     ));
                     return Ok(None);
                 }
-                // Temporarily leave raw mode so the user can type credentials
-                // with normal line editing. Alternate screen stays active; the
-                // prompt + echoed input render inside it.
-                chat_view.set_status(Some(
-                    "Login: switch to terminal to enter credentials.".to_string(),
-                ));
-                let _ = crossterm::terminal::disable_raw_mode();
-                let result = tokio::task::block_in_place(|| {
-                    rt_handle.block_on(crate::account::login_interactive())
-                });
-                // Always restore raw mode before returning to the TUI loop.
-                let _ = crossterm::terminal::enable_raw_mode();
-                match result {
-                    Ok(msg) => {
-                        chat_state.add_system_message(msg);
-                    }
-                    Err(e) => {
-                        chat_state.add_system_message(format!("Login failed: {e}"));
-                    }
-                }
+                self.close_all_popups(chat_view);
+                self.open_login_or_account_panel(chat_view, chat_state, rt_handle);
             }
             "/logout" => {
                 let logged_in = tokio::task::block_in_place(|| {
@@ -1849,29 +2008,6 @@ impl ChatMode {
                         }
                         Err(e) => {
                             chat_state.add_system_message(format!("Logout failed: {e}"));
-                        }
-                    }
-                }
-            }
-            "/devices" => {
-                let logged_in = tokio::task::block_in_place(|| {
-                    rt_handle.block_on(crate::account::is_logged_in())
-                });
-                if !logged_in {
-                    chat_state.add_system_message("Not logged in. Use /login first.".to_string());
-                } else if crate::account::is_token_expired() {
-                    chat_state.add_system_message(
-                        "Account token has expired. Use /login to re-authenticate.".to_string(),
-                    );
-                } else {
-                    match tokio::task::block_in_place(|| {
-                        rt_handle.block_on(crate::account::list_devices())
-                    }) {
-                        Ok(devices) => {
-                            chat_state.add_system_message(crate::account::format_devices(&devices));
-                        }
-                        Err(e) => {
-                            chat_state.add_system_message(format!("Failed to list devices: {e}"));
                         }
                     }
                 }

--- a/src/apps/cli/src/peer_host/args.rs
+++ b/src/apps/cli/src/peer_host/args.rs
@@ -1,0 +1,76 @@
+//! Shared JSON argument helpers for Tauri-shaped HostInvoke payloads.
+
+use serde_json::Value;
+
+/// Extract the `request` object from Tauri-style params (`{ request: { ... } }`).
+/// Falls back to the top-level object when `request` is absent.
+pub(crate) fn request_value(args: &Value) -> &Value {
+    args.get("request").unwrap_or(args)
+}
+
+/// Look up a field by camelCase key, falling back to snake_case.
+fn field<'a>(obj: &'a Value, camel: &str, snake: &str) -> Option<&'a Value> {
+    obj.get(camel).or_else(|| obj.get(snake))
+}
+
+pub(crate) fn get_string(obj: &Value, camel: &str) -> Result<String, String> {
+    let snake = camel_to_snake(camel);
+    field(obj, camel, &snake)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Missing or invalid '{camel}' field"))
+}
+
+pub(crate) fn optional_string(obj: &Value, camel: &str) -> Option<String> {
+    let snake = camel_to_snake(camel);
+    field(obj, camel, &snake)
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+pub(crate) fn optional_bool(obj: &Value, camel: &str) -> Option<bool> {
+    let snake = camel_to_snake(camel);
+    field(obj, camel, &snake).and_then(|v| v.as_bool())
+}
+
+pub(crate) fn get_usize(obj: &Value, camel: &str) -> Result<usize, String> {
+    let snake = camel_to_snake(camel);
+    let value = field(obj, camel, &snake)
+        .ok_or_else(|| format!("Missing or invalid '{camel}' field"))?;
+    value
+        .as_u64()
+        .map(|n| n as usize)
+        .or_else(|| value.as_i64().filter(|n| *n >= 0).map(|n| n as usize))
+        .ok_or_else(|| format!("Missing or invalid '{camel}' field"))
+}
+
+fn camel_to_snake(camel: &str) -> String {
+    let mut out = String::with_capacity(camel.len() + 4);
+    for (i, ch) in camel.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn prefers_camel_then_snake() {
+        let camel = json!({ "workspacePath": "/a" });
+        let snake = json!({ "workspace_path": "/b" });
+        assert_eq!(get_string(&camel, "workspacePath").unwrap(), "/a");
+        assert_eq!(get_string(&snake, "workspacePath").unwrap(), "/b");
+        assert_eq!(optional_string(&camel, "workspacePath").as_deref(), Some("/a"));
+    }
+}

--- a/src/apps/cli/src/peer_host/bootstrap.rs
+++ b/src/apps/cli/src/peer_host/bootstrap.rs
@@ -1,0 +1,73 @@
+//! Bootstrap WorkspaceService / FileSystemService / DialogScheduler for Peer Host.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use bitfun_core::agentic::coordination::{self, DialogScheduler};
+use bitfun_core::agentic::system::AgenticSystem;
+use bitfun_core::infrastructure::try_get_path_manager_arc;
+use bitfun_core::service::filesystem::FileSystemServiceFactory;
+use bitfun_core::service::workspace::{self, WorkspaceService};
+
+use super::fanout::start_peer_event_fanout;
+use super::state::{set_peer_host_state, try_peer_host_state, PeerHostState};
+
+/// Ensure Peer Host services are ready. Idempotent.
+pub(crate) async fn ensure_peer_host_ready(agentic: &AgenticSystem) -> Result<()> {
+    if try_peer_host_state().is_some() {
+        return Ok(());
+    }
+
+    let path_manager = try_get_path_manager_arc().context("path manager")?;
+    let persistence = Arc::new(
+        bitfun_core::agentic::persistence::PersistenceManager::new(path_manager)
+            .context("persistence manager")?,
+    );
+
+    let scheduler = if let Some(existing) = coordination::get_global_scheduler() {
+        existing
+    } else {
+        let session_manager = agentic.coordinator.get_session_manager().clone();
+        let scheduler = DialogScheduler::new(agentic.coordinator.clone(), session_manager);
+        agentic
+            .coordinator
+            .set_scheduler_notifier(scheduler.outcome_sender());
+        agentic
+            .coordinator
+            .set_round_injection_source(scheduler.round_injection_monitor());
+        coordination::set_global_scheduler(scheduler.clone());
+        scheduler
+    };
+
+    let workspace_service = if let Some(existing) = workspace::get_global_workspace_service() {
+        existing
+    } else {
+        let service = Arc::new(
+            WorkspaceService::new()
+                .await
+                .context("WorkspaceService::new")?,
+        );
+        workspace::set_global_workspace_service(service.clone());
+        service
+    };
+
+    let filesystem_service = Arc::new(FileSystemServiceFactory::create_default());
+
+    let state = PeerHostState {
+        coordinator: agentic.coordinator.clone(),
+        scheduler,
+        event_queue: agentic.event_queue.clone(),
+        workspace_service,
+        filesystem_service,
+        persistence,
+    };
+
+    if set_peer_host_state(state.clone()).is_err() {
+        // Another task won the race; treat as success.
+        return Ok(());
+    }
+
+    start_peer_event_fanout(state.event_queue.clone());
+    tracing::info!("CLI peer host services ready");
+    Ok(())
+}

--- a/src/apps/cli/src/peer_host/commands/config.rs
+++ b/src/apps/cli/src/peer_host/commands/config.rs
@@ -1,0 +1,136 @@
+//! Config HostInvoke handlers for CLI Peer Host.
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+use bitfun_core::service::config::get_global_config_service;
+use bitfun_core::util::errors::BitFunError;
+
+use crate::peer_host::args::{optional_bool, request_value};
+
+fn is_expected_config_path_not_found(error: &BitFunError, path: Option<&str>) -> bool {
+    match (error, path) {
+        (BitFunError::NotFound(message), Some(path)) => {
+            message == &format!("Config path '{path}' not found")
+        }
+        _ => false,
+    }
+}
+
+pub(crate) async fn get_config(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let path = request
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty());
+    let skip_retry_on_not_found = optional_bool(request, "skipRetryOnNotFound").unwrap_or(false);
+
+    let config_service = get_global_config_service()
+        .await
+        .map_err(|e| format!("Failed to get config service: {e}"))?;
+
+    match config_service
+        .get_config::<Value>(path.as_deref())
+        .await
+    {
+        Ok(config) => Ok(config),
+        Err(e) => {
+            if skip_retry_on_not_found && is_expected_config_path_not_found(&e, path.as_deref()) {
+                return Err(format!("Failed to get config: {e}"));
+            }
+            tracing::error!("Failed to get config: path={path:?}, error={e}");
+            Err(format!("Failed to get config: {e}"))
+        }
+    }
+}
+
+pub(crate) async fn get_configs(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let paths = request
+        .get("paths")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "Missing or invalid 'paths' field".to_string())?;
+    let skip_retry_on_not_found = optional_bool(request, "skipRetryOnNotFound").unwrap_or(false);
+
+    let config_service = get_global_config_service()
+        .await
+        .map_err(|e| format!("Failed to get config service: {e}"))?;
+
+    let mut configs = BTreeMap::new();
+    for path_value in paths {
+        let path = path_value
+            .as_str()
+            .ok_or_else(|| "Invalid path entry in 'paths'".to_string())?
+            .to_string();
+        if configs.contains_key(&path) {
+            continue;
+        }
+        match config_service.get_config::<Value>(Some(path.as_str())).await {
+            Ok(config) => {
+                configs.insert(path, config);
+            }
+            Err(e) => {
+                if skip_retry_on_not_found
+                    && is_expected_config_path_not_found(&e, Some(path.as_str()))
+                {
+                    return Err(format!("Failed to get config: {e}"));
+                }
+                tracing::error!("Failed to get config: path={path}, error={e}");
+                return Err(format!("Failed to get config: {e}"));
+            }
+        }
+    }
+
+    Ok(json!(configs))
+}
+
+pub(crate) async fn set_config(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let path = request
+        .get("path")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "Missing or invalid 'path' field".to_string())?;
+    let value = request
+        .get("value")
+        .cloned()
+        .ok_or_else(|| "Missing 'value' field".to_string())?;
+
+    let config_service = get_global_config_service()
+        .await
+        .map_err(|e| format!("Failed to get config service: {e}"))?;
+
+    config_service
+        .set_config(&path, value)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to set config: path={path}, error={e}");
+            format!("Failed to set config: {e}")
+        })?;
+
+    Ok(json!("Configuration set successfully"))
+}
+
+pub(crate) async fn get_agent_profile_config(args: &Value) -> Result<Value, String> {
+    // Desktop Tauri takes top-level `agentId` (not always under `request`).
+    let agent_id = crate::peer_host::args::get_string(args, "agentId")
+        .or_else(|_| crate::peer_host::args::get_string(request_value(args), "agentId"))?;
+
+    let config =
+        bitfun_core::service::config::mode_config_canonicalizer::get_agent_profile_view(&agent_id)
+            .await
+            .map_err(|e| format!("Failed to get agent profile config: {e}"))?;
+    serde_json::to_value(config).map_err(|e| format!("Failed to serialize agent profile: {e}"))
+}
+
+pub(crate) async fn get_agent_profile_configs() -> Result<Value, String> {
+    let configs =
+        bitfun_core::service::config::mode_config_canonicalizer::get_agent_profile_views()
+            .await
+            .map_err(|e| format!("Failed to get agent profile configs: {e}"))?;
+    serde_json::to_value(configs)
+        .map_err(|e| format!("Failed to serialize agent profile configs: {e}"))
+}

--- a/src/apps/cli/src/peer_host/commands/dialog.rs
+++ b/src/apps/cli/src/peer_host/commands/dialog.rs
@@ -1,0 +1,91 @@
+//! Dialog / tool confirmation HostInvoke handlers.
+
+use serde_json::{json, Value};
+
+use bitfun_core::agentic::coordination::{DialogSubmissionPolicy, DialogTriggerSource};
+
+use crate::peer_host::args::{get_string, optional_string, request_value};
+use crate::peer_host::state::PeerHostState;
+
+pub(crate) async fn start_dialog_turn(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let user_input = get_string(request, "userInput")?;
+    let original_user_input = optional_string(request, "originalUserInput");
+    let agent_type = get_string(request, "agentType")?;
+    let workspace_path = optional_string(request, "workspacePath");
+    let remote_connection_id = optional_string(request, "remoteConnectionId");
+    let remote_ssh_host = optional_string(request, "remoteSshHost");
+    let turn_id = optional_string(request, "turnId");
+    let user_message_metadata = request.get("userMessageMetadata").cloned();
+
+    let policy = DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopUi);
+    state
+        .scheduler
+        .submit(
+            session_id,
+            user_input,
+            original_user_input,
+            turn_id,
+            agent_type,
+            workspace_path,
+            remote_connection_id,
+            remote_ssh_host,
+            policy,
+            None,
+            user_message_metadata,
+            None,
+        )
+        .await
+        .map_err(|e| format!("Failed to start dialog turn: {e}"))?;
+
+    Ok(json!({ "success": true, "message": "Dialog turn started" }))
+}
+
+pub(crate) async fn cancel_dialog_turn(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let dialog_turn_id = get_string(request, "dialogTurnId")?;
+    state
+        .coordinator
+        .cancel_dialog_turn(&session_id, &dialog_turn_id)
+        .await
+        .map_err(|e| format!("Failed to cancel dialog turn: {e}"))?;
+    Ok(json!({ "success": true }))
+}
+
+pub(crate) async fn confirm_tool_execution(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let tool_id = get_string(request, "toolId")?;
+    let updated_input = request.get("updatedInput").cloned();
+    state
+        .coordinator
+        .confirm_tool(&tool_id, updated_input)
+        .await
+        .map_err(|e| format!("Confirm tool failed: {e}"))?;
+    Ok(Value::Null)
+}
+
+pub(crate) async fn reject_tool_execution(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let tool_id = get_string(request, "toolId")?;
+    let reason = optional_string(request, "reason").unwrap_or_else(|| "User rejected".to_string());
+    state
+        .coordinator
+        .reject_tool(&tool_id, reason)
+        .await
+        .map_err(|e| format!("Reject tool failed: {e}"))?;
+    Ok(Value::Null)
+}

--- a/src/apps/cli/src/peer_host/commands/filesystem.rs
+++ b/src/apps/cli/src/peer_host/commands/filesystem.rs
@@ -1,0 +1,85 @@
+//! Filesystem HostInvoke handlers.
+
+use serde_json::{json, Value};
+
+use crate::peer_host::args::{get_string, optional_string, request_value};
+use crate::peer_host::state::PeerHostState;
+
+fn directory_nodes_to_json(nodes: Vec<bitfun_core::infrastructure::FileTreeNode>) -> Vec<Value> {
+    nodes
+        .into_iter()
+        .map(|node| {
+            json!({
+                "path": node.path,
+                "name": node.name,
+                "isDirectory": node.is_directory,
+                "size": node.size,
+                "extension": node.extension,
+                "lastModified": node.last_modified
+            })
+        })
+        .collect()
+}
+
+pub(crate) async fn get_directory_children(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let path = get_string(request, "path")?;
+    let preferred = optional_string(request, "remoteConnectionId");
+    let nodes = state
+        .filesystem_service
+        .get_directory_contents_with_remote_hint(&path, preferred.as_deref())
+        .await
+        .map_err(|e| format!("Failed to get directory children: {e}"))?;
+    Ok(json!(directory_nodes_to_json(nodes)))
+}
+
+pub(crate) async fn get_directory_children_paginated(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let path = get_string(request, "path")?;
+    let preferred = optional_string(request, "remoteConnectionId");
+    let offset = request.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let limit = request.get("limit").and_then(|v| v.as_u64()).unwrap_or(100) as usize;
+
+    let nodes = state
+        .filesystem_service
+        .get_directory_contents_with_remote_hint(&path, preferred.as_deref())
+        .await
+        .map_err(|e| format!("Failed to get paginated directory children: {e}"))?;
+    let total = nodes.len();
+    let has_more = total > offset + limit;
+    let page_nodes: Vec<_> = nodes.into_iter().skip(offset).take(limit).collect();
+
+    Ok(json!({
+        "children": directory_nodes_to_json(page_nodes),
+        "total": total,
+        "hasMore": has_more,
+        "offset": offset,
+        "limit": limit
+    }))
+}
+
+pub(crate) async fn check_path_exists(args: &Value) -> Result<Value, String> {
+    let path_str = if let Some(req) = args.get("request") {
+        get_string(req, "path")?
+    } else {
+        get_string(args, "path")?
+    };
+    Ok(json!(std::path::Path::new(&path_str).exists()))
+}
+
+pub(crate) async fn create_directory(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let path = get_string(request, "path")?;
+    state
+        .filesystem_service
+        .create_directory(&path)
+        .await
+        .map_err(|e| format!("Failed to create directory: {e}"))?;
+    Ok(Value::Null)
+}

--- a/src/apps/cli/src/peer_host/commands/git.rs
+++ b/src/apps/cli/src/peer_host/commands/git.rs
@@ -1,0 +1,21 @@
+//! Git HostInvoke handlers for CLI Peer Host.
+
+use serde_json::{json, Value};
+
+use bitfun_core::service::git::GitService;
+
+use crate::peer_host::args::{get_string, request_value};
+
+pub(crate) async fn git_is_repository(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let repository_path = get_string(request, "repositoryPath")?;
+    let is_repo = GitService::is_repository(&repository_path)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to check Git repository: path={repository_path}, error={e}"
+            );
+            format!("Failed to check Git repository: {e}")
+        })?;
+    Ok(json!(is_repo))
+}

--- a/src/apps/cli/src/peer_host/commands/mod.rs
+++ b/src/apps/cli/src/peer_host/commands/mod.rs
@@ -1,0 +1,100 @@
+//! Product HostInvoke command handlers for CLI Peer Host.
+
+mod config;
+mod dialog;
+mod filesystem;
+mod git;
+mod session;
+mod snapshot;
+mod soft;
+mod system;
+mod workspace;
+
+use serde_json::Value;
+
+use super::state::PeerHostState;
+
+pub(crate) async fn dispatch(
+    command: &str,
+    args: &Value,
+    state: &PeerHostState,
+) -> Result<Value, String> {
+    match command {
+        // Workspace / config
+        "initialize_workspace_startup_state" => {
+            workspace::initialize_workspace_startup_state(state).await
+        }
+        "get_opened_workspaces" => workspace::get_opened_workspaces(state).await,
+        "get_recent_workspaces" => workspace::get_recent_workspaces(state).await,
+        "get_current_workspace" | "get_workspace_info" => {
+            workspace::get_current_workspace(state).await
+        }
+        "open_workspace" => workspace::open_workspace(state, args).await,
+        "cleanup_invalid_workspaces" => workspace::cleanup_invalid_workspaces(state).await,
+        "reload_config" => workspace::reload_config().await,
+        "get_config" => config::get_config(args).await,
+        "get_configs" => config::get_configs(args).await,
+        "set_config" => config::set_config(args).await,
+        "get_agent_profile_config" => config::get_agent_profile_config(args).await,
+        "get_agent_profile_configs" => config::get_agent_profile_configs().await,
+
+        // Filesystem
+        "get_directory_children" | "list_files" => {
+            filesystem::get_directory_children(state, args).await
+        }
+        "get_directory_children_paginated" => {
+            filesystem::get_directory_children_paginated(state, args).await
+        }
+        "check_path_exists" => filesystem::check_path_exists(args).await,
+        "create_directory" => filesystem::create_directory(state, args).await,
+
+        // Sessions
+        "list_persisted_sessions" => session::list_persisted_sessions(state, args).await,
+        "list_persisted_sessions_page" => session::list_persisted_sessions_page(state, args).await,
+        "list_persisted_sessions_count" => {
+            session::list_persisted_sessions_count(state, args).await
+        }
+        "load_session_turns" => session::load_session_turns(state, args).await,
+        "restore_session_view" => session::restore_session_view(state, args).await,
+        "restore_session_with_turns" => session::restore_session_with_turns(state, args).await,
+        "restore_session" => session::restore_session(state, args).await,
+        "create_session" => session::create_session(state, args).await,
+        "delete_session" => session::delete_session(state, args).await,
+        "rename_session" => session::rename_session(state, args).await,
+        "archive_session" => session::archive_session(state, args).await,
+        "touch_session_activity" => session::touch_session_activity(state, args).await,
+        "get_session_thread_goal" => session::get_session_thread_goal(state, args).await,
+        "update_session_model" => session::update_session_model(state, args).await,
+        "ensure_coordinator_session" => session::ensure_coordinator_session(state, args).await,
+        "get_available_modes" => session::get_available_modes().await,
+        "get_session_stats" => session::get_session_stats(args).await,
+        "save_session_turn" => session::save_session_turn(state, args).await,
+
+        // Snapshot / rollback
+        "rollback_to_turn" => snapshot::rollback_to_turn(state, args).await,
+        "get_session_files" => snapshot::get_session_files(args).await,
+
+        // Dialog / tools
+        "start_dialog_turn" => dialog::start_dialog_turn(state, args).await,
+        "cancel_dialog_turn" => dialog::cancel_dialog_turn(state, args).await,
+        "confirm_tool_execution" => dialog::confirm_tool_execution(state, args).await,
+        "reject_tool_execution" => dialog::reject_tool_execution(state, args).await,
+
+        // Git (local workspace only)
+        "git_is_repository" => git::git_is_repository(args).await,
+
+        // Soft empty / no-op for Desktop-only subsystems
+        "notify_cron_host_ready" => soft::notify_cron_host_ready().await,
+        "list_miniapps" => soft::list_miniapps().await,
+        "miniapp_worker_list_running" => soft::miniapp_worker_list_running().await,
+        "get_acp_clients" => soft::get_acp_clients().await,
+        "list_background_command_activities" => soft::list_background_command_activities().await,
+
+        // System
+        "get_system_info" => system::get_system_info().await,
+
+        other => Err(format!(
+            "command '{other}' is not supported on CLI peer host"
+        )),
+    }
+}

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -1,0 +1,497 @@
+//! Session HostInvoke handlers for CLI Peer Host.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+
+use bitfun_core::agentic::core::{Session, SessionConfig};
+use bitfun_core::agentic::get_agent_registry;
+use bitfun_core::service::session::SessionStatus;
+use bitfun_core::service::snapshot::get_snapshot_manager_for_workspace;
+
+use crate::peer_host::args::{get_string, optional_bool, optional_string, request_value};
+use crate::peer_host::state::PeerHostState;
+
+fn storage_path(workspace_path: &str) -> PathBuf {
+    PathBuf::from(workspace_path)
+}
+
+fn system_time_to_unix_secs(time: SystemTime) -> u64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn session_to_json(session: Session, turn_count: usize) -> Value {
+    json!({
+        "sessionId": session.session_id,
+        "sessionName": session.session_name,
+        "agentType": session.agent_type,
+        "modelName": session.config.model_id,
+        "lastUserDialogAgentType": session.last_user_dialog_agent_type,
+        "lastSubmittedAgentType": session.last_submitted_agent_type,
+        "state": format!("{:?}", session.state),
+        "turnCount": turn_count,
+        "createdAt": system_time_to_unix_secs(session.created_at),
+    })
+}
+
+pub(crate) async fn list_persisted_sessions(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let list = state
+        .persistence
+        .list_session_metadata(&workspace_path)
+        .await
+        .map_err(|e| format!("Failed to list persisted sessions: {e}"))?;
+    serde_json::to_value(list).map_err(|e| format!("serialize sessions: {e}"))
+}
+
+pub(crate) async fn list_persisted_sessions_page(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let limit = request.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
+    let cursor = optional_string(request, "cursor");
+    let page = state
+        .persistence
+        .list_session_metadata_page(&workspace_path, cursor.as_deref(), limit)
+        .await
+        .map_err(|e| format!("Failed to list persisted session page: {e}"))?;
+    serde_json::to_value(page).map_err(|e| format!("serialize session page: {e}"))
+}
+
+pub(crate) async fn list_persisted_sessions_count(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let list = state
+        .persistence
+        .list_session_metadata(&workspace_path)
+        .await
+        .map_err(|e| format!("Failed to count persisted sessions: {e}"))?;
+    Ok(json!(list.len()))
+}
+
+pub(crate) async fn load_session_turns(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let turns = if let Some(limit) = request.get("limit").and_then(|v| v.as_u64()) {
+        state
+            .persistence
+            .load_recent_turns(&workspace_path, &session_id, limit as usize)
+            .await
+    } else {
+        state
+            .persistence
+            .load_session_turns(&workspace_path, &session_id)
+            .await
+    }
+    .map_err(|e| format!("Failed to load session turns: {e}"))?;
+    serde_json::to_value(turns).map_err(|e| format!("serialize turns: {e}"))
+}
+
+pub(crate) async fn restore_session_view(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let include_internal = request
+        .get("includeInternal")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let tail_turn_count = request
+        .get("tailTurnCount")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .filter(|n| *n > 0)
+        .map(|n| n.min(16));
+
+    let (session, turns, total_turn_count, timings) = if let Some(tail) = tail_turn_count {
+        if include_internal {
+            state
+                .coordinator
+                .restore_internal_session_view_from_storage_path_tail_timed(
+                    &workspace_path,
+                    &session_id,
+                    tail,
+                )
+                .await
+        } else {
+            state
+                .coordinator
+                .restore_session_view_from_storage_path_tail_timed(
+                    &workspace_path,
+                    &session_id,
+                    tail,
+                )
+                .await
+        }
+    } else if include_internal {
+        state
+            .coordinator
+            .restore_internal_session_view_from_storage_path_timed(&workspace_path, &session_id)
+            .await
+            .map(|(session, turns, timings)| {
+                let total = turns.len();
+                (session, turns, total, timings)
+            })
+    } else {
+        state
+            .coordinator
+            .restore_session_view_from_storage_path_timed(&workspace_path, &session_id)
+            .await
+            .map(|(session, turns, timings)| {
+                let total = turns.len();
+                (session, turns, total, timings)
+            })
+    }
+    .map_err(|e| format!("Failed to restore session view: {e}"))?;
+
+    let loaded_turn_count = turns.len();
+    let is_partial = loaded_turn_count < total_turn_count;
+    Ok(json!({
+        "session": session_to_json(session, total_turn_count),
+        "turns": turns,
+        "contextRestoreState": "pending",
+        "isPartial": is_partial,
+        "loadedTurnCount": loaded_turn_count,
+        "totalTurnCount": total_turn_count,
+        "timings": timings,
+    }))
+}
+
+pub(crate) async fn restore_session_with_turns(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let include_internal = request
+        .get("includeInternal")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let (session, turns) = if include_internal {
+        state
+            .coordinator
+            .restore_internal_session_with_turns_from_storage_path(&workspace_path, &session_id)
+            .await
+    } else {
+        state
+            .coordinator
+            .restore_session_with_turns_from_storage_path(&workspace_path, &session_id)
+            .await
+    }
+    .map_err(|e| format!("Failed to restore session with turns: {e}"))?;
+
+    let turn_count = turns.len();
+    Ok(json!({
+        "session": session_to_json(session, turn_count),
+        "turns": turns,
+    }))
+}
+
+pub(crate) async fn restore_session(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let include_internal = request
+        .get("includeInternal")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let session = if include_internal {
+        state
+            .coordinator
+            .restore_internal_session_from_storage_path(&workspace_path, &session_id)
+            .await
+    } else {
+        state
+            .coordinator
+            .restore_session_from_storage_path(&workspace_path, &session_id)
+            .await
+    }
+    .map_err(|e| format!("Failed to restore session: {e}"))?;
+
+    let turn_count = session.dialog_turn_ids.len();
+    Ok(session_to_json(session, turn_count))
+}
+
+pub(crate) async fn create_session(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_name = get_string(request, "sessionName")?;
+    let agent_type = get_string(request, "agentType")?;
+    let workspace_path = get_string(request, "workspacePath")?;
+    let session_id = optional_string(request, "sessionId");
+    let workspace_id = optional_string(request, "workspaceId");
+    let remote_connection_id = optional_string(request, "remoteConnectionId");
+    let remote_ssh_host = optional_string(request, "remoteSshHost");
+
+    let model_id = request
+        .get("config")
+        .and_then(|c| {
+            c.get("modelName")
+                .or_else(|| c.get("model_name"))
+                .or_else(|| c.get("modelId"))
+                .or_else(|| c.get("model_id"))
+        })
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| optional_string(request, "modelName"));
+
+    let config = SessionConfig {
+        workspace_path: Some(workspace_path.clone()),
+        workspace_id,
+        remote_connection_id,
+        remote_ssh_host,
+        model_id,
+        ..Default::default()
+    };
+
+    let session = state
+        .coordinator
+        .create_session_with_workspace(session_id, session_name, agent_type, config, workspace_path)
+        .await
+        .map_err(|e| format!("Failed to create session: {e}"))?;
+
+    Ok(json!({
+        "sessionId": session.session_id,
+        "sessionName": session.session_name,
+        "agentType": session.agent_type,
+    }))
+}
+
+pub(crate) async fn delete_session(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+
+    // Prefer coordinator delete when session may be live; also remove persisted files.
+    if let Err(e) = state
+        .coordinator
+        .delete_session(&workspace_path, &session_id)
+        .await
+    {
+        tracing::debug!("coordinator delete_session: {e}; falling back to persistence delete");
+        state
+            .persistence
+            .delete_session(&workspace_path, &session_id)
+            .await
+            .map_err(|err| format!("Failed to delete session: {err}"))?;
+    }
+    Ok(Value::Null)
+}
+
+pub(crate) async fn rename_session(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let title = get_string(request, "sessionName")
+        .or_else(|_| get_string(request, "title"))
+        .or_else(|_| get_string(request, "name"))?;
+    state
+        .coordinator
+        .update_session_title(&session_id, &title)
+        .await
+        .map_err(|e| format!("Failed to rename session: {e}"))?;
+    Ok(Value::Null)
+}
+
+pub(crate) async fn archive_session(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let mut metadata = state
+        .persistence
+        .load_session_metadata(&workspace_path, &session_id)
+        .await
+        .map_err(|e| format!("Failed to load session metadata: {e}"))?
+        .ok_or_else(|| "Session not found".to_string())?;
+    metadata.status = SessionStatus::Archived;
+    state
+        .persistence
+        .save_session_metadata(&workspace_path, &metadata)
+        .await
+        .map_err(|e| format!("Failed to archive session: {e}"))?;
+    Ok(Value::Null)
+}
+
+pub(crate) async fn touch_session_activity(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    state
+        .persistence
+        .touch_session(&workspace_path, &session_id)
+        .await
+        .map_err(|e| format!("Failed to update session activity: {e}"))?;
+    Ok(Value::Null)
+}
+
+pub(crate) async fn get_session_thread_goal(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = optional_string(request, "workspacePath")
+        .map(|p| storage_path(&p))
+        .unwrap_or_else(|| PathBuf::from("."));
+    let goal = state
+        .coordinator
+        .get_thread_goal(&session_id, workspace_path.as_path())
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(json!({ "goal": goal }))
+}
+
+pub(crate) async fn update_session_model(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let model_name = get_string(request, "modelName")?;
+    state
+        .coordinator
+        .update_session_model(&session_id, &model_name)
+        .await
+        .map_err(|e| format!("Failed to update session model: {e}"))?;
+    Ok(Value::Null)
+}
+
+pub(crate) async fn ensure_coordinator_session(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Err("session_id is required".to_string());
+    }
+
+    if state
+        .coordinator
+        .get_session_manager()
+        .get_session(session_id)
+        .is_some()
+    {
+        return Ok(Value::Null);
+    }
+
+    let workspace_path = get_string(request, "workspacePath")?;
+    let workspace_path = workspace_path.trim();
+    if workspace_path.is_empty() {
+        return Err("workspace_path is required when the session is not loaded".to_string());
+    }
+    let storage = storage_path(workspace_path);
+    let include_internal = optional_bool(request, "includeInternal").unwrap_or(false);
+
+    let restore_result = if include_internal {
+        state
+            .coordinator
+            .restore_internal_session_from_storage_path(&storage, session_id)
+            .await
+    } else {
+        state
+            .coordinator
+            .restore_session_from_storage_path(&storage, session_id)
+            .await
+    };
+    restore_result
+        .map(|_| Value::Null)
+        .map_err(|e| e.to_string())
+}
+
+pub(crate) async fn get_available_modes() -> Result<Value, String> {
+    let mode_infos = get_agent_registry().get_modes_info().await;
+    let dtos: Vec<Value> = mode_infos
+        .into_iter()
+        .map(|info| {
+            let config_profile_id = info
+                .config_profile_id
+                .clone()
+                .unwrap_or_else(|| info.id.clone());
+            json!({
+                "id": info.id,
+                "name": info.name,
+                "description": info.description,
+                "isReadonly": info.is_readonly,
+                "toolCount": info.tool_count,
+                "defaultTools": info.default_tools,
+                "promptCacheScopeKey": info.prompt_cache_scope_key,
+                "configProfileId": config_profile_id,
+                "configProfileLabel": info.config_profile_label,
+                "configProfileMemberModeIds": info.config_profile_member_mode_ids,
+                "source": info.source,
+                "path": info.path,
+                "model": info.model,
+            })
+        })
+        .collect();
+    Ok(Value::Array(dtos))
+}
+
+pub(crate) async fn get_session_stats(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = get_string(request, "workspacePath")?;
+    let workspace = PathBuf::from(&workspace_path);
+
+    if let Some(manager) = get_snapshot_manager_for_workspace(&workspace) {
+        return manager
+            .get_session_stats(&session_id)
+            .await
+            .map_err(|e| format!("Failed to get session stats: {e}"));
+    }
+
+    Ok(json!({
+        "session_id": session_id,
+        "total_files": 0,
+        "total_turns": 0,
+        "total_changes": 0
+    }))
+}
+
+pub(crate) async fn save_session_turn(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let workspace_path = storage_path(&get_string(request, "workspacePath")?);
+    let turn_data = request
+        .get("turnData")
+        .or_else(|| request.get("turn_data"))
+        .cloned()
+        .ok_or_else(|| "Missing 'turn_data' field".to_string())?;
+
+    let turn: bitfun_core::service::session::DialogTurnData = serde_json::from_value(turn_data)
+        .map_err(|e| format!("Invalid turn_data: {e}"))?;
+
+    state
+        .persistence
+        .save_dialog_turn(&workspace_path, &turn)
+        .await
+        .map_err(|e| format!("Failed to save session turn: {e}"))?;
+    Ok(Value::Null)
+}

--- a/src/apps/cli/src/peer_host/commands/snapshot.rs
+++ b/src/apps/cli/src/peer_host/commands/snapshot.rs
@@ -1,0 +1,177 @@
+//! Snapshot / rollback HostInvoke handlers for CLI Peer Host.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use bitfun_core::service::snapshot::{
+    get_snapshot_manager_for_workspace, initialize_snapshot_manager_for_workspace, SnapshotManager,
+};
+
+use crate::peer_host::args::{get_string, get_usize, optional_bool, request_value};
+use crate::peer_host::fanout::fanout_peer_device_event;
+use crate::peer_host::state::PeerHostState;
+
+async fn ensure_snapshot_manager(workspace_path: &str) -> Result<Arc<SnapshotManager>, String> {
+    let workspace_dir = PathBuf::from(workspace_path);
+    if let Some(manager) = get_snapshot_manager_for_workspace(&workspace_dir) {
+        return Ok(manager);
+    }
+
+    initialize_snapshot_manager_for_workspace(workspace_dir.clone(), None)
+        .await
+        .map_err(|e| {
+            format!(
+                "Failed to initialize snapshot system for workspace {}: {e}",
+                workspace_dir.display()
+            )
+        })?;
+
+    get_snapshot_manager_for_workspace(&workspace_dir).ok_or_else(|| {
+        format!(
+            "Failed to get snapshot manager for workspace {}",
+            workspace_dir.display()
+        )
+    })
+}
+
+pub(crate) async fn get_session_files(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = get_string(request, "workspacePath")?;
+
+    let manager = ensure_snapshot_manager(&workspace_path).await?;
+    let files = manager
+        .get_session_files(&session_id)
+        .await
+        .map_err(|e| format!("Failed to get session files: {e}"))?;
+
+    Ok(json!(
+        files
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+    ))
+}
+
+pub(crate) async fn rollback_to_turn(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
+    let workspace_path = get_string(request, "workspacePath")?;
+    let turn_index = get_usize(request, "turnIndex")?;
+    let delete_turns = optional_bool(request, "deleteTurns").unwrap_or(false);
+
+    if let Err(e) = state
+        .coordinator
+        .cancel_active_turn_for_session(&session_id, Duration::from_secs(2))
+        .await
+    {
+        tracing::warn!(
+            "Failed to cancel active turn before rollback: session_id={session_id}, turn_index={turn_index}, error={e}"
+        );
+    }
+
+    let manager = ensure_snapshot_manager(&workspace_path).await?;
+    let restored_files = manager
+        .rollback_to_turn(&session_id, turn_index)
+        .await
+        .map_err(|e| format!("Failed to rollback turn: {e}"))?;
+
+    let restored_files_str: Vec<String> = restored_files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+
+    let mut deleted_turns_count = 0usize;
+    if delete_turns {
+        let workspace = PathBuf::from(&workspace_path);
+        let mut rolled_back_parent_turn_ids = HashSet::new();
+
+        match state
+            .persistence
+            .load_session_turns(&workspace, &session_id)
+            .await
+        {
+            Ok(turns) => {
+                rolled_back_parent_turn_ids = turns
+                    .into_iter()
+                    .filter(|turn| turn.turn_index >= turn_index)
+                    .map(|turn| turn.turn_id)
+                    .collect();
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to load parent turns before rollback cleanup: session_id={session_id}, turn_index={turn_index}, error={e}"
+                );
+            }
+        }
+
+        if !rolled_back_parent_turn_ids.is_empty() {
+            if let Err(e) = state
+                .coordinator
+                .delete_hidden_subagent_sessions_for_parent_turns(
+                    &workspace,
+                    &session_id,
+                    &rolled_back_parent_turn_ids,
+                )
+                .await
+            {
+                tracing::warn!(
+                    "Failed to delete hidden subagent sessions during rollback: session_id={session_id}, turn_index={turn_index}, error={e}"
+                );
+            }
+        }
+
+        if let Err(e) = state
+            .coordinator
+            .get_session_manager()
+            .rollback_context_to_turn_start(&workspace, &session_id, turn_index)
+            .await
+        {
+            tracing::warn!(
+                "Rollback agentic context failed: session_id={session_id}, turn_index={turn_index}, error={e}"
+            );
+        }
+
+        match state
+            .persistence
+            .delete_turns_from(&workspace, &session_id, turn_index)
+            .await
+        {
+            Ok(count) => deleted_turns_count = count,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to delete conversation turns: session_id={session_id}, turn_index={turn_index}, error={e}"
+                );
+            }
+        }
+
+        fanout_peer_device_event(
+            "conversation_turns_deleted".to_string(),
+            json!({
+                "session_id": session_id,
+                "remaining_turns": turn_index,
+                "deleted_count": deleted_turns_count,
+            }),
+        );
+    }
+
+    fanout_peer_device_event(
+        "turn_rolled_back".to_string(),
+        json!({
+            "session_id": session_id,
+            "turn_index": turn_index,
+            "files_count": restored_files_str.len(),
+            "deleted_turns": delete_turns,
+            "deleted_turns_count": deleted_turns_count,
+        }),
+    );
+
+    Ok(json!(restored_files_str))
+}

--- a/src/apps/cli/src/peer_host/commands/soft.rs
+++ b/src/apps/cli/src/peer_host/commands/soft.rs
@@ -1,0 +1,26 @@
+//! Soft / empty responses for Desktop subsystems CLI Peer Host does not run.
+
+use serde_json::{json, Value};
+
+/// Desktop cron host readiness signal — CLI has no cron host; acknowledge as ready.
+pub(crate) async fn notify_cron_host_ready() -> Result<Value, String> {
+    Ok(Value::Null)
+}
+
+/// MiniApps are a Desktop-hosted runtime; return empty catalog so hydrate succeeds.
+pub(crate) async fn list_miniapps() -> Result<Value, String> {
+    Ok(json!([]))
+}
+
+pub(crate) async fn miniapp_worker_list_running() -> Result<Value, String> {
+    Ok(json!([]))
+}
+
+/// ACP client list for Desktop settings UI; CLI peer returns none for now.
+pub(crate) async fn get_acp_clients() -> Result<Value, String> {
+    Ok(json!([]))
+}
+
+pub(crate) async fn list_background_command_activities() -> Result<Value, String> {
+    Ok(json!({ "activities": [] }))
+}

--- a/src/apps/cli/src/peer_host/commands/system.rs
+++ b/src/apps/cli/src/peer_host/commands/system.rs
@@ -1,0 +1,12 @@
+//! System HostInvoke handlers.
+
+use serde_json::{json, Value};
+
+pub(crate) async fn get_system_info() -> Result<Value, String> {
+    let info = bitfun_core::service::system::get_system_info();
+    Ok(json!({
+        "platform": info.platform,
+        "arch": info.arch,
+        "osVersion": info.os_version,
+    }))
+}

--- a/src/apps/cli/src/peer_host/commands/workspace.rs
+++ b/src/apps/cli/src/peer_host/commands/workspace.rs
@@ -1,0 +1,87 @@
+//! Workspace and config HostInvoke handlers.
+
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+use crate::peer_host::args::{get_string, request_value};
+use crate::peer_host::state::PeerHostState;
+use crate::peer_host::workspace_dto::{workspace_info_to_json, workspace_list_to_json};
+
+pub(crate) async fn initialize_workspace_startup_state(
+    state: &PeerHostState,
+) -> Result<Value, String> {
+    let cleanup_removed_count = state
+        .workspace_service
+        .cleanup_invalid_workspaces()
+        .await
+        .map_err(|e| format!("Failed to cleanup invalid workspaces: {e}"))?;
+
+    let current_workspace = state.workspace_service.get_current_workspace().await;
+    let recent_workspaces = state.workspace_service.get_recent_workspaces().await;
+    let opened_workspaces = state.workspace_service.get_opened_workspaces().await;
+
+    Ok(json!({
+        "cleanupRemovedCount": cleanup_removed_count,
+        "currentWorkspace": current_workspace.as_ref().map(workspace_info_to_json),
+        "recentWorkspaces": workspace_list_to_json(&recent_workspaces),
+        "openedWorkspaces": workspace_list_to_json(&opened_workspaces),
+        "legacyRemoteWorkspace": Value::Null,
+    }))
+}
+
+pub(crate) async fn get_opened_workspaces(state: &PeerHostState) -> Result<Value, String> {
+    let list = state.workspace_service.get_opened_workspaces().await;
+    Ok(workspace_list_to_json(&list))
+}
+
+pub(crate) async fn get_recent_workspaces(state: &PeerHostState) -> Result<Value, String> {
+    let list = state.workspace_service.get_recent_workspaces().await;
+    Ok(workspace_list_to_json(&list))
+}
+
+pub(crate) async fn get_current_workspace(state: &PeerHostState) -> Result<Value, String> {
+    let ws = state.workspace_service.get_current_workspace().await;
+    Ok(ws
+        .as_ref()
+        .map(workspace_info_to_json)
+        .unwrap_or(Value::Null))
+}
+
+pub(crate) async fn open_workspace(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let path = get_string(request, "path")?;
+    let info = state
+        .workspace_service
+        .open_workspace(PathBuf::from(path))
+        .await
+        .map_err(|e| format!("Failed to open workspace: {e}"))?;
+
+    // Best-effort snapshot init for agent tools (mirrors server bootstrap).
+    if let Err(e) = bitfun_core::service::snapshot::initialize_snapshot_manager_for_workspace(
+        info.root_path.clone(),
+        None,
+    )
+    .await
+    {
+        tracing::warn!("Failed to initialize snapshot system: {e}");
+    }
+
+    Ok(workspace_info_to_json(&info))
+}
+
+pub(crate) async fn reload_config() -> Result<Value, String> {
+    bitfun_core::service::config::reload_global_config()
+        .await
+        .map_err(|e| format!("Failed to reload config: {e}"))?;
+    Ok(json!("Configuration reloaded successfully"))
+}
+
+pub(crate) async fn cleanup_invalid_workspaces(state: &PeerHostState) -> Result<Value, String> {
+    let removed = state
+        .workspace_service
+        .cleanup_invalid_workspaces()
+        .await
+        .map_err(|e| format!("Failed to cleanup invalid workspaces: {e}"))?;
+    Ok(json!(removed))
+}

--- a/src/apps/cli/src/peer_host/control.rs
+++ b/src/apps/cli/src/peer_host/control.rs
@@ -1,0 +1,61 @@
+//! Peer Mode control-plane subscribers (attach / detach / ping).
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use serde_json::{json, Value};
+
+use bitfun_core::service::remote_connect::DeviceIdentity;
+
+static CONTROL_SUBSCRIBERS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn control_subscribers() -> &'static Mutex<HashSet<String>> {
+    CONTROL_SUBSCRIBERS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+pub(crate) fn attach_controller(device_id: String) {
+    if device_id.trim().is_empty() {
+        return;
+    }
+    if let Ok(mut set) = control_subscribers().lock() {
+        set.insert(device_id);
+    }
+}
+
+pub(crate) fn detach_controller(device_id: &str) {
+    if let Ok(mut set) = control_subscribers().lock() {
+        set.remove(device_id);
+    }
+}
+
+pub(crate) fn attached_controllers() -> Vec<String> {
+    control_subscribers()
+        .lock()
+        .map(|set| set.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+pub(crate) fn peer_mode_ping_value() -> Value {
+    let device_id = DeviceIdentity::from_current_machine()
+        .map(|d| d.device_id)
+        .unwrap_or_else(|_| "unknown".to_string());
+    json!({
+        "ok": true,
+        "peer": true,
+        "device_id": device_id,
+    })
+}
+
+pub(crate) fn parse_controller_device_id(args: &Value) -> String {
+    args.get("controllerDeviceId")
+        .or_else(|| args.get("controller_device_id"))
+        .or_else(|| {
+            args.get("request").and_then(|req| {
+                req.get("controllerDeviceId")
+                    .or_else(|| req.get("controller_device_id"))
+            })
+        })
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}

--- a/src/apps/cli/src/peer_host/deny.rs
+++ b/src/apps/cli/src/peer_host/deny.rs
@@ -1,0 +1,96 @@
+//! Deny tables for CLI Peer Host.
+
+/// Commands that must never run on a peer on behalf of a controller.
+/// Mirrors desktop `peer_host_invoke::LOCAL_ONLY_COMMANDS` (minus control-plane
+/// commands which are handled specially before this check).
+static LOCAL_ONLY_COMMANDS: &[&str] = &[
+    "show_main_window",
+    "hide_main_window_after_close_request",
+    "quit_app",
+    "minimize_to_tray",
+    "initialize_tray_after_startup",
+    "startup_window_control",
+    "toggle_main_window_fullscreen",
+    "restart_app",
+    "check_for_updates",
+    "install_update",
+    "account_login",
+    "account_logout",
+    "account_status",
+    "account_get_credential_hint",
+    "account_token_expired",
+    "account_connect_devices",
+    "account_online_devices",
+    "account_list_devices",
+    "account_delete_device",
+    "account_device_rpc",
+    "account_delegate_to_paired",
+    "account_auto_sync",
+    "account_sync_settings",
+    "account_fetch_settings",
+    "account_sync_session",
+    "account_fetch_synced_sessions",
+    "account_delete_synced_session",
+    "account_export_local_session",
+    "account_export_all_sessions",
+    "account_import_remote_sessions",
+    "account_fetch_session_turns",
+    "account_send_session_to_device",
+    "account_execute_on_device",
+    "peer_host_invoke_complete",
+    "peer_controller_set_active",
+    "remote_connect_get_device_info",
+    "remote_connect_get_lan_ip",
+    "remote_connect_get_lan_network_info",
+    "remote_connect_get_methods",
+    "remote_connect_start",
+    "remote_connect_stop",
+    "remote_connect_stop_bot",
+    "remote_connect_status",
+    "remote_connect_get_form_state",
+    "remote_connect_set_form_state",
+    "remote_connect_configure_custom_server",
+    "remote_connect_configure_bot",
+    "remote_connect_weixin_qr_start",
+    "remote_connect_weixin_qr_poll",
+    "remote_connect_get_bot_verbose_mode",
+    "remote_connect_set_bot_verbose_mode",
+    "computer_use_request_permissions",
+    "computer_use_open_system_settings",
+];
+
+/// Desktop IDE surfaces that CLI Peer Host does not implement.
+/// Prefix match is applied for `lsp_`, `canvas_`, `editor_`, `ssh_`,
+/// `terminal_`, `search_` unless the command is explicitly allowlisted.
+///
+/// `git_*` is intentionally not prefix-denied: `git_is_repository` is
+/// implemented; other git commands fall through to the registry miss path.
+static CLI_UNSUPPORTED_EXACT: &[&str] = &[
+    "open_remote_workspace",
+    "remote_get_workspace_info",
+    "explorer_get_file_tree",
+    "explorer_get_children",
+    "explorer_get_children_paginated",
+];
+
+pub(crate) fn is_local_only_command(command: &str) -> bool {
+    LOCAL_ONLY_COMMANDS.iter().any(|denied| *denied == command)
+}
+
+pub(crate) fn is_cli_unsupported_command(command: &str) -> bool {
+    if CLI_UNSUPPORTED_EXACT.iter().any(|c| *c == command) {
+        return true;
+    }
+    let prefixes = [
+        "lsp_",
+        "canvas_",
+        "editor_",
+        "ssh_",
+        "terminal_",
+        "search_",
+        "plugin_",
+        "miniapps_",
+        "review_platform_",
+    ];
+    prefixes.iter().any(|prefix| command.starts_with(prefix))
+}

--- a/src/apps/cli/src/peer_host/dispatch.rs
+++ b/src/apps/cli/src/peer_host/dispatch.rs
@@ -1,0 +1,159 @@
+//! HostInvoke / DeviceEvent dispatch for CLI Peer Host.
+
+use serde_json::{json, Value};
+
+use bitfun_core::service::remote_connect::remote_server::RemoteResponse;
+
+use super::commands;
+use super::control::{
+    attach_controller, detach_controller, parse_controller_device_id, peer_mode_ping_value,
+};
+use super::deny::{is_cli_unsupported_command, is_local_only_command};
+use super::state::peer_host_state;
+
+#[derive(Debug, Clone)]
+struct HostInvokeBridgeResult {
+    ok: bool,
+    value: Option<Value>,
+    error: Option<String>,
+}
+
+impl HostInvokeBridgeResult {
+    fn ok_value(value: Value) -> Self {
+        Self {
+            ok: true,
+            value: Some(value),
+            error: None,
+        }
+    }
+
+    fn err(message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            value: None,
+            error: Some(message.into()),
+        }
+    }
+
+    fn into_remote_response(self) -> RemoteResponse {
+        RemoteResponse::HostInvokeResult {
+            ok: self.ok,
+            value: self.value,
+            error: self.error,
+        }
+    }
+}
+
+/// Handle `RemoteCommand::HostInvoke` and return a HostInvokeResult envelope.
+pub(crate) async fn handle_host_invoke(command: &str, args: Value) -> RemoteResponse {
+    handle_host_invoke_inner(command, args)
+        .await
+        .into_remote_response()
+}
+
+async fn handle_host_invoke_inner(command: &str, args: Value) -> HostInvokeBridgeResult {
+    if command.is_empty() {
+        return HostInvokeBridgeResult::err("HostInvoke command is empty");
+    }
+
+    // Control plane — same special-case path as desktop execute_local_remote_command.
+    if command == "peer_control_attach" {
+        let controller_id = parse_controller_device_id(&args);
+        if controller_id.trim().is_empty() {
+            return HostInvokeBridgeResult::err("controller_device_id is required");
+        }
+        attach_controller(controller_id);
+        return HostInvokeBridgeResult::ok_value(json!({ "attached": true }));
+    }
+    if command == "peer_control_detach" {
+        let controller_id = parse_controller_device_id(&args);
+        detach_controller(&controller_id);
+        return HostInvokeBridgeResult::ok_value(json!({ "detached": true }));
+    }
+    if command == "peer_mode_ping" {
+        return HostInvokeBridgeResult::ok_value(peer_mode_ping_value());
+    }
+
+    if is_local_only_command(command) {
+        return HostInvokeBridgeResult::err(format!(
+            "command '{command}' is local-only and cannot run on peer"
+        ));
+    }
+    if is_cli_unsupported_command(command) {
+        return HostInvokeBridgeResult::err(format!(
+            "command '{command}' is not supported on CLI peer host"
+        ));
+    }
+
+    let state = match peer_host_state() {
+        Ok(s) => s,
+        Err(e) => return HostInvokeBridgeResult::err(e),
+    };
+
+    match commands::dispatch(command, &args, state).await {
+        Ok(value) => HostInvokeBridgeResult::ok_value(value),
+        Err(error) => HostInvokeBridgeResult::err(error),
+    }
+}
+
+/// Peer-side DeviceEvent is a no-op ack (controller is the consumer).
+pub(crate) fn handle_device_event_command() -> RemoteResponse {
+    RemoteResponse::DeviceEventAccepted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn peer_mode_ping_returns_ok_peer_payload() {
+        let resp = handle_host_invoke("peer_mode_ping", json!({})).await;
+        match resp {
+            RemoteResponse::HostInvokeResult {
+                ok: true,
+                value: Some(value),
+                error: None,
+            } => {
+                assert_eq!(value.get("ok"), Some(&json!(true)));
+                assert_eq!(value.get("peer"), Some(&json!(true)));
+                assert!(value.get("device_id").and_then(|v| v.as_str()).is_some());
+            }
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn local_only_commands_are_denied() {
+        let resp = handle_host_invoke("account_logout", json!({})).await;
+        match resp {
+            RemoteResponse::HostInvokeResult {
+                ok: false,
+                error: Some(err),
+                ..
+            } => {
+                assert!(err.contains("local-only"));
+            }
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn attach_detach_updates_subscribers() {
+        let _ = handle_host_invoke(
+            "peer_control_attach",
+            json!({ "controller_device_id": "ctrl-test-1" }),
+        )
+        .await;
+        assert!(super::super::control::attached_controllers()
+            .iter()
+            .any(|id| id == "ctrl-test-1"));
+        let _ = handle_host_invoke(
+            "peer_control_detach",
+            json!({ "controller_device_id": "ctrl-test-1" }),
+        )
+        .await;
+        assert!(!super::super::control::attached_controllers()
+            .iter()
+            .any(|id| id == "ctrl-test-1"));
+    }
+}

--- a/src/apps/cli/src/peer_host/fanout.rs
+++ b/src/apps/cli/src/peer_host/fanout.rs
@@ -1,0 +1,99 @@
+//! DeviceEvent fan-out to attached Peer Mode controllers.
+
+use std::sync::{Arc, OnceLock};
+
+use bitfun_core::agentic::events::EventQueue;
+use bitfun_core::service::remote_connect::encryption::encrypt_to_base64;
+use bitfun_core::service::remote_connect::remote_server::RemoteCommand;
+use bitfun_events::project_agentic_frontend_event;
+use tokio::sync::mpsc;
+
+use super::control::attached_controllers;
+
+static PEER_EVENT_FANOUT_TX: OnceLock<mpsc::UnboundedSender<(String, serde_json::Value)>> =
+    OnceLock::new();
+
+/// Start a second EventQueue subscriber that fans agentic events to controllers.
+pub(crate) fn start_peer_event_fanout(event_queue: Arc<EventQueue>) {
+    tokio::spawn(async move {
+        let mut rx = event_queue.subscribe();
+        loop {
+            match rx.recv().await {
+                Ok(envelope) => {
+                    if attached_controllers().is_empty() {
+                        continue;
+                    }
+                    if let Some(projected) = project_agentic_frontend_event(envelope.event) {
+                        fanout_peer_device_event(projected.event_name, projected.payload);
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::warn!("CLI peer event fanout lagged by {skipped} events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
+/// Queue a DeviceEvent for sequential delivery to attached controllers.
+pub(crate) fn fanout_peer_device_event(event: String, payload: serde_json::Value) {
+    if attached_controllers().is_empty() {
+        return;
+    }
+    let tx = PEER_EVENT_FANOUT_TX.get_or_init(|| {
+        let (tx, mut rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();
+        tokio::spawn(async move {
+            while let Some((event, payload)) = rx.recv().await {
+                fanout_peer_device_event_once(event, payload).await;
+            }
+        });
+        tx
+    });
+    if let Err(e) = tx.send((event, payload)) {
+        tracing::debug!("peer event fanout queue closed: {e}");
+    }
+}
+
+async fn fanout_peer_device_event_once(event: String, payload: serde_json::Value) {
+    let targets = attached_controllers();
+    if targets.is_empty() {
+        return;
+    }
+
+    let (session, relay_client) = match crate::account::peer_fanout_context().await {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            tracing::debug!("peer event fanout skipped: {e}");
+            return;
+        }
+    };
+
+    let envelope = match serde_json::to_string(&RemoteCommand::DeviceEvent {
+        event: event.clone(),
+        payload,
+    }) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("peer event fanout serialize failed: {e}");
+            return;
+        }
+    };
+    let (encrypted_data, nonce) = match encrypt_to_base64(&session.master_key, &envelope) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("peer event fanout encrypt failed: {e}");
+            return;
+        }
+    };
+
+    for target in targets {
+        let correlation_id = uuid::Uuid::new_v4().to_string();
+        if let Err(e) = relay_client
+            .send_device_message(&target, &correlation_id, &encrypted_data, &nonce)
+            .await
+        {
+            tracing::debug!("peer event fanout to {target} failed: {e}");
+        }
+    }
+}

--- a/src/apps/cli/src/peer_host/mod.rs
+++ b/src/apps/cli/src/peer_host/mod.rs
@@ -1,0 +1,18 @@
+//! CLI Peer Device Mode host.
+//!
+//! Desktop controllers reach this process over the same HostInvoke / DeviceEvent
+//! envelopes used for Desktop peers. Execution goes through Core services
+//! (no webview / Tauri bridge).
+
+mod args;
+mod bootstrap;
+mod commands;
+mod control;
+mod deny;
+mod dispatch;
+mod fanout;
+mod state;
+mod workspace_dto;
+
+pub(crate) use bootstrap::ensure_peer_host_ready;
+pub(crate) use dispatch::{handle_device_event_command, handle_host_invoke};

--- a/src/apps/cli/src/peer_host/state.rs
+++ b/src/apps/cli/src/peer_host/state.rs
@@ -1,0 +1,33 @@
+//! Shared Peer Host service handles.
+
+use std::sync::{Arc, OnceLock};
+
+use bitfun_core::agentic::coordination::{ConversationCoordinator, DialogScheduler};
+use bitfun_core::agentic::events::EventQueue;
+use bitfun_core::agentic::persistence::PersistenceManager;
+use bitfun_core::service::filesystem::FileSystemService;
+use bitfun_core::service::workspace::WorkspaceService;
+
+#[derive(Clone)]
+pub(crate) struct PeerHostState {
+    pub(crate) coordinator: Arc<ConversationCoordinator>,
+    pub(crate) scheduler: Arc<DialogScheduler>,
+    pub(crate) event_queue: Arc<EventQueue>,
+    pub(crate) workspace_service: Arc<WorkspaceService>,
+    pub(crate) filesystem_service: Arc<FileSystemService>,
+    pub(crate) persistence: Arc<PersistenceManager>,
+}
+
+static PEER_HOST_STATE: OnceLock<PeerHostState> = OnceLock::new();
+
+pub(crate) fn set_peer_host_state(state: PeerHostState) -> Result<(), PeerHostState> {
+    PEER_HOST_STATE.set(state)
+}
+
+pub(crate) fn try_peer_host_state() -> Option<&'static PeerHostState> {
+    PEER_HOST_STATE.get()
+}
+
+pub(crate) fn peer_host_state() -> Result<&'static PeerHostState, String> {
+    try_peer_host_state().ok_or_else(|| "CLI peer host is not initialized".to_string())
+}

--- a/src/apps/cli/src/peer_host/workspace_dto.rs
+++ b/src/apps/cli/src/peer_host/workspace_dto.rs
@@ -1,0 +1,81 @@
+//! WorkspaceInfo → frontend DTO JSON (aligned with desktop WorkspaceInfoDto).
+
+use bitfun_core::service::remote_ssh::LOCAL_WORKSPACE_SSH_HOST;
+use bitfun_core::service::workspace::manager::{WorkspaceInfo, WorkspaceKind};
+use serde_json::{json, Value};
+
+pub(crate) fn workspace_info_to_json(info: &WorkspaceInfo) -> Value {
+    let connection_id = info
+        .metadata
+        .get("connectionId")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let connection_name = info
+        .metadata
+        .get("connectionName")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let ssh_host = info
+        .metadata
+        .get("sshHost")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| {
+            if matches!(info.workspace_kind, WorkspaceKind::Remote) {
+                None
+            } else {
+                Some(LOCAL_WORKSPACE_SSH_HOST.to_string())
+            }
+        });
+
+    let root_path = info.root_path.to_string_lossy().to_string();
+    let workspace_kind = match info.workspace_kind {
+        WorkspaceKind::Normal => "normal",
+        WorkspaceKind::Assistant => "assistant",
+        WorkspaceKind::Remote => "remote",
+    };
+
+    let mut obj = json!({
+        "id": info.id,
+        "name": info.name,
+        "rootPath": root_path,
+        "workspaceType": info.workspace_type,
+        "workspaceKind": workspace_kind,
+        "assistantId": info.assistant_id,
+        "languages": info.languages,
+        "openedAt": info.opened_at.to_rfc3339(),
+        "lastAccessed": info.last_accessed.to_rfc3339(),
+        "description": info.description,
+        "tags": info.tags,
+        "identity": info.identity,
+        "worktree": info.worktree,
+        "relatedPaths": info.related_paths,
+    });
+
+    if let Some(stats) = &info.statistics {
+        obj["statistics"] = json!({
+            "totalFiles": stats.total_files,
+            "totalLines": 0,
+            "totalSize": stats.total_size_bytes,
+            "filesByLanguage": {},
+            "filesByExtension": stats.file_extensions,
+            "lastUpdated": stats.last_modified.map(|t| t.to_rfc3339()).unwrap_or_default(),
+        });
+    }
+
+    if let Some(cid) = connection_id {
+        obj["connectionId"] = json!(cid);
+    }
+    if let Some(name) = connection_name {
+        obj["connectionName"] = json!(name);
+    }
+    if let Some(host) = ssh_host {
+        obj["sshHost"] = json!(host);
+    }
+
+    obj
+}
+
+pub(crate) fn workspace_list_to_json(list: &[WorkspaceInfo]) -> Value {
+    Value::Array(list.iter().map(workspace_info_to_json).collect())
+}

--- a/src/apps/cli/src/ui/chat/popups.rs
+++ b/src/apps/cli/src/ui/chat/popups.rs
@@ -33,7 +33,10 @@ impl ChatView {
         self.command_palette.is_visible()
     }
 
-    pub(crate) fn command_palette_handle_key(&mut self, key: crossterm::event::KeyEvent) -> PaletteAction {
+    pub(crate) fn command_palette_handle_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+    ) -> PaletteAction {
         self.command_palette.handle_key_event(key)
     }
 
@@ -44,7 +47,10 @@ impl ChatView {
         self.command_palette.handle_mouse_event(mouse)
     }
 
-    pub(crate) fn command_palette_captures_mouse(&self, mouse: &crossterm::event::MouseEvent) -> bool {
+    pub(crate) fn command_palette_captures_mouse(
+        &self,
+        mouse: &crossterm::event::MouseEvent,
+    ) -> bool {
         self.command_palette.captures_mouse(mouse)
     }
 
@@ -306,7 +312,10 @@ impl ChatView {
         self.mcp_add_dialog.is_visible()
     }
 
-    pub(crate) fn mcp_add_dialog_handle_key(&mut self, key: crossterm::event::KeyEvent) -> McpAddAction {
+    pub(crate) fn mcp_add_dialog_handle_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+    ) -> McpAddAction {
         self.mcp_add_dialog.handle_key_event(key)
     }
 
@@ -389,7 +398,10 @@ impl ChatView {
         self.provider_selector.handle_mouse_event(mouse)
     }
 
-    pub(crate) fn provider_selector_captures_mouse(&self, mouse: &crossterm::event::MouseEvent) -> bool {
+    pub(crate) fn provider_selector_captures_mouse(
+        &self,
+        mouse: &crossterm::event::MouseEvent,
+    ) -> bool {
         self.provider_selector.captures_mouse(mouse)
     }
 
@@ -438,5 +450,63 @@ impl ChatView {
         key: crossterm::event::KeyEvent,
     ) -> ModelFormAction {
         self.model_config_form.handle_key_event(key)
+    }
+
+    // ============ Account login form ============
+
+    pub(crate) fn show_login_form(&mut self) {
+        self.login_form.show();
+        self.popup_stack.push(PopupType::LoginForm);
+    }
+
+    pub(crate) fn login_form_visible(&self) -> bool {
+        self.login_form.is_visible()
+    }
+
+    pub(crate) fn hide_login_form(&mut self) {
+        self.login_form.hide();
+    }
+
+    pub(crate) fn reshow_login_form(&mut self) {
+        self.login_form.show();
+    }
+
+    pub(crate) fn login_form_handle_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+    ) -> LoginFormAction {
+        self.login_form.handle_key_event(key)
+    }
+
+    pub(crate) fn login_form_set_error(&mut self, message: impl Into<String>) {
+        self.login_form.set_error(message);
+    }
+
+    pub(crate) fn login_form_insert_paste(&mut self, text: &str) {
+        self.login_form.insert_paste(text);
+    }
+
+    pub(crate) fn show_account_panel(
+        &mut self,
+        info: crate::account::AccountInfo,
+        devices: Vec<crate::account::AccountDevice>,
+        sync_progress: crate::account_sync::SyncProgress,
+    ) {
+        self.login_form.show_account(info, devices, sync_progress);
+        self.popup_stack.push(PopupType::LoginForm);
+    }
+
+    pub(crate) fn show_sync_choice_panel(&mut self, user_id: &str, relay_url: &str) {
+        self.login_form.show_sync_choice(user_id, relay_url);
+        self.popup_stack.push(PopupType::LoginForm);
+    }
+
+    pub(crate) fn update_account_panel_progress(
+        &mut self,
+        devices: Option<Vec<crate::account::AccountDevice>>,
+        sync_progress: crate::account_sync::SyncProgress,
+    ) {
+        self.login_form
+            .update_account_progress(devices, sync_progress);
     }
 }

--- a/src/apps/cli/src/ui/chat/render.rs
+++ b/src/apps/cli/src/ui/chat/render.rs
@@ -99,6 +99,9 @@ impl ChatView {
         // Command palette overlay (Ctrl+P)
         self.command_palette.render(frame, size, &self.theme);
 
+        // Dedicated login page (full viewport takeover)
+        self.login_form.render(frame, size, &self.theme);
+
         // Info popup overlay (topmost)
         if let Some(ref msg) = self.info_popup {
             super::widgets::render_info_popup(frame, size, msg, self.theme.primary);

--- a/src/apps/cli/src/ui/chat/state.rs
+++ b/src/apps/cli/src/ui/chat/state.rs
@@ -11,6 +11,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use super::agent_selector::{AgentItem, AgentSelectorState};
 use super::command_menu::CommandMenuState;
 use super::command_palette::{CommandPaletteState, PaletteAction};
+use super::login_form::{LoginFormAction, LoginFormState};
 use super::markdown::MarkdownRenderer;
 use super::mcp_add_dialog::{McpAddAction, McpAddDialogState};
 use super::mcp_selector::{McpAction, McpItem, McpSelectorState};
@@ -41,6 +42,7 @@ pub(crate) enum PopupType {
     McpAddDialog,
     ProviderSelector,
     ModelConfigForm,
+    LoginForm,
     ThemeSelector,
     InfoPopup,
 }
@@ -152,6 +154,8 @@ pub(crate) struct ChatView {
     provider_selector: ProviderSelectorState,
     /// Model config form state (step 2 of add model)
     model_config_form: ModelConfigFormState,
+    /// Account login form (dedicated full-viewport page)
+    login_form: LoginFormState,
     /// Theme selector popup state
     theme_selector: ThemeSelectorState,
 
@@ -254,6 +258,7 @@ impl ChatView {
             mcp_add_dialog: McpAddDialogState::new(),
             provider_selector: ProviderSelectorState::new(),
             model_config_form: ModelConfigFormState::new(),
+            login_form: LoginFormState::new(),
             theme_selector: ThemeSelectorState::new(),
             pending_command: None,
             pending_mcp_toggle: None,

--- a/src/apps/cli/src/ui/command_palette.rs
+++ b/src/apps/cli/src/ui/command_palette.rs
@@ -106,6 +106,19 @@ fn default_palette_items() -> Vec<PaletteItem> {
             description: "Manage MCP servers".into(),
             group: "MCP".into(),
         },
+        // Account group
+        PaletteItem {
+            id: "login".into(),
+            label: "Login".into(),
+            description: "Log in to BitFun account".into(),
+            group: "Account".into(),
+        },
+        PaletteItem {
+            id: "logout".into(),
+            label: "Logout".into(),
+            description: "Log out of BitFun account".into(),
+            group: "Account".into(),
+        },
         // System group
         PaletteItem {
             id: "help".into(),

--- a/src/apps/cli/src/ui/login_form.rs
+++ b/src/apps/cli/src/ui/login_form.rs
@@ -1,0 +1,952 @@
+//! Full-viewport BitFun account panel (Login / Sync choice / Account status).
+//!
+//! Opened by `/login`. When already logged in, shows account info and sync
+//! progress instead of the credential form.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::account::{AccountDevice, AccountInfo};
+use crate::account_sync::{sync_phase_label, SyncProgress, SyncStatus};
+use crate::ui::theme::{StyleKind, Theme};
+
+/// Credentials collected by the login form.
+#[derive(Debug, Clone)]
+pub(crate) struct LoginCredentials {
+    pub relay_url: String,
+    pub username: String,
+    pub password: String,
+}
+
+/// Action returned after handling a key event.
+#[derive(Debug, Clone)]
+pub(crate) enum LoginFormAction {
+    None,
+    /// Close the panel (Esc on most views).
+    Cancel,
+    /// Submit login credentials.
+    Submit(LoginCredentials),
+    /// User chose "Use local" on the sync conflict page.
+    SyncUseLocal,
+    /// User chose "Use cloud" on the sync conflict page.
+    SyncUseCloud,
+    /// User cancelled the sync choice (logout + back to login).
+    SyncCancel,
+    /// User requested logout from the account page.
+    Logout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PanelMode {
+    Login,
+    SyncChoice,
+    Account,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoginFocus {
+    AuthServer,
+    Username,
+    Password,
+    Login,
+}
+
+const LOGIN_FOCUS_ORDER: [LoginFocus; 4] = [
+    LoginFocus::AuthServer,
+    LoginFocus::Username,
+    LoginFocus::Password,
+    LoginFocus::Login,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SyncChoiceFocus {
+    UseLocal,
+    UseCloud,
+    Cancel,
+}
+
+const SYNC_CHOICE_ORDER: [SyncChoiceFocus; 3] = [
+    SyncChoiceFocus::UseLocal,
+    SyncChoiceFocus::UseCloud,
+    SyncChoiceFocus::Cancel,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AccountFocus {
+    Logout,
+    Close,
+}
+
+/// Full-screen account panel state.
+pub(crate) struct LoginFormState {
+    visible: bool,
+    mode: PanelMode,
+
+    // Login fields
+    auth_server: String,
+    username: String,
+    password: String,
+    login_focus: LoginFocus,
+    cursor: usize,
+    error: Option<String>,
+    status: Option<String>,
+
+    // Sync choice
+    sync_choice_focus: SyncChoiceFocus,
+    pending_user_id: String,
+    pending_relay: String,
+
+    // Account status
+    account_focus: AccountFocus,
+    account_info: Option<AccountInfo>,
+    devices: Vec<AccountDevice>,
+    sync_progress: SyncProgress,
+}
+
+impl LoginFormState {
+    pub(crate) fn new() -> Self {
+        Self {
+            visible: false,
+            mode: PanelMode::Login,
+            auth_server: String::new(),
+            username: String::new(),
+            password: String::new(),
+            login_focus: LoginFocus::AuthServer,
+            cursor: 0,
+            error: None,
+            status: None,
+            sync_choice_focus: SyncChoiceFocus::UseLocal,
+            pending_user_id: String::new(),
+            pending_relay: String::new(),
+            account_focus: AccountFocus::Close,
+            account_info: None,
+            devices: Vec::new(),
+            sync_progress: SyncProgress::default(),
+        }
+    }
+
+    pub(crate) fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub(crate) fn show(&mut self) {
+        self.visible = true;
+        self.mode = PanelMode::Login;
+        self.auth_server.clear();
+        self.username.clear();
+        self.password.clear();
+        self.login_focus = LoginFocus::AuthServer;
+        self.cursor = 0;
+        self.error = None;
+        self.status = None;
+        self.sync_choice_focus = SyncChoiceFocus::UseLocal;
+        self.account_focus = AccountFocus::Close;
+    }
+
+    pub(crate) fn hide(&mut self) {
+        self.visible = false;
+        self.error = None;
+        self.status = None;
+    }
+
+    pub(crate) fn show_sync_choice(&mut self, user_id: &str, relay_url: &str) {
+        self.visible = true;
+        self.mode = PanelMode::SyncChoice;
+        self.pending_user_id = user_id.to_string();
+        self.pending_relay = relay_url.to_string();
+        self.sync_choice_focus = SyncChoiceFocus::UseLocal;
+        self.error = None;
+        self.status = None;
+    }
+
+    pub(crate) fn show_account(
+        &mut self,
+        info: AccountInfo,
+        devices: Vec<AccountDevice>,
+        sync_progress: SyncProgress,
+    ) {
+        self.visible = true;
+        self.mode = PanelMode::Account;
+        self.account_info = Some(info);
+        self.devices = devices;
+        self.sync_progress = sync_progress;
+        self.account_focus = AccountFocus::Close;
+        self.error = None;
+        self.status = None;
+    }
+
+    pub(crate) fn update_account_progress(
+        &mut self,
+        devices: Option<Vec<AccountDevice>>,
+        sync_progress: SyncProgress,
+    ) {
+        if let Some(devices) = devices {
+            self.devices = devices;
+        }
+        self.sync_progress = sync_progress;
+    }
+
+    pub(crate) fn set_error(&mut self, message: impl Into<String>) {
+        self.error = Some(message.into());
+        self.status = None;
+        if self.mode == PanelMode::Login {
+            self.login_focus = LoginFocus::Login;
+        }
+    }
+
+    pub(crate) fn set_status(&mut self, message: impl Into<String>) {
+        self.status = Some(message.into());
+        self.error = None;
+    }
+
+    pub(crate) fn insert_paste(&mut self, text: &str) {
+        if !self.visible || self.mode != PanelMode::Login || self.login_focus == LoginFocus::Login {
+            return;
+        }
+        let cleaned: String = text
+            .chars()
+            .filter(|c| *c != '\n' && *c != '\r' && *c != '\t')
+            .collect();
+        if cleaned.is_empty() {
+            return;
+        }
+        let cursor = self.cursor;
+        if let Some(buf) = self.active_buffer_mut() {
+            let byte = char_to_byte(buf, cursor);
+            buf.insert_str(byte, &cleaned);
+            self.cursor = cursor + cleaned.chars().count();
+        }
+        self.error = None;
+    }
+
+    fn active_buffer(&self) -> &str {
+        match self.login_focus {
+            LoginFocus::AuthServer => &self.auth_server,
+            LoginFocus::Username => &self.username,
+            LoginFocus::Password => &self.password,
+            LoginFocus::Login => "",
+        }
+    }
+
+    fn active_buffer_mut(&mut self) -> Option<&mut String> {
+        match self.login_focus {
+            LoginFocus::AuthServer => Some(&mut self.auth_server),
+            LoginFocus::Username => Some(&mut self.username),
+            LoginFocus::Password => Some(&mut self.password),
+            LoginFocus::Login => None,
+        }
+    }
+
+    fn move_login_focus(&mut self, delta: isize) {
+        let len = LOGIN_FOCUS_ORDER.len() as isize;
+        let idx = LOGIN_FOCUS_ORDER
+            .iter()
+            .position(|f| *f == self.login_focus)
+            .unwrap_or(0) as isize;
+        let next = (idx + delta).rem_euclid(len) as usize;
+        self.login_focus = LOGIN_FOCUS_ORDER[next];
+        self.cursor = self.active_buffer().chars().count();
+    }
+
+    fn move_sync_focus(&mut self, delta: isize) {
+        let len = SYNC_CHOICE_ORDER.len() as isize;
+        let idx = SYNC_CHOICE_ORDER
+            .iter()
+            .position(|f| *f == self.sync_choice_focus)
+            .unwrap_or(0) as isize;
+        let next = (idx + delta).rem_euclid(len) as usize;
+        self.sync_choice_focus = SYNC_CHOICE_ORDER[next];
+    }
+
+    fn validate_login(&self) -> Option<String> {
+        if self.auth_server.trim().is_empty() {
+            return Some("Auth Server is required".into());
+        }
+        if self.username.trim().is_empty() {
+            return Some("Username is required".into());
+        }
+        if self.password.is_empty() {
+            return Some("Password is required".into());
+        }
+        None
+    }
+
+    fn try_submit_login(&mut self) -> LoginFormAction {
+        if let Some(err) = self.validate_login() {
+            self.set_error(err);
+            return LoginFormAction::None;
+        }
+        self.set_status("Logging in...");
+        LoginFormAction::Submit(LoginCredentials {
+            relay_url: self.auth_server.trim().to_string(),
+            username: self.username.trim().to_string(),
+            password: self.password.clone(),
+        })
+    }
+
+    pub(crate) fn handle_key_event(&mut self, key: KeyEvent) -> LoginFormAction {
+        if !self.visible {
+            return LoginFormAction::None;
+        }
+        match self.mode {
+            PanelMode::Login => self.handle_login_key(key),
+            PanelMode::SyncChoice => self.handle_sync_choice_key(key),
+            PanelMode::Account => self.handle_account_key(key),
+        }
+    }
+
+    fn handle_login_key(&mut self, key: KeyEvent) -> LoginFormAction {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) => {
+                self.hide();
+                LoginFormAction::Cancel
+            }
+            (KeyCode::Char('v'), KeyModifiers::CONTROL) => {
+                if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                    if let Ok(text) = clipboard.get_text() {
+                        self.insert_paste(&text);
+                    }
+                }
+                LoginFormAction::None
+            }
+            (KeyCode::Up, _) | (KeyCode::BackTab, _) => {
+                self.move_login_focus(-1);
+                LoginFormAction::None
+            }
+            (KeyCode::Down, _) | (KeyCode::Tab, _) => {
+                self.move_login_focus(1);
+                LoginFormAction::None
+            }
+            (KeyCode::Enter, _) => match self.login_focus {
+                LoginFocus::Login => self.try_submit_login(),
+                _ => {
+                    self.move_login_focus(1);
+                    LoginFormAction::None
+                }
+            },
+            (KeyCode::Left, _) if self.login_focus != LoginFocus::Login => {
+                self.cursor = self.cursor.saturating_sub(1);
+                LoginFormAction::None
+            }
+            (KeyCode::Right, _) if self.login_focus != LoginFocus::Login => {
+                let len = self.active_buffer().chars().count();
+                if self.cursor < len {
+                    self.cursor += 1;
+                }
+                LoginFormAction::None
+            }
+            (KeyCode::Home, _) if self.login_focus != LoginFocus::Login => {
+                self.cursor = 0;
+                LoginFormAction::None
+            }
+            (KeyCode::End, _) if self.login_focus != LoginFocus::Login => {
+                self.cursor = self.active_buffer().chars().count();
+                LoginFormAction::None
+            }
+            (KeyCode::Backspace, _) => {
+                let cursor = self.cursor;
+                if let Some(buf) = self.active_buffer_mut() {
+                    if cursor > 0 {
+                        let byte = char_to_byte(buf, cursor - 1);
+                        let end = char_to_byte(buf, cursor);
+                        buf.replace_range(byte..end, "");
+                        self.cursor = cursor - 1;
+                    }
+                }
+                LoginFormAction::None
+            }
+            (KeyCode::Delete, _) => {
+                let cursor = self.cursor;
+                if let Some(buf) = self.active_buffer_mut() {
+                    let len = buf.chars().count();
+                    if cursor < len {
+                        let start = char_to_byte(buf, cursor);
+                        let end = char_to_byte(buf, cursor + 1);
+                        buf.replace_range(start..end, "");
+                    }
+                }
+                LoginFormAction::None
+            }
+            (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT)
+                if self.login_focus != LoginFocus::Login && !c.is_control() =>
+            {
+                let cursor = self.cursor;
+                if let Some(buf) = self.active_buffer_mut() {
+                    let byte = char_to_byte(buf, cursor);
+                    buf.insert(byte, c);
+                    self.cursor = cursor + 1;
+                }
+                LoginFormAction::None
+            }
+            _ => LoginFormAction::None,
+        }
+    }
+
+    fn handle_sync_choice_key(&mut self, key: KeyEvent) -> LoginFormAction {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) => LoginFormAction::SyncCancel,
+            (KeyCode::Up, _) | (KeyCode::BackTab, _) => {
+                self.move_sync_focus(-1);
+                LoginFormAction::None
+            }
+            (KeyCode::Down, _) | (KeyCode::Tab, _) => {
+                self.move_sync_focus(1);
+                LoginFormAction::None
+            }
+            (KeyCode::Enter, _) => match self.sync_choice_focus {
+                SyncChoiceFocus::UseLocal => LoginFormAction::SyncUseLocal,
+                SyncChoiceFocus::UseCloud => LoginFormAction::SyncUseCloud,
+                SyncChoiceFocus::Cancel => LoginFormAction::SyncCancel,
+            },
+            _ => LoginFormAction::None,
+        }
+    }
+
+    fn handle_account_key(&mut self, key: KeyEvent) -> LoginFormAction {
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) => {
+                self.hide();
+                LoginFormAction::Cancel
+            }
+            (KeyCode::Up, _) | (KeyCode::BackTab, _) | (KeyCode::Left, _) => {
+                self.account_focus = match self.account_focus {
+                    AccountFocus::Logout => AccountFocus::Close,
+                    AccountFocus::Close => AccountFocus::Logout,
+                };
+                LoginFormAction::None
+            }
+            (KeyCode::Down, _) | (KeyCode::Tab, _) | (KeyCode::Right, _) => {
+                self.account_focus = match self.account_focus {
+                    AccountFocus::Logout => AccountFocus::Close,
+                    AccountFocus::Close => AccountFocus::Logout,
+                };
+                LoginFormAction::None
+            }
+            (KeyCode::Enter, _) => match self.account_focus {
+                AccountFocus::Logout => LoginFormAction::Logout,
+                AccountFocus::Close => {
+                    self.hide();
+                    LoginFormAction::Cancel
+                }
+            },
+            _ => LoginFormAction::None,
+        }
+    }
+
+    pub(crate) fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        if !self.visible {
+            return;
+        }
+        frame.render_widget(Clear, area);
+        match self.mode {
+            PanelMode::Login => self.render_login(frame, area, theme),
+            PanelMode::SyncChoice => self.render_sync_choice(frame, area, theme),
+            PanelMode::Account => self.render_account(frame, area, theme),
+        }
+    }
+
+    fn render_login(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let outer = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.style(StyleKind::Primary))
+            .title(" BitFun Account Login ")
+            .title_alignment(Alignment::Center);
+        let inner = outer.inner(area);
+        frame.render_widget(outer, area);
+
+        let form_width = inner.width.min(72).max(40);
+        let form_height = 15u16.min(inner.height.max(12));
+        let form_area = Rect {
+            x: inner.x + (inner.width.saturating_sub(form_width)) / 2,
+            y: inner.y + (inner.height.saturating_sub(form_height)) / 2,
+            width: form_width,
+            height: form_height,
+        };
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(1),
+            ])
+            .split(form_area);
+
+        self.render_field_label(
+            frame,
+            rows[0],
+            "Auth Server",
+            self.login_focus == LoginFocus::AuthServer,
+            theme,
+        );
+        self.render_text_input(frame, rows[1], LoginFocus::AuthServer, theme);
+        self.render_field_label(
+            frame,
+            rows[3],
+            "Username",
+            self.login_focus == LoginFocus::Username,
+            theme,
+        );
+        self.render_text_input(frame, rows[4], LoginFocus::Username, theme);
+        self.render_field_label(
+            frame,
+            rows[6],
+            "Password",
+            self.login_focus == LoginFocus::Password,
+            theme,
+        );
+        self.render_text_input(frame, rows[7], LoginFocus::Password, theme);
+        self.render_button(
+            frame,
+            rows[9],
+            "[  Login  ]",
+            self.login_focus == LoginFocus::Login,
+            theme,
+        );
+        self.render_message(frame, rows[11], theme);
+        self.render_hints(
+            frame,
+            rows[12],
+            "Up/Down Select   Enter Next / Submit   Esc Cancel",
+            theme,
+        );
+    }
+
+    fn render_sync_choice(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let outer = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.style(StyleKind::Primary))
+            .title(" Cloud Settings Found ")
+            .title_alignment(Alignment::Center);
+        let inner = outer.inner(area);
+        frame.render_widget(outer, area);
+
+        let form_width = inner.width.min(76).max(40);
+        let form_height = 14u16.min(inner.height.max(10));
+        let form_area = Rect {
+            x: inner.x + (inner.width.saturating_sub(form_width)) / 2,
+            y: inner.y + (inner.height.saturating_sub(form_height)) / 2,
+            width: form_width,
+            height: form_height,
+        };
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(2),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(1),
+            ])
+            .split(form_area);
+
+        let notice = format!(
+            "Account {} already has cloud settings on {}.\nChoose how to sync this device.",
+            self.pending_user_id, self.pending_relay
+        );
+        frame.render_widget(
+            Paragraph::new(notice).style(theme.style(StyleKind::Muted)),
+            rows[0],
+        );
+
+        self.render_choice_row(
+            frame,
+            rows[2],
+            "Use local",
+            "Keep this device settings and upload them to cloud",
+            self.sync_choice_focus == SyncChoiceFocus::UseLocal,
+            theme,
+        );
+        self.render_choice_row(
+            frame,
+            rows[4],
+            "Use cloud",
+            "Download cloud settings and overwrite this device",
+            self.sync_choice_focus == SyncChoiceFocus::UseCloud,
+            theme,
+        );
+        self.render_button(
+            frame,
+            rows[6],
+            "[  Cancel / Logout  ]",
+            self.sync_choice_focus == SyncChoiceFocus::Cancel,
+            theme,
+        );
+        self.render_hints(
+            frame,
+            rows[9],
+            "Up/Down Select   Enter Confirm   Esc Cancel",
+            theme,
+        );
+    }
+
+    fn render_account(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let outer = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.style(StyleKind::Primary))
+            .title(" BitFun Account ")
+            .title_alignment(Alignment::Center);
+        let inner = outer.inner(area);
+        frame.render_widget(outer, area);
+
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(4), // account info
+                Constraint::Length(3), // sync progress
+                Constraint::Min(4),    // devices
+                Constraint::Length(1), // buttons
+                Constraint::Length(1), // hints
+            ])
+            .split(inner);
+
+        let info = self.account_info.as_ref();
+        let info_lines = vec![
+            Line::from(vec![
+                Span::styled("User: ", theme.style(StyleKind::Muted)),
+                Span::styled(
+                    info.map(|i| i.user_id.as_str()).unwrap_or("-"),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Auth Server: ", theme.style(StyleKind::Muted)),
+                Span::styled(
+                    info.map(|i| i.relay_url.as_str()).unwrap_or("-"),
+                    Style::default().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("This device: ", theme.style(StyleKind::Muted)),
+                Span::styled(
+                    info.map(|i| i.device_name.as_str()).unwrap_or("-"),
+                    Style::default().fg(Color::White),
+                ),
+                Span::styled(
+                    format!(
+                        "  ({})",
+                        info.map(|i| truncate_id(&i.device_id))
+                            .unwrap_or_else(|| "-".into())
+                    ),
+                    theme.style(StyleKind::Muted),
+                ),
+            ]),
+        ];
+        frame.render_widget(Paragraph::new(info_lines), rows[0]);
+
+        let sync = &self.sync_progress;
+        let sync_text = match sync.status {
+            SyncStatus::Idle => "Sync: idle".to_string(),
+            SyncStatus::Syncing => {
+                format!("Syncing: {}  {}%", sync_phase_label(sync), sync.percent)
+            }
+            SyncStatus::Done => format!(
+                "Sync done — settings={} exported={}",
+                sync.settings_synced, sync.sessions_exported
+            ),
+            SyncStatus::Failed => format!(
+                "Sync failed: {}",
+                sync.error.as_deref().unwrap_or("unknown error")
+            ),
+        };
+        let sync_style = match sync.status {
+            SyncStatus::Failed => theme.style(StyleKind::Error),
+            SyncStatus::Done => theme.style(StyleKind::Info),
+            SyncStatus::Syncing => theme.style(StyleKind::Primary),
+            SyncStatus::Idle => theme.style(StyleKind::Muted),
+        };
+        let bar_width = rows[1].width.saturating_sub(2) as usize;
+        let filled = if sync.status == SyncStatus::Syncing || sync.status == SyncStatus::Done {
+            ((sync.percent as usize) * bar_width) / 100
+        } else {
+            0
+        };
+        let bar = format!(
+            "[{}{}]",
+            "#".repeat(filled.min(bar_width)),
+            "-".repeat(bar_width.saturating_sub(filled))
+        );
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(sync_text, sync_style)),
+                Line::from(Span::styled(bar, theme.style(StyleKind::Muted))),
+            ]),
+            rows[1],
+        );
+
+        let mut device_lines = vec![Line::from(Span::styled(
+            "Devices",
+            theme.style(StyleKind::Primary).add_modifier(Modifier::BOLD),
+        ))];
+        if self.devices.is_empty() {
+            device_lines.push(Line::from(Span::styled(
+                "  (no devices listed yet)",
+                theme.style(StyleKind::Muted),
+            )));
+        } else {
+            let local_id = info.map(|i| i.device_id.as_str());
+            for d in &self.devices {
+                let is_local = local_id == Some(d.device_id.as_str());
+                let status = if d.online { "online" } else { "offline" };
+                let badge = if is_local { " [this device]" } else { "" };
+                device_lines.push(Line::from(Span::styled(
+                    format!(
+                        "  {}{}  {}  · {}",
+                        d.device_name,
+                        badge,
+                        truncate_id(&d.device_id),
+                        status
+                    ),
+                    if d.online {
+                        Style::default().fg(Color::White)
+                    } else {
+                        theme.style(StyleKind::Muted)
+                    },
+                )));
+            }
+        }
+        frame.render_widget(Paragraph::new(device_lines), rows[2]);
+
+        let btn_row = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(rows[3]);
+        self.render_button(
+            frame,
+            btn_row[0],
+            "[ Logout ]",
+            self.account_focus == AccountFocus::Logout,
+            theme,
+        );
+        self.render_button(
+            frame,
+            btn_row[1],
+            "[ Close ]",
+            self.account_focus == AccountFocus::Close,
+            theme,
+        );
+        self.render_hints(
+            frame,
+            rows[4],
+            "Tab Switch   Enter Activate   Esc Close",
+            theme,
+        );
+    }
+
+    fn render_field_label(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        text: &str,
+        active: bool,
+        theme: &Theme,
+    ) {
+        let style = if active {
+            theme.style(StyleKind::Primary).add_modifier(Modifier::BOLD)
+        } else {
+            theme.style(StyleKind::Muted)
+        };
+        frame.render_widget(Paragraph::new(Line::from(Span::styled(text, style))), area);
+    }
+
+    fn render_text_input(&self, frame: &mut Frame, area: Rect, item: LoginFocus, theme: &Theme) {
+        let active = self.login_focus == item;
+        let raw = match item {
+            LoginFocus::AuthServer => self.auth_server.as_str(),
+            LoginFocus::Username => self.username.as_str(),
+            LoginFocus::Password => self.password.as_str(),
+            LoginFocus::Login => "",
+        };
+        let display = if item == LoginFocus::Password {
+            "*".repeat(raw.chars().count())
+        } else {
+            raw.to_string()
+        };
+        let prefix = if active { "> " } else { "  " };
+        let mut spans = vec![Span::styled(
+            prefix,
+            if active {
+                theme.style(StyleKind::Primary).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            },
+        )];
+        if active {
+            let cursor = self.cursor.min(display.chars().count());
+            let before: String = display.chars().take(cursor).collect();
+            let after: String = display.chars().skip(cursor).collect();
+            let cursor_char = after.chars().next().unwrap_or(' ');
+            let after_rest: String = after.chars().skip(1).collect();
+            spans.push(Span::styled(before, Style::default().fg(Color::White)));
+            spans.push(Span::styled(
+                cursor_char.to_string(),
+                Style::default().fg(Color::Black).bg(Color::White),
+            ));
+            spans.push(Span::styled(after_rest, Style::default().fg(Color::White)));
+        } else if !display.is_empty() {
+            spans.push(Span::styled(display, Style::default().fg(Color::White)));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    fn render_button(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        label: &str,
+        active: bool,
+        theme: &Theme,
+    ) {
+        let style = if active {
+            Style::default()
+                .bg(theme.primary)
+                .fg(theme.selection_foreground())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            theme.style(StyleKind::Muted)
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(label, style))).alignment(Alignment::Center),
+            area,
+        );
+    }
+
+    fn render_choice_row(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        title: &str,
+        desc: &str,
+        active: bool,
+        theme: &Theme,
+    ) {
+        let marker = if active { "> " } else { "  " };
+        let title_style = if active {
+            theme.style(StyleKind::Primary).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(marker, title_style),
+                Span::styled(format!("{title}  —  {desc}"), title_style),
+            ])),
+            area,
+        );
+    }
+
+    fn render_message(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        if let Some(ref err) = self.error {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    err.as_str(),
+                    theme.style(StyleKind::Error),
+                )))
+                .alignment(Alignment::Center),
+                area,
+            );
+        } else if let Some(ref status) = self.status {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    status.as_str(),
+                    theme.style(StyleKind::Info),
+                )))
+                .alignment(Alignment::Center),
+                area,
+            );
+        }
+    }
+
+    fn render_hints(&self, frame: &mut Frame, area: Rect, hints: &str, theme: &Theme) {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                hints,
+                theme.style(StyleKind::Muted),
+            )))
+            .alignment(Alignment::Center),
+            area,
+        );
+    }
+}
+
+fn char_to_byte(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
+}
+
+fn truncate_id(id: &str) -> String {
+    if id.len() <= 8 {
+        id.to_string()
+    } else {
+        format!("{}…", &id[..8])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyEventKind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::empty(),
+        }
+    }
+
+    #[test]
+    fn submit_requires_all_fields() {
+        let mut form = LoginFormState::new();
+        form.show();
+        form.login_focus = LoginFocus::Login;
+        assert!(matches!(
+            form.handle_key_event(key(KeyCode::Enter)),
+            LoginFormAction::None
+        ));
+        assert!(form.error.is_some());
+    }
+
+    #[test]
+    fn insert_paste_strips_newlines_into_active_field() {
+        let mut form = LoginFormState::new();
+        form.show();
+        form.insert_paste("https://example.com/relay\nextra");
+        assert_eq!(form.auth_server, "https://example.com/relayextra");
+    }
+
+    #[test]
+    fn sync_choice_enter_use_local() {
+        let mut form = LoginFormState::new();
+        form.show_sync_choice("u1", "https://relay");
+        assert!(matches!(
+            form.handle_key_event(key(KeyCode::Enter)),
+            LoginFormAction::SyncUseLocal
+        ));
+    }
+}

--- a/src/apps/cli/src/ui/mod.rs
+++ b/src/apps/cli/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod chat;
 mod command_menu;
 pub(crate) mod command_palette;
 mod diff_render;
+pub(crate) mod login_form;
 mod markdown;
 pub(crate) mod mcp_add_dialog;
 pub(crate) mod mcp_selector;

--- a/src/apps/cli/src/ui/startup.rs
+++ b/src/apps/cli/src/ui/startup.rs
@@ -1,6 +1,7 @@
 use super::agent_selector::{AgentItem, AgentSelectorState};
 use super::command_menu::CommandMenuState;
 use super::command_palette::{CommandPaletteState, PaletteAction};
+use super::login_form::{LoginFormAction, LoginFormState};
 use super::model_config_form::{ModelConfigFormState, ModelFormAction, ModelFormResult};
 use super::model_selector::{ModelItem, ModelSelectorState};
 use super::provider_selector::{ProviderSelection, ProviderSelectorState};
@@ -61,6 +62,7 @@ enum PopupType {
     ThemeSelector,
     ProviderSelector,
     ModelConfigForm,
+    LoginForm,
 }
 
 /// Navigation stack for managing popup hierarchy
@@ -116,8 +118,9 @@ Ctrl+C            Exit";
 
 /// Random tips shown on the startup page
 const TIPS: &[&str] = &[
-    "Type / for slash commands (e.g. /help, /models, /agents)",
+    "Type / for slash commands (e.g. /help, /login, /models)",
     "Press Tab to cycle between agents",
+    "Use /login to sign in for Peer Device Mode / multi-device sync",
     "Use /init to explore your repo and generate AGENTS.md",
     "Press Ctrl+E to toggle browse mode for scrolling history",
     "Use /sessions to list and continue previous conversations",
@@ -188,6 +191,7 @@ pub(crate) struct StartupPage {
     theme_selector: ThemeSelectorState,
     provider_selector: ProviderSelectorState,
     model_config_form: ModelConfigFormState,
+    login_form: LoginFormState,
     theme_preview_original: Option<Theme>,
 
     // ── System context ──
@@ -262,6 +266,7 @@ impl StartupPage {
             theme_selector: ThemeSelectorState::new(),
             provider_selector: ProviderSelectorState::new(),
             model_config_form: ModelConfigFormState::new(),
+            login_form: LoginFormState::new(),
             theme_preview_original: None,
             coordinator,
             agent_type: default_agent,
@@ -320,12 +325,16 @@ impl StartupPage {
             || self.theme_selector.is_visible()
             || self.provider_selector.is_visible()
             || self.model_config_form.is_visible()
+            || self.login_form.is_visible()
     }
 
     pub(crate) fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<StartupResult> {
         terminal.clear()?;
 
         loop {
+            if self.login_form.is_visible() {
+                self.refresh_account_panel_live();
+            }
             terminal.draw(|f| self.render(f))?;
 
             if event::poll(Duration::from_millis(50))? {
@@ -373,8 +382,12 @@ impl StartupPage {
                             }
                         }
                         if !paste_buf.is_empty() {
-                            self.text_input.insert_paste(&paste_buf);
-                            self.refresh_command_menu();
+                            if self.login_form.is_visible() {
+                                self.login_form.insert_paste(&paste_buf);
+                            } else {
+                                self.text_input.insert_paste(&paste_buf);
+                                self.refresh_command_menu();
+                            }
                         }
                         for ev in non_key_events {
                             self.handle_non_key_event(ev, terminal)?;
@@ -425,8 +438,12 @@ impl StartupPage {
                 }
             }
             Event::Paste(text) => {
-                self.text_input.insert_paste(&text);
-                self.refresh_command_menu();
+                if self.login_form.is_visible() {
+                    self.login_form.insert_paste(&text);
+                } else {
+                    self.text_input.insert_paste(&text);
+                    self.refresh_command_menu();
+                }
             }
             Event::Resize(_, _) => {
                 // Avoid full-screen clear on every resize event to reduce flicker.
@@ -481,6 +498,9 @@ impl StartupPage {
 
         // Overlay: command palette (Ctrl+P)
         self.command_palette.render(frame, size, &self.theme);
+
+        // Dedicated login page (full viewport takeover)
+        self.login_form.render(frame, size, &self.theme);
 
         // Overlay: info popup (highest priority)
         if let Some(ref msg) = self.info_popup {
@@ -883,6 +903,12 @@ impl StartupPage {
             return None;
         }
 
+        if self.login_form.is_visible() {
+            self.refresh_account_panel_live();
+            let action = self.login_form.handle_key_event(key);
+            return self.handle_login_form_action(action);
+        }
+
         // ── Command palette intercepts all keys when visible ──
 
         if self.command_palette.is_visible() {
@@ -1067,6 +1093,13 @@ impl StartupPage {
                     prompt: Some("/mcps".to_string()),
                 });
             }
+            // Account group
+            "login" => {
+                self.show_login_form();
+            }
+            "logout" => {
+                return self.handle_command("/logout");
+            }
             // System group
             "help" => {
                 self.info_popup = Some(KEYBOARD_SHORTCUTS_HELP.to_string());
@@ -1129,6 +1162,24 @@ impl StartupPage {
                     prompt: Some("/acp".to_string()),
                 });
             }
+            "/login" => {
+                self.show_login_form();
+            }
+            "/logout" => {
+                let logged_in = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(crate::account::is_logged_in())
+                });
+                if !logged_in {
+                    self.status = Some("Not logged in.".to_string());
+                } else {
+                    match tokio::task::block_in_place(|| {
+                        tokio::runtime::Handle::current().block_on(crate::account::logout())
+                    }) {
+                        Ok(()) => self.status = Some("Logged out.".to_string()),
+                        Err(e) => self.status = Some(format!("Logout failed: {e}")),
+                    }
+                }
+            }
             "/usage" => {
                 self.status = Some("No active session for /usage.".to_string());
             }
@@ -1184,7 +1235,139 @@ impl StartupPage {
         } else if self.model_config_form.is_visible() {
             self.popup_stack.push(PopupType::ModelConfigForm);
             self.model_config_form.hide();
+        } else if self.login_form.is_visible() {
+            self.popup_stack.push(PopupType::LoginForm);
+            self.login_form.hide();
         }
+    }
+
+    fn show_login_form(&mut self) {
+        self.close_all_popups();
+        let logged_in = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(crate::account::is_logged_in())
+        });
+        if logged_in {
+            self.open_account_panel();
+        } else {
+            self.login_form.show();
+        }
+    }
+
+    fn workspace_path_for_sync(&self) -> std::path::PathBuf {
+        self.workspace_path_buf()
+    }
+
+    fn open_account_panel(&mut self) {
+        let (info, devices, progress) = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let info = crate::account::account_info().await;
+                let devices = crate::account::list_devices().await.unwrap_or_default();
+                let progress = crate::account_sync::current_sync_progress().await;
+                (info, devices, progress)
+            })
+        });
+        match info {
+            Ok(info) => self.login_form.show_account(info, devices, progress),
+            Err(e) => {
+                self.status = Some(format!("Failed to load account: {e}"));
+                self.login_form.show();
+            }
+        }
+    }
+
+    fn refresh_account_panel_live(&mut self) {
+        if !self.login_form.is_visible() {
+            return;
+        }
+        let progress = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(crate::account_sync::current_sync_progress())
+        });
+        // Refresh devices occasionally while syncing / after done.
+        let devices = if matches!(
+            progress.status,
+            crate::account_sync::SyncStatus::Syncing | crate::account_sync::SyncStatus::Done
+        ) {
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current()
+                    .block_on(crate::account::list_devices())
+                    .ok()
+            })
+        } else {
+            None
+        };
+        self.login_form.update_account_progress(devices, progress);
+    }
+
+    fn start_sync_and_show_account(&mut self, is_first_login: bool) {
+        let workspace = self.workspace_path_for_sync();
+        crate::account_sync::start_auto_sync_background(is_first_login, workspace);
+        self.open_account_panel();
+        self.status = Some(if is_first_login {
+            "Sync started (use local / upload settings).".to_string()
+        } else {
+            "Sync started (use cloud / download settings).".to_string()
+        });
+    }
+
+    fn handle_login_form_action(&mut self, action: LoginFormAction) -> Option<StartupResult> {
+        match action {
+            LoginFormAction::Submit(creds) => {
+                let result = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(
+                        crate::account::login_with_credentials(
+                            &creds.relay_url,
+                            &creds.username,
+                            &creds.password,
+                        ),
+                    )
+                });
+                match result {
+                    Ok(login) => {
+                        self.status = Some(login.status_message.clone());
+                        if login.has_cloud_settings {
+                            self.login_form
+                                .show_sync_choice(&login.user_id, &login.relay_url);
+                        } else {
+                            self.start_sync_and_show_account(true);
+                        }
+                    }
+                    Err(e) => {
+                        self.login_form.set_error(format!("Login failed: {e}"));
+                    }
+                }
+            }
+            LoginFormAction::SyncUseLocal => {
+                self.start_sync_and_show_account(true);
+            }
+            LoginFormAction::SyncUseCloud => {
+                self.start_sync_and_show_account(false);
+            }
+            LoginFormAction::SyncCancel => {
+                let _ = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(crate::account::logout())
+                });
+                self.login_form.show();
+                self.status = Some("Sync cancelled; logged out.".to_string());
+            }
+            LoginFormAction::Logout => {
+                match tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(crate::account::logout())
+                }) {
+                    Ok(()) => {
+                        self.login_form.show();
+                        self.status = Some("Logged out.".to_string());
+                    }
+                    Err(e) => {
+                        self.login_form.set_error(format!("Logout failed: {e}"));
+                    }
+                }
+            }
+            LoginFormAction::Cancel => {
+                self.status = Some("Account panel closed".to_string());
+            }
+            LoginFormAction::None => {}
+        }
+        None
     }
 
     fn show_session_selector(&mut self) {
@@ -2038,6 +2221,8 @@ impl StartupPage {
             self.provider_selector.hide();
         } else if self.model_config_form.is_visible() {
             self.model_config_form.hide();
+        } else if self.login_form.is_visible() {
+            self.login_form.hide();
         }
 
         // If there's a previous popup in the stack, re-show it
@@ -2052,6 +2237,7 @@ impl StartupPage {
                 PopupType::ThemeSelector => self.theme_selector.reshow(),
                 PopupType::ProviderSelector => self.provider_selector.reshow(),
                 PopupType::ModelConfigForm => self.model_config_form.reshow(),
+                PopupType::LoginForm => self.login_form.show(),
             }
         }
     }
@@ -2068,6 +2254,7 @@ impl StartupPage {
         self.cancel_theme_preview();
         self.provider_selector.hide();
         self.model_config_form.hide();
+        self.login_form.hide();
         self.popup_stack.clear();
     }
 

--- a/src/apps/desktop/src/api/remote_connect_api.rs
+++ b/src/apps/desktop/src/api/remote_connect_api.rs
@@ -2,6 +2,9 @@
 
 use crate::api::session_storage_path::desktop_effective_session_storage_path;
 use bitfun_core::agentic::persistence::PersistenceManager;
+use bitfun_core::service::remote_connect::session_store::{
+    clear_credential_hint, load_credential_hint, save_credential_hint, AccountHint,
+};
 use bitfun_core::service::remote_connect::{
     bot::{self, weixin, BotConfig},
     lan, session_store, sync_state, AccountClient, AccountSession, ConnectionMethod,
@@ -116,8 +119,7 @@ pub fn fanout_peer_device_event(event: String, payload: serde_json::Value) {
         return;
     }
     let tx = PEER_EVENT_FANOUT_TX.get_or_init(|| {
-        let (tx, mut rx) =
-            tokio::sync::mpsc::unbounded_channel::<(String, serde_json::Value)>();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(String, serde_json::Value)>();
         tokio::spawn(async move {
             while let Some((event, payload)) = rx.recv().await {
                 fanout_peer_device_event_once(event, payload).await;
@@ -345,46 +347,7 @@ async fn read_account_context() -> Result<(AccountSession, String), String> {
 }
 
 // ── Credential persistence (non-secret: username + relay_url only) ──────
-
-/// Path to the persisted credential hint file (non-secret data only).
-fn credential_hint_path() -> PathBuf {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    home.join(".bitfun").join("account_hint.json")
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct AccountHint {
-    pub username: String,
-    pub relay_url: String,
-}
-
-/// Persist non-secret credentials (username + relay_url) so the login dialog
-/// can pre-fill them on next startup. No password or master key is stored.
-fn save_credential_hint(username: &str, relay_url: &str) {
-    let hint = AccountHint {
-        username: username.to_string(),
-        relay_url: relay_url.to_string(),
-    };
-    let path = credential_hint_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(json) = serde_json::to_string(&hint) {
-        let _ = std::fs::write(&path, json);
-    }
-}
-
-/// Load the persisted credential hint. Returns None if not found or invalid.
-fn load_credential_hint() -> Option<AccountHint> {
-    let path = credential_hint_path();
-    let json = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&json).ok()
-}
-
-/// Clear the credential hint (called on logout).
-fn clear_credential_hint() {
-    let _ = std::fs::remove_file(credential_hint_path());
-}
+// Owned by shared `session_store` so Desktop and CLI use the same hint file.
 
 /// Tauri command: get the persisted credential hint for pre-filling the login form.
 #[tauri::command]

--- a/src/crates/services/services-integrations/src/remote_connect/session_store.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/session_store.rs
@@ -97,17 +97,17 @@ fn hostname_string() -> Option<String> {
 /// Best-effort current username retrieval (cross-platform).
 fn username_string() -> Option<String> {
     if cfg!(target_os = "windows") {
-        std::env::var("USERNAME").or_else(|_| std::env::var("USER")).ok()
-    } else {
-        std::env::var("USER")
+        std::env::var("USERNAME")
+            .or_else(|_| std::env::var("USER"))
             .ok()
-            .or_else(|| {
-                std::process::Command::new("whoami")
-                    .output()
-                    .ok()
-                    .and_then(|o| String::from_utf8(o.stdout).ok())
-                    .map(|s| s.trim().to_string())
-            })
+    } else {
+        std::env::var("USER").ok().or_else(|| {
+            std::process::Command::new("whoami")
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+        })
     }
 }
 
@@ -130,8 +130,7 @@ pub fn save_session(
     let json = serde_json::to_string(&payload).context("serialize session payload")?;
 
     let key = derive_machine_key();
-    let cipher =
-        Aes256Gcm::new_from_slice(&key).map_err(|e| anyhow!("cipher init: {e}"))?;
+    let cipher = Aes256Gcm::new_from_slice(&key).map_err(|e| anyhow!("cipher init: {e}"))?;
 
     let mut nonce_bytes = [0u8; NONCE_SIZE];
     OsRng.fill_bytes(&mut nonce_bytes);
@@ -164,7 +163,11 @@ pub fn load_session() -> Result<Option<(String, String, [u8; 32], String)>> {
     let encoded = match std::fs::read_to_string(&path) {
         Ok(data) => data,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(anyhow!("read session file: {e}").context(path.to_string_lossy().to_string())),
+        Err(e) => {
+            return Err(
+                anyhow!("read session file: {e}").context(path.to_string_lossy().to_string())
+            )
+        }
     };
 
     let packed = BASE64
@@ -180,8 +183,7 @@ pub fn load_session() -> Result<Option<(String, String, [u8; 32], String)>> {
         .map_err(|_| anyhow!("nonce conversion"))?;
 
     let key = derive_machine_key();
-    let cipher =
-        Aes256Gcm::new_from_slice(&key).map_err(|e| anyhow!("cipher init: {e}"))?;
+    let cipher = Aes256Gcm::new_from_slice(&key).map_err(|e| anyhow!("cipher init: {e}"))?;
     let plaintext = cipher
         .decrypt(Nonce::from_slice(&nonce_arr), ciphertext)
         .map_err(|e| anyhow!("decrypt session: {e}"))?;
@@ -209,6 +211,52 @@ pub fn load_session() -> Result<Option<(String, String, [u8; 32], String)>> {
 /// Remove the persisted session file (called on logout).
 pub fn clear_session() {
     if let Ok(path) = session_file_path() {
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+// ── Credential hint (non-secret: username + relay_url) ─────────────────
+// Shared by Desktop and CLI so login forms pre-fill the same values.
+
+fn credential_hint_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
+    Ok(home.join(".bitfun").join("account_hint.json"))
+}
+
+/// Non-secret login pre-fill (never stores password or master key).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountHint {
+    pub username: String,
+    pub relay_url: String,
+}
+
+/// Persist username + relay URL for the next login form.
+pub fn save_credential_hint(username: &str, relay_url: &str) {
+    let hint = AccountHint {
+        username: username.to_string(),
+        relay_url: relay_url.to_string(),
+    };
+    let Ok(path) = credential_hint_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string(&hint) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Load the persisted credential hint, if any.
+pub fn load_credential_hint() -> Option<AccountHint> {
+    let path = credential_hint_path().ok()?;
+    let json = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&json).ok()
+}
+
+/// Clear the credential hint (called on logout).
+pub fn clear_credential_hint() {
+    if let Ok(path) = credential_hint_path() {
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Summary
- Add CLI Peer Device Mode host: Core-backed HostInvoke registry (workspace/config/session/dialog/git/snapshot rollback) with soft empty responses for Desktop-only surfaces (MiniApps/ACP/cron), so Desktop→CLI peer matches Desktop→Desktop for hydrate/chat/rollback flows.
- Add CLI login TUI and account sync panel (local vs cloud settings choice, device list, logout), plus shared same-machine device identity for Desktop/CLI AuthConnect election.
- Update peer-device-mode docs/specs and ignore local `.tmp/` / `tmp/` scratch dirs.

## Test plan
- [ ] Rebuild CLI on Linux: `cargo build -p bitfun-cli`
- [ ] Login on CLI (`/login`), confirm sync choice / account page
- [ ] From Mac Desktop (same account), Peer Mode into the CLI host
- [ ] Open host workspace → create session → send message (no `update_session_model` / `get_config` unsupported errors)
- [ ] Rollback a turn on peer session (no `rollback_to_turn` unsupported error)
- [ ] Confirm MiniApps/ACP hydrate does not hard-fail (empty lists)