### PR TITLE
feat(review-platform): add GitHub CLI auth and simplify UI

### DIFF
--- a/src/apps/desktop/src/api/review_platform_api.rs
+++ b/src/apps/desktop/src/api/review_platform_api.rs
@@ -22,6 +22,13 @@ pub struct ReviewPlatformWorkspaceSnapshotRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ReviewPlatformWorkspaceContextRequest {
+    pub repository_path: String,
+    pub remote_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReviewPlatformPullRequestDetailRequest {
     pub repository_path: String,
     pub remote_id: String,
@@ -86,6 +93,22 @@ pub async fn review_platform_get_workspace_snapshot(
             error
         )
     })
+}
+
+#[tauri::command]
+pub async fn review_platform_get_workspace_context(
+    _state: State<'_, AppState>,
+    request: ReviewPlatformWorkspaceContextRequest,
+) -> Result<ReviewPlatformWorkspaceSnapshot, String> {
+    ReviewPlatformService::workspace_context(&request.repository_path, request.remote_id.as_deref())
+        .await
+        .map_err(|error| {
+            error!(
+            "Failed to get review platform workspace context: path={}, remote_id={:?}, error={}",
+            request.repository_path, request.remote_id, error
+        );
+            format!("Failed to get review platform workspace context: {}", error)
+        })
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1006,6 +1006,7 @@ pub async fn run() {
             git_resolve_revision,
             git_get_repository,
             review_platform_get_workspace_snapshot,
+            review_platform_get_workspace_context,
             review_platform_get_pull_request_detail,
             review_platform_get_pull_request_review_target,
             review_platform_get_issue,

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/agentic.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/agentic.rs
@@ -107,6 +107,13 @@ mod tests {
     use crate::agentic::tools::framework::ToolExposure;
 
     #[test]
+    fn agentic_mode_enables_review_platform_by_default() {
+        let tools = AgenticMode::new().default_tools();
+
+        assert!(tools.contains(&"ReviewPlatform".to_string()));
+    }
+
+    #[test]
     fn agentic_mode_expands_web_research_tools() {
         let mode = AgenticMode::new();
         let overrides = mode.tool_exposure_overrides();

--- a/src/crates/assembly/core/src/agentic/agents/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/mod.rs
@@ -123,6 +123,7 @@ pub fn shared_coding_mode_tools() -> Vec<String> {
         "AskUserQuestion".to_string(),
         "CreatePlan".to_string(),
         "Git".to_string(),
+        "ReviewPlatform".to_string(),
         "ControlHub".to_string(),
         "InitMiniApp".to_string(),
     ];
@@ -289,6 +290,13 @@ mod tests {
     }
 
     #[test]
+    fn shared_coding_mode_tools_include_review_platform() {
+        let tools = shared_coding_mode_tools();
+
+        assert!(tools.contains(&"ReviewPlatform".to_string()));
+    }
+
+    #[test]
     fn shared_coding_mode_tools_include_canvas_provider_tools() {
         let tools = shared_coding_mode_tools();
 
@@ -296,6 +304,16 @@ mod tests {
         assert!(tools.contains(&"ReadCanvas".to_string()));
         assert!(tools.contains(&"UpdateCanvas".to_string()));
         assert!(tools.contains(&"PatchCanvas".to_string()));
+    }
+
+    #[test]
+    fn shared_coding_modes_share_default_tools() {
+        let shared_tools = shared_coding_mode_tools();
+
+        assert_eq!(AgenticMode::new().default_tools(), shared_tools);
+        assert_eq!(MultitaskMode::new().default_tools(), shared_tools);
+        assert_eq!(PlanMode::new().default_tools(), shared_tools);
+        assert_eq!(DebugMode::new().default_tools(), shared_tools);
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/tools/implementations/review_platform_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/review_platform_tool.rs
@@ -209,9 +209,9 @@ impl ReviewPlatformTool {
             "authChallenge": {
                 "state": state,
                 "message": if status == 403 {
-                    "Review platform token is missing required permissions. Update the token in the pull request panel, then retry."
+                    "Review platform authentication is missing required permissions. Update authentication in the pull request panel, then retry."
                 } else {
-                    "Review platform authentication is required or the configured token was rejected. Add or update the token in the pull request panel, then retry."
+                    "Review platform authentication is required or was rejected. Configure authentication in the pull request panel, then retry."
                 },
             },
             "openPanel": {
@@ -260,7 +260,7 @@ impl Tool for ReviewPlatformTool {
 
 Use this for remote review-platform operations such as discovering remotes, loading the workspace PR snapshot, counting pull requests, listing pull requests, opening full or paginated pull request detail, loading CI logs, creating a pull request, replying to review threads, submitting a comment review, approving, revoking approval, requesting changes, or resolving a review thread. Use the Git tool for local repository state and branch/commit/push operations.
 
-Authentication-token actions are available only when the user explicitly provides a token or asks to clear a stored token. Never guess or expose token values.
+GitHub authentication is owned by the local `gh` CLI and must never use token actions. Authentication-token actions are only for GitLab and GitCode when the user explicitly provides a token or asks to clear a stored token. Never guess or expose token values.
 
 When returning pull request results to the user, include the provider web URL so the chat UI can open the pull request detail panel naturally."#.to_string())
     }
@@ -335,7 +335,7 @@ When returning pull request results to the user, include the provider web URL so
                 "platform": {
                     "type": "string",
                     "enum": ["github", "gitlab", "gitcode", "unknown"],
-                    "description": "Review platform kind for update_auth_token or clear_auth_token."
+                    "description": "GitLab or GitCode platform kind for update_auth_token or clear_auth_token. GitHub uses local gh authentication."
                 },
                 "host": {
                     "type": "string",
@@ -343,7 +343,7 @@ When returning pull request results to the user, include the provider web URL so
                 },
                 "token": {
                     "type": "string",
-                    "description": "Personal access token for update_auth_token. Only provide this when the user explicitly asks to store that token."
+                    "description": "GitLab or GitCode personal access token for update_auth_token. Only provide this when the user explicitly asks to store that token. Never provide a GitHub token."
                 },
                 "title": {
                     "type": "string",
@@ -488,7 +488,7 @@ When returning pull request results to the user, include the provider web URL so
                 .pointer("/authChallenge/message")
                 .and_then(Value::as_str)
                 .unwrap_or("Review platform authentication is required.");
-            return format!("{} Ask the user to configure the token in the pull request panel, then retry this action.", message);
+            return format!("{} Ask the user to configure provider authentication in the pull request panel, then retry this action.", message);
         }
         if let Some(action_result) = Self::render_action_result(output) {
             return action_result;

--- a/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn product_agentic_manifest_exposes_canvas_tools_directly() {
+    async fn product_agentic_manifest_exposes_default_product_tools() {
         let policy = crate::agentic::agents::get_agent_registry()
             .get_agent_tool_policy("agentic", None)
             .await;
@@ -491,6 +491,12 @@ mod tests {
         assert!(manifest
             .allowed_tool_names
             .contains(&"PatchCanvas".to_string()));
+        assert!(manifest
+            .allowed_tool_names
+            .contains(&"ReviewPlatform".to_string()));
+        assert!(manifest
+            .collapsed_tool_names
+            .contains(&"ReviewPlatform".to_string()));
         assert!(manifest
             .tool_definitions
             .iter()

--- a/src/crates/assembly/core/src/service/review_platform/mod.rs
+++ b/src/crates/assembly/core/src/service/review_platform/mod.rs
@@ -69,6 +69,15 @@ impl ReviewPlatformService {
             .await
     }
 
+    pub async fn workspace_context(
+        repository_path: &str,
+        remote_id: Option<&str>,
+    ) -> Result<ReviewPlatformWorkspaceSnapshot, ReviewPlatformError> {
+        owner_service()?
+            .workspace_context(repository_path, remote_id)
+            .await
+    }
+
     pub async fn pull_request_detail(
         repository_path: &str,
         remote_id: &str,

--- a/src/crates/services/services-integrations/src/review_platform.rs
+++ b/src/crates/services/services-integrations/src/review_platform.rs
@@ -6,7 +6,7 @@
 
 use crate::review_platform_http::{
     send_json as send_review_json, send_json_response as send_review_json_response,
-    send_json_response_bounded as send_review_json_response_bounded, send_text as send_review_text,
+    send_json_response_bounded as send_review_json_response_bounded,
     send_text_bounded as send_review_text_bounded, ReviewHttpClient, ReviewHttpError,
     ReviewHttpHeaders, ReviewHttpRequest, ReviewJsonResponse, ReviewTextResponse,
 };
@@ -46,6 +46,8 @@ const MAX_ISSUE_COMMENTS_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
 const MAX_ISSUE_BODY_CHARS: usize = 128_000;
 const MAX_ISSUE_COMMENT_BODY_CHARS: usize = 32_000;
 const MAX_ISSUE_COMMENTS_AGGREGATE_CHARS: usize = 512_000;
+const DEFAULT_GH_OUTPUT_MAX_BYTES: usize = 16 * 1024 * 1024;
+const GH_ERROR_OUTPUT_MAX_CHARS: usize = 8 * 1024;
 
 static TOKEN_STORE_LOCKS: OnceLock<StdMutex<HashMap<PathBuf, Weak<AsyncMutex<()>>>>> =
     OnceLock::new();
@@ -109,6 +111,7 @@ pub enum ReviewAuthState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReviewAuthSource {
+    GhCli,
     Env,
     Stored,
     None,
@@ -217,6 +220,7 @@ pub struct ReviewPlatformCiItem {
 #[serde(rename_all = "camelCase")]
 pub struct ReviewPlatformPullRequest {
     pub id: String,
+    pub provider_id: Option<String>,
     pub number: i64,
     pub title: String,
     pub state: ReviewItemState,
@@ -652,13 +656,9 @@ impl ReviewPlatformAuthTokens {
 
     fn registered_platform_for_host(&self, host: &str) -> Option<ReviewPlatformKind> {
         let host = normalize_provider_host(host).ok()?;
-        let mut platforms = [
-            ReviewPlatformKind::Github,
-            ReviewPlatformKind::Gitlab,
-            ReviewPlatformKind::Gitcode,
-        ]
-        .into_iter()
-        .filter(|platform| self.get(*platform, &host).is_some());
+        let mut platforms = [ReviewPlatformKind::Gitlab, ReviewPlatformKind::Gitcode]
+            .into_iter()
+            .filter(|platform| self.get(*platform, &host).is_some());
         let platform = platforms.next()?;
         platforms.next().is_none().then_some(platform)
     }
@@ -730,6 +730,7 @@ impl ReviewPlatformService {
 
         let mut seen = HashSet::new();
         let mut remotes = Vec::new();
+        let mut gh_auth_by_host: HashMap<String, GhAuthStatus> = HashMap::new();
 
         for line in output.lines() {
             let parts: Vec<&str> = line.split_whitespace().collect();
@@ -745,7 +746,20 @@ impl ReviewPlatformService {
             if !seen.insert(key) {
                 continue;
             }
-            if let Some(remote) = parse_remote(remote_name, remote_url, auth_tokens) {
+            if let Some(mut remote) = parse_remote(remote_name, remote_url, auth_tokens) {
+                if matches!(
+                    remote.platform,
+                    ReviewPlatformKind::Github | ReviewPlatformKind::Unknown
+                ) {
+                    let status = if let Some(status) = gh_auth_by_host.get(&remote.host) {
+                        status.clone()
+                    } else {
+                        let status = gh_auth_status(&remote.host).await;
+                        gh_auth_by_host.insert(remote.host.clone(), status.clone());
+                        status
+                    };
+                    hydrate_github_remote_auth(&mut remote, status);
+                }
                 remotes.push(remote);
             }
         }
@@ -759,6 +773,27 @@ impl ReviewPlatformService {
         remote_id: Option<&str>,
         page: Option<u32>,
         per_page: Option<u32>,
+    ) -> Result<ReviewPlatformWorkspaceSnapshot, ReviewPlatformError> {
+        self.workspace_snapshot_internal(repository_path, remote_id, page, per_page, true)
+            .await
+    }
+
+    pub async fn workspace_context(
+        &self,
+        repository_path: &str,
+        remote_id: Option<&str>,
+    ) -> Result<ReviewPlatformWorkspaceSnapshot, ReviewPlatformError> {
+        self.workspace_snapshot_internal(repository_path, remote_id, None, None, false)
+            .await
+    }
+
+    async fn workspace_snapshot_internal(
+        &self,
+        repository_path: &str,
+        remote_id: Option<&str>,
+        page: Option<u32>,
+        per_page: Option<u32>,
+        include_pull_requests: bool,
     ) -> Result<ReviewPlatformWorkspaceSnapshot, ReviewPlatformError> {
         if self.is_remote_workspace_path(repository_path).await {
             return Ok(empty_snapshot(
@@ -807,11 +842,79 @@ impl ReviewPlatformService {
             ));
         }
 
+        if remote.platform == ReviewPlatformKind::Github
+            && remote.auth_state != ReviewAuthState::Connected
+        {
+            let challenge = github_cli_auth_challenge(&remote);
+            let repository = Some(repository_ref(&remote, Some(root)));
+            let account = account_for_remote(&remote);
+            let capabilities = capabilities_for_remote(&remote);
+            return Ok(auth_required_snapshot(
+                remotes,
+                remote,
+                repository,
+                account,
+                capabilities,
+                challenge,
+            ));
+        }
+
+        if include_pull_requests
+            && remote_id.is_none()
+            && remote.platform == ReviewPlatformKind::Github
+        {
+            let page = github_current_user_open_pull_requests_for_remotes(
+                &remotes,
+                &auth_tokens,
+                pagination_request,
+            )
+            .await?;
+            let selected_remote_id = page
+                .items
+                .first()
+                .and_then(|pull_request| pull_request.provider_id.clone())
+                .unwrap_or_else(|| remote.id.clone());
+            let selected_remote = remotes
+                .iter()
+                .find(|candidate| candidate.id == selected_remote_id)
+                .cloned()
+                .unwrap_or_else(|| remote.clone());
+            return Ok(ReviewPlatformWorkspaceSnapshot {
+                remotes,
+                selected_remote_id: Some(selected_remote.id.clone()),
+                accounts: vec![account_for_remote(&selected_remote)],
+                repository: Some(repository_ref(&selected_remote, Some(root))),
+                pull_requests: page.items,
+                pagination: page.pagination,
+                capabilities: capabilities_for_remote(&selected_remote),
+                message: None,
+                auth_challenge: None,
+            });
+        }
+
         let ctx = provider_context(remote.clone(), &auth_tokens)?;
         let provider = provider_for(ctx.remote.platform);
         let repository = Some(repository_ref(&ctx.remote, Some(root)));
         let account = account_for_remote(&ctx.remote);
         let capabilities = capabilities_for_remote(&remote);
+        if !include_pull_requests {
+            return Ok(ReviewPlatformWorkspaceSnapshot {
+                remotes,
+                selected_remote_id: Some(remote.id.clone()),
+                accounts: vec![account],
+                repository,
+                pull_requests: Vec::new(),
+                pagination: ReviewPlatformPagination {
+                    page: DEFAULT_PR_PAGE,
+                    per_page: DEFAULT_PR_PAGE_SIZE,
+                    total: Some(0),
+                    has_next: false,
+                },
+                capabilities,
+                message: None,
+                auth_challenge: None,
+            });
+        }
         match provider.list_pull_requests(&ctx, pagination_request).await {
             Ok(page) => Ok(ReviewPlatformWorkspaceSnapshot {
                 remotes,
@@ -1236,6 +1339,12 @@ impl ReviewPlatformService {
         host: &str,
         token: &str,
     ) -> Result<(), ReviewPlatformError> {
+        if platform == ReviewPlatformKind::Github {
+            return Err(ReviewPlatformError::Api(format!(
+                "GitHub tokens are not stored by BitFun. Authenticate the local GitHub CLI with `gh auth login --hostname {}`.",
+                normalize_provider_host(host)?
+            )));
+        }
         let token = token.trim();
         if token.is_empty() {
             return Err(ReviewPlatformError::Api(
@@ -1265,6 +1374,12 @@ impl ReviewPlatformService {
         platform: ReviewPlatformKind,
         host: &str,
     ) -> Result<(), ReviewPlatformError> {
+        if platform == ReviewPlatformKind::Github {
+            return Err(ReviewPlatformError::Api(format!(
+                "GitHub authentication is managed by the local GitHub CLI. Use `gh auth logout --hostname {}` if you want to sign out.",
+                normalize_provider_host(host)?
+            )));
+        }
         let key = token_key(platform, host)
             .ok_or_else(|| ReviewPlatformError::UnsupportedPlatform(host.to_string()))?;
         let _transaction = self.token_store_lock.lock().await;
@@ -1503,27 +1618,17 @@ async fn github_review_target_parts(
     ctx: &ProviderContext,
     pull_request_id: &str,
 ) -> Result<(ReviewPlatformPullRequest, Vec<ReviewPlatformFile>), ReviewPlatformError> {
-    let client = http_client()?;
     let base = format!(
         "{}/repos/{}/{}/pulls/{}",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
     );
     let initial_detail =
-        send_bounded_json(github_request(client.clone(), &base, ctx.token.as_deref())).await?;
-    let token = ctx.token.clone();
+        github_api_get_json(ctx, &base, &[], MAX_REVIEW_TARGET_RESPONSE_BYTES).await?;
     let files_url = format!("{}/files", base);
-    let files = fetch_bounded_paginated_array(
-        |page| {
-            let page = page.to_string();
-            github_request(client.clone(), &files_url, token.as_deref())
-                .query(&[("per_page", "100"), ("page", &page)])
-        },
-        github_next_page,
-        MAX_REVIEW_TARGET_LIST_ITEMS,
-    )
-    .await?;
+    let files =
+        fetch_bounded_github_paginated_array(ctx, &files_url, MAX_REVIEW_TARGET_LIST_ITEMS).await?;
     let confirmed_detail =
-        send_bounded_json(github_request(client, &base, ctx.token.as_deref())).await?;
+        github_api_get_json(ctx, &base, &[], MAX_REVIEW_TARGET_RESPONSE_BYTES).await?;
     let initial_pull_request = github_pull_request_from_value(&initial_detail);
     let confirmed_pull_request = github_pull_request_from_value(&confirmed_detail);
     ensure_pull_request_revisions_stable(&initial_pull_request, &confirmed_pull_request)?;
@@ -1542,22 +1647,16 @@ async fn github_review_file_parts(
     file_path: &str,
     file_page_hint: Option<u32>,
 ) -> Result<(ReviewPlatformPullRequest, Vec<ReviewPlatformFile>), ReviewPlatformError> {
-    let client = http_client()?;
     let base = format!(
         "{}/repos/{}/{}/pulls/{}",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
     );
     let initial_detail =
-        send_bounded_json(github_request(client.clone(), &base, ctx.token.as_deref())).await?;
-    let token = ctx.token.clone();
+        github_api_get_json(ctx, &base, &[], MAX_REVIEW_TARGET_RESPONSE_BYTES).await?;
     let files_url = format!("{}/files", base);
-    let file = fetch_bounded_paginated_file(
-        |page| {
-            let page = page.to_string();
-            github_request(client.clone(), &files_url, token.as_deref())
-                .query(&[("per_page", "100"), ("page", &page)])
-        },
-        github_next_page,
+    let file = fetch_bounded_github_file(
+        ctx,
+        &files_url,
         file_page_hint.unwrap_or(1),
         if file_page_hint.is_some() {
             100
@@ -1565,11 +1664,10 @@ async fn github_review_file_parts(
             MAX_REVIEW_TARGET_LIST_ITEMS
         },
         file_path,
-        github_file_from_value,
     )
     .await?;
     let confirmed_detail =
-        send_bounded_json(github_request(client, &base, ctx.token.as_deref())).await?;
+        github_api_get_json(ctx, &base, &[], MAX_REVIEW_TARGET_RESPONSE_BYTES).await?;
     let initial_pull_request = github_pull_request_from_value(&initial_detail);
     let confirmed_pull_request = github_pull_request_from_value(&confirmed_detail);
     ensure_pull_request_revisions_stable(&initial_pull_request, &confirmed_pull_request)?;
@@ -1734,41 +1832,7 @@ impl ReviewProvider for GithubProvider {
         ctx: &ProviderContext,
         pagination: PullRequestPagination,
     ) -> Result<ReviewPlatformPullRequestPage, ReviewPlatformError> {
-        let url = format!(
-            "{}/repos/{}/{}/pulls",
-            ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name
-        );
-        let per_page = pagination.per_page.to_string();
-        let page = pagination.page.to_string();
-        let response = send_json_response(
-            github_request(http_client()?, &url, ctx.token.as_deref()).query(&[
-                ("state", "all"),
-                ("per_page", &per_page),
-                ("page", &page),
-            ]),
-        )
-        .await?;
-        let items = response.value.as_array().ok_or_else(|| {
-            ReviewPlatformError::Parse("GitHub pull response was not an array".to_string())
-        })?;
-        let total = pagination_total_from_links(&response.headers, pagination, items.len());
-        let has_next = link_header_has_rel(&response.headers, "next");
-
-        let pull_requests = items
-            .iter()
-            .map(github_pull_request_from_value)
-            .collect::<Vec<_>>();
-        let pull_requests = enrich_github_pull_request_counts(ctx, pull_requests).await;
-
-        Ok(ReviewPlatformPullRequestPage {
-            items: pull_requests,
-            pagination: ReviewPlatformPagination {
-                page: pagination.page,
-                per_page: pagination.per_page,
-                total,
-                has_next,
-            },
-        })
+        github_current_user_open_pull_requests(ctx, pagination).await
     }
 
     async fn pull_request_detail(
@@ -1780,70 +1844,24 @@ impl ReviewProvider for GithubProvider {
             "{}/repos/{}/{}/pulls/{}",
             ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
         );
-        let client = http_client()?;
-        let detail = send_json(github_request(client.clone(), &base, ctx.token.as_deref())).await?;
-        let token = ctx.token.clone();
+        let detail = github_api_get_json(ctx, &base, &[], DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
         let files_url = format!("{}/files", base);
-        let files = fetch_paginated_array(
-            |page| {
-                let page = page.to_string();
-                github_request(client.clone(), &files_url, token.as_deref())
-                    .query(&[("per_page", "100"), ("page", &page)])
-            },
-            github_next_page,
-        )
-        .await?;
-        let token = ctx.token.clone();
+        let files = fetch_github_paginated_array(ctx, &files_url).await?;
         let commits_url = format!("{}/commits", base);
-        let commits = fetch_paginated_array(
-            |page| {
-                let page = page.to_string();
-                github_request(client.clone(), &commits_url, token.as_deref())
-                    .query(&[("per_page", "100"), ("page", &page)])
-            },
-            github_next_page,
-        )
-        .await?;
-        let token = ctx.token.clone();
+        let commits = fetch_github_paginated_array(ctx, &commits_url).await?;
         let reviews_url = format!("{}/reviews", base);
-        let reviews = fetch_paginated_array(
-            |page| {
-                let page = page.to_string();
-                github_request(client.clone(), &reviews_url, token.as_deref())
-                    .query(&[("per_page", "100"), ("page", &page)])
-            },
-            github_next_page,
-        )
-        .await?;
-        let token = ctx.token.clone();
+        let reviews = fetch_github_paginated_array(ctx, &reviews_url).await?;
         let review_comments_url = format!("{}/comments", base);
-        let review_comments = fetch_paginated_array(
-            |page| {
-                let page = page.to_string();
-                github_request(client.clone(), &review_comments_url, token.as_deref())
-                    .query(&[("per_page", "100"), ("page", &page)])
-            },
-            github_next_page,
-        )
-        .await?;
-        let token = ctx.token.clone();
+        let review_comments = fetch_github_paginated_array(ctx, &review_comments_url).await?;
         let issue_comments_url = format!(
             "{}/repos/{}/{}/issues/{}/comments",
             ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
         );
-        let issue_comments = fetch_paginated_array(
-            |page| {
-                let page = page.to_string();
-                github_request(client.clone(), &issue_comments_url, token.as_deref())
-                    .query(&[("per_page", "100"), ("page", &page)])
-            },
-            github_next_page,
-        )
-        .await?;
+        let issue_comments = fetch_github_paginated_array(ctx, &issue_comments_url).await?;
 
         let mut pull_request = github_pull_request_from_value(&detail);
         pull_request.review_decision = github_review_decision(&reviews);
-        let (checks, ci) = github_checks_and_ci(ctx, &client, &detail).await;
+        let (checks, ci) = github_checks_and_ci(ctx, &detail).await;
         pull_request.checks = checks;
 
         Ok(ReviewPlatformPullRequestDetail {
@@ -1920,12 +1938,11 @@ impl ReviewProvider for GithubProvider {
             });
         }
 
-        let client = http_client()?;
         let base = format!(
             "{}/repos/{}/{}/pulls/{}",
             ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
         );
-        let detail = send_json(github_request(client.clone(), &base, ctx.token.as_deref())).await?;
+        let detail = github_api_get_json(ctx, &base, &[], DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
         let sha = nested_string(&detail, &["head", "sha"]);
         if sha.trim().is_empty() {
             return Ok(ReviewPlatformCiLog {
@@ -1937,7 +1954,7 @@ impl ReviewProvider for GithubProvider {
         }
 
         let check_run_id = ci_item_id.strip_prefix("check-run-").unwrap_or(ci_item_id);
-        github_actions_log_for_check_run_item(ctx, &client, check_run_id, ci_item_name, &sha).await
+        github_actions_log_for_check_run_item(ctx, check_run_id, ci_item_name, &sha).await
     }
 
     async fn create_pull_request(
@@ -1945,7 +1962,6 @@ impl ReviewProvider for GithubProvider {
         ctx: &ProviderContext,
         request: &ReviewPlatformCreatePullRequestRequest,
     ) -> Result<ReviewPlatformActionResult, ReviewPlatformError> {
-        let token = require_write_token(ctx, "Creating a pull request")?;
         let url = format!(
             "{}/repos/{}/{}/pulls",
             ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name
@@ -1957,9 +1973,7 @@ impl ReviewProvider for GithubProvider {
             "body": request.body.clone().unwrap_or_default(),
             "draft": request.draft.unwrap_or(false),
         });
-        let value =
-            send_json(github_post_request(http_client()?, &url, Some(token)).json(&payload))
-                .await?;
+        let value = github_api_post_json(ctx, &url, &payload).await?;
         let pull_request = github_pull_request_from_value(&value);
         let web_url = Some(pull_request.web_url.clone());
         Ok(ReviewPlatformActionResult {
@@ -1976,7 +1990,6 @@ impl ReviewProvider for GithubProvider {
         ctx: &ProviderContext,
         request: &ReviewPlatformReplyToThreadRequest,
     ) -> Result<ReviewPlatformActionResult, ReviewPlatformError> {
-        let token = require_write_token(ctx, "Replying to a pull request thread")?;
         let comment_id = parse_provider_comment_id(&request.thread_id).ok_or_else(|| {
             ReviewPlatformError::Api(
                 "GitHub replies require a review comment thread id such as comment-123".to_string(),
@@ -1990,11 +2003,7 @@ impl ReviewProvider for GithubProvider {
             request.pull_request_id,
             comment_id
         );
-        let value = send_json(
-            github_post_request(http_client()?, &url, Some(token))
-                .json(&json!({ "body": request.body })),
-        )
-        .await?;
+        let value = github_api_post_json(ctx, &url, &json!({ "body": request.body })).await?;
         let thread = github_thread_from_review_comment(&value);
         Ok(ReviewPlatformActionResult {
             success: true,
@@ -2056,16 +2065,17 @@ async fn github_submit_review(
     event: &str,
     body: &str,
 ) -> Result<ReviewPlatformActionResult, ReviewPlatformError> {
-    let token = require_write_token(ctx, "Submitting a pull request review")?;
     let url = format!(
         "{}/repos/{}/{}/pulls/{}/reviews",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
     );
-    let value = send_json(
-        github_post_request(http_client()?, &url, Some(token)).json(&json!({
+    let value = github_api_post_json(
+        ctx,
+        &url,
+        &json!({
             "body": body,
             "event": event,
-        })),
+        }),
     )
     .await?;
     Ok(ReviewPlatformActionResult {
@@ -2086,14 +2096,13 @@ async fn github_pull_request_detail_page(
     section: ReviewPlatformDetailSection,
     pagination: PullRequestPagination,
 ) -> Result<ReviewPlatformPullRequestDetailPage, ReviewPlatformError> {
-    let client = http_client()?;
     let base = format!(
         "{}/repos/{}/{}/pulls/{}",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
     );
-    let detail = send_json(github_request(client.clone(), &base, ctx.token.as_deref())).await?;
+    let detail = github_api_get_json(ctx, &base, &[], DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
     let mut pull_request = github_pull_request_from_value(&detail);
-    let (checks, ci_all) = github_checks_and_ci(ctx, &client, &detail).await;
+    let (checks, ci_all) = github_checks_and_ci(ctx, &detail).await;
     pull_request.checks = checks;
 
     let mut files = Vec::new();
@@ -2109,82 +2118,45 @@ async fn github_pull_request_detail_page(
             ci = slice_page(ci_all, pagination);
         }
         ReviewPlatformDetailSection::Files => {
-            let response = fetch_array_page(
-                github_request(
-                    client.clone(),
-                    &format!("{}/files", base),
-                    ctx.token.as_deref(),
-                ),
-                pagination,
-            )
-            .await?;
-            section_pagination = pagination_from_response(&response, pagination);
-            files = array_items(&response.value)
+            let (response, page_info) =
+                github_api_array_page(ctx, &format!("{}/files", base), pagination, &[]).await?;
+            section_pagination = page_info;
+            files = array_items(&response)
                 .iter()
                 .map(github_file_from_value)
                 .collect();
         }
         ReviewPlatformDetailSection::Commits => {
-            let response = fetch_array_page(
-                github_request(
-                    client.clone(),
-                    &format!("{}/commits", base),
-                    ctx.token.as_deref(),
-                ),
-                pagination,
-            )
-            .await?;
-            section_pagination = pagination_from_response(&response, pagination);
-            commits = array_items(&response.value)
+            let (response, page_info) =
+                github_api_array_page(ctx, &format!("{}/commits", base), pagination, &[]).await?;
+            section_pagination = page_info;
+            commits = array_items(&response)
                 .iter()
                 .map(github_commit_from_value)
                 .collect();
         }
         ReviewPlatformDetailSection::Reviews => {
             let reviews_url = format!("{}/reviews", base);
-            let reviews = fetch_array_page(
-                github_request(client.clone(), &reviews_url, ctx.token.as_deref()),
-                pagination,
-            )
-            .await?;
-            let review_comments = fetch_array_page(
-                github_request(
-                    client.clone(),
-                    &format!("{}/comments", base),
-                    ctx.token.as_deref(),
+            let (reviews, reviews_page) =
+                github_api_array_page(ctx, &reviews_url, pagination, &[]).await?;
+            let (review_comments, review_comments_page) =
+                github_api_array_page(ctx, &format!("{}/comments", base), pagination, &[]).await?;
+            let (issue_comments, issue_comments_page) = github_api_array_page(
+                ctx,
+                &format!(
+                    "{}/repos/{}/{}/issues/{}/comments",
+                    ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request_id
                 ),
                 pagination,
+                &[],
             )
             .await?;
-            let issue_comments = fetch_array_page(
-                github_request(
-                    client.clone(),
-                    &format!(
-                        "{}/repos/{}/{}/issues/{}/comments",
-                        ctx.api_base_url,
-                        ctx.remote.owner,
-                        ctx.remote.repository_name,
-                        pull_request_id
-                    ),
-                    ctx.token.as_deref(),
-                ),
-                pagination,
-            )
-            .await?;
-            pull_request.review_decision = github_review_decision(&reviews.value);
+            pull_request.review_decision = github_review_decision(&reviews);
             section_pagination = combine_page_pagination(
                 pagination,
-                &[
-                    pagination_from_response(&reviews, pagination),
-                    pagination_from_response(&review_comments, pagination),
-                    pagination_from_response(&issue_comments, pagination),
-                ],
+                &[reviews_page, review_comments_page, issue_comments_page],
             );
-            threads = github_threads(
-                &reviews.value,
-                &review_comments.value,
-                &issue_comments.value,
-            );
+            threads = github_threads(&reviews, &review_comments, &issue_comments);
         }
     }
 
@@ -3198,10 +3170,6 @@ async fn send_bounded_json_response(
         .map_err(review_http_error)
 }
 
-async fn send_text(request: ReviewHttpRequest) -> Result<ReviewTextResponse, ReviewPlatformError> {
-    send_review_text(request).await.map_err(review_http_error)
-}
-
 async fn send_bounded_text(
     request: ReviewHttpRequest,
     max_bytes: usize,
@@ -3424,37 +3392,6 @@ fn query_param_u32(url: &str, name: &str) -> Option<u32> {
     None
 }
 
-async fn enrich_github_pull_request_counts(
-    ctx: &ProviderContext,
-    pull_requests: Vec<ReviewPlatformPullRequest>,
-) -> Vec<ReviewPlatformPullRequest> {
-    let Ok(client) = http_client() else {
-        return pull_requests;
-    };
-    let futures = pull_requests.into_iter().map(|mut pull_request| {
-        let client = client.clone();
-        let url = format!(
-            "{}/repos/{}/{}/pulls/{}",
-            ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, pull_request.id
-        );
-        let token = ctx.token.clone();
-        async move {
-            if let Ok(value) = send_json(github_request(client, &url, token.as_deref())).await {
-                pull_request.additions = value_i64(&value, "additions") as i32;
-                pull_request.deletions = value_i64(&value, "deletions") as i32;
-                pull_request.changed_files = value_i64(&value, "changed_files") as i32;
-                pull_request.comments =
-                    (value_i64(&value, "comments") + value_i64(&value, "review_comments")) as i32;
-            }
-            pull_request
-        }
-    });
-    stream::iter(futures)
-        .buffered(PROVIDER_ENRICH_CONCURRENCY)
-        .collect()
-        .await
-}
-
 async fn enrich_gitlab_pull_request_counts(
     ctx: &ProviderContext,
     pull_requests: Vec<ReviewPlatformPullRequest>,
@@ -3513,34 +3450,6 @@ async fn enrich_gitcode_pull_request_counts(
         .buffered(PROVIDER_ENRICH_CONCURRENCY)
         .collect()
         .await
-}
-
-fn github_request(client: ReviewHttpClient, url: &str, token: Option<&str>) -> ReviewHttpRequest {
-    let mut request = client
-        .get(url)
-        .header(USER_AGENT_HEADER, USER_AGENT_VALUE)
-        .header(ACCEPT_HEADER, "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28");
-    if let Some(token) = token {
-        request = request.header(AUTHORIZATION_HEADER, format!("Bearer {}", token));
-    }
-    request
-}
-
-fn github_post_request(
-    client: ReviewHttpClient,
-    url: &str,
-    token: Option<&str>,
-) -> ReviewHttpRequest {
-    let mut request = client
-        .post(url)
-        .header(USER_AGENT_HEADER, USER_AGENT_VALUE)
-        .header(ACCEPT_HEADER, "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28");
-    if let Some(token) = token {
-        request = request.header(AUTHORIZATION_HEADER, format!("Bearer {}", token));
-    }
-    request
 }
 
 fn gitlab_request(client: ReviewHttpClient, url: &str, token: Option<&str>) -> ReviewHttpRequest {
@@ -3744,12 +3653,18 @@ fn provider_context_for_identity_with_trust(
 ) -> Result<ProviderContext, ReviewPlatformError> {
     let host = normalize_provider_host(host)?;
     let project_path = normalize_project_path(platform, project_path)?;
-    let stored_token = auth_tokens.get(platform, &host).map(str::to_string);
+    let stored_token = (platform != ReviewPlatformKind::Github)
+        .then(|| auth_tokens.get(platform, &host).map(str::to_string))
+        .flatten();
     let public_anonymous_host = matches!(
         (platform, host.as_str()),
         (ReviewPlatformKind::Github, "github.com") | (ReviewPlatformKind::Gitlab, "gitlab.com")
     );
-    if !public_anonymous_host && stored_token.is_none() && !trusted_remote {
+    if platform != ReviewPlatformKind::Github
+        && !public_anonymous_host
+        && stored_token.is_none()
+        && !trusted_remote
+    {
         return Err(ReviewPlatformError::Api(format!(
             "A stored {} token is required for non-public provider host {}",
             platform_label(platform),
@@ -3761,14 +3676,16 @@ fn provider_context_for_identity_with_trust(
             .then(|| env_token_for_platform(platform))
             .flatten()
     });
-    let auth_source = if stored_token.is_some() {
+    let auth_source = if platform == ReviewPlatformKind::Github {
+        ReviewAuthSource::GhCli
+    } else if stored_token.is_some() {
         ReviewAuthSource::Stored
     } else if token.is_some() {
         ReviewAuthSource::Env
     } else {
         ReviewAuthSource::None
     };
-    let auth_state = if token.is_some() {
+    let auth_state = if platform == ReviewPlatformKind::Github || token.is_some() {
         ReviewAuthState::Connected
     } else {
         ReviewAuthState::NotRequired
@@ -3891,29 +3808,61 @@ async fn acquire_issue_evidence(
     pagination: IssuePagination,
 ) -> Result<ReviewPlatformIssueEvidence, ReviewPlatformError> {
     let plan = issue_request_plan(context, identity, pagination)?;
-    let client = http_client()?;
     let page = plan.pagination.page.to_string();
     let per_page = plan.pagination.per_page.to_string();
     match identity.platform {
         ReviewPlatformKind::Github => {
-            let issue = send_review_json_response_bounded(
-                github_request(client.clone(), &plan.issue_url, context.token.as_deref()),
-                MAX_ISSUE_RESPONSE_BYTES,
-            )
-            .await
-            .map_err(|error| review_evidence_http_error(error, "issue_response"))?
-            .value;
+            let issue =
+                github_api_get_json(context, &plan.issue_url, &[], MAX_ISSUE_RESPONSE_BYTES)
+                    .await
+                    .map_err(|error| review_evidence_error(error, "issue_response"))?;
             reject_pull_request_issue_target(identity, &issue)?;
-            let comments = send_review_json_response_bounded(
-                github_request(client, &plan.comments_url, context.token.as_deref())
-                    .query(&[("page", &page), ("per_page", &per_page)]),
+            let comments = github_api_get_json(
+                context,
+                &plan.comments_url,
+                &[
+                    ("page".to_string(), page),
+                    ("per_page".to_string(), per_page),
+                ],
                 MAX_ISSUE_COMMENTS_RESPONSE_BYTES,
             )
             .await
-            .map_err(|error| review_evidence_http_error(error, "issue_comments_response"));
-            map_issue_comments_response(identity, &issue, plan.pagination, comments)
+            .map_err(|error| review_evidence_error(error, "issue_comments_response"));
+            match comments {
+                Ok(comments) => {
+                    let has_next = comments
+                        .as_array()
+                        .is_some_and(|items| items.len() == plan.pagination.per_page as usize);
+                    map_github_issue(
+                        identity,
+                        &issue,
+                        &comments,
+                        plan.pagination,
+                        has_next,
+                        has_next.then(|| plan.pagination.page.saturating_add(1).to_string()),
+                    )
+                }
+                Err(ReviewPlatformError::EvidenceTooLarge { .. }) => {
+                    let mut evidence = map_github_issue(
+                        identity,
+                        &issue,
+                        &Value::Array(Vec::new()),
+                        plan.pagination,
+                        false,
+                        None,
+                    )?;
+                    evidence.completeness = ReviewEvidenceCompleteness::Partial;
+                    evidence
+                        .limitations
+                        .push("issue_comments_response_too_large".to_string());
+                    evidence.fingerprint = issue_fingerprint(&evidence, plan.pagination);
+                    Ok(evidence)
+                }
+                Err(error) => Err(error),
+            }
         }
         ReviewPlatformKind::Gitlab => {
+            let client = http_client()?;
             let issue = send_review_json_response_bounded(
                 gitlab_request(client.clone(), &plan.issue_url, context.token.as_deref()),
                 MAX_ISSUE_RESPONSE_BYTES,
@@ -4045,6 +3994,9 @@ fn token_for_remote(
     remote: &ReviewPlatformRemote,
     auth_tokens: &ReviewPlatformAuthTokens,
 ) -> Option<String> {
+    if remote.platform == ReviewPlatformKind::Github {
+        return None;
+    }
     auth_tokens
         .get(remote.platform, &remote.host)
         .map(str::to_string)
@@ -4053,7 +4005,7 @@ fn token_for_remote(
 
 fn env_token_for_platform(platform: ReviewPlatformKind) -> Option<String> {
     let names: &[&str] = match platform {
-        ReviewPlatformKind::Github => &["GITHUB_TOKEN", "GH_TOKEN"],
+        ReviewPlatformKind::Github => &[],
         ReviewPlatformKind::Gitlab => &["GITLAB_TOKEN", "GITLAB_PRIVATE_TOKEN"],
         ReviewPlatformKind::Gitcode => &["GITCODE_TOKEN"],
         ReviewPlatformKind::Unknown => &[],
@@ -4073,6 +4025,9 @@ fn auth_for_platform_host(
 ) -> (ReviewAuthState, ReviewAuthSource) {
     if platform == ReviewPlatformKind::Unknown {
         return (ReviewAuthState::Unsupported, ReviewAuthSource::Unsupported);
+    }
+    if platform == ReviewPlatformKind::Github {
+        return (ReviewAuthState::NotConnected, ReviewAuthSource::None);
     }
     if auth_tokens.get(platform, host).is_some() {
         return (ReviewAuthState::Connected, ReviewAuthSource::Stored);
@@ -4175,6 +4130,9 @@ fn canonicalize_stored_tokens(
             passthrough.insert(raw_key, entry);
             continue;
         };
+        if canonical_key.starts_with("github:") {
+            continue;
+        }
         entry.token = entry.token.trim().to_string();
         if entry.token.is_empty() {
             continue;
@@ -4249,6 +4207,629 @@ async fn execute_git_command(
         String::from_utf8_lossy(&output.stderr).to_string()
     };
     Err(ReviewPlatformError::InvalidRepository(message))
+}
+
+fn review_evidence_error(error: ReviewPlatformError, resource: &str) -> ReviewPlatformError {
+    match error {
+        ReviewPlatformError::EvidenceTooLarge { limit, .. } => {
+            ReviewPlatformError::EvidenceTooLarge {
+                resource: resource.to_string(),
+                limit,
+            }
+        }
+        error => error,
+    }
+}
+
+fn github_api_endpoint(ctx: &ProviderContext, url: &str) -> Result<String, ReviewPlatformError> {
+    url.strip_prefix(&ctx.api_base_url)
+        .map(|endpoint| endpoint.trim_start_matches('/').to_string())
+        .filter(|endpoint| !endpoint.is_empty())
+        .ok_or_else(|| {
+            ReviewPlatformError::Api(
+                "GitHub API endpoint does not match the selected GitHub host".to_string(),
+            )
+        })
+}
+
+async fn github_api_get_json(
+    ctx: &ProviderContext,
+    url: &str,
+    query: &[(String, String)],
+    max_output_bytes: usize,
+) -> Result<Value, ReviewPlatformError> {
+    let endpoint = github_api_endpoint(ctx, url)?;
+    let mut args = vec![
+        "api".to_string(),
+        "--hostname".to_string(),
+        ctx.remote.host.clone(),
+        "--method".to_string(),
+        "GET".to_string(),
+        "--header".to_string(),
+        "Accept: application/vnd.github+json".to_string(),
+        endpoint,
+    ];
+    for (key, value) in query {
+        args.push("--raw-field".to_string());
+        args.push(format!("{key}={value}"));
+    }
+    let output = execute_gh(&args, None, max_output_bytes).await?;
+    serde_json::from_slice(&output)
+        .map_err(|error| ReviewPlatformError::Parse(format!("Invalid GitHub CLI JSON: {error}")))
+}
+
+async fn github_api_post_json(
+    ctx: &ProviderContext,
+    url: &str,
+    body: &Value,
+) -> Result<Value, ReviewPlatformError> {
+    let endpoint = github_api_endpoint(ctx, url)?;
+    let args = vec![
+        "api".to_string(),
+        "--hostname".to_string(),
+        ctx.remote.host.clone(),
+        "--method".to_string(),
+        "POST".to_string(),
+        "--header".to_string(),
+        "Accept: application/vnd.github+json".to_string(),
+        "--input".to_string(),
+        "-".to_string(),
+        endpoint,
+    ];
+    let input =
+        serde_json::to_vec(body).map_err(|error| ReviewPlatformError::Parse(error.to_string()))?;
+    let output = execute_gh(&args, Some(&input), DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
+    serde_json::from_slice(&output)
+        .map_err(|error| ReviewPlatformError::Parse(format!("Invalid GitHub CLI JSON: {error}")))
+}
+
+async fn github_api_get_text(
+    ctx: &ProviderContext,
+    url: &str,
+    max_output_bytes: usize,
+) -> Result<ReviewTextResponse, ReviewPlatformError> {
+    let endpoint = github_api_endpoint(ctx, url)?;
+    let args = vec![
+        "api".to_string(),
+        "--hostname".to_string(),
+        ctx.remote.host.clone(),
+        "--method".to_string(),
+        "GET".to_string(),
+        endpoint,
+    ];
+    let output = execute_gh(&args, None, max_output_bytes).await?;
+    Ok(ReviewTextResponse {
+        text: String::from_utf8_lossy(&output).to_string(),
+        truncated: false,
+    })
+}
+
+async fn github_current_user_open_pull_requests(
+    ctx: &ProviderContext,
+    pagination: PullRequestPagination,
+) -> Result<ReviewPlatformPullRequestPage, ReviewPlatformError> {
+    let limit = github_pull_request_list_limit(pagination);
+    let items = github_current_user_open_pull_request_values(ctx, limit).await?;
+    Ok(paginate_github_pull_requests(items, pagination))
+}
+
+async fn github_current_user_open_pull_requests_for_remotes(
+    remotes: &[ReviewPlatformRemote],
+    auth_tokens: &ReviewPlatformAuthTokens,
+    pagination: PullRequestPagination,
+) -> Result<ReviewPlatformPullRequestPage, ReviewPlatformError> {
+    let mut seen_repositories = HashSet::new();
+    let contexts = remotes
+        .iter()
+        .filter(|remote| {
+            remote.platform == ReviewPlatformKind::Github
+                && remote.supported
+                && remote.auth_state == ReviewAuthState::Connected
+        })
+        .filter(|remote| {
+            seen_repositories.insert(format!("{}:{}", remote.host, remote.project_path))
+        })
+        .filter_map(|remote| provider_context(remote.clone(), auth_tokens).ok())
+        .collect::<Vec<_>>();
+    let limit = github_pull_request_list_limit(pagination);
+    let results =
+        stream::iter(contexts.into_iter().map(|ctx| async move {
+            github_current_user_open_pull_request_values(&ctx, limit).await
+        }))
+        .buffered(PROVIDER_ENRICH_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut pull_requests = Vec::new();
+    let mut first_error = None;
+    let mut successful_repositories = 0usize;
+    for result in results {
+        match result {
+            Ok(items) => {
+                successful_repositories += 1;
+                pull_requests.extend(items);
+            }
+            Err(error) => {
+                first_error.get_or_insert(error);
+            }
+        }
+    }
+    if successful_repositories == 0 {
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+    }
+
+    Ok(aggregate_github_pull_requests(pull_requests, pagination))
+}
+
+fn aggregate_github_pull_requests(
+    mut pull_requests: Vec<ReviewPlatformPullRequest>,
+    pagination: PullRequestPagination,
+) -> ReviewPlatformPullRequestPage {
+    pull_requests.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    let mut seen_pull_requests = HashSet::new();
+    pull_requests.retain(|pull_request| seen_pull_requests.insert(pull_request.web_url.clone()));
+    paginate_github_pull_requests(pull_requests, pagination)
+}
+
+fn github_pull_request_list_limit(pagination: PullRequestPagination) -> u32 {
+    pagination
+        .page
+        .saturating_mul(pagination.per_page)
+        .saturating_add(1)
+        .min(1_000)
+}
+
+async fn github_current_user_open_pull_request_values(
+    ctx: &ProviderContext,
+    limit: u32,
+) -> Result<Vec<ReviewPlatformPullRequest>, ReviewPlatformError> {
+    let repository = format!(
+        "{}/{}/{}",
+        ctx.remote.host, ctx.remote.owner, ctx.remote.repository_name
+    );
+    let args = vec![
+        "pr".to_string(),
+        "list".to_string(),
+        "--repo".to_string(),
+        repository,
+        "--author".to_string(),
+        "@me".to_string(),
+        "--state".to_string(),
+        "open".to_string(),
+        "--limit".to_string(),
+        limit.to_string(),
+        "--json".to_string(),
+        [
+            "number",
+            "title",
+            "state",
+            "isDraft",
+            "author",
+            "headRefName",
+            "headRefOid",
+            "baseRefName",
+            "baseRefOid",
+            "updatedAt",
+            "url",
+            "additions",
+            "deletions",
+            "changedFiles",
+            "comments",
+            "reviewDecision",
+            "statusCheckRollup",
+        ]
+        .join(","),
+    ];
+    let output = execute_gh(&args, None, DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
+    let value: Value = serde_json::from_slice(&output)
+        .map_err(|error| ReviewPlatformError::Parse(format!("Invalid GitHub CLI JSON: {error}")))?;
+    let items = value.as_array().ok_or_else(|| {
+        ReviewPlatformError::Parse("GitHub CLI pull response was not an array".to_string())
+    })?;
+    Ok(items
+        .iter()
+        .map(|value| github_pull_request_from_gh_cli_value(value, Some(&ctx.remote.id)))
+        .collect())
+}
+
+fn paginate_github_pull_requests(
+    items: Vec<ReviewPlatformPullRequest>,
+    pagination: PullRequestPagination,
+) -> ReviewPlatformPullRequestPage {
+    let start = pagination
+        .page
+        .saturating_sub(1)
+        .saturating_mul(pagination.per_page) as usize;
+    let end = start.saturating_add(pagination.per_page as usize);
+    let has_next = items.len() > end;
+    let total = (!has_next).then_some(items.len() as u64);
+    let pull_requests = items
+        .into_iter()
+        .skip(start)
+        .take(pagination.per_page as usize)
+        .collect();
+
+    ReviewPlatformPullRequestPage {
+        items: pull_requests,
+        pagination: ReviewPlatformPagination {
+            page: pagination.page,
+            per_page: pagination.per_page,
+            total,
+            has_next,
+        },
+    }
+}
+
+fn github_pull_request_from_gh_cli_value(
+    value: &Value,
+    provider_id: Option<&str>,
+) -> ReviewPlatformPullRequest {
+    let number = value_i64(value, "number");
+    let state = if value_bool(value, "isDraft") {
+        ReviewItemState::Draft
+    } else {
+        match value_string(value, "state").to_ascii_uppercase().as_str() {
+            "MERGED" => ReviewItemState::Merged,
+            "CLOSED" => ReviewItemState::Closed,
+            _ => ReviewItemState::Open,
+        }
+    };
+    let review_decision = match value_string(value, "reviewDecision").as_str() {
+        "APPROVED" => ReviewDecision::Approved,
+        "CHANGES_REQUESTED" => ReviewDecision::ChangesRequested,
+        "COMMENTED" => ReviewDecision::Commented,
+        _ => ReviewDecision::Pending,
+    };
+
+    ReviewPlatformPullRequest {
+        id: number.to_string(),
+        provider_id: provider_id.map(str::to_string),
+        number,
+        title: value_string(value, "title"),
+        state,
+        author: nested_string(value, &["author", "login"]),
+        source_branch: value_string(value, "headRefName"),
+        target_branch: value_string(value, "baseRefName"),
+        base_revision: non_empty_option(value_string(value, "baseRefOid")),
+        head_revision: non_empty_option(value_string(value, "headRefOid")),
+        updated_at: value_string(value, "updatedAt"),
+        web_url: value_string(value, "url"),
+        additions: value_i64(value, "additions") as i32,
+        deletions: value_i64(value, "deletions") as i32,
+        changed_files: value_i64(value, "changedFiles") as i32,
+        comments: value
+            .get("comments")
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or_default() as i32,
+        review_decision,
+        checks: github_checks_from_gh_cli_value(value),
+    }
+}
+
+fn github_checks_from_gh_cli_value(value: &Value) -> ReviewChecks {
+    let mut checks = empty_checks();
+    for item in value
+        .get("statusCheckRollup")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+    {
+        let outcome = first_non_empty(&[
+            value_string(item, "conclusion"),
+            value_string(item, "state"),
+            value_string(item, "status"),
+        ])
+        .to_ascii_lowercase();
+        if matches!(outcome.as_str(), "success" | "neutral" | "skipped") {
+            checks.passed += 1;
+        } else if matches!(
+            outcome.as_str(),
+            "failure" | "failed" | "error" | "cancelled" | "timed_out" | "action_required"
+        ) {
+            checks.failed += 1;
+        } else {
+            checks.pending += 1;
+        }
+    }
+    checks.total = checks.passed + checks.failed + checks.pending;
+    checks
+}
+
+async fn github_api_array_page(
+    ctx: &ProviderContext,
+    url: &str,
+    pagination: PullRequestPagination,
+    extra_query: &[(String, String)],
+) -> Result<(Value, ReviewPlatformPagination), ReviewPlatformError> {
+    let mut query = extra_query.to_vec();
+    query.push(("per_page".to_string(), pagination.per_page.to_string()));
+    query.push(("page".to_string(), pagination.page.to_string()));
+    let value = github_api_get_json(ctx, url, &query, DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
+    let item_count = value
+        .as_array()
+        .ok_or_else(|| {
+            ReviewPlatformError::Parse("GitHub paginated response was not an array".to_string())
+        })?
+        .len();
+    Ok((
+        value,
+        ReviewPlatformPagination {
+            page: pagination.page,
+            per_page: pagination.per_page,
+            total: None,
+            has_next: item_count == pagination.per_page as usize,
+        },
+    ))
+}
+
+async fn fetch_github_paginated_array(
+    ctx: &ProviderContext,
+    url: &str,
+) -> Result<Value, ReviewPlatformError> {
+    let mut page = 1u32;
+    let mut values = Vec::new();
+    loop {
+        let query = vec![
+            ("per_page".to_string(), "100".to_string()),
+            ("page".to_string(), page.to_string()),
+        ];
+        let value = github_api_get_json(ctx, url, &query, DEFAULT_GH_OUTPUT_MAX_BYTES).await?;
+        let items = value.as_array().ok_or_else(|| {
+            ReviewPlatformError::Parse("GitHub paginated response was not an array".to_string())
+        })?;
+        let item_count = items.len();
+        values.extend(items.iter().cloned());
+        if item_count < 100 {
+            break;
+        }
+        page = page.saturating_add(1);
+    }
+    Ok(Value::Array(values))
+}
+
+async fn fetch_bounded_github_paginated_array(
+    ctx: &ProviderContext,
+    url: &str,
+    max_items: usize,
+) -> Result<Value, ReviewPlatformError> {
+    let mut page = 1u32;
+    let mut values = Vec::new();
+    while values.len() < max_items {
+        let query = vec![
+            ("per_page".to_string(), "100".to_string()),
+            ("page".to_string(), page.to_string()),
+        ];
+        let value = github_api_get_json(ctx, url, &query, MAX_REVIEW_TARGET_RESPONSE_BYTES).await?;
+        let items = value.as_array().ok_or_else(|| {
+            ReviewPlatformError::Parse("GitHub paginated response was not an array".to_string())
+        })?;
+        let item_count = items.len();
+        values.extend(items.iter().take(max_items - values.len()).cloned());
+        if item_count < 100 || values.len() >= max_items {
+            break;
+        }
+        if page as usize >= MAX_REVIEW_TARGET_PAGES {
+            return Err(ReviewPlatformError::EvidenceTooLarge {
+                resource: "GitHub pagination pages".to_string(),
+                limit: MAX_REVIEW_TARGET_PAGES,
+            });
+        }
+        page = page.saturating_add(1);
+    }
+    Ok(Value::Array(values))
+}
+
+async fn fetch_bounded_github_file(
+    ctx: &ProviderContext,
+    url: &str,
+    start_page: u32,
+    max_items: usize,
+    file_path: &str,
+) -> Result<Option<ReviewPlatformFile>, ReviewPlatformError> {
+    let mut page = start_page.max(1);
+    let mut visited = 0usize;
+    let mut request_count = 0usize;
+    while visited < max_items {
+        let query = vec![
+            ("per_page".to_string(), "100".to_string()),
+            ("page".to_string(), page.to_string()),
+        ];
+        let value = github_api_get_json(ctx, url, &query, MAX_REVIEW_TARGET_RESPONSE_BYTES).await?;
+        request_count += 1;
+        let items = value.as_array().ok_or_else(|| {
+            ReviewPlatformError::Parse("GitHub paginated response was not an array".to_string())
+        })?;
+        for item in items.iter().take(max_items - visited) {
+            let file = github_file_from_value(item);
+            if file.path == file_path || file.old_path.as_deref() == Some(file_path) {
+                return Ok(Some(file));
+            }
+            visited += 1;
+        }
+        if items.len() < 100 || visited >= max_items {
+            break;
+        }
+        if request_count >= MAX_REVIEW_TARGET_PAGES {
+            return Err(ReviewPlatformError::EvidenceTooLarge {
+                resource: "GitHub pagination pages".to_string(),
+                limit: MAX_REVIEW_TARGET_PAGES,
+            });
+        }
+        page = page.saturating_add(1);
+    }
+    Ok(None)
+}
+
+#[derive(Debug, Clone, Default)]
+struct GhAuthStatus {
+    installed: bool,
+    connected: bool,
+    username: Option<String>,
+}
+
+async fn execute_gh(
+    args: &[String],
+    stdin: Option<&[u8]>,
+    max_output_bytes: usize,
+) -> Result<Vec<u8>, ReviewPlatformError> {
+    let mut command = process_manager::create_tokio_command("gh");
+    command
+        .args(args)
+        .env_remove("GH_TOKEN")
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("GH_ENTERPRISE_TOKEN")
+        .env_remove("GITHUB_ENTERPRISE_TOKEN");
+    if stdin.is_some() {
+        command.stdin(std::process::Stdio::piped());
+    }
+    command
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().map_err(|error| {
+        ReviewPlatformError::Api(format!(
+            "GitHub CLI is required but could not be started: {error}. Install `gh` and run `gh auth login`."
+        ))
+    })?;
+    if let Some(input) = stdin {
+        let mut child_stdin = child.stdin.take().ok_or_else(|| {
+            ReviewPlatformError::Api("Failed to open GitHub CLI input".to_string())
+        })?;
+        child_stdin.write_all(input).await.map_err(|error| {
+            ReviewPlatformError::Api(format!("Failed to send a request to GitHub CLI: {error}"))
+        })?;
+    }
+    let output = child.wait_with_output().await.map_err(|error| {
+        ReviewPlatformError::Api(format!("Failed to wait for GitHub CLI: {error}"))
+    })?;
+    if output.stdout.len() > max_output_bytes {
+        return Err(ReviewPlatformError::EvidenceTooLarge {
+            resource: "GitHub CLI response".to_string(),
+            limit: max_output_bytes,
+        });
+    }
+    if output.status.success() {
+        return Ok(output.stdout);
+    }
+
+    let raw_message = if output.stderr.is_empty() {
+        String::from_utf8_lossy(&output.stdout).to_string()
+    } else {
+        String::from_utf8_lossy(&output.stderr).to_string()
+    };
+    let message = sanitize_gh_error(&raw_message);
+    if let Some(status) = gh_http_status(&message) {
+        return Err(ReviewPlatformError::Http {
+            status,
+            message: format!(": {message}"),
+        });
+    }
+    Err(ReviewPlatformError::Api(message))
+}
+
+fn sanitize_gh_error(message: &str) -> String {
+    let message = message.trim();
+    let truncated = message
+        .chars()
+        .take(GH_ERROR_OUTPUT_MAX_CHARS)
+        .collect::<String>();
+    if truncated.is_empty() {
+        "GitHub CLI command failed".to_string()
+    } else {
+        truncated
+    }
+}
+
+fn gh_http_status(message: &str) -> Option<u16> {
+    let marker = "HTTP ";
+    let start = message.find(marker)? + marker.len();
+    message.get(start..start + 3)?.parse().ok()
+}
+
+fn parse_gh_auth_status(host: &str, value: &Value) -> GhAuthStatus {
+    let accounts = value
+        .get("hosts")
+        .and_then(|hosts| hosts.get(host))
+        .and_then(Value::as_array);
+    let active = accounts.and_then(|accounts| {
+        accounts.iter().find(|account| {
+            account.get("active").and_then(Value::as_bool) == Some(true)
+                && account.get("state").and_then(Value::as_str) == Some("success")
+        })
+    });
+    GhAuthStatus {
+        installed: true,
+        connected: active.is_some(),
+        username: active
+            .and_then(|account| account.get("login"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    }
+}
+
+async fn gh_auth_status(host: &str) -> GhAuthStatus {
+    let args = vec![
+        "auth".to_string(),
+        "status".to_string(),
+        "--active".to_string(),
+        "--hostname".to_string(),
+        host.to_string(),
+        "--json".to_string(),
+        "hosts".to_string(),
+    ];
+    match execute_gh(&args, None, 256 * 1024).await {
+        Ok(output) => match serde_json::from_slice::<Value>(&output) {
+            Ok(value) => parse_gh_auth_status(host, &value),
+            Err(_error) => GhAuthStatus {
+                installed: true,
+                ..GhAuthStatus::default()
+            },
+        },
+        Err(error) => GhAuthStatus {
+            installed: !error.to_string().contains("could not be started"),
+            ..GhAuthStatus::default()
+        },
+    }
+}
+
+fn hydrate_github_remote_auth(remote: &mut ReviewPlatformRemote, status: GhAuthStatus) {
+    if remote.platform == ReviewPlatformKind::Unknown && !status.connected {
+        return;
+    }
+    if remote.platform == ReviewPlatformKind::Unknown {
+        remote.platform = ReviewPlatformKind::Github;
+        remote.id = format!(
+            "{}:{}:{}",
+            remote.name,
+            remote.platform.as_str(),
+            remote.project_path.replace('/', "__")
+        );
+        remote.supported = true;
+    }
+    remote.auth_state = if status.connected {
+        ReviewAuthState::Connected
+    } else {
+        ReviewAuthState::NotConnected
+    };
+    remote.auth_source = if status.connected {
+        ReviewAuthSource::GhCli
+    } else {
+        ReviewAuthSource::None
+    };
+    remote.message = if status.connected {
+        status
+            .username
+            .map(|username| format!("Authenticated via GitHub CLI as {username}."))
+    } else if status.installed {
+        Some(format!(
+            "Run `gh auth login --hostname {}` to connect this GitHub host.",
+            remote.host
+        ))
+    } else {
+        Some("Install GitHub CLI, then run `gh auth login` to connect GitHub.".to_string())
+    };
 }
 
 fn normalize_repository_root(root: &str) -> String {
@@ -4422,7 +5003,17 @@ fn select_remote<'a>(
     }
     remotes
         .iter()
-        .find(|remote| remote.supported)
+        .find(|remote| {
+            remote.supported
+                && remote.platform == ReviewPlatformKind::Github
+                && remote.auth_state == ReviewAuthState::Connected
+        })
+        .or_else(|| {
+            remotes
+                .iter()
+                .find(|remote| remote.supported && remote.platform == ReviewPlatformKind::Github)
+        })
+        .or_else(|| remotes.iter().find(|remote| remote.supported))
         .or_else(|| remotes.first())
 }
 
@@ -4553,13 +5144,18 @@ fn account_for_remote(remote: &ReviewPlatformRemote) -> ReviewPlatformAccount {
         id: remote.id.clone(),
         platform: remote.platform,
         label: format!("{} ({})", platform_label(remote.platform), remote.host),
-        username: None,
+        username: remote
+            .message
+            .as_deref()
+            .and_then(|message| message.strip_prefix("Authenticated via GitHub CLI as "))
+            .and_then(|message| message.strip_suffix('.'))
+            .map(str::to_string),
         host: remote.host.clone(),
         auth_state: remote.auth_state,
         auth_source: remote.auth_source,
         scopes: if matches!(
             remote.auth_source,
-            ReviewAuthSource::Env | ReviewAuthSource::Stored
+            ReviewAuthSource::GhCli | ReviewAuthSource::Env | ReviewAuthSource::Stored
         ) {
             vec!["pull_request:read".to_string()]
         } else {
@@ -4607,7 +5203,7 @@ fn platform_label(platform: ReviewPlatformKind) -> &'static str {
 
 fn required_scopes_for_platform(platform: ReviewPlatformKind) -> Vec<String> {
     match platform {
-        ReviewPlatformKind::Github => vec!["repo".to_string(), "pull_requests:read".to_string()],
+        ReviewPlatformKind::Github => vec!["repo".to_string(), "workflow".to_string()],
         ReviewPlatformKind::Gitlab => {
             vec!["read_api".to_string(), "api for write actions".to_string()]
         }
@@ -4639,6 +5235,9 @@ fn auth_challenge_for_remote(
     error: &ReviewPlatformError,
     has_token: bool,
 ) -> ReviewPlatformAuthChallenge {
+    if remote.platform == ReviewPlatformKind::Github {
+        return github_cli_auth_challenge(remote);
+    }
     let status = match error {
         ReviewPlatformError::Http { status, .. } => *status,
         _ => 0,
@@ -4678,6 +5277,21 @@ fn auth_challenge_for_remote(
             reason
         ),
         required_scopes: required_scopes_for_platform(remote.platform),
+    }
+}
+
+fn github_cli_auth_challenge(remote: &ReviewPlatformRemote) -> ReviewPlatformAuthChallenge {
+    ReviewPlatformAuthChallenge {
+        platform: ReviewPlatformKind::Github,
+        host: remote.host.clone(),
+        remote_id: remote.id.clone(),
+        project_path: remote.project_path.clone(),
+        state: ReviewPlatformAuthChallengeState::Missing,
+        message: format!(
+            "Authenticate GitHub with the local CLI, then retry: `gh auth login --hostname {}`.",
+            remote.host
+        ),
+        required_scopes: required_scopes_for_platform(ReviewPlatformKind::Github),
     }
 }
 
@@ -4858,7 +5472,6 @@ fn is_ci_error_line(line: &str) -> bool {
 
 async fn github_checks_and_ci(
     ctx: &ProviderContext,
-    client: &ReviewHttpClient,
     pull_detail: &Value,
 ) -> (ReviewChecks, Vec<ReviewPlatformCiItem>) {
     let sha = nested_string(pull_detail, &["head", "sha"]);
@@ -4871,12 +5484,8 @@ async fn github_checks_and_ci(
         "{}/repos/{}/{}/commits/{}/status",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, sha
     );
-    if let Ok(status) = send_json(github_request(
-        client.clone(),
-        &status_url,
-        ctx.token.as_deref(),
-    ))
-    .await
+    if let Ok(status) =
+        github_api_get_json(ctx, &status_url, &[], DEFAULT_GH_OUTPUT_MAX_BYTES).await
     {
         let statuses = status
             .get("statuses")
@@ -4911,9 +5520,11 @@ async fn github_checks_and_ci(
         "{}/repos/{}/{}/commits/{}/check-runs",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, sha
     );
-    if let Ok(check_runs) = send_json(
-        github_request(client.clone(), &check_runs_url, ctx.token.as_deref())
-            .query(&[("per_page", "100")]),
+    if let Ok(check_runs) = github_api_get_json(
+        ctx,
+        &check_runs_url,
+        &[("per_page".to_string(), "100".to_string())],
+        DEFAULT_GH_OUTPUT_MAX_BYTES,
     )
     .await
     {
@@ -4951,18 +5562,19 @@ async fn github_checks_and_ci(
     (checks, ci_items)
 }
 
-async fn github_actions_jobs_for_head_sha(
-    ctx: &ProviderContext,
-    client: &ReviewHttpClient,
-    sha: &str,
-) -> Vec<Value> {
+async fn github_actions_jobs_for_head_sha(ctx: &ProviderContext, sha: &str) -> Vec<Value> {
     let runs_url = format!(
         "{}/repos/{}/{}/actions/runs",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name
     );
-    let runs = match send_json(
-        github_request(client.clone(), &runs_url, ctx.token.as_deref())
-            .query(&[("head_sha", sha), ("per_page", "100")]),
+    let runs = match github_api_get_json(
+        ctx,
+        &runs_url,
+        &[
+            ("head_sha".to_string(), sha.to_string()),
+            ("per_page".to_string(), "100".to_string()),
+        ],
+        DEFAULT_GH_OUTPUT_MAX_BYTES,
     )
     .await
     {
@@ -4985,9 +5597,11 @@ async fn github_actions_jobs_for_head_sha(
             "{}/repos/{}/{}/actions/runs/{}/jobs",
             ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, run_id
         );
-        if let Ok(value) = send_json(
-            github_request(client.clone(), &jobs_url, ctx.token.as_deref())
-                .query(&[("per_page", "100")]),
+        if let Ok(value) = github_api_get_json(
+            ctx,
+            &jobs_url,
+            &[("per_page".to_string(), "100".to_string())],
+            DEFAULT_GH_OUTPUT_MAX_BYTES,
         )
         .await
         {
@@ -5008,12 +5622,11 @@ async fn github_actions_jobs_for_head_sha(
 
 async fn github_actions_log_for_check_run_item(
     ctx: &ProviderContext,
-    client: &ReviewHttpClient,
     check_run_id: &str,
     check_run_name: &str,
     head_sha: &str,
 ) -> Result<ReviewPlatformCiLog, ReviewPlatformError> {
-    let action_jobs = github_actions_jobs_for_head_sha(ctx, client, head_sha).await;
+    let action_jobs = github_actions_jobs_for_head_sha(ctx, head_sha).await;
     let check_run = action_jobs
         .iter()
         .find(|job| {
@@ -5048,12 +5661,7 @@ async fn github_actions_log_for_check_run_item(
         "{}/repos/{}/{}/actions/jobs/{}/logs",
         ctx.api_base_url, ctx.remote.owner, ctx.remote.repository_name, job_id
     );
-    let response = send_text(github_request(
-        client.clone(),
-        &logs_url,
-        ctx.token.as_deref(),
-    ))
-    .await?;
+    let response = github_api_get_text(ctx, &logs_url, 1024 * 1024).await?;
     let (log, truncated) = ci_log_value_from_response(response);
     let message = if truncated {
         Some("GitHub Actions job log evidence was truncated to the Review budget.".to_string())
@@ -5741,6 +6349,7 @@ fn github_pull_request_from_value(value: &Value) -> ReviewPlatformPullRequest {
 
     ReviewPlatformPullRequest {
         id: number.to_string(),
+        provider_id: None,
         number,
         title: value_string(value, "title"),
         state,
@@ -5778,6 +6387,7 @@ fn gitlab_pull_request_from_value(value: &Value) -> ReviewPlatformPullRequest {
 
     ReviewPlatformPullRequest {
         id: number.to_string(),
+        provider_id: None,
         number,
         title: value_string(value, "title"),
         state,
@@ -5816,6 +6426,7 @@ fn gitcode_pull_request_from_value(value: &Value) -> ReviewPlatformPullRequest {
     };
     ReviewPlatformPullRequest {
         id: number.to_string(),
+        provider_id: None,
         number,
         title: value_string(value, "title"),
         state,
@@ -6802,7 +7413,7 @@ mod tests {
         let service = ReviewPlatformService::new_local_only(path.clone());
 
         service
-            .update_auth_token(ReviewPlatformKind::Github, "GitHub.com", " secret-token ")
+            .update_auth_token(ReviewPlatformKind::Gitlab, "GitLab.com", " secret-token ")
             .await
             .expect("token update should write injected store");
 
@@ -6811,12 +7422,78 @@ mod tests {
             .await
             .expect("stored token file should be readable");
         assert_eq!(
-            tokens.get(ReviewPlatformKind::Github, "github.com"),
+            tokens.get(ReviewPlatformKind::Gitlab, "gitlab.com"),
             Some("secret-token")
         );
         assert!(path.exists());
 
         let _ = fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn github_token_actions_are_rejected() {
+        let path = temp_token_store_path("github-token-rejected");
+        let service = ReviewPlatformService::new_local_only(path.clone());
+
+        let update = service
+            .update_auth_token(ReviewPlatformKind::Github, "github.com", "secret-token")
+            .await;
+        let clear = service
+            .clear_auth_token(ReviewPlatformKind::Github, "github.com")
+            .await;
+
+        assert!(
+            matches!(update, Err(ReviewPlatformError::Api(message)) if message.contains("gh auth login"))
+        );
+        assert!(
+            matches!(clear, Err(ReviewPlatformError::Api(message)) if message.contains("gh auth logout"))
+        );
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn legacy_github_tokens_are_removed_during_canonicalization() {
+        let (stored, changed) = canonicalize_stored_tokens(StoredReviewPlatformTokens {
+            tokens: HashMap::from([
+                (
+                    "github:github.com".to_string(),
+                    StoredReviewPlatformToken {
+                        token: "legacy-github-token".to_string(),
+                        updated_at: "2026-07-14T00:00:00Z".to_string(),
+                    },
+                ),
+                (
+                    "gitlab:gitlab.com".to_string(),
+                    StoredReviewPlatformToken {
+                        token: "gitlab-token".to_string(),
+                        updated_at: "2026-07-14T00:00:00Z".to_string(),
+                    },
+                ),
+            ]),
+        });
+
+        assert!(changed);
+        assert!(!stored.tokens.contains_key("github:github.com"));
+        assert!(stored.tokens.contains_key("gitlab:gitlab.com"));
+    }
+
+    #[test]
+    fn gh_auth_status_uses_only_the_active_successful_account() {
+        let status = parse_gh_auth_status(
+            "github.com",
+            &json!({
+                "hosts": {
+                    "github.com": [
+                        { "state": "failure", "active": false, "login": "old" },
+                        { "state": "success", "active": true, "login": "octocat" }
+                    ]
+                }
+            }),
+        );
+
+        assert!(status.installed);
+        assert!(status.connected);
+        assert_eq!(status.username.as_deref(), Some("octocat"));
     }
 
     #[tokio::test]
@@ -6827,7 +7504,7 @@ mod tests {
 
         assert_eq!(service.token_store_path(), mixed_path.as_path());
         service
-            .update_auth_token(ReviewPlatformKind::Github, "github.com", "case-token")
+            .update_auth_token(ReviewPlatformKind::Gitlab, "gitlab.com", "case-token")
             .await
             .expect("mixed-case token path should be writable");
         let created_names = std::fs::read_dir(
@@ -6867,7 +7544,7 @@ mod tests {
         let service = ReviewPlatformService::new_local_only(path.clone());
 
         service
-            .update_auth_token(ReviewPlatformKind::Github, " GitHub.COM. ", "secret-token")
+            .update_auth_token(ReviewPlatformKind::Gitlab, " GitLab.COM. ", "secret-token")
             .await
             .expect("normalized token should save");
         let tokens = service
@@ -6875,19 +7552,19 @@ mod tests {
             .await
             .expect("normalized token should load");
         assert_eq!(
-            tokens.get(ReviewPlatformKind::Github, "github.com."),
+            tokens.get(ReviewPlatformKind::Gitlab, "gitlab.com."),
             Some("secret-token")
         );
 
         service
-            .clear_auth_token(ReviewPlatformKind::Github, "GITHUB.COM.")
+            .clear_auth_token(ReviewPlatformKind::Gitlab, "GITLAB.COM.")
             .await
             .expect("normalized token should clear");
         let tokens = service
             .load_stored_tokens()
             .await
             .expect("cleared token store should load");
-        assert_eq!(tokens.get(ReviewPlatformKind::Github, "github.com"), None);
+        assert_eq!(tokens.get(ReviewPlatformKind::Gitlab, "gitlab.com"), None);
         let _ = fs::remove_file(path).await;
     }
 
@@ -6898,7 +7575,7 @@ mod tests {
             &path,
             serde_json::to_vec(&json!({
                 "tokens": {
-                    "github:GitHub.COM.": {
+                    "gitlab:GitLab.COM.": {
                         "token": "legacy-token",
                         "updatedAt": "2026-07-11T00:00:00Z"
                     }
@@ -6916,7 +7593,7 @@ mod tests {
             .expect("legacy token store should load");
 
         assert_eq!(
-            tokens.get(ReviewPlatformKind::Github, "github.com"),
+            tokens.get(ReviewPlatformKind::Gitlab, "gitlab.com"),
             Some("legacy-token")
         );
         let _ = fs::remove_file(path).await;
@@ -6929,11 +7606,11 @@ mod tests {
             &path,
             serde_json::to_vec(&json!({
                 "tokens": {
-                    "github:GitHub.COM.": {
+                    "gitlab:GitLab.COM.": {
                         "token": "legacy-token",
                         "updatedAt": "2026-07-12T00:00:00Z"
                     },
-                    "github:github.com": {
+                    "gitlab:gitlab.com": {
                         "token": "canonical-token",
                         "updatedAt": "2026-07-11T00:00:00Z"
                     }
@@ -6950,7 +7627,7 @@ mod tests {
             .await
             .expect("conflicting token store should migrate");
         assert_eq!(
-            tokens.get(ReviewPlatformKind::Github, "github.com"),
+            tokens.get(ReviewPlatformKind::Gitlab, "gitlab.com"),
             Some("canonical-token")
         );
         let migrated: StoredReviewPlatformTokens = serde_json::from_slice(
@@ -6963,13 +7640,13 @@ mod tests {
         assert_eq!(
             migrated
                 .tokens
-                .get("github:github.com")
+                .get("gitlab:gitlab.com")
                 .map(|entry| entry.token.as_str()),
             Some("canonical-token")
         );
 
         service
-            .update_auth_token(ReviewPlatformKind::Github, "GITHUB.COM.", "new-token")
+            .update_auth_token(ReviewPlatformKind::Gitlab, "GITLAB.COM.", "new-token")
             .await
             .expect("canonical token update should succeed");
         let updated: StoredReviewPlatformTokens = serde_json::from_slice(
@@ -6982,7 +7659,7 @@ mod tests {
         assert_eq!(
             updated
                 .tokens
-                .get("github:github.com")
+                .get("gitlab:gitlab.com")
                 .map(|entry| entry.token.as_str()),
             Some("new-token")
         );
@@ -6995,11 +7672,11 @@ mod tests {
         let first = ReviewPlatformService::new_local_only(path.clone());
         let second = ReviewPlatformService::new_local_only(path.clone());
 
-        let (github, gitlab) = tokio::join!(
-            first.update_auth_token(ReviewPlatformKind::Github, "github.com", "github-token"),
+        let (gitcode, gitlab) = tokio::join!(
+            first.update_auth_token(ReviewPlatformKind::Gitcode, "gitcode.com", "gitcode-token"),
             second.update_auth_token(ReviewPlatformKind::Gitlab, "gitlab.com", "gitlab-token")
         );
-        github.expect("GitHub token update should succeed");
+        gitcode.expect("GitCode token update should succeed");
         gitlab.expect("GitLab token update should succeed");
 
         let stored = first
@@ -7007,8 +7684,8 @@ mod tests {
             .await
             .expect("concurrent token store should load");
         assert_eq!(
-            stored.get(ReviewPlatformKind::Github, "github.com"),
-            Some("github-token")
+            stored.get(ReviewPlatformKind::Gitcode, "gitcode.com"),
+            Some("gitcode-token")
         );
         assert_eq!(
             stored.get(ReviewPlatformKind::Gitlab, "gitlab.com"),
@@ -7023,19 +7700,19 @@ mod tests {
         let first = ReviewPlatformService::new_local_only(path.clone());
         let second = ReviewPlatformService::new_local_only(path.clone());
         first
-            .update_auth_token(ReviewPlatformKind::Github, "github.com", "old-github")
+            .update_auth_token(ReviewPlatformKind::Gitcode, "gitcode.com", "old-gitcode")
             .await
-            .expect("GitHub fixture token should save");
+            .expect("GitCode fixture token should save");
         first
             .update_auth_token(ReviewPlatformKind::Gitlab, "gitlab.com", "old-gitlab")
             .await
             .expect("GitLab fixture token should save");
 
         let (update, clear) = tokio::join!(
-            first.update_auth_token(ReviewPlatformKind::Github, "github.com", "new-github"),
+            first.update_auth_token(ReviewPlatformKind::Gitcode, "gitcode.com", "new-gitcode"),
             second.clear_auth_token(ReviewPlatformKind::Gitlab, "gitlab.com")
         );
-        update.expect("GitHub token update should succeed");
+        update.expect("GitCode token update should succeed");
         clear.expect("GitLab token clear should succeed");
 
         let stored = second
@@ -7043,8 +7720,8 @@ mod tests {
             .await
             .expect("updated token store should load");
         assert_eq!(
-            stored.get(ReviewPlatformKind::Github, "github.com"),
-            Some("new-github")
+            stored.get(ReviewPlatformKind::Gitcode, "gitcode.com"),
+            Some("new-gitcode")
         );
         assert_eq!(stored.get(ReviewPlatformKind::Gitlab, "gitlab.com"), None);
         let temp_prefix = format!(
@@ -7108,6 +7785,47 @@ mod tests {
         );
         assert!(snapshot.remotes.is_empty());
         assert!(snapshot.pull_requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn workspace_context_discovers_repository_without_listing_pull_requests() {
+        let repository = tempfile::tempdir().expect("temporary repository should be created");
+        let repository_path = repository
+            .path()
+            .to_str()
+            .expect("repository path should be UTF-8");
+        execute_git_command(repository_path, &["init"])
+            .await
+            .expect("temporary repository should initialize");
+        execute_git_command(
+            repository_path,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://gitlab.com/example/repo.git",
+            ],
+        )
+        .await
+        .expect("GitLab remote should be added");
+        let path = temp_token_store_path("workspace-context");
+        let service = ReviewPlatformService::new_local_only(path.clone());
+
+        let snapshot = service
+            .workspace_context(repository_path, None)
+            .await
+            .expect("workspace context should not call the provider list API");
+
+        assert!(snapshot.pull_requests.is_empty());
+        assert_eq!(snapshot.pagination.total, Some(0));
+        assert_eq!(
+            snapshot
+                .repository
+                .as_ref()
+                .map(|repository| repository.project_path.as_str()),
+            Some("example/repo")
+        );
+        let _ = fs::remove_file(path).await;
     }
 
     #[tokio::test]
@@ -7201,6 +7919,99 @@ mod tests {
             pull_request.head_revision.as_deref(),
             Some("2222222222222222222222222222222222222222")
         );
+    }
+
+    #[test]
+    fn github_cli_pull_request_maps_open_user_list_fields() {
+        let pull_request = github_pull_request_from_gh_cli_value(
+            &json!({
+                "number": 42,
+                "title": "Current user pull request",
+                "state": "OPEN",
+                "isDraft": false,
+                "author": { "login": "octocat" },
+                "headRefName": "feature",
+                "headRefOid": "2222222222222222222222222222222222222222",
+                "baseRefName": "main",
+                "baseRefOid": "1111111111111111111111111111111111111111",
+                "updatedAt": "2026-07-14T00:00:00Z",
+                "url": "https://github.com/example/repo/pull/42",
+                "additions": 12,
+                "deletions": 3,
+                "changedFiles": 2,
+                "comments": [{ "id": "one" }, { "id": "two" }],
+                "reviewDecision": "CHANGES_REQUESTED",
+                "statusCheckRollup": [
+                    { "conclusion": "SUCCESS", "status": "COMPLETED" },
+                    { "conclusion": "FAILURE", "status": "COMPLETED" },
+                    { "conclusion": "", "status": "IN_PROGRESS" }
+                ]
+            }),
+            Some("origin:github:example__repo"),
+        );
+
+        assert_eq!(pull_request.number, 42);
+        assert_eq!(
+            pull_request.provider_id.as_deref(),
+            Some("origin:github:example__repo")
+        );
+        assert_eq!(pull_request.author, "octocat");
+        assert_eq!(pull_request.state, ReviewItemState::Open);
+        assert_eq!(
+            pull_request.review_decision,
+            ReviewDecision::ChangesRequested
+        );
+        assert_eq!(pull_request.comments, 2);
+        assert_eq!(pull_request.checks.total, 3);
+        assert_eq!(pull_request.checks.passed, 1);
+        assert_eq!(pull_request.checks.failed, 1);
+        assert_eq!(pull_request.checks.pending, 1);
+    }
+
+    #[test]
+    fn github_workspace_pull_requests_deduplicate_urls_not_numbers() {
+        let make_pull_request = |provider_id: &str, url: &str, updated_at: &str| {
+            github_pull_request_from_gh_cli_value(
+                &json!({
+                    "number": 42,
+                    "title": provider_id,
+                    "state": "OPEN",
+                    "isDraft": false,
+                    "author": { "login": "octocat" },
+                    "headRefName": "feature",
+                    "baseRefName": "main",
+                    "updatedAt": updated_at,
+                    "url": url,
+                    "comments": [],
+                    "statusCheckRollup": []
+                }),
+                Some(provider_id),
+            )
+        };
+        let page = aggregate_github_pull_requests(
+            vec![
+                make_pull_request(
+                    "fork",
+                    "https://github.com/example/fork/pull/42",
+                    "2026-07-14T01:00:00Z",
+                ),
+                make_pull_request(
+                    "upstream",
+                    "https://github.com/example/upstream/pull/42",
+                    "2026-07-14T02:00:00Z",
+                ),
+                make_pull_request(
+                    "duplicate-upstream",
+                    "https://github.com/example/upstream/pull/42",
+                    "2026-07-14T00:00:00Z",
+                ),
+            ],
+            PullRequestPagination::new(Some(1), Some(10)),
+        );
+
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.items[0].provider_id.as_deref(), Some("upstream"));
+        assert_eq!(page.items[1].provider_id.as_deref(), Some("fork"));
     }
 
     #[test]
@@ -8381,7 +9192,7 @@ mod tests {
     }
 
     #[test]
-    fn existing_self_hosted_github_remote_keeps_token_on_same_authority() {
+    fn existing_self_hosted_github_remote_ignores_stored_tokens() {
         let host = "github.example.internal";
         let mut tokens = ReviewPlatformAuthTokens::default();
         tokens.tokens.insert(
@@ -8394,7 +9205,7 @@ mod tests {
             "example/repo",
             &tokens,
         )
-        .expect("stored token should authorize a self-hosted GitHub context");
+        .expect("GitHub CLI should authorize a self-hosted GitHub context");
 
         let existing_remote_context = provider_context(identity_context.remote, &tokens)
             .expect("existing remote context should remain valid");
@@ -8403,9 +9214,10 @@ mod tests {
             existing_remote_context.api_base_url,
             "https://github.example.internal/api/v3"
         );
+        assert_eq!(existing_remote_context.token, None);
         assert_eq!(
-            existing_remote_context.token.as_deref(),
-            Some("stored-token")
+            existing_remote_context.remote.auth_source,
+            ReviewAuthSource::GhCli
         );
     }
 
@@ -8726,63 +9538,23 @@ mod tests {
         assert!(evidence.next_cursor.is_none());
     }
 
-    #[tokio::test]
-    async fn issue_acquisition_rejects_github_pull_request_before_comments_fetch() {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("mock provider should bind");
-        listener
-            .set_nonblocking(true)
-            .expect("mock provider should be nonblocking");
-        let address = listener.local_addr().expect("mock provider address");
-        let server = thread::spawn(move || {
-            let mut request_count = 0usize;
-            let deadline = Instant::now() + Duration::from_millis(500);
-            while Instant::now() < deadline {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        request_count += 1;
-                        let mut request = [0u8; 4096];
-                        let _ = stream.read(&mut request);
-                        let body = if request_count == 1 {
-                            r#"{"number":42,"pull_request":{"url":"https://api.github.com/repos/example/repo/pulls/42"}}"#
-                        } else {
-                            "[]"
-                        };
-                        let response = format!(
-                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                            body.len(),
-                            body
-                        );
-                        stream
-                            .write_all(response.as_bytes())
-                            .expect("mock response should write");
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
-                    }
-                    Err(error) => panic!("mock provider accept failed: {error}"),
-                }
-            }
-            request_count
-        });
+    #[test]
+    fn issue_acquisition_rejects_github_pull_request_payload() {
         let identity = github_issue_identity();
-        let mut context = provider_context_for_identity(
-            identity.platform,
-            &identity.host,
-            &identity.project_path,
-            &ReviewPlatformAuthTokens::default(),
-        )
-        .expect("public GitHub context should be valid");
-        context.api_base_url = format!("http://{address}");
-
-        let result =
-            acquire_issue_evidence(&context, &identity, IssuePagination::new(None, None)).await;
-        let request_count = server.join().expect("mock provider should join");
+        let result = reject_pull_request_issue_target(
+            &identity,
+            &json!({
+                "number": 42,
+                "pull_request": {
+                    "url": "https://api.github.com/repos/example/repo/pulls/42"
+                }
+            }),
+        );
 
         assert!(matches!(
             result,
             Err(ReviewPlatformError::TargetIsPullRequest { .. })
         ));
-        assert_eq!(request_count, 1, "comments must not be requested for a PR");
     }
 
     #[test]

--- a/src/crates/services/services-integrations/src/review_platform_http.rs
+++ b/src/crates/services/services-integrations/src/review_platform_http.rs
@@ -9,7 +9,6 @@ use thiserror::Error;
 const REVIEW_PLATFORM_TIMEOUT_SECS: u64 = 25;
 const MAX_REVIEW_PLATFORM_REDIRECTS: usize = 5;
 const DEFAULT_JSON_RESPONSE_MAX_BYTES: usize = 16 * 1024 * 1024;
-const DEFAULT_TEXT_RESPONSE_MAX_BYTES: usize = 1024 * 1024;
 const HTTP_ERROR_BODY_MAX_BYTES: usize = 8 * 1024;
 
 #[derive(Debug, Error)]
@@ -225,12 +224,6 @@ fn append_bounded_chunk(
     }
     body.extend_from_slice(chunk);
     Ok(())
-}
-
-pub(crate) async fn send_text(
-    request: ReviewHttpRequest,
-) -> Result<ReviewTextResponse, ReviewHttpError> {
-    send_text_bounded(request, DEFAULT_TEXT_RESPONSE_MAX_BYTES).await
 }
 
 pub(crate) async fn send_text_bounded(

--- a/src/web-ui/src/app/components/panels/review-platform/ReviewPlatformPanel.scss
+++ b/src/web-ui/src/app/components/panels/review-platform/ReviewPlatformPanel.scss
@@ -41,13 +41,9 @@
   &__status-line,
   &__detail-meta,
   &__detail-actions,
-  &__agent-link-actions,
-  &__summary-strip,
-  &__summary-grid span,
   &__timeline-item,
   &__thread-head,
   &__account,
-  &__capability-row,
   &__pagination {
     display: flex;
     align-items: center;
@@ -90,8 +86,7 @@
   &__detail-meta,
   &__timeline-main span,
   &__thread-anchor,
-  &__status-line,
-  &__summary-label {
+  &__status-line {
     color: var(--color-text-secondary);
     font-size: 11px;
   }
@@ -194,8 +189,32 @@
 
   &__auth-actions {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
     gap: 8px;
+  }
+
+  &__gh-auth {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+
+    code {
+      overflow-x: auto;
+      padding: 9px 10px;
+      border: 1px solid var(--border-base);
+      border-radius: 6px;
+      background: var(--element-bg-soft);
+      color: var(--color-text-primary);
+      font-family: var(--font-family-mono);
+      white-space: nowrap;
+    }
+  }
+
+  &__gh-auth-error {
+    color: var(--color-error);
   }
 
   &__auth-gate {
@@ -471,8 +490,7 @@
   }
 
   &__decision,
-  &__file-status,
-  &__capability-chip {
+  &__file-status {
     display: inline-flex;
     align-items: center;
     width: fit-content;
@@ -530,11 +548,13 @@
   }
 
   &__detail-title-row {
+    width: 100%;
     display: flex;
     align-items: center;
     gap: 7px;
 
     h3 {
+      flex: 1 1 auto;
       min-width: 0;
       margin: 0;
       overflow: hidden;
@@ -544,6 +564,33 @@
       font-weight: 650;
       letter-spacing: 0;
     }
+  }
+
+  &__detail-state {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    min-height: 20px;
+    padding: 0 7px;
+    border-radius: 5px;
+    font-size: 10px;
+    font-weight: 650;
+  }
+
+  &__detail-state--open,
+  &__detail-state--draft {
+    color: var(--color-success);
+    background: var(--color-success-bg);
+  }
+
+  &__detail-state--merged {
+    color: var(--color-purple-500);
+    background: var(--color-purple-100);
+  }
+
+  &__detail-state--closed {
+    color: var(--color-error);
+    background: var(--color-error-bg);
   }
 
   &__detail-meta {
@@ -591,84 +638,87 @@
     }
   }
 
-  &__summary-strip {
-    gap: 8px;
-    padding: 12px 14px 0;
-    flex-wrap: wrap;
-  }
-
-  &__agent-link-panel {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    margin: 10px 14px 0;
-    padding: 10px 12px;
-    border: 1px solid color-mix(in srgb, var(--color-accent-500) 20%, var(--border-base));
-    border-radius: 7px;
-    background:
-      linear-gradient(180deg, color-mix(in srgb, var(--color-accent-500) 8%, transparent), transparent),
-      color-mix(in srgb, var(--color-bg-elevated) 70%, transparent);
-  }
-
-  &__agent-link-main {
-    min-width: 0;
+  &__fact-list {
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    padding: 8px 14px 10px;
+    border-bottom: 1px solid var(--border-base);
+  }
 
-    strong,
-    span {
+  &__detail-title-block {
+    flex: 1 1 auto;
+    max-width: 100%;
+  }
+
+  &__fact-row {
+    min-width: 0;
+    min-height: 32px;
+    display: grid;
+    grid-template-columns: 148px minmax(0, 1fr);
+    align-items: center;
+    gap: 12px;
+  }
+
+  &__fact-label {
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-text-secondary);
+    font-size: 11px;
+
+    svg {
+      flex: 0 0 auto;
+      color: var(--color-text-muted);
+    }
+  }
+
+  &__fact-value {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-text-primary);
+    font-size: 12px;
+
+    strong {
+      min-width: 0;
+      font-weight: 600;
+    }
+
+    > span:not(.review-platform__additions, .review-platform__deletions) {
+      color: var(--color-text-secondary);
+    }
+  }
+
+  &__fact-value--branch {
+    flex-wrap: wrap;
+
+    strong {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    svg {
+      flex: 0 0 auto;
+      color: var(--color-text-muted);
+    }
+  }
+
+  &__fact-value--review {
+    justify-content: space-between;
+
+    > span {
       min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
 
-    strong {
-      color: var(--color-text-primary);
-      font-size: 12px;
-      font-weight: 650;
+    .btn {
+      flex: 0 0 auto;
     }
-
-    span {
-      color: var(--color-text-secondary);
-      font-size: 11px;
-    }
-  }
-
-  &__agent-link-label {
-    color: var(--color-accent-500) !important;
-    font-weight: 650;
-    text-transform: uppercase;
-    letter-spacing: 0;
-  }
-
-  &__agent-link-actions {
-    gap: 6px;
-    flex-shrink: 0;
-  }
-
-  &__summary-card {
-    min-width: 106px;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    padding: 10px 12px;
-    border: 1px solid var(--border-base);
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--color-bg-elevated) 74%, transparent);
-
-    strong {
-      font-size: 14px;
-      font-weight: 650;
-    }
-  }
-
-  &__capability-row {
-    gap: 8px;
-    flex-wrap: wrap;
-    margin-bottom: 14px;
   }
 
   &__section-heading {
@@ -697,33 +747,6 @@
     flex: 0 0 auto;
     color: var(--color-text-secondary);
     font-size: 11px;
-  }
-
-  &__card-heading {
-    min-height: 30px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin: -2px 0 8px;
-
-    > span {
-      min-width: 0;
-      color: var(--color-text-primary);
-      font-size: 12px;
-      font-weight: 650;
-    }
-
-    .btn {
-      flex-shrink: 0;
-      gap: 5px;
-    }
-  }
-
-  &__capability-chip {
-    color: var(--color-text-secondary);
-    background: color-mix(in srgb, var(--element-bg-soft) 76%, transparent);
-    border: 1px solid var(--border-base);
   }
 
   &__tabs {
@@ -797,6 +820,54 @@
     height: 100%;
     overflow-y: auto;
     padding: 12px 14px;
+  }
+
+  &__overview-scroll {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  &__detail-section {
+    width: min(100%, 1120px);
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--border-base);
+
+    &:last-child {
+      padding-bottom: 0;
+      border-bottom: 0;
+    }
+  }
+
+  &__detail-section-heading {
+    min-height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+
+    > span:first-child {
+      color: var(--color-text-primary);
+      font-size: 13px;
+      font-weight: 650;
+    }
+  }
+
+  &__detail-section-actions {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  &__section-empty {
+    color: var(--color-text-secondary);
+    font-size: 12px;
   }
 
   &__body-copy,
@@ -963,21 +1034,12 @@
     }
   }
 
-  &__summary-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(120px, 1fr));
-    gap: 8px;
-
-    span {
-      min-height: 34px;
-      gap: 6px;
-      padding: 0 10px;
-      border: 1px solid var(--border-base);
-      border-radius: 7px;
-      background: color-mix(in srgb, var(--element-bg-soft) 66%, transparent);
-      color: var(--color-text-secondary);
-      font-size: 11px;
-    }
+  &__body-markdown--plain {
+    margin-bottom: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
   }
 
   &__additions {
@@ -1240,21 +1302,6 @@
     line-height: 1.2;
   }
 
-  &__ci-log-chip {
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    width: fit-content;
-    padding: 2px 6px;
-    border: 1px solid color-mix(in srgb, var(--color-accent-500) 26%, var(--border-base));
-    border-radius: 5px;
-    color: var(--color-accent-500);
-    background: color-mix(in srgb, var(--color-accent-500) 9%, transparent);
-    font-size: 10px;
-    font-weight: 650;
-    line-height: 1.2;
-  }
-
   &__ci-actions {
     flex-shrink: 0;
     display: flex;
@@ -1280,21 +1327,6 @@
   &__ci-status--pending {
     color: var(--color-warning);
     background: var(--color-warning-bg);
-  }
-
-  &__ci-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    color: var(--color-text-secondary);
-    font-size: 11px;
-    line-height: 1.4;
-
-    span {
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
   }
 
   &__ci-log-panel {
@@ -1583,23 +1615,6 @@
       border-bottom: 1px solid var(--border-base);
     }
 
-    &__summary-grid {
-      grid-template-columns: repeat(2, minmax(120px, 1fr));
-    }
-
-    &__summary-strip {
-      gap: 6px;
-    }
-
-    &__agent-link-panel {
-      align-items: flex-start;
-      flex-direction: column;
-    }
-
-    &__agent-link-actions {
-      width: 100%;
-      flex-wrap: wrap;
-    }
   }
 
   @container review-platform (max-width: 980px) {
@@ -1613,21 +1628,11 @@
       border-bottom: 1px solid var(--border-base);
     }
 
-    &__summary-grid {
-      grid-template-columns: repeat(2, minmax(120px, 1fr));
-    }
-
-    &__summary-strip {
-      gap: 6px;
-    }
-
-    &__agent-link-panel,
     &__detail-header {
       align-items: flex-start;
       flex-direction: column;
     }
 
-    &__agent-link-actions,
     &__detail-actions {
       width: 100%;
       flex-wrap: wrap;
@@ -1650,8 +1655,25 @@
       justify-content: flex-start;
     }
 
-    &__summary-grid {
+    &__fact-row {
       grid-template-columns: 1fr;
+      gap: 4px;
+      padding-block: 6px;
+    }
+
+    &__fact-value--review,
+    &__detail-section-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    &__fact-value--review > span {
+      white-space: normal;
+    }
+
+    &__detail-section-actions {
+      width: 100%;
+      justify-content: space-between;
     }
 
     &__file-row {

--- a/src/web-ui/src/app/components/panels/review-platform/ReviewPlatformPanel.tsx
+++ b/src/web-ui/src/app/components/panels/review-platform/ReviewPlatformPanel.tsx
@@ -7,6 +7,7 @@ import {
   CircleDot,
   Clock3,
   Code2,
+  Copy,
   GitCommitHorizontal,
   GitPullRequest,
   GitPullRequestClosed,
@@ -19,6 +20,7 @@ import {
   ShieldCheck,
   Sparkles,
   Trash2,
+  Terminal,
   UserRound,
   XCircle,
 } from 'lucide-react';
@@ -40,6 +42,7 @@ import type { FlowToolItem, Session } from '@/flow_chat/types/flow-chat';
 import { findLatestCodeReviewResultState, summarizeCodeReviewResult } from '@/flow_chat/utils/reviewSessionSummary';
 import { parsePullRequestUrl, remoteMatchesPullRequestLink } from '@/shared/utils/pullRequestLinks';
 import { useContextStore } from '@/shared/stores/contextStore';
+import { quickActions } from '@/shared/services/ide-control';
 import type { PullRequestContext } from '@/shared/types/context';
 import {
   currentPullRequestReviewStatusText,
@@ -63,7 +66,7 @@ interface ReviewPlatformPanelProps {
   detailOnly?: boolean;
 }
 
-type DetailTab = 'overview' | 'ci' | 'changes' | 'commits' | 'reviews';
+type DetailTab = 'overview' | 'changes' | 'commits';
 type ListStateFilter = 'all' | 'open' | 'draft' | 'merged' | 'closed';
 type SnapshotCacheState = 'none' | 'cached' | 'refreshing';
 
@@ -158,8 +161,8 @@ function detailPageInfo(pagination: ReviewPlatformPagination, itemCount: number)
   };
 }
 
-function snapshotCacheKey(workspacePath: string, remoteId: string | null, page: number, perPage: number): string {
-  return `${workspacePath}::${remoteId ?? 'default'}::${page}::${perPage}`;
+function snapshotCacheKey(workspacePath: string, remoteId: string | null, page: number, perPage: number, mode: 'list' | 'context'): string {
+  return `${workspacePath}::${remoteId ?? 'default'}::${page}::${perPage}::${mode}`;
 }
 
 function detailCacheKey(workspacePath: string, remoteId: string, pullRequestId: string): string {
@@ -325,6 +328,8 @@ function authLabel(account: ReviewPlatformAccount | null): string {
 
 function authSourceLabel(source: ReviewPlatformAccount['authSource'] | undefined): string {
   switch (source) {
+    case 'gh_cli':
+      return 'GitHub CLI';
     case 'stored':
       return 'Saved token';
     case 'env':
@@ -337,6 +342,7 @@ function authSourceLabel(source: ReviewPlatformAccount['authSource'] | undefined
 }
 
 function authChallengeTitle(challenge: ReviewPlatformAuthChallenge): string {
+  if (challenge.platform === 'github') return 'GitHub CLI authentication required';
   switch (challenge.state) {
     case 'missing':
       return 'Token required';
@@ -653,6 +659,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   const reviewLaunchInFlight = useRef(false);
   const [snapshot, setSnapshot] = useState<ReviewPlatformWorkspaceSnapshot>(emptySnapshot);
   const [selectedRemoteId, setSelectedRemoteId] = useState<string | null>(null);
+  const [listRemoteId, setListRemoteId] = useState<string | null>(null);
   const [selectedPrId, setSelectedPrId] = useState<string | null>(null);
   const [detail, setDetail] = useState<ReviewPlatformPullRequestDetail | null>(null);
   const [verifiedDetailKey, setVerifiedDetailKey] = useState<string | null>(null);
@@ -686,16 +693,30 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   const [reviewLaunching, setReviewLaunching] = useState(false);
   const { confirmDeepReviewLaunch, deepReviewConsentDialog } = useDeepReviewConsent();
 
-  const repository = snapshot.repository;
   const account = snapshot.accounts[0] ?? null;
   const selectedRemote = useMemo(
     () => snapshot.remotes.find(remote => remote.id === selectedRemoteId) ?? snapshot.remotes[0] ?? null,
     [selectedRemoteId, snapshot.remotes],
   );
+  const repository = useMemo<ReviewPlatformRepositoryRef | null>(() => {
+    if (!snapshot.repository || !selectedRemote) return snapshot.repository;
+    return {
+      ...snapshot.repository,
+      providerId: selectedRemote.id,
+      platform: selectedRemote.platform,
+      host: selectedRemote.host,
+      owner: selectedRemote.owner,
+      name: selectedRemote.repositoryName,
+      projectPath: selectedRemote.projectPath,
+      webUrl: selectedRemote.webUrl,
+    };
+  }, [selectedRemote, snapshot.repository]);
   const authChallenge = snapshot.authChallenge ?? null;
   const selectedPrFromList = useMemo(
-    () => snapshot.pullRequests.find(pr => pr.id === selectedPrId) ?? null,
-    [selectedPrId, snapshot.pullRequests],
+    () => snapshot.pullRequests.find(pr => (
+      pr.id === selectedPrId && (!pr.providerId || pr.providerId === selectedRemoteId)
+    )) ?? null,
+    [selectedPrId, selectedRemoteId, snapshot.pullRequests],
   );
   const selectedPr = detail ?? selectedPrFromList;
   const hasDetail = detail !== null;
@@ -744,6 +765,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     if (!workspacePath) {
       setSnapshot(emptySnapshot());
       setSelectedRemoteId(null);
+      setListRemoteId(null);
       setSelectedPrId(null);
       setDetail(null);
       setVerifiedDetailKey(null);
@@ -753,9 +775,15 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
       return;
     }
 
-    const requestedRemoteId = nextRemoteId !== undefined ? nextRemoteId : readRememberedRemote(workspacePath);
+    const requestedRemoteId = nextRemoteId !== undefined
+      ? nextRemoteId
+      : detailOnly
+        ? readRememberedRemote(workspacePath)
+        : null;
     const requestedPage = Math.max(1, options?.page ?? 1);
-    const requestedCacheKey = snapshotCacheKey(workspacePath, requestedRemoteId ?? null, requestedPage, PR_PAGE_SIZE);
+    const snapshotMode = detailOnly ? 'context' : 'list';
+    setListRemoteId(requestedRemoteId ?? null);
+    const requestedCacheKey = snapshotCacheKey(workspacePath, requestedRemoteId ?? null, requestedPage, PR_PAGE_SIZE, snapshotMode);
     const cached = snapshotCache.get(requestedCacheKey);
     const force = options?.force === true;
 
@@ -764,7 +792,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
       setSnapshot(cached.snapshot);
       setSelectedRemoteId(remoteId);
       setPageIndex(Math.max(0, (cached.snapshot.pagination.page || requestedPage) - 1));
-      setSelectedPrId(null);
+      setSelectedPrId(detailOnly ? null : cached.snapshot.pullRequests[0]?.id ?? null);
       setDetail(null);
       setVerifiedDetailKey(null);
       setDetailError(null);
@@ -784,21 +812,23 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const next = await reviewPlatformAPI.getWorkspaceSnapshot(workspacePath, requestedRemoteId ?? null, requestedPage, PR_PAGE_SIZE);
+      const next = detailOnly
+        ? await reviewPlatformAPI.getWorkspaceContext(workspacePath, requestedRemoteId ?? null)
+        : await reviewPlatformAPI.getWorkspaceSnapshot(workspacePath, requestedRemoteId ?? null, requestedPage, PR_PAGE_SIZE);
       if (snapshotRequestSeq.current !== requestSeq) return;
       setSnapshot(next);
       const remoteId = next.selectedRemoteId ?? next.remotes[0]?.id ?? null;
       setSelectedRemoteId(remoteId);
       setPageIndex(Math.max(0, (next.pagination.page || requestedPage) - 1));
       rememberRemote(workspacePath, remoteId);
-      setSelectedPrId(null);
+      setSelectedPrId(detailOnly ? null : next.pullRequests[0]?.id ?? null);
       setDetail(null);
       setVerifiedDetailKey(null);
       setDetailError(null);
       const entry = { snapshot: next, fetchedAt: Date.now() };
       snapshotCache.set(requestedCacheKey, entry);
       if (remoteId) {
-        snapshotCache.set(snapshotCacheKey(workspacePath, remoteId, requestedPage, PR_PAGE_SIZE), entry);
+        snapshotCache.set(snapshotCacheKey(workspacePath, remoteId, requestedPage, PR_PAGE_SIZE, snapshotMode), entry);
       }
       setSnapshotCacheState('cached');
     } catch (err) {
@@ -814,7 +844,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
         setLoading(false);
       }
     }
-  }, [workspacePath]);
+  }, [detailOnly, workspacePath]);
 
   const loadDetail = useCallback(async (repo: ReviewPlatformRepositoryRef | null, remoteId: string, pullRequestId: string, options?: { force?: boolean }) => {
     const requestSeq = ++detailRequestSeq.current;
@@ -1015,6 +1045,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   ]);
 
   useEffect(() => {
+    setActiveTab('overview');
     setExpandedFileKeys(new Set());
     setExpandedCiItemIds(new Set());
     setCiLogById({});
@@ -1037,14 +1068,15 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
 
   useEffect(() => {
     if (!hasDetail || !selectedRemoteId || !selectedPrId || (!repository && !workspacePath)) return;
-    if (activeTab === 'ci') {
-      void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'ci', ciPageIndex, CI_PAGE_SIZE);
+    if (activeTab === 'overview') {
+      void (async () => {
+        await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'ci', ciPageIndex, CI_PAGE_SIZE);
+        await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'reviews', reviewPageIndex, REVIEW_PAGE_SIZE);
+      })();
     } else if (activeTab === 'changes') {
       void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'files', changePageIndex, CHANGE_PAGE_SIZE);
     } else if (activeTab === 'commits') {
       void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'commits', commitPageIndex, COMMIT_PAGE_SIZE);
-    } else if (activeTab === 'reviews') {
-      void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'reviews', reviewPageIndex, REVIEW_PAGE_SIZE);
     }
   }, [
     activeTab,
@@ -1210,7 +1242,8 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   }, [snapshot.pullRequests]);
 
   const headerLabel = selectedRemote ? remoteLabel(selectedRemote) : repository ? repository.projectPath : 'No repository';
-  const panelTitle = detailOnly ? 'Pull Request' : 'Pull Requests';
+  const isGithubUserList = !detailOnly && selectedRemote?.platform === 'github';
+  const panelTitle = detailOnly ? 'Pull Request' : isGithubUserList ? 'My Open Pull Requests' : 'Pull Requests';
 
   const handleRemoteChange = useCallback((value: string | number | (string | number)[]) => {
     const remoteId = Array.isArray(value) ? String(value[0] ?? '') : String(value);
@@ -1218,6 +1251,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     setSelectedPrId(null);
     setDetail(null);
     setDetailError(null);
+    setStateFilter('all');
     setPageIndex(0);
     rememberRemote(workspacePath, remoteId || null);
     void loadSnapshot(remoteId || null, { page: 1 });
@@ -1229,8 +1263,8 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     setDetail(null);
     setDetailError(null);
     setPageIndex(nextPage - 1);
-    void loadSnapshot(selectedRemoteId, { page: nextPage });
-  }, [loadSnapshot, selectedRemoteId]);
+    void loadSnapshot(listRemoteId, { page: nextPage });
+  }, [listRemoteId, loadSnapshot]);
 
   const toggleFileExpanded = useCallback((key: string) => {
     setExpandedFileKeys(prev => {
@@ -1374,14 +1408,6 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
       void loadCiLog(item);
     }
   }, [expandedCiItemIds, loadCiLog, selectedRemote]);
-
-  const handleOpenParentChat = useCallback(async () => {
-    if (!parentSession) {
-      notificationService.warning('Open or create a chat session before linking PR context.', { duration: 3500 });
-      return;
-    }
-    await openMainSession(parentSession.sessionId);
-  }, [parentSession]);
 
   const addPullRequestContextToChat = useCallback(async (input: {
     label: string;
@@ -1612,8 +1638,8 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     snapshotCache.clear();
     detailCache.clear();
     detailPageCache.clear();
-    void loadSnapshot(remoteId, { force: true, page: currentPageIndex + 1 });
-  }, [currentPageIndex, loadSnapshot]);
+    void loadSnapshot(detailOnly ? remoteId : listRemoteId, { force: true, page: currentPageIndex + 1 });
+  }, [currentPageIndex, detailOnly, listRemoteId, loadSnapshot]);
 
   const handleOpenAuthModal = useCallback(() => {
     setAuthToken('');
@@ -1622,7 +1648,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   }, []);
 
   const handleSaveAuthToken = useCallback(async () => {
-    if (!selectedRemote || selectedRemote.platform === 'unknown') return;
+    if (!selectedRemote || selectedRemote.platform === 'unknown' || selectedRemote.platform === 'github') return;
     const token = authToken.trim();
     if (!token) {
       setAuthError('Token is required.');
@@ -1648,6 +1674,40 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
       setAuthSaving(false);
     }
   }, [authToken, refreshAuthSnapshot, selectedRemote]);
+
+  const handleOpenGithubAuthTerminal = useCallback(async () => {
+    if (!selectedRemote || selectedRemote.platform !== 'github') return;
+    const command = `gh auth login --hostname ${selectedRemote.host}`;
+    setAuthSaving(true);
+    setAuthError(null);
+    try {
+      await systemAPI.setClipboard(command);
+      setAuthModalOpen(false);
+      quickActions.openTerminal(undefined, workspacePath);
+      notificationService.success('GitHub CLI login command copied. Paste it in the terminal to continue.', {
+        duration: 3500,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to open GitHub CLI authentication.';
+      setAuthError(message);
+      log.error('Failed to prepare GitHub CLI authentication', { error: err, host: selectedRemote.host });
+    } finally {
+      setAuthSaving(false);
+    }
+  }, [selectedRemote, workspacePath]);
+
+  const handleCopyGithubAuthCommand = useCallback(async () => {
+    if (!selectedRemote || selectedRemote.platform !== 'github') return;
+    setAuthError(null);
+    try {
+      await systemAPI.setClipboard(`gh auth login --hostname ${selectedRemote.host}`);
+      notificationService.success('GitHub CLI login command copied.', { duration: 2500 });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to copy GitHub CLI login command.';
+      setAuthError(message);
+      log.error('Failed to copy GitHub CLI authentication command', { error: err, host: selectedRemote.host });
+    }
+  }, [selectedRemote]);
 
   const handleClearAuthToken = useCallback(async () => {
     if (!selectedRemote || selectedRemote.platform === 'unknown') return;
@@ -1680,12 +1740,12 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
           <strong>{authChallengeTitle(authChallenge)}</strong>
           <span>{authChallenge.message}</span>
           <span>{authChallenge.host} · {authChallenge.projectPath}</span>
-          <span>Required scopes: {authChallengeScopes(authChallenge)}</span>
+          <span>{selectedRemote.platform === 'github' ? 'CLI authorization' : 'Required scopes'}: {authChallengeScopes(authChallenge)}</span>
         </div>
         <div className="review-platform__auth-gate-actions">
           <Button className="review-platform__panel-button" size="small" variant="primary" onClick={handleOpenAuthModal} disabled={authSaving}>
             <KeyRound size={13} />
-            {authChallenge.state === 'missing' ? 'Add token' : 'Update token'}
+            {selectedRemote.platform === 'github' ? 'Authenticate' : authChallenge.state === 'missing' ? 'Add token' : 'Update token'}
           </Button>
           <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={() => refreshAuthSnapshot(selectedRemote.id)} disabled={authSaving || loading}>
             <RefreshCw size={13} />
@@ -1698,8 +1758,12 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
 
   const handleRetryDetail = useCallback(() => {
     if ((!repository && !workspacePath) || !selectedRemoteId || !selectedPrId) return;
-    if (activeTab === 'ci') {
-      void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'ci', ciPageIndex, CI_PAGE_SIZE, { force: true });
+    if (activeTab === 'overview') {
+      void (async () => {
+        await loadDetail(repository, selectedRemoteId, selectedPrId, { force: true });
+        await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'ci', ciPageIndex, CI_PAGE_SIZE, { force: true });
+        await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'reviews', reviewPageIndex, REVIEW_PAGE_SIZE, { force: true });
+      })();
       return;
     }
     if (activeTab === 'changes') {
@@ -1708,10 +1772,6 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     }
     if (activeTab === 'commits') {
       void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'commits', commitPageIndex, COMMIT_PAGE_SIZE, { force: true });
-      return;
-    }
-    if (activeTab === 'reviews') {
-      void loadDetailSection(repository, selectedRemoteId, selectedPrId, 'reviews', reviewPageIndex, REVIEW_PAGE_SIZE, { force: true });
       return;
     }
     void loadDetail(repository, selectedRemoteId, selectedPrId, { force: true });
@@ -1732,10 +1792,15 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   const handleRefreshDetail = useCallback(async () => {
     if ((!repository && !workspacePath) || !selectedRemoteId || !selectedPrId) return;
     await loadDetail(repository, selectedRemoteId, selectedPrId, { force: true });
-    if (activeTab === 'ci') {
+    if (activeTab === 'overview') {
       await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'ci', ciPageIndex, CI_PAGE_SIZE, { force: true });
+      await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'reviews', reviewPageIndex, REVIEW_PAGE_SIZE, { force: true });
+    } else if (activeTab === 'changes') {
+      await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'files', changePageIndex, CHANGE_PAGE_SIZE, { force: true });
+    } else if (activeTab === 'commits') {
+      await loadDetailSection(repository, selectedRemoteId, selectedPrId, 'commits', commitPageIndex, COMMIT_PAGE_SIZE, { force: true });
     }
-  }, [activeTab, ciPageIndex, loadDetail, loadDetailSection, repository, selectedPrId, selectedRemoteId, workspacePath]);
+  }, [activeTab, changePageIndex, ciPageIndex, commitPageIndex, loadDetail, loadDetailSection, repository, reviewPageIndex, selectedPrId, selectedRemoteId, workspacePath]);
 
   const remoteStatus = selectedRemote
     ? `${providerLabel(selectedRemote)} · ${authLabel(account)}`
@@ -1747,7 +1812,11 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
   const emptyStateMessage = snapshot.message
     || account?.message
     || selectedRemote?.message
-    || (snapshot.remotes.length ? 'No pull requests match the current filter.' : 'No supported remotes were detected.');
+    || (snapshot.remotes.length
+      ? isGithubUserList && !query.trim()
+        ? 'No open pull requests authored by the current GitHub CLI account.'
+        : 'No pull requests match the current filter.'
+      : 'No supported remotes were detected.');
   const loadingLabel = loading
     ? snapshotCacheState === 'refreshing'
       ? 'Refreshing cached pull requests...'
@@ -1755,7 +1824,16 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
     : snapshotCacheState === 'cached'
       ? 'Cached pull requests'
       : null;
-  const parentSessionLabel = parentSession ? getSessionTitle(parentSession, 'Current chat') : 'No chat session linked';
+  const checksStatusText = !displayPr || displayPr.checks.total === 0
+    ? 'No checks'
+    : displayPr.checks.failed > 0
+      ? `${displayPr.checks.failed} failed`
+      : displayPr.checks.pending > 0
+        ? `${displayPr.checks.pending} pending`
+        : 'All checks passed';
+  const commentsText = reviewItemCount > 0
+    ? `${reviewItemCount} comment${reviewItemCount === 1 ? '' : 's'}`
+    : 'No comments';
   const reviewStatusText = latestCurrentReview
     ? currentPullRequestReviewStatusText(latestCurrentReview)
     : latestStaleReview
@@ -1814,7 +1892,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
               className="review-platform__icon-button"
               size="xs"
               variant="ghost"
-              tooltip={account?.authSource === 'stored' ? 'Update token' : 'Add token'}
+              tooltip={selectedRemote?.platform === 'github' ? 'GitHub CLI authentication' : account?.authSource === 'stored' ? 'Update token' : 'Add token'}
               disabled={!selectedRemote || selectedRemote.platform === 'unknown' || loading || authSaving}
               onClick={handleOpenAuthModal}
             >
@@ -1837,7 +1915,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
               size="xs"
               variant="ghost"
               tooltip="Refresh"
-              onClick={() => void loadSnapshot(selectedRemoteId, { force: true, page: currentPageIndex + 1 })}
+              onClick={() => void loadSnapshot(listRemoteId, { force: true, page: currentPageIndex + 1 })}
               isLoading={loading}
             >
               <RefreshCw size={14} />
@@ -1850,7 +1928,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
       <div className="review-platform__subbar">
         <div className="review-platform__status-line">
           <span><CircleDot size={12} /> {summary.open} open on page</span>
-          <span><GitPullRequestClosed size={12} /> {summary.merged} merged on page</span>
+          {!isGithubUserList && <span><GitPullRequestClosed size={12} /> {summary.merged} merged on page</span>}
           <span><Sparkles size={12} /> {summary.reviewRequired} review on page</span>
           <span><Link2 size={12} /> {remoteStatus}</span>
           {loadingLabel && (
@@ -1877,18 +1955,20 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
               prefix={<Search size={14} />}
               suffix={query ? <IconButton className="review-platform__icon-button" size="xs" variant="ghost" onClick={() => setQuery('')}><XCircle size={14} /></IconButton> : undefined}
             />
-            <div className="review-platform__state-filters">
-              {(['all', 'open', 'draft', 'merged', 'closed'] as ListStateFilter[]).map(state => (
-                <button
-                  key={state}
-                  type="button"
-                  className={`review-platform__state-chip${stateFilter === state ? ' is-active' : ''}`}
-                  onClick={() => setStateFilter(state)}
-                >
-                  {state === 'all' ? 'All' : stateLabel(state)}
-                </button>
-              ))}
-            </div>
+            {!isGithubUserList && (
+              <div className="review-platform__state-filters">
+                {(['all', 'open', 'draft', 'merged', 'closed'] as ListStateFilter[]).map(state => (
+                  <button
+                    key={state}
+                    type="button"
+                    className={`review-platform__state-chip${stateFilter === state ? ' is-active' : ''}`}
+                    onClick={() => setStateFilter(state)}
+                  >
+                    {state === 'all' ? 'All' : stateLabel(state)}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="review-platform__list-scroll">
@@ -1899,7 +1979,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
               <div className="review-platform__error-state">
                 <XCircle size={16} />
                 <span>{error}</span>
-                <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={() => void loadSnapshot(selectedRemoteId, { force: true, page: currentPageIndex + 1 })}>
+                <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={() => void loadSnapshot(listRemoteId, { force: true, page: currentPageIndex + 1 })}>
                   Retry
                 </Button>
               </div>
@@ -1912,18 +1992,27 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
             )}
             {!loading && !error && visiblePullRequests.map(pr => (
               (() => {
+                const pullRequestRemote = pr.providerId
+                  ? snapshot.remotes.find(remote => remote.id === pr.providerId)
+                  : selectedRemote;
                 return (
                   <button
-                    key={pr.id}
+                    key={`${pr.providerId ?? selectedRemoteId ?? 'remote'}:${pr.id}`}
                     type="button"
-                    className={`review-platform__pr-row${selectedPrId === pr.id ? ' is-selected' : ''}`}
-                    onClick={() => setSelectedPrId(pr.id)}
+                    className={`review-platform__pr-row${selectedPrId === pr.id && (!pr.providerId || pr.providerId === selectedRemoteId) ? ' is-selected' : ''}`}
+                    onClick={() => {
+                      if (pr.providerId && pr.providerId !== selectedRemoteId) {
+                        setSelectedRemoteId(pr.providerId);
+                        rememberRemote(workspacePath, pr.providerId);
+                      }
+                      setSelectedPrId(pr.id);
+                    }}
                   >
                     <span className="review-platform__pr-icon">{getPrIcon(pr)}</span>
                     <span className="review-platform__pr-main">
                       <span className="review-platform__pr-title">{pr.title}</span>
                       <span className="review-platform__pr-meta">
-                        #{pr.number} · {pr.sourceBranch} → {pr.targetBranch}
+                        {pullRequestRemote?.projectPath ? `${pullRequestRemote.projectPath} · ` : ''}#{pr.number} · {pr.sourceBranch} → {pr.targetBranch}
                       </span>
                       <span className="review-platform__pr-meta review-platform__pr-meta--secondary">
                         {pr.author} · {formatRelativeTime(pr.updatedAt)}
@@ -1999,7 +2088,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
                 {selectedRemote && selectedRemote.platform !== 'unknown' && (
                   <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={handleOpenAuthModal} disabled={authSaving}>
                     <KeyRound size={13} />
-                    {account?.authSource === 'stored' ? 'Update token' : 'Add token'}
+                    {selectedRemote.platform === 'github' ? 'Authenticate' : account?.authSource === 'stored' ? 'Update token' : 'Add token'}
                   </Button>
                 )}
               </div>
@@ -2020,32 +2109,16 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
                   <div className="review-platform__detail-title-row">
                     {getPrIcon(selectedPr)}
                     <h3>{selectedPr.title}</h3>
+                    <span className={`review-platform__detail-state review-platform__detail-state--${displayPr?.state ?? selectedPr.state}`}>
+                      {stateLabel(displayPr?.state ?? selectedPr.state)}
+                    </span>
                   </div>
                   <div className="review-platform__detail-meta">
                     <span>#{selectedPr.number}</span>
-                    <span><UserRound size={12} /> {selectedPr.author}</span>
                     <span><Clock3 size={12} /> {formatAbsoluteTime(selectedPr.updatedAt) || formatRelativeTime(selectedPr.updatedAt)}</span>
-                    <span><Code2 size={12} /> {selectedPr.sourceBranch} → {selectedPr.targetBranch}</span>
                   </div>
                 </div>
                 <div className="review-platform__detail-actions">
-                  <IconButton
-                    className="review-platform__icon-button"
-                    size="xs"
-                    variant="ghost"
-                    tooltip="Refresh pull request"
-                    disabled={detailLoading}
-                    onClick={handleRefreshDetail}
-                    isLoading={detailLoading}
-                  >
-                    <RefreshCw size={14} />
-                  </IconButton>
-                  {detailOnly && selectedRemote && selectedRemote.platform !== 'unknown' && (
-                    <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={handleOpenAuthModal} disabled={authSaving}>
-                      <KeyRound size={13} />
-                      {account?.authSource === 'stored' ? 'Update token' : 'Token'}
-                    </Button>
-                  )}
                   <Tooltip content={!parentSession ? 'Open or create a chat first' : 'Start Review'}>
                     <span>
                       <Button
@@ -2068,61 +2141,77 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
                       </Button>
                     </span>
                   </Tooltip>
-                  <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={handleFillPrContext} disabled={!selectedPr}>
-                    <MessageSquareText size={13} />
-                    Add context
-                  </Button>
                   <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={handleOpenExternal} disabled={!selectedPr.webUrl && !initialPullRequestUrl}>
                     <Link2 size={13} />
                     Open
                   </Button>
-                </div>
-              </div>
-
-              <div className="review-platform__summary-strip">
-                <div className="review-platform__summary-card">
-                  <span className="review-platform__summary-label">Files</span>
-                  <strong>{displayPr?.changedFiles ?? selectedPr.changedFiles}</strong>
-                </div>
-                <div className="review-platform__summary-card">
-                  <span className="review-platform__summary-label">Additions</span>
-                  <strong className="review-platform__additions">+{displayPr?.additions ?? selectedPr.additions}</strong>
-                </div>
-                <div className="review-platform__summary-card">
-                  <span className="review-platform__summary-label">Deletions</span>
-                  <strong className="review-platform__deletions">-{displayPr?.deletions ?? selectedPr.deletions}</strong>
-                </div>
-                <div className="review-platform__summary-card">
-                  <span className="review-platform__summary-label">Checks</span>
-                  <strong>{checksText}</strong>
-                </div>
-              </div>
-
-              <section className="review-platform__agent-link-panel" aria-label="Conversation and review agents">
-                <div className="review-platform__agent-link-main">
-                  <span className="review-platform__agent-link-label">Conversation link</span>
-                  <strong>{parentSessionLabel}</strong>
-                  <span>
-                    {reviewStatusText}
-                  </span>
-                </div>
-                <div className="review-platform__agent-link-actions">
-                  <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleOpenParentChat} disabled={!parentSession}>
-                    <MessageSquareText size={13} />
-                    Open chat
-                  </Button>
-                  <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleFillPrContext} disabled={!parentSession || !selectedPr}>
-                    <Code2 size={13} />
-                    Insert context
-                  </Button>
-                  {(latestCurrentReview || latestStaleReview || latestUnknownReview) && (
-                    <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleOpenLatestReview}>
-                      <Sparkles size={13} />
-                      Open Review
-                    </Button>
+                  {detailOnly && selectedRemote && selectedRemote.platform !== 'unknown' && (
+                    <IconButton
+                      className="review-platform__icon-button"
+                      size="xs"
+                      variant="ghost"
+                      tooltip={selectedRemote.platform === 'github' ? 'GitHub CLI authentication' : account?.authSource === 'stored' ? 'Update token' : 'Add token'}
+                      onClick={handleOpenAuthModal}
+                      disabled={authSaving}
+                    >
+                      <KeyRound size={14} />
+                    </IconButton>
                   )}
+                  <IconButton
+                    className="review-platform__icon-button"
+                    size="xs"
+                    variant="ghost"
+                    tooltip="Refresh pull request"
+                    disabled={detailLoading}
+                    onClick={handleRefreshDetail}
+                    isLoading={detailLoading}
+                  >
+                    <RefreshCw size={14} />
+                  </IconButton>
                 </div>
-              </section>
+              </div>
+
+              <div className="review-platform__fact-list">
+                <div className="review-platform__fact-row">
+                  <span className="review-platform__fact-label"><Code2 size={14} /> Branches</span>
+                  <div className="review-platform__fact-value review-platform__fact-value--branch">
+                    <strong>{displayPr?.sourceBranch ?? selectedPr.sourceBranch}</strong>
+                    <ChevronRight size={13} />
+                    <strong>{displayPr?.targetBranch ?? selectedPr.targetBranch}</strong>
+                    <span>{displayPr?.changedFiles ?? selectedPr.changedFiles} files</span>
+                    <span className="review-platform__additions">+{displayPr?.additions ?? selectedPr.additions}</span>
+                    <span className="review-platform__deletions">-{displayPr?.deletions ?? selectedPr.deletions}</span>
+                  </div>
+                </div>
+                <div className="review-platform__fact-row">
+                  <span className="review-platform__fact-label"><UserRound size={14} /> Author</span>
+                  <div className="review-platform__fact-value">
+                    <strong>{displayPr?.author ?? selectedPr.author}</strong>
+                  </div>
+                </div>
+                <div className="review-platform__fact-row">
+                  <span className="review-platform__fact-label"><MessageSquareText size={14} /> Comments</span>
+                  <div className="review-platform__fact-value">{commentsText}</div>
+                </div>
+                <div className="review-platform__fact-row">
+                  <span className="review-platform__fact-label"><CheckCircle2 size={14} /> Checks</span>
+                  <div className="review-platform__fact-value">
+                    <strong>{checksStatusText}</strong>
+                    {displayPr && displayPr.checks.total > 0 && <span>{checksText}</span>}
+                  </div>
+                </div>
+                <div className="review-platform__fact-row">
+                  <span className="review-platform__fact-label"><Sparkles size={14} /> BitFun Review</span>
+                  <div className="review-platform__fact-value review-platform__fact-value--review">
+                    <span>{reviewStatusText}</span>
+                    {(latestCurrentReview || latestStaleReview || latestUnknownReview) && (
+                      <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleOpenLatestReview}>
+                        Open Review
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
 
               <Tabs
                 activeKey={activeTab}
@@ -2132,10 +2221,10 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
                 className="review-platform__tabs"
               >
                 <TabPane tabKey="overview" label="Overview">
-                  <section className="review-platform__tab-content">
-                    <div className="review-platform__body-markdown">
-                      <div className="review-platform__card-heading">
-                        <span>Overview</span>
+                  <div className="review-platform__tab-content review-platform__overview-scroll">
+                    <section className="review-platform__detail-section">
+                      <div className="review-platform__detail-section-heading">
+                        <span>Description</span>
                         <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleFillPrContext} disabled={!selectedPr}>
                           <MessageSquareText size={13} />
                           Add to chat
@@ -2149,170 +2238,168 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
                             Retry
                           </Button>
                         </div>
-                      ) : detail?.body ? (
-                        <MarkdownRenderer content={detail.body} basePath={workspacePath} />
+                      ) : detail ? (
+                        <div className="review-platform__body-markdown review-platform__body-markdown--plain">
+                          {detail.body
+                            ? <MarkdownRenderer content={detail.body} basePath={workspacePath} />
+                            : <span className="review-platform__section-empty">No description was provided.</span>}
+                        </div>
                       ) : (
                         renderDetailLoading('Loading pull request summary...')
                       )}
-                    </div>
-                    <div className="review-platform__capability-row">
-                      <span className="review-platform__capability-chip">State: {stateLabel(displayPr?.state ?? selectedPr.state)}</span>
-                      <span className={`review-platform__decision review-platform__decision--${displayPr?.reviewDecision ?? selectedPr.reviewDecision}`}>
-                        {decisionLabel(displayPr?.reviewDecision ?? selectedPr.reviewDecision)}
-                      </span>
-                      <span className="review-platform__capability-chip">
-                        {selectedRemote ? providerLabel(selectedRemote) : 'Unknown provider'}
-                      </span>
-                    </div>
-                    <div className="review-platform__summary-grid">
-                      <span><CheckCircle2 size={13} /> {checksText} checks</span>
-                      <span><MessageSquareText size={13} /> {reviewItemCount} review items</span>
-                      <span><UserRound size={13} /> {displayPr?.author ?? selectedPr.author}</span>
-                      <span><Clock3 size={13} /> {formatAbsoluteTime(displayPr?.updatedAt ?? selectedPr.updatedAt)}</span>
-                    </div>
-                  </section>
-                </TabPane>
+                    </section>
 
-                <TabPane tabKey="ci" label="CI">
-                  <section className="review-platform__tab-content review-platform__ci-list">
-                    <div className="review-platform__section-heading">
-                      <span>CI</span>
-                      <span className="review-platform__section-count">
-                        {ciTotal ? `${ciTotal} items · ${checksText}` : checksText}
-                      </span>
-                      <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleAddCiPageContext} disabled={!selectedPr || !detail || detailLoading}>
-                        <MessageSquareText size={13} />
-                        Add page
-                      </Button>
-                    </div>
-                    {detailError && (
-                      <div className="review-platform__detail-error">
-                        <XCircle size={14} />
-                        <span>{detailError}</span>
-                        <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={handleRetryDetail}>
-                          Retry
-                        </Button>
+                    <section className="review-platform__detail-section review-platform__ci-list">
+                      <div className="review-platform__detail-section-heading">
+                        <span>Checks</span>
+                        <div className="review-platform__detail-section-actions">
+                          <span className="review-platform__section-count">
+                            {ciTotal ? `${ciTotal} items · ${checksText}` : checksStatusText}
+                          </span>
+                          <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleAddCiPageContext} disabled={!selectedPr || !detail || detailLoading}>
+                            <MessageSquareText size={13} />
+                            Add page
+                          </Button>
+                        </div>
                       </div>
-                    )}
-                    {detailLoading && renderDetailLoading(pagedCiItems.length ? 'Refreshing CI...' : 'Loading CI...', pagedCiItems.length > 0)}
-                    {pagedCiItems.map(item => {
-                      const tone = ciItemTone(item);
-                      const isCiExpanded = expandedCiItemIds.has(item.id);
-                      const ciLog = ciLogById[item.id];
-                      const ciLogLoading = ciLogLoadingIds.has(item.id);
-                      const ciLogError = ciLogErrorById[item.id];
-                      const logAvailable = canLoadCiLog(selectedRemote, item);
-                      const expandable = canExpandCiItem(selectedRemote, item);
-                      return (
-                        <article key={item.id} className={`review-platform__ci-item review-platform__ci-item--${tone}`}>
-                          <div className="review-platform__ci-head">
-                            <div className="review-platform__ci-main">
-                              <strong>{item.name}</strong>
-                              <span>
-                                {[item.detail, item.stage].filter(Boolean).join(' · ') || (item.webUrl ? 'Provider details available' : 'No extra details provided')}
-                              </span>
-                            </div>
-                            <div className="review-platform__ci-actions">
-                              {ciLog && logAvailable && (
-                                <span className="review-platform__ci-log-chip">
-                                  {ciLog.log ? (ciLog.truncated ? 'Errors truncated' : 'Errors loaded') : 'No errors'}
+                      {detailLoading && renderDetailLoading(pagedCiItems.length ? 'Refreshing checks...' : 'Loading checks...', pagedCiItems.length > 0)}
+                      {pagedCiItems.map(item => {
+                        const tone = ciItemTone(item);
+                        const isCiExpanded = expandedCiItemIds.has(item.id);
+                        const ciLog = ciLogById[item.id];
+                        const ciLogLoading = ciLogLoadingIds.has(item.id);
+                        const ciLogError = ciLogErrorById[item.id];
+                        const logAvailable = canLoadCiLog(selectedRemote, item);
+                        const expandable = canExpandCiItem(selectedRemote, item);
+                        return (
+                          <article key={item.id} className={`review-platform__ci-item review-platform__ci-item--${tone}`}>
+                            <div className="review-platform__ci-head">
+                              <div className="review-platform__ci-main">
+                                <strong>{item.name}</strong>
+                                <span>{[item.detail, item.stage].filter(Boolean).join(' · ')}</span>
+                              </div>
+                              <div className="review-platform__ci-actions">
+                                <span className={`review-platform__ci-status review-platform__ci-status--${tone}`}>
+                                  {ciItemStatusText(item)}
                                 </span>
-                              )}
-                              <span className={`review-platform__ci-status review-platform__ci-status--${tone}`}>
-                                {ciItemStatusText(item)}
-                              </span>
-                              {expandable && (
+                                {expandable && (
+                                  <IconButton
+                                    className="review-platform__icon-button review-platform__ci-action"
+                                    size="xs"
+                                    variant="ghost"
+                                    tooltip={isCiExpanded ? 'Collapse details' : 'Expand details'}
+                                    onClick={() => toggleCiExpanded(item)}
+                                    disabled={ciLogLoading}
+                                    aria-busy={ciLogLoading}
+                                  >
+                                    {isCiExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                                  </IconButton>
+                                )}
                                 <IconButton
                                   className="review-platform__icon-button review-platform__ci-action"
                                   size="xs"
                                   variant="ghost"
-                                  tooltip={isCiExpanded ? 'Collapse details' : 'Expand details'}
-                                  onClick={() => toggleCiExpanded(item)}
-                                  disabled={ciLogLoading}
-                                  aria-busy={ciLogLoading}
+                                  tooltip="Add this result to chat"
+                                  onClick={() => void handleAddCiItemContext(item)}
+                                  disabled={!selectedPr}
                                 >
-                                  {isCiExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                                  <MessageSquareText size={13} />
                                 </IconButton>
-                              )}
-                              <IconButton
-                                className="review-platform__icon-button review-platform__ci-action"
-                                size="xs"
-                                variant="ghost"
-                                tooltip="Add this result to chat"
-                                onClick={() => void handleAddCiItemContext(item)}
-                                disabled={!selectedPr}
-                              >
-                                <MessageSquareText size={13} />
-                              </IconButton>
-                              {item.webUrl && (
-                                <IconButton
-                                  className="review-platform__icon-button review-platform__ci-action"
-                                  size="xs"
-                                  variant="ghost"
-                                  tooltip="Open result in provider"
-                                  onClick={() => void handleOpenCiUrl(item.webUrl)}
-                                >
-                                  <Link2 size={12} />
-                                </IconButton>
-                              )}
-                            </div>
-                          </div>
-                          {(item.startedAt || item.finishedAt) && (
-                            <div className="review-platform__ci-meta">
-                              {item.startedAt && <span>Started: {formatAbsoluteTime(item.startedAt) || item.startedAt}</span>}
-                              {item.finishedAt && <span>Finished: {formatAbsoluteTime(item.finishedAt) || item.finishedAt}</span>}
-                            </div>
-                          )}
-                          {isCiExpanded && (
-                            <div className="review-platform__ci-log-panel">
-                              <div className="review-platform__ci-detail-grid">
-                                {item.stage && (
-                                  <div>
-                                    <span>Stage</span>
-                                    <strong>{item.stage}</strong>
-                                  </div>
-                                )}
-                                {item.detail && (
-                                  <div>
-                                    <span>Detail</span>
-                                    <strong>{item.detail}</strong>
-                                  </div>
-                                )}
                                 {item.webUrl && (
-                                  <div>
-                                    <span>URL</span>
-                                    <strong>{item.webUrl}</strong>
-                                  </div>
+                                  <IconButton
+                                    className="review-platform__icon-button review-platform__ci-action"
+                                    size="xs"
+                                    variant="ghost"
+                                    tooltip="Open result in provider"
+                                    onClick={() => void handleOpenCiUrl(item.webUrl)}
+                                  >
+                                    <Link2 size={12} />
+                                  </IconButton>
                                 )}
                               </div>
-                              {ciLogLoading && renderDetailLoading('Loading CI details...')}
-                              {!ciLogLoading && ciLogError && logAvailable && (
-                                <div className="review-platform__detail-error">
-                                  <XCircle size={14} />
-                                  <span>{ciLogError}</span>
-                                  <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={() => void loadCiLog(item)}>
-                                    Retry
-                                  </Button>
-                                </div>
-                              )}
-                              {!ciLogLoading && !ciLogError && (ciLog?.log || item.log) && (
-                                <pre className="review-platform__ci-log-block">{ciLog?.log || item.log}</pre>
-                              )}
-                              {!ciLogLoading && !ciLogError && ciLog && !ciLog.log && !item.log && ciLog.message && (
-                                <div className="review-platform__ci-log-empty">
-                                  {ciLog.message}
-                                </div>
-                              )}
                             </div>
-                          )}
-                        </article>
-                      );
-                    })}
-                    {!detailLoading && detail && ciItems.length === 0 && (
-                      <div className="review-platform__empty-state">No CI entries were returned by this provider.</div>
-                    )}
-                    {renderDetailPagination('CI', ciPage, ciTotal, setCiPageIndex)}
-                  </section>
+                            {isCiExpanded && (
+                              <div className="review-platform__ci-log-panel">
+                                <div className="review-platform__ci-detail-grid">
+                                  {item.stage && <div><span>Stage</span><strong>{item.stage}</strong></div>}
+                                  {item.detail && <div><span>Detail</span><strong>{item.detail}</strong></div>}
+                                  {item.webUrl && <div><span>URL</span><strong>{item.webUrl}</strong></div>}
+                                </div>
+                                {ciLogLoading && renderDetailLoading('Loading check details...')}
+                                {!ciLogLoading && ciLogError && logAvailable && (
+                                  <div className="review-platform__detail-error">
+                                    <XCircle size={14} />
+                                    <span>{ciLogError}</span>
+                                    <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={() => void loadCiLog(item)}>Retry</Button>
+                                  </div>
+                                )}
+                                {!ciLogLoading && !ciLogError && (ciLog?.log || item.log) && <pre className="review-platform__ci-log-block">{ciLog?.log || item.log}</pre>}
+                                {!ciLogLoading && !ciLogError && ciLog && !ciLog.log && !item.log && ciLog.message && <div className="review-platform__ci-log-empty">{ciLog.message}</div>}
+                              </div>
+                            )}
+                          </article>
+                        );
+                      })}
+                      {!detailLoading && detail && ciItems.length === 0 && <div className="review-platform__empty-state">No checks were reported.</div>}
+                      {renderDetailPagination('Checks', ciPage, ciTotal, setCiPageIndex)}
+                    </section>
+
+                    <section className="review-platform__detail-section review-platform__threads">
+                      <div className="review-platform__detail-section-heading">
+                        <span>Comments</span>
+                        <div className="review-platform__detail-section-actions">
+                          <span className="review-platform__section-count">{reviewItemCount}</span>
+                          <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleAddReviewsContext} disabled={!selectedPr || !detail}>
+                            <MessageSquareText size={13} />
+                            Add to chat
+                          </Button>
+                        </div>
+                      </div>
+                      {detailLoading && renderDetailLoading(reviewThreads.length ? 'Refreshing comments...' : 'Loading comments...', reviewThreads.length > 0)}
+                      {pagedReviewThreads.map(thread => {
+                        const parent = thread.replyToProviderCommentId
+                          ? reviewThreadByCommentId.get(thread.replyToProviderCommentId)
+                          : null;
+                        return (
+                          <article
+                            key={thread.id}
+                            className={[
+                              'review-platform__thread',
+                              thread.resolved ? 'is-resolved' : '',
+                              `review-platform__thread--${thread.kind}`,
+                              parent ? 'review-platform__thread--reply' : '',
+                            ].filter(Boolean).join(' ')}
+                          >
+                            <div className="review-platform__thread-head">
+                              <div className="review-platform__thread-tags">
+                                <span className={`review-platform__thread-tag review-platform__thread-tag--${thread.kind}`}>
+                                  {thread.kind === 'review' ? 'Review' : 'Comment'}
+                                </span>
+                                <span className={`review-platform__thread-tag review-platform__thread-tag--${thread.resolved ? 'resolved' : 'open'}`}>
+                                  {thread.resolved ? 'Resolved' : 'Open'}
+                                </span>
+                              </div>
+                              <span>{formatRelativeTime(thread.updatedAt) || formatAbsoluteTime(thread.updatedAt)}</span>
+                            </div>
+                            <div className="review-platform__thread-meta"><strong>{thread.author}</strong></div>
+                            {parent && (
+                              <div className="review-platform__thread-reply-block">
+                                <div className="review-platform__thread-reply-header">
+                                  <span className="review-platform__thread-reply-label">Reply to</span>
+                                  <span className="review-platform__thread-reply-author">@{parent.author}</span>
+                                </div>
+                                <div className="review-platform__thread-reply-body"><MarkdownRenderer content={parent.body} basePath={workspacePath} /></div>
+                              </div>
+                            )}
+                            <div className="review-platform__thread-body"><MarkdownRenderer content={thread.body} basePath={workspacePath} /></div>
+                            {thread.filePath && <span className="review-platform__thread-anchor">{thread.filePath}{thread.line ? `:${thread.line}` : ''}</span>}
+                          </article>
+                        );
+                      })}
+                      {!detailLoading && detail && reviewThreads.length === 0 && <div className="review-platform__empty-state">No comments yet.</div>}
+                      {renderDetailPagination('Comments', reviewPage, reviewThreads.length, setReviewPageIndex)}
+                    </section>
+                  </div>
                 </TabPane>
 
                 <TabPane tabKey="changes" label="Changes">
@@ -2415,82 +2502,6 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
                   </section>
                 </TabPane>
 
-                <TabPane tabKey="reviews" label="Reviews">
-                  <section className="review-platform__tab-content review-platform__threads">
-                    <div className="review-platform__section-heading">
-                      <span>Reviews</span>
-                      <span className="review-platform__section-count">{reviewItemCount} items</span>
-                      <Button className="review-platform__panel-button" size="small" variant="ghost" onClick={handleAddReviewsContext} disabled={!selectedPr || !detail}>
-                        <MessageSquareText size={13} />
-                        Add to chat
-                      </Button>
-                    </div>
-                    {detailError && (
-                      <div className="review-platform__detail-error">
-                        <XCircle size={14} />
-                        <span>{detailError}</span>
-                        <Button className="review-platform__panel-button" size="small" variant="secondary" onClick={handleRetryDetail}>
-                          Retry
-                        </Button>
-                      </div>
-                    )}
-                    {detailLoading && renderDetailLoading(reviewThreads.length ? 'Refreshing reviews...' : 'Loading reviews...', reviewThreads.length > 0)}
-                    {pagedReviewThreads.map(thread => {
-                      const parent = thread.replyToProviderCommentId
-                        ? reviewThreadByCommentId.get(thread.replyToProviderCommentId)
-                        : null;
-                      return (
-                        <article
-                          key={thread.id}
-                          className={[
-                            'review-platform__thread',
-                            thread.resolved ? 'is-resolved' : '',
-                            `review-platform__thread--${thread.kind}`,
-                            parent ? 'review-platform__thread--reply' : '',
-                          ].filter(Boolean).join(' ')}
-                        >
-                          <div className="review-platform__thread-head">
-                            <div className="review-platform__thread-tags">
-                              <span className={`review-platform__thread-tag review-platform__thread-tag--${thread.kind}`}>
-                                {thread.kind === 'review' ? 'Review' : 'Comment'}
-                              </span>
-                              <span className={`review-platform__thread-tag review-platform__thread-tag--${thread.resolved ? 'resolved' : 'open'}`}>
-                                {thread.resolved ? 'Resolved' : 'Open'}
-                              </span>
-                            </div>
-                            <span>{formatRelativeTime(thread.updatedAt) || formatAbsoluteTime(thread.updatedAt)}</span>
-                          </div>
-                          <div className="review-platform__thread-meta">
-                            <strong>{thread.author}</strong>
-                          </div>
-                          {parent && (
-                            <div className="review-platform__thread-reply-block">
-                              <div className="review-platform__thread-reply-header">
-                                <span className="review-platform__thread-reply-label">Reply to</span>
-                                <span className="review-platform__thread-reply-author">@{parent.author}</span>
-                              </div>
-                              <div className="review-platform__thread-reply-body">
-                                <MarkdownRenderer content={parent.body} basePath={workspacePath} />
-                              </div>
-                            </div>
-                          )}
-                          <div className="review-platform__thread-body">
-                            <MarkdownRenderer content={thread.body} basePath={workspacePath} />
-                          </div>
-                          {thread.filePath && (
-                            <span className="review-platform__thread-anchor">
-                              {thread.filePath}{thread.line ? `:${thread.line}` : ''}
-                            </span>
-                          )}
-                        </article>
-                      );
-                    })}
-                    {!detailLoading && detail && reviewThreads.length === 0 && (
-                      <div className="review-platform__empty-state">No reviews or comments were returned by this provider.</div>
-                    )}
-                    {renderDetailPagination('Reviews', reviewPage, reviewThreads.length, setReviewPageIndex)}
-                  </section>
-                </TabPane>
               </Tabs>
             </>
           )}
@@ -2504,7 +2515,7 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
             setAuthError(null);
           }
         }}
-        title={`${selectedRemote ? providerLabel(selectedRemote) : 'Provider'} token`}
+        title={selectedRemote?.platform === 'github' ? 'GitHub CLI authentication' : `${selectedRemote ? providerLabel(selectedRemote) : 'Provider'} token`}
         size="small"
         contentInset
       >
@@ -2519,20 +2530,28 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
             <span>{selectedRemote?.host ?? 'No remote'}</span>
             <strong>{selectedRemote?.projectPath ?? ''}</strong>
           </div>
-          <Input
-            type="password"
-            autoComplete="off"
-            autoFocus
-            label="Token"
-            value={authToken}
-            disabled={authSaving}
-            error={Boolean(authError)}
-            errorMessage={authError ?? undefined}
-            onChange={event => {
-              setAuthToken(event.target.value);
-              if (authError) setAuthError(null);
-            }}
-          />
+          {selectedRemote?.platform === 'github' ? (
+            <div className="review-platform__gh-auth">
+              <span>Run this command in the integrated terminal, finish the GitHub CLI flow, then retry.</span>
+              <code>{`gh auth login --hostname ${selectedRemote.host}`}</code>
+              {authError && <span className="review-platform__gh-auth-error">{authError}</span>}
+            </div>
+          ) : (
+            <Input
+              type="password"
+              autoComplete="off"
+              autoFocus
+              label="Token"
+              value={authToken}
+              disabled={authSaving}
+              error={Boolean(authError)}
+              errorMessage={authError ?? undefined}
+              onChange={event => {
+                setAuthToken(event.target.value);
+                if (authError) setAuthError(null);
+              }}
+            />
+          )}
           <div className="review-platform__auth-actions">
             <Button
               type="button"
@@ -2547,16 +2566,43 @@ export const ReviewPlatformPanel: React.FC<ReviewPlatformPanelProps> = ({
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              className="review-platform__panel-button"
-              size="small"
-              variant="primary"
-              isLoading={authSaving}
-              disabled={!authToken.trim()}
-            >
-              Save
-            </Button>
+            {selectedRemote?.platform === 'github' ? (
+              <>
+                <Button
+                  type="button"
+                  className="review-platform__panel-button"
+                  size="small"
+                  variant="secondary"
+                  disabled={authSaving}
+                  onClick={() => void handleCopyGithubAuthCommand()}
+                >
+                  <Copy size={13} />
+                  Copy
+                </Button>
+                <Button
+                  type="button"
+                  className="review-platform__panel-button"
+                  size="small"
+                  variant="primary"
+                  isLoading={authSaving}
+                  onClick={() => void handleOpenGithubAuthTerminal()}
+                >
+                  <Terminal size={13} />
+                  Open terminal
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="submit"
+                className="review-platform__panel-button"
+                size="small"
+                variant="primary"
+                isLoading={authSaving}
+                disabled={!authToken.trim()}
+              >
+                Save
+              </Button>
+            )}
           </div>
         </form>
       </Modal>

--- a/src/web-ui/src/infrastructure/api/service-api/ReviewPlatformAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ReviewPlatformAPI.test.ts
@@ -59,4 +59,20 @@ describe('ReviewPlatformAPI identity evidence wire', () => {
       { request },
     );
   });
+
+  it('loads workspace context without requesting a pull request list', async () => {
+    const context = { remotes: [], pullRequests: [] };
+    invokeMock.mockResolvedValueOnce(context);
+
+    await expect(
+      reviewPlatformAPI.getWorkspaceContext('D:/workspace/example', 'origin:github:example__repo'),
+    ).resolves.toBe(context);
+
+    expect(invokeMock).toHaveBeenCalledWith('review_platform_get_workspace_context', {
+      request: {
+        repositoryPath: 'D:/workspace/example',
+        remoteId: 'origin:github:example__repo',
+      },
+    });
+  });
 });

--- a/src/web-ui/src/infrastructure/api/service-api/ReviewPlatformAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ReviewPlatformAPI.ts
@@ -6,7 +6,7 @@ const log = createLogger('ReviewPlatformAPI');
 
 export type ReviewPlatformKind = 'github' | 'gitlab' | 'gitcode' | 'unknown';
 export type ReviewAuthState = 'not_connected' | 'not_required' | 'connected' | 'expired' | 'error' | 'unsupported';
-export type ReviewAuthSource = 'env' | 'stored' | 'none' | 'unsupported';
+export type ReviewAuthSource = 'gh_cli' | 'env' | 'stored' | 'none' | 'unsupported';
 export type ReviewAuthChallengeState = 'missing' | 'invalid' | 'insufficient_scope';
 export type ReviewItemState = 'open' | 'merged' | 'closed' | 'draft';
 export type ReviewDecision = 'approved' | 'changes_requested' | 'commented' | 'pending';
@@ -87,6 +87,7 @@ export interface ReviewPlatformCiItem {
 
 export interface ReviewPlatformPullRequest {
   id: string;
+  providerId?: string | null;
   number: number;
   title: string;
   state: ReviewItemState;
@@ -240,6 +241,11 @@ export interface ReviewPlatformWorkspaceSnapshotRequest {
   perPage?: number;
 }
 
+export interface ReviewPlatformWorkspaceContextRequest {
+  repositoryPath: string;
+  remoteId?: string | null;
+}
+
 export interface ReviewPlatformPullRequestDetailRequest {
   repositoryPath: string;
   remoteId: string;
@@ -304,6 +310,23 @@ export class ReviewPlatformAPI {
         remoteId,
         page,
         perPage,
+      });
+    }
+  }
+
+  async getWorkspaceContext(
+    repositoryPath: string,
+    remoteId?: string | null,
+  ): Promise<ReviewPlatformWorkspaceSnapshot> {
+    try {
+      return await api.invoke('review_platform_get_workspace_context', {
+        request: { repositoryPath, remoteId },
+      });
+    } catch (error) {
+      log.error('Failed to load review platform workspace context', { repositoryPath, remoteId, error });
+      throw createTauriCommandError('review_platform_get_workspace_context', error, {
+        repositoryPath,
+        remoteId,
       });
     }
   }


### PR DESCRIPTION
- Support gh CLI-based authentication for GitHub, removing token storage
- Add workspace_context API to load repo context without PR list
- Update tool contracts: GitHub uses gh auth, tokens only for GitLab/GitCode
- Implement multi-remote PR listing with provider-aware selection

## Summary

<!-- Briefly describe what changed. -->

Fixes #

## Type and Areas

Type:

<!-- Feature / bug fix / regression fix / refactor / UI/UX / docs / test / CI / dependency / other. -->

Areas:

<!-- Rust core, desktop/Tauri, web UI, mobile web, server/relay, AI adapters, installer, docs, etc. -->

## Motivation / Impact

<!-- What problem does this solve, and what changes for users or developers? Write "No direct user-facing change" if applicable. -->

## Verification

<!-- List exact commands, manual checks, and outcomes. For docs-only or template-only changes, use the lightest relevant checks or explain why runtime checks were skipped. -->

## Reviewer Notes

<!-- Optional: screenshots, architecture notes, compatibility risks, migration notes, or rollback guidance. -->

## Checklist

- [ ] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [ ] Relevant verification is recorded above, or skipped checks are explained.
- [ ] User-facing strings, docs, and locales are updated where applicable.
