### PR TITLE
feat(agentic): add explicit background subagent result waiting

### DIFF
--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -7896,7 +7896,7 @@ export const requiredContentRules = [
   {
     path: 'src/crates/assembly/core/src/agentic/tools/implementations/task/background.rs',
     reason:
-      'core Task background acknowledgement must remain assistant-visible and not expose internal background task ids',
+      'core Task background acknowledgement must remain assistant-visible and expose the task id needed for explicit result collection',
     patterns: [
       {
         regex: /Background subagent started successfully/,
@@ -7910,7 +7910,7 @@ export const requiredContentRules = [
       'core Task tests must preserve background acknowledgement shape',
     patterns: [
       {
-        regex: /\bbackground_subagent_start_acknowledgement_uses_session_id_only\b/,
+        regex: /\bbackground_subagent_start_acknowledgement_exposes_agent_wait_task_id\b/,
         message: 'missing background task start acknowledgement regression',
       },
       {

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -3361,7 +3361,7 @@ export function runManifestParserSelfTest({
     {
       path: 'src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs',
       contracts: [
-        'background_subagent_start_acknowledgement_uses_session_id_only',
+        'background_subagent_start_acknowledgement_exposes_agent_wait_task_id',
         '<background_task',
       ],
     },

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/claw.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/claw.rs
@@ -17,6 +17,7 @@ impl ClawMode {
         Self {
             default_tools: vec![
                 "Task".to_string(),
+                "AgentWait".to_string(),
                 "Read".to_string(),
                 "view_image".to_string(),
                 "analyze_image".to_string(),

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/cowork.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/cowork.rs
@@ -31,6 +31,7 @@ impl CoworkMode {
                 "AskUserQuestion".to_string(),
                 "TodoWrite".to_string(),
                 "Task".to_string(),
+                "AgentWait".to_string(),
                 "Skill".to_string(),
                 // Discovery + editing
                 "LS".to_string(),

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/deep_research.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/deep_research.rs
@@ -21,6 +21,7 @@ impl DeepResearchMode {
         Self {
             default_tools: vec![
                 "Task".to_string(),
+                "AgentWait".to_string(),
                 "WebSearch".to_string(),
                 "WebFetch".to_string(),
                 "Read".to_string(),

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/team.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/team.rs
@@ -22,6 +22,7 @@ impl TeamMode {
             default_tools: vec![
                 "Skill".to_string(),
                 "Task".to_string(),
+                "AgentWait".to_string(),
                 "Read".to_string(),
                 "view_image".to_string(),
                 "analyze_image".to_string(),

--- a/src/crates/assembly/core/src/agentic/agents/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/mod.rs
@@ -107,6 +107,7 @@ fn append_provider_group_tools(tools: &mut Vec<String>, provider_id: &'static st
 pub fn shared_coding_mode_tools() -> Vec<String> {
     let mut tools = vec![
         "Task".to_string(),
+        "AgentWait".to_string(),
         "Read".to_string(),
         "view_image".to_string(),
         "analyze_image".to_string(),

--- a/src/crates/assembly/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
@@ -7,7 +7,7 @@ Before starting work, check whether the task contains two or more orthogonal bra
 ## Subagent Delegation Strategy
 
 - Prefer background subagents (setting `run_in_background: true` on the Task call) whenever the branch is independent and does not block your immediate next step.
-- Background subagent results are delivered back to you automatically when they finish. Do not poll or repeatedly check on background work just for status updates. If your current path is blocked on a background result and there is no other productive local work to do, it is fine to end the current turn instead of waiting idly.
+- Background Task responses include a `background_task_id`. Results are not delivered automatically. Continue independent work, then call AgentWait with the relevant task IDs before ending a turn whose answer depends on them. Do not poll background work for status updates.
 - Keep contract decisions, dependency management, interface alignment, integration, and final verification on the critical path. Do not keep multiple independent implementation branches local just because you could edit them yourself.
 
 ## Task Handoff Instructions

--- a/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
@@ -1,0 +1,436 @@
+use super::coordinator::{SubagentResult, SubagentResultStatus};
+use crate::agentic::session::SessionManager;
+use crate::util::errors::{BitFunError, BitFunResult};
+use dashmap::DashMap;
+use log::warn;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::Notify;
+use tokio::time::{sleep_until, Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+const OUTCOME_METADATA_KEY_PREFIX: &str = "backgroundSubagentOutcome:";
+const RESULT_DEBOUNCE: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BackgroundSubagentOutcomeStatus {
+    Running,
+    Completed,
+    PartialTimeout,
+    Failed,
+    Cancelled,
+}
+
+impl BackgroundSubagentOutcomeStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::PartialTimeout => "partial_timeout",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    fn is_terminal(self) -> bool {
+        !matches!(self, Self::Running)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BackgroundSubagentOutcome {
+    pub background_task_id: String,
+    pub parent_session_id: String,
+    pub parent_dialog_turn_id: String,
+    pub subagent_session_id: String,
+    pub subagent_dialog_turn_id: String,
+    pub subagent_type: String,
+    pub task_description: String,
+    pub status: BackgroundSubagentOutcomeStatus,
+    pub content: Option<String>,
+    pub error: Option<String>,
+    pub created_at_ms: u64,
+    pub completed_at_ms: Option<u64>,
+    pub consumed_at_ms: Option<u64>,
+}
+
+impl BackgroundSubagentOutcome {
+    pub(crate) fn running(
+        background_task_id: String,
+        parent_session_id: String,
+        parent_dialog_turn_id: String,
+        subagent_session_id: String,
+        subagent_dialog_turn_id: String,
+        subagent_type: String,
+        task_description: String,
+    ) -> Self {
+        Self {
+            background_task_id,
+            parent_session_id,
+            parent_dialog_turn_id,
+            subagent_session_id,
+            subagent_dialog_turn_id,
+            subagent_type,
+            task_description,
+            status: BackgroundSubagentOutcomeStatus::Running,
+            content: None,
+            error: None,
+            created_at_ms: unix_time_ms(),
+            completed_at_ms: None,
+            consumed_at_ms: None,
+        }
+    }
+
+    fn complete_from_subagent_result(&mut self, result: &SubagentResult) {
+        self.status = match result.status {
+            SubagentResultStatus::Completed => BackgroundSubagentOutcomeStatus::Completed,
+            SubagentResultStatus::PartialTimeout => BackgroundSubagentOutcomeStatus::PartialTimeout,
+        };
+        self.content = Some(result.text.clone());
+        self.error = result.reason.clone();
+        self.completed_at_ms = Some(unix_time_ms());
+    }
+
+    fn fail(&mut self, error: &BitFunError) {
+        self.status = BackgroundSubagentOutcomeStatus::Failed;
+        self.content = None;
+        self.error = Some(error.to_string());
+        self.completed_at_ms = Some(unix_time_ms());
+    }
+
+    fn cancel(&mut self) {
+        self.status = BackgroundSubagentOutcomeStatus::Cancelled;
+        self.content = None;
+        self.error = Some("Background subagent task was cancelled".to_string());
+        self.completed_at_ms = Some(unix_time_ms());
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackgroundSubagentWaitStatus {
+    Completed,
+    TimedOut,
+    Cancelled,
+    NoMatchingTasks,
+}
+
+impl BackgroundSubagentWaitStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::TimedOut => "timed_out",
+            Self::Cancelled => "cancelled",
+            Self::NoMatchingTasks => "no_matching_tasks",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BackgroundSubagentWaitResult {
+    pub status: BackgroundSubagentWaitStatus,
+    pub outcomes: Vec<BackgroundSubagentOutcome>,
+    pub pending_background_task_ids: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct OutcomeClaim {
+    had_matching_tasks: bool,
+    outcomes: Vec<BackgroundSubagentOutcome>,
+    pending_background_task_ids: Vec<String>,
+}
+
+pub(crate) struct BackgroundSubagentOutcomeStore {
+    outcomes: DashMap<String, BackgroundSubagentOutcome>,
+    changes: Notify,
+    session_manager: Arc<SessionManager>,
+}
+
+impl BackgroundSubagentOutcomeStore {
+    pub(crate) fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self {
+            outcomes: DashMap::new(),
+            changes: Notify::new(),
+            session_manager,
+        }
+    }
+
+    pub(crate) async fn register(&self, outcome: BackgroundSubagentOutcome) -> BitFunResult<()> {
+        self.outcomes
+            .insert(outcome.background_task_id.clone(), outcome.clone());
+        if let Err(error) = self.persist(&outcome).await {
+            self.outcomes.remove(&outcome.background_task_id);
+            return Err(error);
+        }
+        self.changes.notify_waiters();
+        Ok(())
+    }
+
+    pub(crate) async fn complete(
+        &self,
+        background_task_id: &str,
+        result: Result<&SubagentResult, &BitFunError>,
+    ) {
+        let outcome = {
+            let Some(mut entry) = self.outcomes.get_mut(background_task_id) else {
+                warn!(
+                    "Background subagent outcome record is missing at completion: background_task_id={}",
+                    background_task_id
+                );
+                return;
+            };
+            if entry.status == BackgroundSubagentOutcomeStatus::Cancelled {
+                return;
+            }
+            match result {
+                Ok(result) => entry.complete_from_subagent_result(result),
+                Err(error) => entry.fail(error),
+            }
+            entry.clone()
+        };
+        self.persist_best_effort(&outcome).await;
+        self.changes.notify_waiters();
+    }
+
+    pub(crate) async fn cancel(&self, background_task_ids: &[String]) {
+        for background_task_id in background_task_ids {
+            let outcome = {
+                let Some(mut entry) = self.outcomes.get_mut(background_task_id) else {
+                    continue;
+                };
+                if entry.status.is_terminal() {
+                    continue;
+                }
+                entry.cancel();
+                entry.clone()
+            };
+            self.persist_best_effort(&outcome).await;
+        }
+        self.changes.notify_waiters();
+    }
+
+    pub(crate) async fn wait_for(
+        &self,
+        parent_session_id: &str,
+        parent_dialog_turn_id: &str,
+        requested_task_ids: &[String],
+        timeout: Duration,
+        cancellation_token: Option<&CancellationToken>,
+    ) -> BitFunResult<BackgroundSubagentWaitResult> {
+        self.hydrate_parent_session(parent_session_id).await?;
+
+        let deadline = Instant::now() + timeout;
+        let mut collected = Vec::new();
+        let mut debounce_deadline = None;
+
+        loop {
+            let notified = self.changes.notified();
+            tokio::pin!(notified);
+
+            let claim = self
+                .claim_available(parent_session_id, parent_dialog_turn_id, requested_task_ids)
+                .await?;
+            if !claim.had_matching_tasks && collected.is_empty() {
+                return Ok(BackgroundSubagentWaitResult {
+                    status: BackgroundSubagentWaitStatus::NoMatchingTasks,
+                    outcomes: Vec::new(),
+                    pending_background_task_ids: Vec::new(),
+                });
+            }
+
+            collected.extend(claim.outcomes);
+            if !collected.is_empty() && claim.pending_background_task_ids.is_empty() {
+                return Ok(wait_result_for_outcomes(collected, Vec::new()));
+            }
+            if !collected.is_empty() && debounce_deadline.is_none() {
+                debounce_deadline = Some((Instant::now() + RESULT_DEBOUNCE).min(deadline));
+            }
+
+            let wake_at = debounce_deadline.unwrap_or(deadline);
+            if Instant::now() >= wake_at {
+                if collected.is_empty() {
+                    return Ok(BackgroundSubagentWaitResult {
+                        status: BackgroundSubagentWaitStatus::TimedOut,
+                        outcomes: Vec::new(),
+                        pending_background_task_ids: claim.pending_background_task_ids,
+                    });
+                }
+                return Ok(wait_result_for_outcomes(
+                    collected,
+                    claim.pending_background_task_ids,
+                ));
+            }
+
+            match cancellation_token {
+                Some(token) => {
+                    tokio::select! {
+                        _ = token.cancelled() => {
+                            return Err(BitFunError::cancelled("AgentWait was cancelled".to_string()));
+                        }
+                        _ = &mut notified => {}
+                        _ = sleep_until(wake_at) => {}
+                    }
+                }
+                None => {
+                    tokio::select! {
+                        _ = &mut notified => {}
+                        _ = sleep_until(wake_at) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    async fn claim_available(
+        &self,
+        parent_session_id: &str,
+        parent_dialog_turn_id: &str,
+        requested_task_ids: &[String],
+    ) -> BitFunResult<OutcomeClaim> {
+        let task_ids = if requested_task_ids.is_empty() {
+            self.outcomes
+                .iter()
+                .filter(|entry| {
+                    entry.parent_session_id == parent_session_id
+                        && entry.parent_dialog_turn_id == parent_dialog_turn_id
+                        && entry.consumed_at_ms.is_none()
+                })
+                .map(|entry| entry.background_task_id.clone())
+                .collect::<Vec<_>>()
+        } else {
+            requested_task_ids.to_vec()
+        };
+
+        if task_ids.is_empty() {
+            return Ok(OutcomeClaim::default());
+        }
+
+        let mut claim = OutcomeClaim::default();
+        let mut consumed = Vec::new();
+        for background_task_id in task_ids {
+            let Some(mut entry) = self.outcomes.get_mut(&background_task_id) else {
+                if requested_task_ids.is_empty() {
+                    continue;
+                }
+                return Err(BitFunError::tool(format!(
+                    "Background task was not found: {}",
+                    background_task_id
+                )));
+            };
+            if entry.parent_session_id != parent_session_id {
+                return Err(BitFunError::tool(format!(
+                    "Background task does not belong to the current session: {}",
+                    background_task_id
+                )));
+            }
+            if entry.consumed_at_ms.is_some() {
+                continue;
+            }
+            claim.had_matching_tasks = true;
+            if entry.status.is_terminal() {
+                entry.consumed_at_ms = Some(unix_time_ms());
+                let outcome = entry.clone();
+                claim.outcomes.push(outcome.clone());
+                consumed.push(outcome);
+            } else {
+                claim
+                    .pending_background_task_ids
+                    .push(entry.background_task_id.clone());
+            }
+        }
+
+        for outcome in consumed {
+            self.persist_best_effort(&outcome).await;
+        }
+        Ok(claim)
+    }
+
+    async fn hydrate_parent_session(&self, parent_session_id: &str) -> BitFunResult<()> {
+        let Some(custom_metadata) = self
+            .session_manager
+            .load_session_custom_metadata(parent_session_id)
+            .await?
+        else {
+            return Ok(());
+        };
+        let Some(metadata) = custom_metadata.as_object() else {
+            return Ok(());
+        };
+        for (key, value) in metadata {
+            if !key.starts_with(OUTCOME_METADATA_KEY_PREFIX) {
+                continue;
+            }
+            let Ok(outcome) = serde_json::from_value::<BackgroundSubagentOutcome>(value.clone())
+            else {
+                warn!(
+                    "Ignoring invalid persisted background subagent outcome: session_id={}, metadata_key={}",
+                    parent_session_id, key
+                );
+                continue;
+            };
+            if outcome.parent_session_id == parent_session_id {
+                self.outcomes
+                    .entry(outcome.background_task_id.clone())
+                    .or_insert(outcome);
+            }
+        }
+        Ok(())
+    }
+
+    async fn persist(&self, outcome: &BackgroundSubagentOutcome) -> BitFunResult<()> {
+        let value = serde_json::to_value(outcome).map_err(|error| {
+            BitFunError::tool(format!(
+                "Failed to serialize background task outcome: {}",
+                error
+            ))
+        })?;
+        self.session_manager
+            .merge_session_custom_metadata(
+                &outcome.parent_session_id,
+                json!({ outcome_metadata_key(&outcome.background_task_id): value }),
+            )
+            .await
+    }
+
+    async fn persist_best_effort(&self, outcome: &BackgroundSubagentOutcome) {
+        if let Err(error) = self.persist(outcome).await {
+            warn!(
+                "Failed to persist background subagent outcome: background_task_id={}, parent_session_id={}, error={}",
+                outcome.background_task_id, outcome.parent_session_id, error
+            );
+        }
+    }
+}
+
+fn wait_result_for_outcomes(
+    outcomes: Vec<BackgroundSubagentOutcome>,
+    pending_background_task_ids: Vec<String>,
+) -> BackgroundSubagentWaitResult {
+    let status = if outcomes
+        .iter()
+        .all(|outcome| outcome.status == BackgroundSubagentOutcomeStatus::Cancelled)
+    {
+        BackgroundSubagentWaitStatus::Cancelled
+    } else {
+        BackgroundSubagentWaitStatus::Completed
+    };
+    BackgroundSubagentWaitResult {
+        status,
+        outcomes,
+        pending_background_task_ids,
+    }
+}
+
+fn outcome_metadata_key(background_task_id: &str) -> String {
+    format!("{}{}", OUTCOME_METADATA_KEY_PREFIX, background_task_id)
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -9,6 +9,7 @@ use super::{
     },
     turn_outcome::TurnOutcome,
     turn_settlement::TurnSettlementTracker,
+    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitResult,
 };
 use crate::agentic::agents::get_agent_registry;
 use crate::agentic::context_profile::ContextProfilePolicy;
@@ -72,10 +73,9 @@ use bitfun_agent_runtime::remote_file_delivery::{
 };
 use bitfun_agent_runtime::user_questions::USER_INPUT_AVAILABLE_CONTEXT_KEY;
 use bitfun_runtime_ports::{
-    AgentBackgroundResultRequest, AgentSessionWorkspaceBinding, AgentThreadGoalDeliveryKind,
-    AgentThreadGoalDeliveryRequest, DelegationPolicy, RemoteExecPort, SessionStoragePathRequest,
-    SessionStorePort, SubagentContextMode, TerminalPort, ThreadGoal, ThreadGoalContinuationPlan,
-    ThreadGoalStatus,
+    AgentSessionWorkspaceBinding, AgentThreadGoalDeliveryKind, AgentThreadGoalDeliveryRequest,
+    DelegationPolicy, RemoteExecPort, SessionStoragePathRequest, SessionStorePort,
+    SubagentContextMode, TerminalPort, ThreadGoal, ThreadGoalContinuationPlan, ThreadGoalStatus,
 };
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
@@ -341,95 +341,6 @@ impl SubagentResult {
 pub struct BackgroundSubagentStartResult {
     pub background_task_id: String,
     pub session_id: String,
-}
-
-fn format_background_subagent_delivery_text(
-    subagent_session_id: &str,
-    outcome: Result<&SubagentResult, &BitFunError>,
-) -> String {
-    match outcome {
-        Ok(result) => {
-            if result.is_partial_timeout() {
-                format!(
-                    "Background subagent (session_id='{}') completed with partial timeout result:\n<partial_result status=\"partial_timeout\">\n{}\n</partial_result>",
-                    subagent_session_id, result.text
-                )
-            } else {
-                format!(
-                    "Background subagent (session_id='{}') completed successfully:\n<result>\n{}\n</result>",
-                    subagent_session_id, result.text
-                )
-            }
-        }
-        Err(error) => {
-            format!(
-                "Background subagent (session_id='{}') failed before producing a final result.\nError: {}",
-                subagent_session_id, error
-            )
-        }
-    }
-}
-
-fn format_background_subagent_display_text(
-    outcome: Result<&SubagentResult, &BitFunError>,
-) -> String {
-    match outcome {
-        Ok(result) => {
-            if result.is_partial_timeout() {
-                "Background subagent completed with a partial timeout result.".to_string()
-            } else {
-                "Background subagent completed successfully.".to_string()
-            }
-        }
-        Err(_) => "Background subagent failed before producing a final result.".to_string(),
-    }
-}
-
-fn background_subagent_delivery_metadata(
-    background_task_id: &str,
-    parent: &SubagentParentInfo,
-    subagent_session_id: &str,
-    subagent_dialog_turn_id: &str,
-    require_tool_confirmation: bool,
-    agent_type: &str,
-    task_description: &str,
-) -> serde_json::Map<String, serde_json::Value> {
-    let mut metadata = serde_json::Map::from_iter([
-        ("kind".to_string(), serde_json::json!("background_result")),
-        ("sourceKind".to_string(), serde_json::json!("subagent")),
-        (
-            "backgroundTaskId".to_string(),
-            serde_json::json!(background_task_id),
-        ),
-        (
-            "parentSessionId".to_string(),
-            serde_json::json!(parent.session_id.as_str()),
-        ),
-        (
-            "parentDialogTurnId".to_string(),
-            serde_json::json!(parent.dialog_turn_id.as_str()),
-        ),
-        (
-            "subagentSessionId".to_string(),
-            serde_json::json!(subagent_session_id),
-        ),
-        (
-            "subagentDialogTurnId".to_string(),
-            serde_json::json!(subagent_dialog_turn_id),
-        ),
-        ("subagentType".to_string(), serde_json::json!(agent_type)),
-        (
-            "taskDescription".to_string(),
-            serde_json::json!(task_description),
-        ),
-    ]);
-    if require_tool_confirmation {
-        metadata.insert(
-            "require_tool_confirmation".to_string(),
-            serde_json::Value::Bool(true),
-        );
-    }
-    metadata
 }
 
 fn build_subagent_session_relationship(
@@ -811,6 +722,8 @@ pub struct ConversationCoordinator {
     active_subagent_executions: Arc<DashMap<String, ActiveSubagentExecution>>,
     /// Background Task runs keyed by background_task_id.
     background_subagent_tasks: Arc<DashMap<String, BackgroundSubagentTaskControl>>,
+    /// Parent-owned terminal outcomes consumed only through AgentWait.
+    background_subagent_outcomes: Arc<BackgroundSubagentOutcomeStore>,
     /// Cancelled deliveries consumed by the scheduler after it acquires the
     /// parent session's operation lock.
     background_subagent_delivery_suppressions: Arc<DashMap<String, ()>>,
@@ -1358,6 +1271,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         event_queue: Arc<EventQueue>,
         event_router: Arc<EventRouter>,
     ) -> Self {
+        let background_subagent_outcomes = Arc::new(BackgroundSubagentOutcomeStore::new(
+            Arc::clone(&session_manager),
+        ));
         Self {
             session_manager,
             execution_engine,
@@ -1369,6 +1285,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             subagent_timeout_registry: Arc::new(RwLock::new(HashMap::new())),
             active_subagent_executions: Arc::new(DashMap::new()),
             background_subagent_tasks: Arc::new(DashMap::new()),
+            background_subagent_outcomes,
             background_subagent_delivery_suppressions: Arc::new(DashMap::new()),
             scheduler_notify_tx: OnceLock::new(),
             round_injection_source: OnceLock::new(),
@@ -6995,12 +6912,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .map(|(background_task_id, _)| background_task_id.clone())
             .collect::<Vec<_>>();
         let cancelled = self.cancel_background_subagent_controls(controls).await?;
-        if let Some(scheduler) = get_global_scheduler() {
-            scheduler
-                .cancel_background_result_deliveries(parent_session_id, &background_task_ids)
-                .await
-                .map_err(BitFunError::tool)?;
-        }
+        self.background_subagent_outcomes
+            .cancel(&background_task_ids)
+            .await;
         Ok(cancelled)
     }
 
@@ -7015,8 +6929,34 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .iter()
             .map(|(_, control)| control.subagent_session_id.clone())
             .collect::<Vec<_>>();
+        let background_task_ids = controls
+            .iter()
+            .map(|(background_task_id, _)| background_task_id.clone())
+            .collect::<Vec<_>>();
         self.cancel_background_subagent_controls(controls).await?;
+        self.background_subagent_outcomes
+            .cancel(&background_task_ids)
+            .await;
         Ok(subagent_session_ids)
+    }
+
+    pub(crate) async fn wait_for_background_subagent_outcomes(
+        &self,
+        parent_session_id: &str,
+        parent_dialog_turn_id: &str,
+        background_task_ids: &[String],
+        timeout: Duration,
+        cancellation_token: Option<&CancellationToken>,
+    ) -> BitFunResult<BackgroundSubagentWaitResult> {
+        self.background_subagent_outcomes
+            .wait_for(
+                parent_session_id,
+                parent_dialog_turn_id,
+                background_task_ids,
+                timeout,
+                cancellation_token,
+            )
+            .await
     }
 
     pub(crate) fn take_background_subagent_delivery_suppression(
@@ -7211,10 +7151,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         &self,
         request: SubagentExecutionRequest,
         timeout_seconds: Option<u64>,
-        allow_review_follow_up: bool,
     ) -> BitFunResult<BackgroundSubagentStartResult> {
         let request = self
-            .resolve_hidden_subagent_execution_request(request, Some(allow_review_follow_up))
+            .resolve_hidden_subagent_execution_request(request, None)
             .await?;
         let mut request = self
             .prepare_hidden_subagent_execution_request(request)
@@ -7240,7 +7179,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 ));
             }
         };
-        let parent_session = match self
+        let _parent_session = match self
             .session_manager
             .get_session(&subagent_parent_info.session_id)
         {
@@ -7254,16 +7193,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 )));
             }
         };
-        let parent_agent_type = parent_session.agent_type.clone();
-        let parent_workspace_path = parent_session.config.workspace_path.clone();
-        let parent_remote_connection_id = parent_session.config.remote_connection_id.clone();
-        let parent_remote_ssh_host = parent_session.config.remote_ssh_host.clone();
-        let parent_requires_tool_confirmation = get_global_scheduler().is_some_and(|scheduler| {
-            scheduler.active_turn_requires_tool_confirmation(
-                &subagent_parent_info.session_id,
-                &subagent_parent_info.dialog_turn_id,
-            )
-        });
         let background_task_id = format!("bg-subagent-{}", uuid::Uuid::new_v4());
         let background_task_id_for_delivery = background_task_id.clone();
         let task_description = request.user_input_text.clone();
@@ -7277,6 +7206,23 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 ));
             }
         };
+        if let Err(error) = self
+            .background_subagent_outcomes
+            .register(BackgroundSubagentOutcome::running(
+                background_task_id.clone(),
+                subagent_parent_info.session_id.clone(),
+                subagent_parent_info.dialog_turn_id.clone(),
+                subagent_session_id.clone(),
+                subagent_dialog_turn_id.clone(),
+                logical_agent_type.clone(),
+                task_description.clone(),
+            ))
+            .await
+        {
+            self.cleanup_prepared_hidden_subagent_session_if_unsubmitted(&request)
+                .await;
+            return Err(error);
+        }
         let parent_cancel_token = self
             .execution_engine
             .cancel_token_for_dialog_turn(&subagent_parent_info.dialog_turn_id)
@@ -7289,6 +7235,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             {
                 Ok(submit_result) => submit_result,
                 Err(error) => {
+                    self.background_subagent_outcomes
+                        .cancel(std::slice::from_ref(&background_task_id))
+                        .await;
                     self.cleanup_prepared_hidden_subagent_session_if_unsubmitted(&request)
                         .await;
                     return Err(BitFunError::tool(error));
@@ -7306,8 +7255,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             let background_subagent_tasks = self.background_subagent_tasks.clone();
             let background_delivery_suppressions =
                 self.background_subagent_delivery_suppressions.clone();
-            let subagent_session_id_for_delivery = subagent_session_id.clone();
-            let subagent_dialog_turn_id_for_delivery = subagent_dialog_turn_id.clone();
+            let background_subagent_outcomes = self.background_subagent_outcomes.clone();
 
             tokio::spawn(async move {
                 let result = match parent_cancel_token.as_ref() {
@@ -7339,50 +7287,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     return;
                 }
 
-                let (delivery_text, display_text) = match result {
-                    Ok(result) => (
-                        format_background_subagent_delivery_text(
-                            &subagent_session_id_for_delivery,
-                            Ok(&result),
-                        ),
-                        format_background_subagent_display_text(Ok(&result)),
-                    ),
-                    Err(error) => (
-                        format_background_subagent_delivery_text(
-                            &subagent_session_id_for_delivery,
-                            Err(&error),
-                        ),
-                        format_background_subagent_display_text(Err(&error)),
-                    ),
-                };
-
-                let metadata = background_subagent_delivery_metadata(
-                    &background_task_id_for_delivery,
-                    &subagent_parent_info,
-                    &subagent_session_id_for_delivery,
-                    &subagent_dialog_turn_id_for_delivery,
-                    parent_requires_tool_confirmation,
-                    &logical_agent_type,
-                    &task_description,
-                );
-
-                let runtime =
-                    match CoreServiceAgentRuntime::global_agent_runtime_with_lifecycle_delivery() {
-                        Ok(runtime) => runtime,
-                        Err(error) => {
-                            background_subagent_tasks.remove(&background_task_id_for_delivery);
-                            background_delivery_suppressions
-                                .remove(&background_task_id_for_delivery);
-                            warn!(
-                                "Agent runtime lifecycle delivery is not available; background subagent result dropped: background_task_id={}, parent_session_id={}, error={}",
-                                background_task_id_for_delivery,
-                                subagent_parent_info.session_id,
-                                error
-                            );
-                            return;
-                        }
-                    };
-
                 if suppress_delivery.load(Ordering::SeqCst) {
                     background_subagent_tasks.remove(&background_task_id_for_delivery);
                     background_delivery_suppressions.remove(&background_task_id_for_delivery);
@@ -7393,28 +7297,11 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     return;
                 }
 
-                if let Err(error) = runtime
-                    .deliver_background_result(AgentBackgroundResultRequest {
-                        session_id: subagent_parent_info.session_id.clone(),
-                        agent_type: parent_agent_type,
-                        workspace_path: parent_workspace_path,
-                        remote_connection_id: parent_remote_connection_id,
-                        remote_ssh_host: parent_remote_ssh_host,
-                        content: delivery_text,
-                        display_content: Some(display_text),
-                        metadata,
-                    })
-                    .await
-                {
-                    background_subagent_tasks.remove(&background_task_id_for_delivery);
-                    background_delivery_suppressions.remove(&background_task_id_for_delivery);
-                    warn!(
-                        "Failed to deliver background subagent result through scheduler path: background_task_id={}, parent_session_id={}, error={}",
-                        background_task_id_for_delivery,
-                        subagent_parent_info.session_id,
-                        CoreServiceAgentRuntime::runtime_error_message(error)
-                    );
-                }
+                background_subagent_outcomes
+                    .complete(&background_task_id_for_delivery, result.as_ref())
+                    .await;
+                background_subagent_tasks.remove(&background_task_id_for_delivery);
+                background_delivery_suppressions.remove(&background_task_id_for_delivery);
             });
 
             return Ok(BackgroundSubagentStartResult {
@@ -7452,33 +7339,16 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let background_subagent_tasks = self.background_subagent_tasks.clone();
         let background_delivery_suppressions =
             self.background_subagent_delivery_suppressions.clone();
-        let subagent_session_id_for_delivery = subagent_session_id.clone();
-        let subagent_dialog_turn_id_for_delivery = subagent_dialog_turn_id.clone();
+        let background_subagent_outcomes = self.background_subagent_outcomes.clone();
 
         tokio::spawn(async move {
-            let (delivery_text, display_text) = match coordinator
+            let result = coordinator
                 .execute_hidden_subagent_internal(
                     request,
                     Some(&execution_cancel_token),
                     timeout_seconds,
                 )
-                .await
-            {
-                Ok(result) => (
-                    format_background_subagent_delivery_text(
-                        &subagent_session_id_for_delivery,
-                        Ok(&result),
-                    ),
-                    format_background_subagent_display_text(Ok(&result)),
-                ),
-                Err(error) => (
-                    format_background_subagent_delivery_text(
-                        &subagent_session_id_for_delivery,
-                        Err(&error),
-                    ),
-                    format_background_subagent_display_text(Err(&error)),
-                ),
-            };
+                .await;
             cancel_bridge_handle.abort();
             if suppress_delivery.load(Ordering::SeqCst) {
                 background_subagent_tasks.remove(&background_task_id_for_delivery);
@@ -7490,30 +7360,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 return;
             }
 
-            let metadata = background_subagent_delivery_metadata(
-                &background_task_id_for_delivery,
-                &subagent_parent_info,
-                &subagent_session_id_for_delivery,
-                &subagent_dialog_turn_id_for_delivery,
-                parent_requires_tool_confirmation,
-                &logical_agent_type,
-                &task_description,
-            );
-
-            let runtime =
-                match CoreServiceAgentRuntime::global_agent_runtime_with_lifecycle_delivery() {
-                    Ok(runtime) => runtime,
-                    Err(error) => {
-                        background_subagent_tasks.remove(&background_task_id_for_delivery);
-                        background_delivery_suppressions.remove(&background_task_id_for_delivery);
-                        warn!(
-                            "Agent runtime lifecycle delivery is not available; background subagent result dropped: background_task_id={}, parent_session_id={}, error={}",
-                            background_task_id_for_delivery, subagent_parent_info.session_id, error
-                        );
-                        return;
-                    }
-                };
-
             if suppress_delivery.load(Ordering::SeqCst) {
                 background_subagent_tasks.remove(&background_task_id_for_delivery);
                 background_delivery_suppressions.remove(&background_task_id_for_delivery);
@@ -7524,28 +7370,11 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 return;
             }
 
-            if let Err(error) = runtime
-                .deliver_background_result(AgentBackgroundResultRequest {
-                    session_id: subagent_parent_info.session_id.clone(),
-                    agent_type: parent_agent_type,
-                    workspace_path: parent_workspace_path,
-                    remote_connection_id: parent_remote_connection_id,
-                    remote_ssh_host: parent_remote_ssh_host,
-                    content: delivery_text,
-                    display_content: Some(display_text),
-                    metadata,
-                })
-                .await
-            {
-                background_subagent_tasks.remove(&background_task_id_for_delivery);
-                background_delivery_suppressions.remove(&background_task_id_for_delivery);
-                warn!(
-                    "Failed to deliver background subagent result: background_task_id={}, parent_session_id={}, error={}",
-                    background_task_id_for_delivery,
-                    subagent_parent_info.session_id,
-                    CoreServiceAgentRuntime::runtime_error_message(error)
-                );
-            }
+            background_subagent_outcomes
+                .complete(&background_task_id_for_delivery, result.as_ref())
+                .await;
+            background_subagent_tasks.remove(&background_task_id_for_delivery);
+            background_delivery_suppressions.remove(&background_task_id_for_delivery);
         });
 
         Ok(BackgroundSubagentStartResult {
@@ -8678,13 +8507,13 @@ fn merge_prepended_messages_for_turn(
 #[cfg(test)]
 mod tests {
     use super::{
-        background_subagent_delivery_metadata, build_subagent_session_relationship,
-        logical_subagent_type_or_runtime, merge_prepended_messages_for_turn,
-        normalize_subagent_max_concurrency, resolve_agent_session_create_created_by,
-        resolve_agent_submission_turn_id, resolve_subagent_model_selection,
-        runtime_port_error_preserving_message, should_require_tool_confirmation,
-        turn_review_manifest_for_agent, validate_background_subagent_delivery,
-        ConversationCoordinator, SubagentExecutionRequest, TEST_AGENT_MODEL_DEFAULTS,
+        build_subagent_session_relationship, logical_subagent_type_or_runtime,
+        merge_prepended_messages_for_turn, normalize_subagent_max_concurrency,
+        resolve_agent_session_create_created_by, resolve_agent_submission_turn_id,
+        resolve_subagent_model_selection, runtime_port_error_preserving_message,
+        should_require_tool_confirmation, turn_review_manifest_for_agent,
+        validate_background_subagent_delivery, BackgroundSubagentOutcome, ConversationCoordinator,
+        SubagentExecutionRequest, TEST_AGENT_MODEL_DEFAULTS,
     };
     use crate::agentic::agents::{CustomSubagent, CustomSubagentKind, UserContextPolicy};
     use crate::agentic::core::{
@@ -9156,63 +8985,6 @@ mod tests {
     }
 
     #[test]
-    fn background_subagent_delivery_identifies_its_exact_parent_turn() {
-        let parent = SubagentParentInfo {
-            session_id: "parent-session".to_string(),
-            dialog_turn_id: "parent-turn".to_string(),
-            tool_call_id: "tool-call".to_string(),
-        };
-
-        let metadata = background_subagent_delivery_metadata(
-            "background-task",
-            &parent,
-            "subagent-session",
-            "subagent-turn",
-            true,
-            "agentic",
-            "Investigate",
-        );
-
-        assert_eq!(metadata["kind"], serde_json::json!("background_result"));
-        assert_eq!(metadata["sourceKind"], serde_json::json!("subagent"));
-        assert_eq!(
-            metadata["parentSessionId"],
-            serde_json::json!("parent-session")
-        );
-        assert_eq!(
-            metadata["parentDialogTurnId"],
-            serde_json::json!("parent-turn")
-        );
-        assert_eq!(
-            metadata["subagentSessionId"],
-            serde_json::json!("subagent-session")
-        );
-        assert_eq!(
-            metadata["subagentDialogTurnId"],
-            serde_json::json!("subagent-turn")
-        );
-        assert_eq!(
-            metadata["require_tool_confirmation"],
-            serde_json::json!(true)
-        );
-        assert!(should_require_tool_confirmation(
-            DialogSubmissionPolicy::for_source(AgentSubmissionSource::AgentSession),
-            Some(&serde_json::Value::Object(metadata))
-        ));
-
-        let non_peer_metadata = background_subagent_delivery_metadata(
-            "background-task",
-            &parent,
-            "subagent-session",
-            "subagent-turn",
-            false,
-            "agentic",
-            "Investigate",
-        );
-        assert!(!non_peer_metadata.contains_key("require_tool_confirmation"));
-    }
-
-    #[test]
     fn hidden_subagent_dialog_turn_id_reuses_existing_or_generates_raw_uuid() {
         let mut missing = None;
         let generated = super::ensure_hidden_subagent_dialog_turn_id(&mut missing);
@@ -9227,6 +8999,93 @@ mod tests {
             "child-turn"
         );
         assert_eq!(existing.as_deref(), Some("child-turn"));
+    }
+
+    #[tokio::test]
+    async fn background_subagent_outcome_is_consumed_only_by_agent_wait() {
+        let (coordinator, _) = test_coordinator();
+        let background_task_id = "background-task".to_string();
+        coordinator
+            .background_subagent_outcomes
+            .register(BackgroundSubagentOutcome::running(
+                background_task_id.clone(),
+                "parent-session".to_string(),
+                "parent-turn".to_string(),
+                "subagent-session".to_string(),
+                "subagent-turn".to_string(),
+                "GeneralPurpose".to_string(),
+                "Inspect implementation".to_string(),
+            ))
+            .await
+            .expect("register outcome");
+        let completed = super::SubagentResult::completed("done".to_string());
+        coordinator
+            .background_subagent_outcomes
+            .complete(&background_task_id, Ok(&completed))
+            .await;
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                "parent-turn",
+                std::slice::from_ref(&background_task_id),
+                Duration::from_millis(10),
+                None,
+            )
+            .await
+            .expect("AgentWait should collect the completed outcome");
+
+        assert_eq!(result.status.as_str(), "completed");
+        assert_eq!(result.outcomes.len(), 1);
+        assert_eq!(result.outcomes[0].content.as_deref(), Some("done"));
+        assert!(result.pending_background_task_ids.is_empty());
+
+        let second = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                "parent-turn",
+                std::slice::from_ref(&background_task_id),
+                Duration::from_millis(10),
+                None,
+            )
+            .await
+            .expect("a consumed outcome should not be delivered twice");
+        assert_eq!(second.status.as_str(), "no_matching_tasks");
+        assert!(second.outcomes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_wait_timeout_keeps_background_outcome_pending_without_follow_up() {
+        let (coordinator, _) = test_coordinator();
+        let background_task_id = "background-task-timeout".to_string();
+        coordinator
+            .background_subagent_outcomes
+            .register(BackgroundSubagentOutcome::running(
+                background_task_id.clone(),
+                "parent-session".to_string(),
+                "parent-turn".to_string(),
+                "subagent-session".to_string(),
+                "subagent-turn".to_string(),
+                "GeneralPurpose".to_string(),
+                "Inspect implementation".to_string(),
+            ))
+            .await
+            .expect("register outcome");
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                "parent-turn",
+                std::slice::from_ref(&background_task_id),
+                Duration::from_millis(1),
+                None,
+            )
+            .await
+            .expect("AgentWait timeout should be returned normally");
+
+        assert_eq!(result.status.as_str(), "timed_out");
+        assert!(result.outcomes.is_empty());
+        assert_eq!(result.pending_background_task_ids, vec![background_task_id]);
     }
 
     #[test]
@@ -9245,25 +9104,6 @@ mod tests {
             relationship.continuation_policy,
             Some(SessionContinuationPolicy::FreshOnly)
         );
-
-        let parent = SubagentParentInfo {
-            session_id: "parent-session".to_string(),
-            dialog_turn_id: "parent-turn".to_string(),
-            tool_call_id: "tool-call".to_string(),
-        };
-        let metadata = background_subagent_delivery_metadata(
-            "background-task",
-            &parent,
-            "subagent-session",
-            "subagent-turn",
-            false,
-            &logical_type,
-            "Review",
-        );
-        assert_eq!(metadata["subagentType"], serde_json::json!("Reviewer"));
-        assert!(!serde_json::Value::Object(metadata)
-            .to_string()
-            .contains(runtime_type));
     }
 
     #[tokio::test]
@@ -9461,65 +9301,6 @@ mod tests {
             validate_background_subagent_delivery("ReviewFixer", None, false)
                 .await
                 .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn continued_review_session_cannot_run_in_background_implicitly() {
-        let (coordinator, session_manager) = test_coordinator();
-        let review_session = coordinator
-            .create_hidden_agent_session(
-                None,
-                "Reusable review".to_string(),
-                "CodeReview".to_string(),
-                SessionConfig {
-                    model_id: Some("primary".to_string()),
-                    workspace_path: Some(std::env::temp_dir().to_string_lossy().into_owned()),
-                    ..Default::default()
-                },
-                Some("session-parent-session".to_string()),
-                SessionKind::Subagent,
-            )
-            .await
-            .expect("review session should be created");
-        let request = SubagentExecutionRequest {
-            task_description: "Continue reviewing the current diff".to_string(),
-            context_mode: SubagentContextMode::Fresh,
-            target_session_id: Some(review_session.session_id.clone()),
-            subagent_type: None,
-            logical_subagent_type: None,
-            continuation_policy: SessionContinuationPolicy::Reusable,
-            model_binding_policy: SessionModelBindingPolicy::Mutable,
-            workspace_path: None,
-            model_id: Some("fast".to_string()),
-            subagent_parent_info: SubagentParentInfo {
-                session_id: "parent-session".to_string(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            },
-            context: HashMap::new(),
-            delegation_policy: DelegationPolicy::top_level().spawn_child(),
-            external_generation_lease: None,
-        };
-
-        let error = coordinator
-            .start_background_subagent(request, None, false)
-            .await
-            .expect_err(
-                "continued review should not run in the background without explicit intent",
-            );
-
-        assert!(error.to_string().contains("one final review"));
-        assert!(error.to_string().contains("allow_review_follow_up=true"));
-        assert_eq!(
-            session_manager
-                .get_session(&review_session.session_id)
-                .expect("review session should remain available")
-                .config
-                .model_id
-                .as_deref(),
-            Some("primary"),
-            "rejected delivery must not mutate the review session model"
         );
     }
 
@@ -9836,64 +9617,6 @@ mod tests {
             None,
             "parent-session"
         ));
-    }
-
-    #[test]
-    fn background_subagent_delivery_text_uses_session_id() {
-        let completed = super::SubagentResult::completed("done".to_string());
-        let completed_text =
-            super::format_background_subagent_delivery_text("subagent-session-123", Ok(&completed));
-        assert!(completed_text.contains(
-            "Background subagent (session_id='subagent-session-123') completed successfully:"
-        ));
-        assert!(completed_text.contains("<result>\n"));
-        assert!(!completed_text.contains("background_task_id"));
-        assert!(!completed_text.contains("bg-subagent-123"));
-
-        let partial =
-            super::SubagentResult::partial_timeout("partial".to_string(), "timeout".to_string());
-        let partial_text =
-            super::format_background_subagent_delivery_text("subagent-session-456", Ok(&partial));
-        assert!(partial_text.contains(
-            "Background subagent (session_id='subagent-session-456') completed with partial timeout result:"
-        ));
-        assert!(partial_text.contains("<partial_result status=\"partial_timeout\">\n"));
-        assert!(!partial_text.contains("background_task_id"));
-        assert!(!partial_text.contains("bg-subagent-456"));
-
-        let failed_text = super::format_background_subagent_delivery_text(
-            "subagent-session-789",
-            Err(&crate::util::errors::BitFunError::tool("boom".to_string())),
-        );
-        assert!(failed_text.contains(
-            "Background subagent (session_id='subagent-session-789') failed before producing a final result."
-        ));
-        assert!(!failed_text.contains("background_task_id"));
-        assert!(!failed_text.contains("bg-subagent-789"));
-        assert!(failed_text.contains("Error:"));
-    }
-
-    #[test]
-    fn background_subagent_display_text_is_concise() {
-        let completed = super::SubagentResult::completed("done".to_string());
-        assert_eq!(
-            super::format_background_subagent_display_text(Ok(&completed)),
-            "Background subagent completed successfully."
-        );
-
-        let partial =
-            super::SubagentResult::partial_timeout("partial".to_string(), "timeout".to_string());
-        assert_eq!(
-            super::format_background_subagent_display_text(Ok(&partial)),
-            "Background subagent completed with a partial timeout result."
-        );
-
-        assert_eq!(
-            super::format_background_subagent_display_text(Err(
-                &crate::util::errors::BitFunError::tool("boom".to_string())
-            )),
-            "Background subagent failed before producing a final result."
-        );
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/mod.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Top-level component that integrates all subsystems
 
+mod background_outcomes;
 pub mod coordinator;
 pub mod scheduler;
 pub mod state_manager;
@@ -12,6 +13,10 @@ pub use coordinator::*;
 pub use scheduler::*;
 pub use state_manager::*;
 pub use turn_outcome::*;
+
+pub(crate) use background_outcomes::{
+    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitResult,
+};
 
 pub use coordinator::get_global_coordinator;
 pub use scheduler::get_global_scheduler;

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -51,7 +51,7 @@ use bitfun_services_core::session::{
 };
 use dashmap::{mapref::entry::Entry, DashMap};
 use log::{debug, error, info, warn};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -4637,6 +4637,22 @@ impl SessionManager {
             merge_session_custom_metadata_value(metadata, patch)
         })
         .await
+    }
+
+    pub(crate) async fn load_session_custom_metadata(
+        &self,
+        session_id: &str,
+    ) -> BitFunResult<Option<Value>> {
+        if !self.should_persist_session_id(session_id) {
+            return Ok(None);
+        }
+
+        let workspace_path = self.metadata_workspace_path_for_update(session_id).await?;
+        Ok(self
+            .persistence_manager
+            .load_session_metadata(&workspace_path, session_id)
+            .await?
+            .and_then(|metadata| metadata.custom_metadata))
     }
 
     pub async fn merge_session_relationship(

--- a/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
@@ -1,0 +1,271 @@
+use crate::agentic::coordination::{
+    get_global_coordinator, BackgroundSubagentOutcome, BackgroundSubagentWaitResult,
+};
+use crate::agentic::tools::framework::{
+    Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
+};
+use crate::util::errors::{BitFunError, BitFunResult};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use tokio::time::Duration;
+
+const DEFAULT_TIMEOUT_MS: u64 = 10 * 60 * 1_000;
+const MAX_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
+
+pub struct AgentWaitTool;
+
+impl Default for AgentWaitTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentWaitTool {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn parse_request(input: &Value) -> BitFunResult<(Vec<String>, u64)> {
+        let object = input
+            .as_object()
+            .ok_or_else(|| BitFunError::tool("AgentWait input must be an object".to_string()))?;
+        for key in object.keys() {
+            if key != "background_task_ids" && key != "timeout_ms" {
+                return Err(BitFunError::tool(format!(
+                    "Unsupported AgentWait parameter: {}",
+                    key
+                )));
+            }
+        }
+
+        let background_task_ids = match object.get("background_task_ids") {
+            None => Vec::new(),
+            Some(Value::Array(values)) => {
+                let mut seen = HashSet::new();
+                values
+                    .iter()
+                    .map(|value| {
+                        let value = value.as_str().ok_or_else(|| {
+                            BitFunError::tool(
+                                "background_task_ids must contain strings".to_string(),
+                            )
+                        })?;
+                        let value = value.trim();
+                        if value.is_empty() {
+                            return Err(BitFunError::tool(
+                                "background_task_ids cannot contain empty values".to_string(),
+                            ));
+                        }
+                        if !seen.insert(value.to_string()) {
+                            return Err(BitFunError::tool(format!(
+                                "background_task_ids contains a duplicate task ID: {}",
+                                value
+                            )));
+                        }
+                        Ok(value.to_string())
+                    })
+                    .collect::<BitFunResult<Vec<_>>>()?
+            }
+            Some(_) => {
+                return Err(BitFunError::tool(
+                    "background_task_ids must be an array of strings".to_string(),
+                ));
+            }
+        };
+
+        let timeout_ms = match object.get("timeout_ms") {
+            None => DEFAULT_TIMEOUT_MS,
+            Some(value) => value.as_u64().ok_or_else(|| {
+                BitFunError::tool("timeout_ms must be a positive integer".to_string())
+            })?,
+        };
+        if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
+            return Err(BitFunError::tool(format!(
+                "timeout_ms must be between 1 and {}",
+                MAX_TIMEOUT_MS
+            )));
+        }
+        Ok((background_task_ids, timeout_ms))
+    }
+
+    fn outcome_json(outcome: &BackgroundSubagentOutcome) -> Value {
+        json!({
+            "background_task_id": outcome.background_task_id,
+            "subagent_session_id": outcome.subagent_session_id,
+            "outcome": outcome.status.as_str(),
+            "content": outcome.content,
+            "error": outcome.error,
+        })
+    }
+
+    fn assistant_result(result: &BackgroundSubagentWaitResult) -> String {
+        if result.outcomes.is_empty() {
+            return format!(
+                "AgentWait finished with status {}. Pending background task IDs: {}.",
+                result.status.as_str(),
+                result.pending_background_task_ids.join(", ")
+            );
+        }
+
+        let mut message = format!("AgentWait finished with status {}.", result.status.as_str());
+        for outcome in &result.outcomes {
+            message.push_str(&format!(
+                "\n<background_subagent_result task_id=\"{}\" session_id=\"{}\" status=\"{}\">",
+                outcome.background_task_id,
+                outcome.subagent_session_id,
+                outcome.status.as_str(),
+            ));
+            if let Some(content) = &outcome.content {
+                message.push_str(content);
+            }
+            if let Some(error) = &outcome.error {
+                message.push_str("\nError: ");
+                message.push_str(error);
+            }
+            message.push_str("</background_subagent_result>");
+        }
+        if !result.pending_background_task_ids.is_empty() {
+            message.push_str(&format!(
+                "\nPending background task IDs: {}.",
+                result.pending_background_task_ids.join(", ")
+            ));
+        }
+        message
+    }
+}
+
+#[async_trait]
+impl Tool for AgentWaitTool {
+    fn name(&self) -> &str {
+        "AgentWait"
+    }
+
+    fn manages_own_execution_timeout(&self) -> bool {
+        true
+    }
+
+    async fn description(&self) -> BitFunResult<String> {
+        Ok("Wait for background Task results that belong to the current parent turn. Provide exact background_task_ids when known, or omit the field to collect unconsumed background tasks created by this turn. Use this only when the unfinished answer depends on those results. The tool returns after matching tasks finish, after its timeout, or when the current turn is cancelled.".to_string())
+    }
+
+    fn short_description(&self) -> String {
+        "Wait for selected background subagent results.".to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "background_task_ids": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional exact background task IDs returned by Task. Omit to wait for any unconsumed background task created by the current turn."
+                },
+                "timeout_ms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_TIMEOUT_MS,
+                    "default": DEFAULT_TIMEOUT_MS,
+                    "description": "Maximum time to wait in milliseconds. Defaults to ten minutes."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn is_readonly(&self) -> bool {
+        false
+    }
+
+    fn needs_permissions(&self, _input: Option<&Value>) -> bool {
+        false
+    }
+
+    fn render_tool_use_message(&self, _input: &Value, options: &ToolRenderOptions) -> String {
+        if options.verbose {
+            "Waiting for background subagent results".to_string()
+        } else {
+            "Waiting for background tasks".to_string()
+        }
+    }
+
+    async fn validate_input(
+        &self,
+        input: &Value,
+        _context: Option<&ToolUseContext>,
+    ) -> ValidationResult {
+        match Self::parse_request(input) {
+            Ok(_) => ValidationResult {
+                result: true,
+                message: None,
+                error_code: None,
+                meta: None,
+            },
+            Err(error) => ValidationResult {
+                result: false,
+                message: Some(error.to_string()),
+                error_code: None,
+                meta: None,
+            },
+        }
+    }
+
+    async fn call_impl(
+        &self,
+        input: &Value,
+        context: &ToolUseContext,
+    ) -> BitFunResult<Vec<ToolResult>> {
+        let (background_task_ids, timeout_ms) = Self::parse_request(input)?;
+        let session_id = context
+            .session_id
+            .as_deref()
+            .ok_or_else(|| BitFunError::tool("session_id is required in context".to_string()))?;
+        let dialog_turn_id = context.dialog_turn_id.as_deref().ok_or_else(|| {
+            BitFunError::tool("dialog_turn_id is required in context".to_string())
+        })?;
+        let coordinator = get_global_coordinator()
+            .ok_or_else(|| BitFunError::tool("coordinator not initialized".to_string()))?;
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                session_id,
+                dialog_turn_id,
+                &background_task_ids,
+                Duration::from_millis(timeout_ms),
+                context.cancellation_token(),
+            )
+            .await?;
+        let data = json!({
+            "status": result.status.as_str(),
+            "results": result.outcomes.iter().map(Self::outcome_json).collect::<Vec<_>>(),
+            "pending_background_task_ids": result.pending_background_task_ids,
+        });
+        Ok(vec![ToolResult::Result {
+            data,
+            result_for_assistant: Some(Self::assistant_result(&result)),
+            image_attachments: None,
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentWaitTool, DEFAULT_TIMEOUT_MS};
+
+    #[test]
+    fn empty_input_uses_the_default_timeout_and_current_turn_selector() {
+        let (task_ids, timeout_ms) =
+            AgentWaitTool::parse_request(&serde_json::json!({})).expect("valid request");
+        assert!(task_ids.is_empty());
+        assert_eq!(timeout_ms, DEFAULT_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn duplicate_task_ids_are_rejected() {
+        let error = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": ["bg-1", "bg-1"]
+        }))
+        .expect_err("duplicate task IDs must fail");
+        assert!(error.to_string().contains("duplicate"));
+    }
+}

--- a/src/crates/assembly/core/src/agentic/tools/implementations/mod.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/mod.rs
@@ -1,5 +1,6 @@
 //! Tool implementation module
 
+pub mod agent_wait_tool;
 pub mod analyze_image_tool;
 pub mod ask_user_question_tool;
 pub mod bash_tool;
@@ -46,6 +47,7 @@ pub mod web;
 
 #[deprecated(note = "GetToolSpecTool is owned by the product tool runtime boundary")]
 pub use crate::agentic::tools::product_runtime::GetToolSpecTool;
+pub use agent_wait_tool::AgentWaitTool;
 pub use analyze_image_tool::AnalyzeImageTool;
 pub use ask_user_question_tool::AskUserQuestionTool;
 pub use bash_tool::BashTool;

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/background.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/background.rs
@@ -1,10 +1,13 @@
 use super::*;
 
 impl TaskTool {
-    pub(super) fn background_subagent_started_assistant_message(session_id: &str) -> String {
+    pub(super) fn background_subagent_started_assistant_message(
+        session_id: &str,
+        background_task_id: &str,
+    ) -> String {
         format!(
-            "Background subagent started successfully.\nsession_id: \"{}\"\nNote: Its final result will be delivered back automatically to you when it is finished. Avoid polling for status updates. If your current path is blocked on this result and there is no other useful work to do, it is fine to end the current turn.",
-            session_id
+            "Background subagent started successfully.\nsession_id: \"{}\"\nbackground_task_id: \"{}\"\nUse AgentWait with this background_task_id when you need its result. The result will not be delivered automatically.",
+            session_id, background_task_id
         )
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/execution.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/execution.rs
@@ -61,7 +61,6 @@ struct BackgroundTaskStartRequest<'a> {
     subagent_context: Option<HashMap<String, String>>,
     prepared_prompt: String,
     timeout_seconds: Option<u64>,
-    allow_review_follow_up: bool,
     tool_call_id: String,
     session_id: String,
     dialog_turn_id: String,
@@ -181,7 +180,6 @@ impl TaskTool {
         let model_id = invocation.model_id.clone();
         let mut timeout_seconds = invocation.timeout_seconds;
         let run_in_background = invocation.run_in_background;
-        let allow_review_follow_up = invocation.allow_review_follow_up;
         let is_retry = invocation.is_retry;
         let requested_auto_retry = invocation.requested_auto_retry;
         let is_auto_retry = is_retry && requested_auto_retry;
@@ -227,12 +225,6 @@ impl TaskTool {
                     if !supports_follow_up && model_id.is_some() {
                         return Err(BitFunError::tool(
                             "external_subagent_model_override_unsupported: external subagents use the approved model binding"
-                                .to_string(),
-                        ));
-                    }
-                    if !supports_follow_up && allow_review_follow_up {
-                        return Err(BitFunError::tool(
-                            "external_subagent_follow_up_unsupported: external subagents are fresh-only"
                                 .to_string(),
                         ));
                     }
@@ -596,7 +588,6 @@ impl TaskTool {
                 subagent_context,
                 prepared_prompt,
                 timeout_seconds,
-                allow_review_follow_up,
                 tool_call_id,
                 session_id,
                 dialog_turn_id,
@@ -655,7 +646,6 @@ impl TaskTool {
             subagent_context,
             prepared_prompt,
             timeout_seconds,
-            allow_review_follow_up,
             tool_call_id,
             session_id,
             dialog_turn_id,
@@ -684,7 +674,6 @@ impl TaskTool {
                     external_generation_lease,
                 },
                 timeout_seconds,
-                allow_review_follow_up,
             )
             .await?;
 
@@ -698,6 +687,7 @@ impl TaskTool {
             }),
             result_for_assistant: Some(Self::background_subagent_started_assistant_message(
                 &background_result.session_id,
+                &background_result.background_task_id,
             )),
             image_attachments: None,
         }])

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/input.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/input.rs
@@ -74,7 +74,6 @@ pub(super) struct TaskInvocation {
     pub(super) model_id: Option<String>,
     pub(super) timeout_seconds: Option<u64>,
     pub(super) run_in_background: bool,
-    pub(super) allow_review_follow_up: bool,
     pub(super) is_retry: bool,
     pub(super) requested_auto_retry: bool,
 }
@@ -97,12 +96,7 @@ impl TaskTool {
                     "action is not supported for DeepReview Task calls".to_string(),
                 ));
             }
-            for field in [
-                "fork_context",
-                "session_id",
-                "run_in_background",
-                "allow_review_follow_up",
-            ] {
+            for field in ["fork_context", "session_id", "run_in_background"] {
                 if input.get(field).is_some() {
                     return Err(BitFunError::tool(format!(
                         "{field} is not allowed for DeepReview Task calls"
@@ -120,7 +114,6 @@ impl TaskTool {
                 model_id: Self::optional_trimmed_string(input, "model_id")?,
                 timeout_seconds: Self::optional_timeout_seconds(input)?,
                 run_in_background: false,
-                allow_review_follow_up: false,
                 is_retry: input.get("retry").and_then(Value::as_bool).unwrap_or(false),
                 requested_auto_retry: input
                     .get("auto_retry")
@@ -141,13 +134,6 @@ impl TaskTool {
             ));
         }
         let run_in_background = Self::optional_bool(input, "run_in_background")?.unwrap_or(false);
-        let allow_review_follow_up =
-            Self::optional_bool(input, "allow_review_follow_up")?.unwrap_or(false);
-        if action != TaskAction::Cancel && allow_review_follow_up && !run_in_background {
-            return Err(BitFunError::tool(
-                "allow_review_follow_up=true requires run_in_background=true".to_string(),
-            ));
-        }
 
         match action {
             TaskAction::Spawn => {
@@ -193,7 +179,6 @@ impl TaskTool {
                     model_id: Self::optional_trimmed_string(input, "model_id")?,
                     timeout_seconds: None,
                     run_in_background,
-                    allow_review_follow_up,
                     is_retry: false,
                     requested_auto_retry: false,
                 })
@@ -225,7 +210,6 @@ impl TaskTool {
                     model_id: Self::optional_trimmed_string(input, "model_id")?,
                     timeout_seconds: None,
                     run_in_background,
-                    allow_review_follow_up,
                     is_retry: false,
                     requested_auto_retry: false,
                 })
@@ -241,7 +225,6 @@ impl TaskTool {
                         "subagent_type",
                         "model_id",
                         "run_in_background",
-                        "allow_review_follow_up",
                         "retry",
                         "auto_retry",
                         "retry_coverage",
@@ -259,7 +242,6 @@ impl TaskTool {
                     model_id: None,
                     timeout_seconds: None,
                     run_in_background: false,
-                    allow_review_follow_up: false,
                     is_retry: false,
                     requested_auto_retry: false,
                 })
@@ -276,19 +258,7 @@ impl TaskTool {
             Ok(invocation) => invocation,
             Err(error) => return Self::invalid_input(error.to_string()),
         };
-        if invocation.action == TaskAction::Spawn && invocation.run_in_background {
-            if let Some(subagent_type) = invocation.subagent_type.as_deref() {
-                if let Err(error) = validate_background_subagent_delivery(
-                    subagent_type,
-                    workspace_root,
-                    invocation.allow_review_follow_up,
-                )
-                .await
-                {
-                    return Self::invalid_input(error.to_string());
-                }
-            }
-        }
+        let _ = workspace_root;
         if invocation.action != TaskAction::Cancel {
             if let Some(result) = Self::validate_prompt_size(input) {
                 return result;

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/mod.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/mod.rs
@@ -1,9 +1,7 @@
 use crate::agentic::agents::{
     get_agent_registry, AgentInfo, SubagentListScope, SubagentQueryContext,
 };
-use crate::agentic::coordination::{
-    get_global_coordinator, validate_background_subagent_delivery, SubagentExecutionRequest,
-};
+use crate::agentic::coordination::{get_global_coordinator, SubagentExecutionRequest};
 use crate::agentic::deep_review::task_adapter::{
     self as deep_review_task_adapter, DeepReviewLaunchBatchInfo,
     DeepReviewProviderQueueWaitOutcome, DeepReviewQueueWaitOutcome, DeepReviewQueueWaitSkipReason,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/schema.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/schema.rs
@@ -70,13 +70,6 @@ impl TaskTool {
                 "description": "Optional for action='spawn' and action='send_input'. Defaults to false."
             }),
         );
-        properties.insert(
-            "allow_review_follow_up".to_string(),
-            json!({
-                "type": "boolean",
-                "description": "Optional for action='spawn' and action='send_input'. Use with run_in_background=true only when the user explicitly asked not to wait for a review result. This permits delivery in a later follow-up and does not change normal cancellation behavior."
-            }),
-        );
         json!({
             "type": "object",
             "properties": properties,
@@ -117,9 +110,8 @@ The two modes are mutually exclusive: do not provide `subagent_type` when `fork_
 
 `run_in_background` usage:
 - false: Wait for the agent to finish and return its result to you.
-- true: Run the agent in the background without blocking you. When the subagent finishes, its result will be delivered to you in a follow-up message. You can process remaining work before receiving the result.
-- Review subagents are completion dependencies by default. Launch multiple review Task calls in one assistant message to run them concurrently, and wait for their results so you can merge one final review.
-- If the user explicitly asks not to wait for a review result, set both `run_in_background=true` and `allow_review_follow_up=true`. This permits the result to arrive in a later follow-up; it does not change normal cancellation behavior. Never use it merely to improve parallelism.
+- true: Run the agent in the background without blocking you. The response includes a `background_task_id`; use AgentWait when you need one or more background results. Completed background tasks never automatically create a follow-up turn.
+- When an unfinished answer depends on background work, call AgentWait before ending the current turn. If the result is no longer needed, finish normally without waiting.
 
 Usage notes:
 - Include a short description of what the agent will do for this round (for `spawn` and `send_input`).
@@ -133,7 +125,7 @@ Usage notes:
 Examples (assume "example-reviewer" is present in the agent listing):
 <examples>
 - Start a new specialized subagent: `{ "action": "spawn", "description": "Inspect parser flow", "subagent_type": "example-reviewer", "prompt": "Inspect the parser flow in src/parser.rs and report risks, key functions, and any missing tests." }`
-- Allow a review follow-up only when the user asked not to wait: `{ "action": "spawn", "description": "Review parser later", "subagent_type": "example-reviewer", "prompt": "Review the parser and report findings when finished.", "run_in_background": true, "allow_review_follow_up": true }`
+- Start a background review and collect it later: `{ "action": "spawn", "description": "Review parser", "subagent_type": "example-reviewer", "prompt": "Review the parser and report findings.", "run_in_background": true }`
 - Start by forking the current context: `{ "action": "spawn", "description": "Check migration impact", "fork_context": true, "prompt": "Using the current context, check whether the migration affects config loading. Stay read-only and report the answer with file references." }`
 - Continue an existing subagent with a specific model: `{ "action": "send_input", "description": "Continue parser review", "session_id": "subagent-session-123", "model_id": "fast", "prompt": "Continue from your prior parser review and focus on the error recovery paths." }`
 - Cancel a background subagent: `{ "action": "cancel", "session_id": "subagent-session-123" }`

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs
@@ -128,23 +128,8 @@ fn task_schema_accepts_optional_model_id() {
         .any(|value| value.as_str() == Some("model_id")));
 }
 
-#[test]
-fn task_schema_exposes_explicit_review_follow_up_control() {
-    let schema = TaskTool::new().input_schema();
-    let follow_up = &schema["properties"]["allow_review_follow_up"];
-
-    assert_eq!(follow_up["type"], "boolean");
-    let description = follow_up["description"]
-        .as_str()
-        .expect("allow_review_follow_up description should be a string");
-    assert!(description.contains("explicitly"));
-    assert!(description.contains("review"));
-    assert!(description.contains("run_in_background=true"));
-    assert!(schema["properties"].get("detach_from_parent").is_none());
-}
-
 #[tokio::test]
-async fn validate_input_rejects_review_background_without_explicit_follow_up_permission() {
+async fn validate_input_accepts_review_background_for_agent_wait() {
     let validation = TaskTool::new()
         .validate_input(
             &json!({
@@ -158,72 +143,7 @@ async fn validate_input_rejects_review_background_without_explicit_follow_up_per
         )
         .await;
 
-    assert!(!validation.result);
-    let message = validation
-        .message
-        .as_deref()
-        .expect("validation should explain how review delivery works");
-    assert!(message.contains("one final review"));
-    assert!(message.contains("allow_review_follow_up=true"));
-}
-
-#[tokio::test]
-async fn validate_input_accepts_explicit_review_follow_up() {
-    let validation = TaskTool::new()
-        .validate_input(
-            &json!({
-                "action": "spawn",
-                "description": "Review later",
-                "prompt": "Review the current diff",
-                "subagent_type": "CodeReview",
-                "run_in_background": true,
-                "allow_review_follow_up": true
-            }),
-            None,
-        )
-        .await;
-
     assert!(validation.result, "{:?}", validation.message);
-}
-
-#[tokio::test]
-async fn validate_input_rejects_review_follow_up_without_background_execution() {
-    let validation = TaskTool::new()
-        .validate_input(
-            &json!({
-                "action": "spawn",
-                "description": "Review changes",
-                "prompt": "Review the current diff",
-                "subagent_type": "CodeReview",
-                "allow_review_follow_up": true
-            }),
-            None,
-        )
-        .await;
-
-    assert!(!validation.result);
-    assert!(validation.message.as_deref().is_some_and(|message| {
-        message.contains("allow_review_follow_up=true requires run_in_background=true")
-    }));
-}
-
-#[test]
-fn parse_input_preserves_review_follow_up_for_send_input() {
-    let invocation = TaskTool::parse_invocation(
-        &json!({
-            "action": "send_input",
-            "description": "Continue review later",
-            "prompt": "Continue the review and report when finished",
-            "session_id": "review-session-1",
-            "run_in_background": true,
-            "allow_review_follow_up": true
-        }),
-        false,
-    )
-    .expect("review follow-up send_input should parse");
-
-    assert!(invocation.run_in_background);
-    assert!(invocation.allow_review_follow_up);
 }
 
 #[tokio::test]
@@ -242,26 +162,6 @@ async fn validate_input_preserves_non_review_background_tasks() {
         .await;
 
     assert!(validation.result, "{:?}", validation.message);
-}
-
-#[tokio::test]
-async fn validate_input_rejects_review_follow_up_for_cancel() {
-    let validation = TaskTool::new()
-        .validate_input(
-            &json!({
-                "action": "cancel",
-                "session_id": "subagent-session-1",
-                "allow_review_follow_up": true
-            }),
-            None,
-        )
-        .await;
-
-    assert!(!validation.result);
-    assert!(validation
-        .message
-        .as_deref()
-        .is_some_and(|message| message.contains("allow_review_follow_up is not allowed")));
 }
 
 #[test]
@@ -378,16 +278,18 @@ async fn managed_review_agent_requires_an_exact_packet_id() {
 }
 
 #[test]
-fn background_subagent_start_acknowledgement_uses_session_id_only() {
-    let message = TaskTool::background_subagent_started_assistant_message("subagent-session-123");
+fn background_subagent_start_acknowledgement_exposes_agent_wait_task_id() {
+    let message = TaskTool::background_subagent_started_assistant_message(
+        "subagent-session-123",
+        "bg-subagent-123",
+    );
 
     assert!(message.starts_with("Background subagent started successfully."));
     assert!(message.contains("session_id: \"subagent-session-123\""));
-    assert!(message.contains("Avoid polling for status updates."));
+    assert!(message.contains("background_task_id: \"bg-subagent-123\""));
+    assert!(message.contains("Use AgentWait"));
     assert!(!message.contains("GeneralPurpose"));
     assert!(!message.contains("<background_task"));
-    assert!(!message.contains("bg-subagent-123"));
-    assert!(!message.contains("background_task_id="));
 }
 
 #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/tools/product_runtime/materialization.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime/materialization.rs
@@ -30,6 +30,7 @@ impl StaticToolProviderFactory<dyn Tool> for ProductConcreteToolFactory {
             "ExecControl" => Some(Arc::new(ExecControlTool::new())),
             "GetTime" => Some(Arc::new(GetTimeTool::new())),
             "Task" => Some(Arc::new(TaskTool::new())),
+            "AgentWait" => Some(Arc::new(AgentWaitTool::new())),
             "LaunchReviewAgent" => Some(Arc::new(LaunchReviewAgentTool::new())),
             "Skill" => Some(Arc::new(SkillTool::new())),
             "AskUserQuestion" => Some(Arc::new(AskUserQuestionTool::new())),

--- a/src/crates/assembly/core/src/agentic/tools/registry.rs
+++ b/src/crates/assembly/core/src/agentic/tools/registry.rs
@@ -466,6 +466,7 @@ mod tests {
             "ExecControl",
             "GetTime",
             "Task",
+            "AgentWait",
             "LaunchReviewAgent",
             "Skill",
             "AskUserQuestion",

--- a/src/crates/execution/tool-provider-groups/src/lib.rs
+++ b/src/crates/execution/tool-provider-groups/src/lib.rs
@@ -140,6 +140,7 @@ const PRODUCT_TOOL_PROVIDER_GROUP_PLAN: &[ToolProviderGroupPlan] = &[
         feature_groups: CORE_AGENT_FEATURE_GROUPS,
         tool_names: &[
             "Task",
+            "AgentWait",
             "LaunchReviewAgent",
             "Skill",
             "AskUserQuestion",
@@ -360,6 +361,7 @@ mod tests {
                 "ExecControl",
                 "GetTime",
                 "Task",
+                "AgentWait",
                 "LaunchReviewAgent",
                 "Skill",
                 "AskUserQuestion",

--- a/src/web-ui/src/app/scenes/agents/components/toolGroups.test.ts
+++ b/src/web-ui/src/app/scenes/agents/components/toolGroups.test.ts
@@ -18,6 +18,9 @@ const tools: GroupableTool[] = [
   { name: 'Glob', description: 'Find files', is_readonly: true },
   { name: 'Edit', description: 'Edit files', is_readonly: false },
   { name: 'Write', description: 'Write files', is_readonly: false },
+  { name: 'Task', description: 'Delegate work to an agent', is_readonly: false },
+  { name: 'AgentWait', description: 'Wait for background agent results', is_readonly: true },
+  { name: 'Skill', description: 'Load a skill', is_readonly: true },
   { name: 'analyze_image', description: 'Analyze an image', is_readonly: true },
   { name: 'view_image', description: 'View an image', is_readonly: true },
   { name: 'AskUserQuestion', description: 'Ask the user a question', is_readonly: true },
@@ -44,6 +47,13 @@ describe('tool groups', () => {
 
     expect(files?.tools.map((tool) => tool.name)).toContain('Read');
     expect(editing?.tools.map((tool) => tool.name)).not.toContain('Read');
+  });
+
+  it('groups AgentWait with delegation and skills', () => {
+    const groups = resolveToolGroups(tools, [], t as never);
+
+    expect(groups.find((group) => group.id === 'builtin:delegation')?.tools.map((tool) => tool.name))
+      .toEqual(['AgentWait', 'Skill', 'Task']);
   });
 
   it('groups image, canvas, and computer automation tools by their user-facing purpose', () => {

--- a/src/web-ui/src/app/scenes/agents/components/toolGroups.ts
+++ b/src/web-ui/src/app/scenes/agents/components/toolGroups.ts
@@ -48,7 +48,7 @@ const BUILTIN_TOOL_GROUPS: BuiltinToolGroupDefinition[] = [
   {
     id: 'builtin:delegation',
     labelKey: 'agentsOverview.toolGroups.delegation',
-    toolNames: ['Task', 'Skill'],
+    toolNames: ['Task', 'AgentWait', 'Skill'],
   },
   {
     id: 'builtin:web',


### PR DESCRIPTION
## Summary

Replace automatic background-subagent result delivery with explicit `AgentWait` collection.

- Add durable, parent-owned background task outcomes and the `AgentWait` tool.
- Make background `Task` calls return `background_task_id`; completed results no longer wake or inject into the parent session automatically.
- Remove the public `allow_review_follow_up` control and expose `AgentWait` in applicable agent modes and the Web UI delegation group.

## Type and Areas

Type:

Feature / regression fix

Areas:

Rust core, agent runtime, web UI

## Motivation / Impact

Automatic result delivery could wake a parent session after it had independently completed its work, while parents that depended on a result could appear to stop prematurely. Background work is now collected only when the parent explicitly calls `AgentWait`.

A background `Task` response now includes `background_task_id`. Agents whose final answer depends on background work must call `AgentWait`; otherwise they can finish without being reactivated by a late result.

## Verification

- `pnpm run fmt:rs` passed.
- `cargo check -p bitfun-core --tests -j 1` passed.
- Focused `bitfun-core` lib tests passed for `agent_wait_tool`, one-time outcome consumption, timeout retention, and Task schema removal of `allow_review_follow_up`.
- `pnpm --dir src/web-ui run test:run src/app/scenes/agents/components/toolGroups.test.ts` passed (6 tests).
- `pnpm run type-check:web` passed.
- `git diff --cached --check` passed.

## Reviewer Notes

- `AgentWait` can target explicit task IDs or collect unconsumed background outcomes from the current parent turn.
- Outcomes are consumed only through `AgentWait`; a timeout leaves unfinished tasks available for a later wait.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above.
- [x] User-facing strings, docs, and locales are updated where applicable.