### PR TITLE
fix(agentic): preserve background subagent dialog turn ids

### DIFF
--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -495,13 +495,19 @@ pub(crate) struct HiddenSubagentExecutionRequest {
     external_generation_lease: Option<crate::agentic::agents::ExternalSubagentGenerationLease>,
 }
 
+fn ensure_hidden_subagent_dialog_turn_id(dialog_turn_id: &mut Option<String>) -> String {
+    dialog_turn_id
+        .get_or_insert_with(|| uuid::Uuid::new_v4().to_string())
+        .clone()
+}
+
 impl HiddenSubagentExecutionRequest {
     pub(super) fn target_session_id(&self) -> Option<&str> {
         self.target_session_id.as_deref()
     }
 
-    pub(super) fn set_dialog_turn_id(&mut self, dialog_turn_id: String) {
-        self.dialog_turn_id = Some(dialog_turn_id);
+    pub(super) fn ensure_dialog_turn_id(&mut self) -> String {
+        ensure_hidden_subagent_dialog_turn_id(&mut self.dialog_turn_id)
     }
 
     pub(super) fn logical_agent_type(&self) -> &str {
@@ -5336,7 +5342,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
         let turn_index = self.session_manager.get_turn_count(&session_id);
         let requested_dialog_turn_id =
-            dialog_turn_id.unwrap_or_else(|| format!("subagent-{}", uuid::Uuid::new_v4()));
+            dialog_turn_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let dialog_turn_id = self
             .session_manager
             .start_dialog_turn_with_existing_context(
@@ -7191,23 +7197,15 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let request = self
             .resolve_hidden_subagent_execution_request(request, Some(allow_review_follow_up))
             .await?;
-        let request = self
+        let mut request = self
             .prepare_hidden_subagent_execution_request(request)
             .await?;
+        let subagent_dialog_turn_id = request.ensure_dialog_turn_id();
         let subagent_session_id = request
             .target_session_id()
             .ok_or_else(|| {
                 BitFunError::Validation(
                     "prepared hidden subagent request is missing target_session_id".to_string(),
-                )
-            })?
-            .to_string();
-        let subagent_dialog_turn_id = request
-            .dialog_turn_id
-            .as_deref()
-            .ok_or_else(|| {
-                BitFunError::Validation(
-                    "prepared hidden subagent request is missing dialog_turn_id".to_string(),
                 )
             })?
             .to_string();
@@ -8860,6 +8858,23 @@ mod tests {
             "Investigate",
         );
         assert!(!non_peer_metadata.contains_key("require_tool_confirmation"));
+    }
+
+    #[test]
+    fn hidden_subagent_dialog_turn_id_reuses_existing_or_generates_raw_uuid() {
+        let mut missing = None;
+        let generated = super::ensure_hidden_subagent_dialog_turn_id(&mut missing);
+
+        assert_eq!(missing.as_deref(), Some(generated.as_str()));
+        assert!(uuid::Uuid::parse_str(&generated).is_ok());
+        assert!(!generated.starts_with("subagent-"));
+
+        let mut existing = Some("child-turn".to_string());
+        assert_eq!(
+            super::ensure_hidden_subagent_dialog_turn_id(&mut existing),
+            "child-turn"
+        );
+        assert_eq!(existing.as_deref(), Some("child-turn"));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -1014,8 +1014,7 @@ impl DialogScheduler {
                 "prepared hidden subagent request is missing target_session_id".to_string()
             })?
             .to_string();
-        let resolved_turn_id = format!("subagent-{}", Uuid::new_v4());
-        request.set_dialog_turn_id(resolved_turn_id.clone());
+        let resolved_turn_id = request.ensure_dialog_turn_id();
         let agent_type = request.logical_agent_type().to_string();
         let user_input = request.user_input_text().to_string();
         let session = self


### PR DESCRIPTION
## Summary

Fixes a background subagent regression introduced by `5e48999f94daf119c1217ed6b71ba878d564f5dd` (`refactor(cli): route Peer Host through the assembled runtime`).

- Allocate the child `dialog_turn_id` before composing background-result metadata.
- Reuse that ID in the scheduler and direct hidden-subagent paths.
- Generate new child turn IDs as raw UUIDs rather than `subagent-<uuid>`.
- Add coverage for raw UUID generation and preallocated-ID reuse.

Fixes #

## Type and Areas

Type: Regression fix

Areas: Rust core, agent coordination, subagent scheduling

## Motivation / Impact

`5e48999` added exact parent/child turn lineage to background-result metadata for Peer Host routing and delivery control. It also read `request.dialog_turn_id` before the scheduler or direct execution path assigned it.

The prepared hidden-subagent request intentionally has no turn ID at that stage, so every background subagent failed with:

`prepared hidden subagent request is missing dialog_turn_id`

The fix establishes the child turn ID at the background-launch boundary and preserves it through scheduling and execution. This keeps metadata, the scheduler queue, and the actual child DialogTurn aligned.

No migration is required. Existing persisted turns remain unchanged.

## Verification

- `pnpm run fmt:rs`
- `git diff --check`
- `cargo check -p bitfun-core -j 1`
- `cargo test -p bitfun-core hidden_subagent_dialog_turn_id_reuses_existing_or_generates_raw_uuid -- --nocapture`
- `cargo test -p bitfun-core --lib hidden_subagent_dialog_turn_id_reuses_existing_or_generates_raw_uuid -j 1 -- --nocapture`
- Manual: reproduced the original background-subagent failure, then confirmed the same scenario succeeds after the fix.

## Reviewer Notes

The regression came from moving the requirement for a child turn ID ahead of its existing allocation point. The scheduler now reuses a preallocated ID, and the non-scheduler path already consumes a supplied ID, so both execution modes retain one stable identity for Peer Host lineage and background-result delivery.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, with local test limitations explained.
- [x] No user-facing strings, docs, or locale resources changed.