### PR TITLE
Allocate best-effort titles for forked sessions

### DIFF
--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -59,6 +59,8 @@ const SESSION_TURN_READ_CONCURRENCY: usize = 4;
 
 static SESSION_METADATA_UPDATE_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
     OnceLock::new();
+static SESSION_BRANCH_ALLOCATION_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
+    OnceLock::new();
 
 async fn memory_pollution_guard_enabled() -> bool {
     match get_global_config_service().await {
@@ -530,6 +532,18 @@ impl PersistenceManager {
         let mut registry_guard = registry.lock().await;
         registry_guard
             .entry(metadata_path)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    pub(super) async fn get_session_branch_allocation_lock(
+        &self,
+        workspace_path: &Path,
+    ) -> Arc<Mutex<()>> {
+        let registry = SESSION_BRANCH_ALLOCATION_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut registry_guard = registry.lock().await;
+        registry_guard
+            .entry(workspace_path.to_path_buf())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
     }

--- a/src/crates/assembly/core/src/agentic/persistence/session_branch.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/session_branch.rs
@@ -1,7 +1,10 @@
 use super::manager::PersistenceManager;
 use crate::agentic::core::{Session, SessionKind};
 use crate::util::errors::{BitFunError, BitFunResult};
-use bitfun_services_core::session::{build_branched_session_metadata, BranchSessionMetadataFacts};
+use bitfun_services_core::session::{
+    build_branched_session_metadata, format_branch_session_name, resolve_branch_session_lineage,
+    BranchSessionMetadataFacts,
+};
 pub use bitfun_services_core::session::{SessionBranchRequest, SessionBranchResult};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -14,6 +17,11 @@ impl PersistenceManager {
     ) -> BitFunResult<SessionBranchResult> {
         bitfun_core_types::validate_session_id(&request.source_session_id)
             .map_err(BitFunError::Validation)?;
+        let branch_allocation_lock = self
+            .get_session_branch_allocation_lock(workspace_path)
+            .await;
+        let _branch_allocation_guard = branch_allocation_lock.lock().await;
+
         let source_session = self
             .load_session(workspace_path, &request.source_session_id)
             .await?;
@@ -26,6 +34,14 @@ impl PersistenceManager {
                     request.source_session_id
                 ))
             })?;
+        let metadata_list = self
+            .list_session_metadata_including_internal(workspace_path)
+            .await?;
+        let branch_lineage = resolve_branch_session_lineage(
+            &source_metadata,
+            &source_session.session_name,
+            &metadata_list,
+        );
         let source_turns = self
             .load_session_turns(workspace_path, &request.source_session_id)
             .await?;
@@ -49,7 +65,8 @@ impl PersistenceManager {
                 ))
             })?;
 
-        let target_session_name = source_session.session_name.clone();
+        let target_session_name =
+            format_branch_session_name(&branch_lineage.base_session_name, branch_lineage.ordinal);
         let target_agent_type = source_session.agent_type.clone();
 
         let mut target_session = Session::new(
@@ -159,6 +176,7 @@ impl PersistenceManager {
                 source_turn_id: &request.source_turn_id,
                 source_turn_index,
                 branched_turns: &branched_turns,
+                branch_lineage: &branch_lineage,
                 now_ms,
             });
 
@@ -247,6 +265,34 @@ mod tests {
         );
         turn.mark_completed();
         turn
+    }
+
+    async fn rename_persisted_session(
+        manager: &PersistenceManager,
+        workspace_path: &Path,
+        session_id: &str,
+        session_name: &str,
+    ) {
+        let mut session = manager
+            .load_session(workspace_path, session_id)
+            .await
+            .expect("session should load for rename");
+        session.session_name = session_name.to_string();
+        manager
+            .save_session(workspace_path, &session)
+            .await
+            .expect("renamed session should save");
+
+        let mut metadata = manager
+            .load_session_metadata(workspace_path, session_id)
+            .await
+            .expect("metadata should load for rename")
+            .expect("metadata should exist for rename");
+        metadata.session_name = session_name.to_string();
+        manager
+            .save_session_metadata(workspace_path, &metadata)
+            .await
+            .expect("renamed metadata should save");
     }
 
     #[tokio::test]
@@ -382,7 +428,7 @@ mod tests {
             .expect("branch should succeed");
 
         assert_ne!(result.session_id, source_session.session_id);
-        assert_eq!(result.session_name, "Source Title");
+        assert_eq!(result.session_name, "Source Title (1)");
         assert_eq!(result.agent_type, "agentic");
 
         let branched_turns = manager
@@ -448,7 +494,7 @@ mod tests {
             .await
             .expect("branched metadata load should succeed")
             .expect("branched metadata should exist");
-        assert_eq!(branched_metadata.session_name, "Source Title");
+        assert_eq!(branched_metadata.session_name, "Source Title (1)");
         assert_eq!(branched_metadata.session_kind, SessionKind::Standard);
         assert_eq!(branched_metadata.tags, vec!["kept".to_string()]);
         assert!(branched_metadata.relationship.is_none());
@@ -467,8 +513,238 @@ mod tests {
             serde_json::json!({
                 "sessionId": source_session.session_id,
                 "turnId": "turn-0",
-                "turnIndex": 1
+                "turnIndex": 1,
+                "baseTitle": "Source Title"
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_session_advances_the_family_title_without_growing_suffixes() {
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+        let mut source_session = Session::new(
+            "Source Title".to_string(),
+            "agentic".to_string(),
+            Default::default(),
+        );
+        source_session.kind = SessionKind::Standard;
+        manager
+            .save_session(workspace.path(), &source_session)
+            .await
+            .expect("source session should save");
+        manager
+            .save_dialog_turn(
+                workspace.path(),
+                &build_turn(&source_session.session_id, "turn-0", 0, "first"),
+            )
+            .await
+            .expect("source turn should save");
+
+        let first_branch = manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: source_session.session_id.clone(),
+                    source_turn_id: "turn-0".to_string(),
+                },
+            )
+            .await
+            .expect("first branch should succeed");
+        assert_eq!(first_branch.session_name, "Source Title (1)");
+
+        let nested_branch = manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: first_branch.session_id,
+                    source_turn_id: "turn-0".to_string(),
+                },
+            )
+            .await
+            .expect("nested branch should succeed");
+        assert_eq!(nested_branch.session_name, "Source Title (2)");
+
+        let sibling_branch = manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: source_session.session_id.clone(),
+                    source_turn_id: "turn-0".to_string(),
+                },
+            )
+            .await
+            .expect("sibling branch should succeed");
+        assert_eq!(sibling_branch.session_name, "Source Title (3)");
+
+        let nested_metadata = manager
+            .load_session_metadata(workspace.path(), &nested_branch.session_id)
+            .await
+            .expect("nested metadata should load")
+            .expect("nested metadata should exist");
+        assert_eq!(
+            nested_metadata.custom_metadata.and_then(|metadata| {
+                metadata
+                    .get("forkOrigin")
+                    .and_then(|origin| origin.get("baseTitle"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            }),
+            Some("Source Title".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_session_respects_inherited_and_unrelated_renamed_suffixes() {
+        let workspace = TestWorkspace::new();
+        let manager =
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager");
+        let mut source_session = Session::new(
+            "Source Title".to_string(),
+            "agentic".to_string(),
+            Default::default(),
+        );
+        source_session.kind = SessionKind::Standard;
+        manager
+            .save_session(workspace.path(), &source_session)
+            .await
+            .expect("source session should save");
+        manager
+            .save_dialog_turn(
+                workspace.path(),
+                &build_turn(&source_session.session_id, "turn-0", 0, "first"),
+            )
+            .await
+            .expect("source turn should save");
+
+        let first_branch = manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: source_session.session_id.clone(),
+                    source_turn_id: "turn-0".to_string(),
+                },
+            )
+            .await
+            .expect("first branch should succeed");
+        assert_eq!(first_branch.session_name, "Source Title (1)");
+
+        rename_persisted_session(
+            &manager,
+            workspace.path(),
+            &first_branch.session_id,
+            "Source Title (2)",
+        )
+        .await;
+        let inherited_suffix_branch = manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: first_branch.session_id.clone(),
+                    source_turn_id: "turn-0".to_string(),
+                },
+            )
+            .await
+            .expect("inherited suffix branch should succeed");
+        assert_eq!(inherited_suffix_branch.session_name, "Source Title (3)");
+
+        rename_persisted_session(
+            &manager,
+            workspace.path(),
+            &first_branch.session_id,
+            "Another title (2)",
+        )
+        .await;
+        let unrelated_suffix_branch = manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: first_branch.session_id,
+                    source_turn_id: "turn-0".to_string(),
+                },
+            )
+            .await
+            .expect("unrelated suffix branch should succeed");
+        assert_eq!(
+            unrelated_suffix_branch.session_name,
+            "Another title (2) (1)"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_branches_allocate_distinct_workspace_title_ordinals() {
+        let workspace = TestWorkspace::new();
+        let manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let mut source_session = Session::new(
+            "Source Title".to_string(),
+            "agentic".to_string(),
+            Default::default(),
+        );
+        source_session.kind = SessionKind::Standard;
+        manager
+            .save_session(workspace.path(), &source_session)
+            .await
+            .expect("source session should save");
+        manager
+            .save_dialog_turn(
+                workspace.path(),
+                &build_turn(&source_session.session_id, "turn-0", 0, "first"),
+            )
+            .await
+            .expect("source turn should save");
+
+        let mut second_source_session = Session::new(
+            "Source Title".to_string(),
+            "agentic".to_string(),
+            Default::default(),
+        );
+        second_source_session.kind = SessionKind::Standard;
+        manager
+            .save_session(workspace.path(), &second_source_session)
+            .await
+            .expect("second source session should save");
+        manager
+            .save_dialog_turn(
+                workspace.path(),
+                &build_turn(&second_source_session.session_id, "turn-0", 0, "first"),
+            )
+            .await
+            .expect("second source turn should save");
+
+        let source_session_id = source_session.session_id.clone();
+        let first_manager = Arc::clone(&manager);
+        let second_manager = Arc::clone(&manager);
+        let first_request = SessionBranchRequest {
+            source_session_id: source_session_id.clone(),
+            source_turn_id: "turn-0".to_string(),
+        };
+        let second_request = SessionBranchRequest {
+            source_session_id: second_source_session.session_id,
+            source_turn_id: "turn-0".to_string(),
+        };
+        let (first_result, second_result) = tokio::join!(
+            first_manager.branch_session(workspace.path(), &first_request),
+            second_manager.branch_session(workspace.path(), &second_request),
+        );
+
+        let mut session_names = vec![
+            first_result
+                .expect("first concurrent branch should succeed")
+                .session_name,
+            second_result
+                .expect("second concurrent branch should succeed")
+                .session_name,
+        ];
+        session_names.sort();
+        assert_eq!(
+            session_names,
+            vec![
+                "Source Title (1)".to_string(),
+                "Source Title (2)".to_string()
+            ]
         );
     }
 

--- a/src/crates/services/services-core/src/session/lineage.rs
+++ b/src/crates/services/services-core/src/session/lineage.rs
@@ -42,6 +42,13 @@ pub struct SessionBranchResult {
     pub agent_type: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchSessionLineage {
+    pub base_session_name: String,
+    /// Positive ordinal allocated in the base session-title namespace.
+    pub ordinal: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct BranchSessionMetadataFacts<'a> {
     pub source_metadata: &'a SessionMetadata,
@@ -52,7 +59,55 @@ pub struct BranchSessionMetadataFacts<'a> {
     pub source_turn_id: &'a str,
     pub source_turn_index: usize,
     pub branched_turns: &'a [DialogTurnData],
+    pub branch_lineage: &'a BranchSessionLineage,
     pub now_ms: u64,
+}
+
+/// Resolves the title namespace and the next compact branch title.
+///
+/// A title matching the inherited `base title (N)` keeps that title namespace,
+/// even when a user changed `N`; any other renamed title becomes a new base.
+/// The next ordinal is allocated from matching titles across the workspace, not
+/// from the fork root, so nested forks do not accumulate suffixes.
+pub fn resolve_branch_session_lineage(
+    source_metadata: &SessionMetadata,
+    source_session_name: &str,
+    metadata_list: &[SessionMetadata],
+) -> BranchSessionLineage {
+    let source_session_name = source_session_name.trim();
+    let base_session_name = fork_base_session_name(source_metadata)
+        .filter(|base_session_name| {
+            branch_session_name_ordinal(source_session_name, base_session_name).is_some()
+        })
+        .unwrap_or_else(|| source_session_name.to_string());
+
+    let max_ordinal = std::iter::once(source_session_name)
+        .chain(
+            metadata_list
+                .iter()
+                .map(|metadata| metadata.session_name.as_str()),
+        )
+        .filter_map(|session_name| branch_session_name_ordinal(session_name, &base_session_name))
+        .max()
+        .unwrap_or_default();
+
+    BranchSessionLineage {
+        base_session_name,
+        ordinal: max_ordinal.saturating_add(1),
+    }
+}
+
+pub fn format_branch_session_name(base_session_name: &str, ordinal: usize) -> String {
+    format!("{base_session_name} ({ordinal})")
+}
+
+fn branch_session_name_ordinal(session_name: &str, base_session_name: &str) -> Option<usize> {
+    let suffix = session_name
+        .trim()
+        .strip_prefix(base_session_name)?
+        .strip_prefix(" (")?
+        .strip_suffix(')')?;
+    suffix.parse::<usize>().ok().filter(|value| *value > 0)
 }
 
 pub fn apply_session_lineage(metadata: &mut SessionMetadata, relationship: SessionRelationship) {
@@ -216,6 +271,7 @@ pub fn build_branched_session_metadata(facts: BranchSessionMetadataFacts<'_>) ->
         facts.source_session_id,
         facts.source_turn_id,
         facts.source_turn_index,
+        facts.branch_lineage,
     );
     metadata.relationship = None;
     metadata.todos = None;
@@ -258,6 +314,7 @@ fn build_branch_custom_metadata(
     source_session_id: &str,
     source_turn_id: &str,
     source_turn_index: usize,
+    branch_lineage: &BranchSessionLineage,
 ) -> Option<JsonValue> {
     let mut base = match strip_child_session_metadata(source_metadata) {
         Some(JsonValue::Object(map)) => map,
@@ -270,10 +327,26 @@ fn build_branch_custom_metadata(
             "sessionId": source_session_id,
             "turnId": source_turn_id,
             "turnIndex": source_turn_index + 1,
+            "baseTitle": branch_lineage.base_session_name,
         }),
     );
 
     Some(JsonValue::Object(base))
+}
+
+fn fork_base_session_name(metadata: &SessionMetadata) -> Option<String> {
+    metadata
+        .custom_metadata
+        .as_ref()?
+        .get("forkOrigin")?
+        .get("baseTitle")?
+        .as_str()
+        .and_then(normalize_nonempty)
+}
+
+fn normalize_nonempty(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 #[cfg(test)]
@@ -501,6 +574,10 @@ mod tests {
         source.unread_completion = Some("completed".to_string());
         source.needs_user_attention = Some("ask_user".to_string());
         let turns = vec![turn("target", "turn-1", 0), turn("target", "turn-2", 1)];
+        let branch_lineage = BranchSessionLineage {
+            base_session_name: "Source".to_string(),
+            ordinal: 1,
+        };
 
         let branched = build_branched_session_metadata(BranchSessionMetadataFacts {
             source_metadata: &source,
@@ -511,6 +588,7 @@ mod tests {
             source_turn_id: "turn-2",
             source_turn_index: 1,
             branched_turns: &turns,
+            branch_lineage: &branch_lineage,
             now_ms: 42,
         });
 
@@ -541,8 +619,82 @@ mod tests {
             json!({
                 "sessionId": "source",
                 "turnId": "turn-2",
-                "turnIndex": 2
+                "turnIndex": 2,
+                "baseTitle": "Source"
             })
+        );
+    }
+
+    #[test]
+    fn branch_lineage_uses_the_inherited_title_namespace_for_renamed_suffixes() {
+        let mut root = metadata("root");
+        root.session_name = "Title".to_string();
+
+        let mut first_branch = metadata("first-branch");
+        first_branch.session_name = "Title (2)".to_string();
+        first_branch.custom_metadata = Some(json!({
+            "forkOrigin": {
+                "sessionId": "root",
+                "turnId": "turn-0",
+                "turnIndex": 1,
+                "baseTitle": "Title"
+            }
+        }));
+
+        let nested_lineage = resolve_branch_session_lineage(
+            &first_branch,
+            &first_branch.session_name,
+            &[root.clone(), first_branch.clone()],
+        );
+        assert_eq!(nested_lineage.base_session_name, "Title");
+        assert_eq!(nested_lineage.ordinal, 3);
+        assert_eq!(
+            format_branch_session_name(&nested_lineage.base_session_name, nested_lineage.ordinal),
+            "Title (3)"
+        );
+
+        let mut second_branch = metadata("second-branch");
+        second_branch.session_name = "Title (3)".to_string();
+        second_branch.custom_metadata = Some(json!({
+            "forkOrigin": {
+                "sessionId": "first-branch",
+                "turnId": "turn-0",
+                "turnIndex": 1,
+                "baseTitle": "Title"
+            }
+        }));
+
+        let sibling_lineage = resolve_branch_session_lineage(
+            &root,
+            &root.session_name,
+            &[root.clone(), first_branch, second_branch],
+        );
+        assert_eq!(sibling_lineage.base_session_name, "Title");
+        assert_eq!(sibling_lineage.ordinal, 4);
+    }
+
+    #[test]
+    fn branch_lineage_treats_an_unrelated_suffix_as_a_new_title_base() {
+        let mut root = metadata("root");
+        root.session_name = "Title".to_string();
+        let mut branch = metadata("branch");
+        branch.session_name = "Another title (2)".to_string();
+        branch.custom_metadata = Some(json!({
+            "forkOrigin": {
+                "sessionId": "root",
+                "turnId": "turn-0",
+                "turnIndex": 1,
+                "baseTitle": "Title"
+            }
+        }));
+
+        let lineage =
+            resolve_branch_session_lineage(&branch, &branch.session_name, &[root, branch.clone()]);
+        assert_eq!(lineage.base_session_name, "Another title (2)");
+        assert_eq!(lineage.ordinal, 1);
+        assert_eq!(
+            format_branch_session_name(&lineage.base_session_name, lineage.ordinal),
+            "Another title (2) (1)"
         );
     }
 }

--- a/src/crates/services/services-core/src/session/mod.rs
+++ b/src/crates/services/services-core/src/session/mod.rs
@@ -11,6 +11,7 @@ pub use bitfun_core_types::SessionKind;
 pub use layout::SessionStorageLayout;
 pub use lineage::{
     apply_session_lineage, build_branched_session_metadata, collect_hidden_subagent_cascade,
+    format_branch_session_name, resolve_branch_session_lineage, BranchSessionLineage,
     BranchSessionMetadataFacts, SessionBranchRequest, SessionBranchResult,
 };
 pub use memory_workspace::{

--- a/src/web-ui/src/shared/types/session-history.ts
+++ b/src/web-ui/src/shared/types/session-history.ts
@@ -33,6 +33,7 @@ export interface SessionCustomMetadata extends Record<string, unknown> {
     sessionId?: string | null;
     turnId?: string | null;
     turnIndex?: number | null;
+    baseTitle?: string | null;
   } | null;
   lastFinishedAt?: number | null;
   titleSource?: SessionTitleSource | null;


### PR DESCRIPTION
## Summary

Assign compact `base title (N)` suffixes to forked sessions instead of reusing the source title.

Fixes #1596

## Type and Areas

Type:

Bug fix

Areas:

Rust core, web UI

## Motivation / Impact

Forked sessions previously reused the source title. New forks now select the next available suffix across the workspace, so nested forks remain `title (N)` rather than accumulating suffixes.

A renamed branch retains its inherited namespace only while its current title matches `base title (N)`. Otherwise, its current title starts a new namespace.

## Verification

- `pnpm run fmt:rs`
- `pnpm run type-check:web`
- `cargo test -p bitfun-services-core branch_lineage --lib -j 1`
- `cargo test -p bitfun-core branch_session --lib -j 1`
- `cargo test -p bitfun-core concurrent_branches_allocate_distinct_workspace_title_ordinals --lib -j 1`
- `git diff --check`
- `git diff --cached --check`

All passed.

## Reviewer Notes

Title allocation is best-effort.

The in-process lock serializes concurrent forks within one runtime instance using the same workspace-path form. Duplicate titles can still occur when separate processes, such as the desktop app and CLI, fork sessions in the same workspace during the same allocation window. The same limitation applies if one in-process caller uses the logical workspace root while another uses the resolved sessions directory.

Existing sessions without `forkOrigin.baseTitle` use their current title as the base on their next fork.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above.
- [x] User-facing strings, docs, and locales are unchanged.