### PR TITLE
fix(file-explorer): align default exclusions with VS Code

### DIFF
--- a/src/crates/services/services-core/src/filesystem/tree.rs
+++ b/src/crates/services/services-core/src/filesystem/tree.rs
@@ -108,22 +108,15 @@ impl Default for FileTreeOptions {
     fn default() -> Self {
         Self {
             max_depth: Some(50),
-            include_hidden: false,
+            include_hidden: true,
             include_git_info: false,
             include_mime_types: false,
             skip_patterns: vec![
-                "node_modules".to_string(),
-                "target".to_string(),
                 ".git".to_string(),
-                "dist".to_string(),
-                "build".to_string(),
-                ".next".to_string(),
-                ".nuxt".to_string(),
-                ".cache".to_string(),
-                "coverage".to_string(),
-                "__pycache__".to_string(),
-                ".vscode".to_string(),
-                ".idea".to_string(),
+                ".svn".to_string(),
+                ".hg".to_string(),
+                ".DS_Store".to_string(),
+                "Thumbs.db".to_string(),
             ],
             max_file_size_mb: Some(100),
             follow_symlinks: false,
@@ -776,8 +769,7 @@ impl FileTreeService {
     }
 
     fn should_skip_file(&self, file_name: &str) -> bool {
-        // Skip hidden files and directories (unless explicitly included)
-        // But .gitignore and .bitfun are always shown
+        // Skip hidden files and directories unless explicitly included.
         if !self.options.include_hidden
             && file_name.starts_with('.')
             && file_name != ".gitignore"
@@ -1595,6 +1587,30 @@ pub enum SearchMatchType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_tree_visibility_matches_vscode_baseline() {
+        let service = FileTreeService::default();
+
+        for name in [".git", ".svn", ".hg", ".DS_Store", "Thumbs.db"] {
+            assert!(service.should_skip_file(name), "{name} should be excluded");
+        }
+
+        for name in [
+            ".env",
+            ".github",
+            ".vscode",
+            "node_modules",
+            "target",
+            "dist",
+            "build",
+        ] {
+            assert!(
+                !service.should_skip_file(name),
+                "{name} should be visible by default"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn content_search_preserves_matching_lines_and_preview_ranges() {

--- a/src/web-ui/src/app/components/panels/FilesPanel.tsx
+++ b/src/web-ui/src/app/components/panels/FilesPanel.tsx
@@ -266,7 +266,7 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
     rootPath: workspacePath,
     autoLoad: true,
     enablePathCompression: true,
-    showHiddenFiles: false,
+    showHiddenFiles: true,
     // Local filesystem watchers are unavailable for remote SSH workspaces.
     enableAutoWatch: !isRemoteCurrentWorkspace,
   });

--- a/src/web-ui/src/tools/file-explorer/controller/ExplorerController.ts
+++ b/src/web-ui/src/tools/file-explorer/controller/ExplorerController.ts
@@ -94,7 +94,7 @@ export class ExplorerController {
     autoLoad: true,
     enableAutoWatch: true,
     enablePathCompression: true,
-    showHiddenFiles: false,
+    showHiddenFiles: true,
     sortBy: 'name',
     sortOrder: 'asc',
     excludePatterns: [],

--- a/src/web-ui/src/tools/file-explorer/hooks/useExplorerController.ts
+++ b/src/web-ui/src/tools/file-explorer/hooks/useExplorerController.ts
@@ -12,7 +12,7 @@ const EMPTY_SNAPSHOT: ExplorerSnapshot = {
   loadingPaths: new Set(),
   options: {
     enablePathCompression: true,
-    showHiddenFiles: false,
+    showHiddenFiles: true,
     sortBy: 'name',
     sortOrder: 'asc',
     excludePatterns: [],

--- a/src/web-ui/src/tools/file-explorer/model/ExplorerModel.ts
+++ b/src/web-ui/src/tools/file-explorer/model/ExplorerModel.ts
@@ -8,7 +8,7 @@ import type { ExplorerControllerConfig, ExplorerNodeRecord, ExplorerSnapshot } f
 
 const DEFAULT_OPTIONS: FileSystemOptions = {
   enablePathCompression: true,
-  showHiddenFiles: false,
+  showHiddenFiles: true,
   sortBy: 'name',
   sortOrder: 'asc',
   maxDepth: undefined,


### PR DESCRIPTION
## Summary

- Align default file-tree exclusions with VS Code's built-in baseline.
- Show dotfiles, IDE metadata, dependency directories, and build outputs by default.
- Keep `.git`, `.svn`, `.hg`, `.DS_Store`, and `Thumbs.db` excluded.
- Add a Rust contract test for the default visibility behavior.

Fixes #

## Type and Areas

Type:

bug fix / UI/UX / test

Areas:

Rust core, desktop/Tauri, web UI

## Motivation / Impact

The workspace explorer previously hid a broad hard-coded set of project directories such as `target`, `node_modules`, `dist`, and `.vscode`. It now follows VS Code's narrower built-in exclusion baseline, making project files and generated outputs visible by default.

The follow-up work for user-configurable glob exclusions, `.gitignore` handling, persistence, and remote-rule unification is intentionally out of scope.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-services-core default_tree_visibility_matches_vscode_baseline`
- `pnpm run type-check:web`
- `git diff --check`

## Reviewer Notes

This change only updates default visibility. Search filtering and remote SSH directory filtering remain unchanged.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.