### PR TITLE
fix(web-ui): allow Tab focus traversal inside modal dialogs

### DIFF
--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -188,14 +188,21 @@ function registerGlobalErrorHandlers() {
 
 registerGlobalErrorHandlers();
 
-// Disable Tab-key focus traversal globally.
-// Tab still works inside Monaco Editor and xterm terminal where it has semantic meaning.
+// Disable Tab-key focus traversal globally (IDE-style chrome).
+// Allow Tab where it has semantic meaning: Monaco, xterm, and modal/dialog forms
+// (SSH connect, account login, settings dialogs, etc. — Modal focus trap keeps focus inside).
 document.addEventListener(
   'keydown',
   (e: KeyboardEvent) => {
     if (e.key !== 'Tab') return;
     const target = e.target as Element | null;
-    if (target?.closest('.monaco-editor, .xterm')) return;
+    if (
+      target?.closest(
+        '.monaco-editor, .xterm, [role="dialog"], [aria-modal="true"]'
+      )
+    ) {
+      return;
+    }
     e.preventDefault();
   },
   true


### PR DESCRIPTION
## Summary

- Keep the global IDE-style Tab blocker for app chrome, but allow Tab / Shift+Tab inside modal dialogs (`[role="dialog"]` / `[aria-modal="true"]`).
- Fixes Tab not moving between inputs in Remote SSH “New Connection” and Account Login forms (and other Modal-based forms).

Fixes #

## Type and Areas

Type:

bug fix / UI/UX

Areas:

web UI

## Motivation / Impact

Global Tab `preventDefault` in `main.tsx` blocked focus traversal everywhere except Monaco and xterm. Modal forms (SSH connect, account login) could not Tab between fields. Users can now Tab inside dialogs; main chrome Tab behavior is unchanged.

## Verification

- `pnpm run type-check:web` (pass)
- Manual: open Remote SSH → New Connection and Account Login; Tab / Shift+Tab should move between inputs and stay trapped in the modal

## Reviewer Notes

Root cause is the capture-phase Tab blocker added in `5566db603` (PR #150). This change only widens the allowlist; it does not remove the global blocker.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.