### PR TITLE
fix(remote-connect): install rustls CryptoProvider on all platforms

### DIFF
--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -977,6 +977,11 @@ async fn run_interactive_with_session(
 }
 
 fn main() {
+    // Install rustls CryptoProvider before any TLS-capable work (relay WS,
+    // reqwest rustls paths, Feishu wss). Required when both ring and aws-lc-rs
+    // are linked: rustls cannot auto-select a provider.
+    bitfun_core::service::remote_connect::ensure_rustls_crypto_provider();
+
     let worker = std::thread::Builder::new()
         .stack_size(16 * 1024 * 1024)
         .spawn(|| {

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -280,7 +280,6 @@ pub async fn run() {
     // Install the rustls ring CryptoProvider as the process-level default early,
     // so that all subsequent TLS operations (relay_client, reqwest, tokio-tungstenite)
     // reuse the same provider instead of each attempting their own install_default().
-    // This is a no-op on non-Windows platforms where tokio-tungstenite handles it.
     bitfun_core::service::remote_connect::ensure_rustls_crypto_provider();
 
     eprintln!("=== BitFun Desktop Starting ===");

--- a/src/crates/assembly/core/src/service/remote_connect/mod.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/mod.rs
@@ -423,6 +423,40 @@ impl RemoteConnectService {
             )
             .await?;
 
+        // Wait for RoomCreated before HTTP upload / QR generation so the relay
+        // has registered the room (avoids upload 404 races on BitFun/Custom).
+        // Mirror start_device_connection's AuthOk wait pattern.
+        {
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+            let expected_room = qr_payload.room_id.clone();
+            let mut got_room = false;
+            while !got_room {
+                match tokio::time::timeout_at(deadline, event_rx.recv()).await {
+                    Ok(Some(relay_client::RelayEvent::RoomCreated { room_id })) => {
+                        if room_id == expected_room {
+                            info!("Room created on relay: {room_id}");
+                            got_room = true;
+                        } else {
+                            log::warn!(
+                                "Unexpected RoomCreated room_id={room_id}, expected={expected_room}"
+                            );
+                        }
+                    }
+                    Ok(Some(other)) => {
+                        log::debug!(
+                            "Skipping relay event while waiting for RoomCreated: {other:?}"
+                        );
+                    }
+                    Ok(None) => {
+                        anyhow::bail!("relay connection closed before RoomCreated");
+                    }
+                    Err(_) => {
+                        anyhow::bail!("timeout waiting for RoomCreated");
+                    }
+                }
+            }
+        }
+
         let web_app_url: String = match &method {
             ConnectionMethod::Lan { .. } | ConnectionMethod::Ngrok => relay_url.clone(),
             ConnectionMethod::BitfunServer => {

--- a/src/crates/services/services-integrations/src/remote_connect/bot/feishu.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/feishu.rs
@@ -332,6 +332,9 @@ impl FeishuBotApi {
     }
 
     pub async fn connect_ws(&self, url: &str) -> Result<FeishuWsConnection> {
+        // Feishu uses wss:// and bypasses RelayClient::dial; ensure CryptoProvider
+        // is installed so rustls does not panic when ring + aws-lc-rs are both linked.
+        crate::remote_connect::ensure_rustls_crypto_provider();
         let (ws_stream, _) = tokio_tungstenite::connect_async(url)
             .await
             .map_err(|e| anyhow!("feishu ws connect: {e}"))?;

--- a/src/crates/services/services-integrations/src/remote_connect/relay_client.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/relay_client.rs
@@ -25,16 +25,12 @@ use tokio_tungstenite::{tungstenite::client::IntoClientRequest, Connector};
 /// `install_default()` returns `Err` only when a provider is already installed,
 /// which is harmless — we silently ignore it.
 ///
-/// This is safe to call multiple times and from any thread.
-#[cfg(windows)]
+/// This is safe to call multiple times and from any thread. Required on all
+/// platforms: rustls 0.23 does not auto-select a provider when multiple TLS
+/// stacks are linked into the process.
 pub fn ensure_rustls_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
-
-/// No-op on non-Windows platforms: tokio-tungstenite's built-in TLS support
-/// handles CryptoProvider installation automatically.
-#[cfg(not(windows))]
-pub fn ensure_rustls_crypto_provider() {}
 
 type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
@@ -558,6 +554,11 @@ impl RelayClient {
 }
 
 async fn dial(ws_url: &str) -> Result<WsStream> {
+    // Ensure CryptoProvider is installed before any rustls TLS handshake.
+    // Startup already calls this; calling again is a no-op once installed and
+    // protects reconnect / late-init paths.
+    ensure_rustls_crypto_provider();
+
     let config = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default()
         .max_message_size(Some(64 * 1024 * 1024))
         .max_frame_size(Some(64 * 1024 * 1024))
@@ -591,8 +592,8 @@ async fn dial(ws_url: &str) -> Result<WsStream> {
 
     #[cfg(not(windows))]
     {
-        // Non-Windows uses tokio-tungstenite's built-in rustls connector,
-        // which installs the CryptoProvider as needed.
+        // Non-Windows uses tokio-tungstenite's built-in rustls connector.
+        // CryptoProvider must already be installed (see ensure_rustls_crypto_provider).
         let (stream, _) = tokio_tungstenite::connect_async_with_config(ws_url, Some(config), false)
             .await
             .map_err(|e| anyhow!("dial {ws_url}: {e}"))?;


### PR DESCRIPTION
## Summary
- Fix macOS BitFun Server / relay WSS dial panic when `ring` and `aws-lc-rs` are both linked: install the rustls `ring` CryptoProvider on all platforms (not Windows-only), and re-ensure in `dial()`, CLI startup, and Feishu `wss` connect.
- Wait for `RoomCreated` before mobile-web upload so BitFun/Custom Server QR generation does not race a missing room (404 → fallback).
- Regression originated from #1101, which correctly fixed Windows reconnect races but left non-Windows `ensure_rustls_crypto_provider()` as a no-op under an incorrect auto-install assumption.

## Test plan
- [x] `cargo check -p bitfun-services-integrations --features remote-connect,product-full`
- [x] `cargo check -p bitfun-core --features product-full`
- [x] `cargo check -p bitfun-cli`
- [x] `cargo check -p bitfun-desktop`
- [x] Manual: Desktop → Remote Control → Network Relay → BitFun Server connects and shows QR (macOS)
- [ ] Smoke: LAN relay still works
- [ ] Smoke: Feishu bot connect still works when configured