### PR TITLE
fix(web-ui): make input fill wrapper height for consistent vertical alignment

### DIFF
--- a/src/web-ui/src/component-library/components/Input/Input.scss
+++ b/src/web-ui/src/component-library/components/Input/Input.scss
@@ -127,6 +127,7 @@
 .bitfun-input {
   flex: 1;
   min-width: 0;
+  height: 100%;
   background: transparent;
   border: none !important;
   outline: none !important;


### PR DESCRIPTION
## Summary
- Add `height: 100%` to `.bitfun-input` so the native input element fills its flex wrapper
- Fixes vertical alignment issues when the input wrapper has a fixed or inherited height

## Test plan
- [x] `pnpm run type-check:web`
- [ ] Verify Input components with prefix/suffix icons render with correct vertical centering
- [ ] Verify multiline and single-line inputs still behave as expected