### PR TITLE
feat(external-sources): improve subagent detail, OpenCode card, MCP empty state

### DIFF
--- a/scripts/core-boundaries/rules/source/public-api-rules.mjs
+++ b/scripts/core-boundaries/rules/source/public-api-rules.mjs
@@ -576,6 +576,12 @@ export const externalSourceCorePublicApiEntries = [
       'BitFun CLI and desktop host APIs',
     ),
   ),
+  externalSourceEntry(
+    'external_source_location_for_host_action',
+    'bitfun-core external source composition owner',
+    'Desktop external-source configuration host adapter',
+    true,
+  ),
   ...[
     'ExternalToolActivationState',
     'ExternalToolApprovalRequest',

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -3532,8 +3532,15 @@ pub async fn reveal_in_explorer(
             ))
         }
     };
+    reveal_local_path_in_explorer(path, &request.path)
+}
+
+pub(crate) fn reveal_local_path_in_explorer(
+    path: &std::path::Path,
+    display_path: &str,
+) -> Result<(), String> {
     if !path.exists() {
-        return Err(format!("Path does not exist: {}", request.path));
+        return Err(format!("Path does not exist: {display_path}"));
     }
     let is_directory = path.is_dir();
     let path_str = path.to_string_lossy().to_string();

--- a/src/apps/desktop/src/api/external_sources_api.rs
+++ b/src/apps/desktop/src/api/external_sources_api.rs
@@ -1,7 +1,8 @@
 //! Desktop host API for ecosystem-neutral external AI application sources.
 
 use bitfun_core::external_sources::{
-    choose_external_mcp_conflict, choose_external_subagent_conflict, external_source_snapshot,
+    choose_external_mcp_conflict, choose_external_subagent_conflict,
+    external_source_location_for_host_action, external_source_snapshot,
     set_external_mcp_server_decision, set_external_prompt_command_conflict_choice,
     set_external_source_enabled, set_external_subagent_activation,
     set_external_tool_conflict_choice, set_external_tool_target_decision,
@@ -28,6 +29,13 @@ pub struct SetExternalSourceEnabledRequest {
     pub source_key: String,
     pub enabled: bool,
     pub expected_preference_revision: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RevealExternalSourceLocationRequest {
+    pub workspace_path: Option<String>,
+    pub source_key: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,6 +162,18 @@ pub async fn get_external_source_snapshot(
     external_source_snapshot(workspace, request.force_refresh)
         .await
         .map(Into::into)
+        .map_err(bitfun_core::external_sources::sanitize_external_source_operation_error)
+}
+
+#[tauri::command]
+pub async fn reveal_external_source_location(
+    request: RevealExternalSourceLocationRequest,
+) -> ExternalSourceOperationResult<()> {
+    let workspace = require_local_workspace(request.workspace_path.as_deref()).await?;
+    let path = external_source_location_for_host_action(workspace, &request.source_key)
+        .await
+        .map_err(bitfun_core::external_sources::sanitize_external_source_operation_error)?;
+    super::commands::reveal_local_path_in_explorer(&path, &request.source_key)
         .map_err(bitfun_core::external_sources::sanitize_external_source_operation_error)
 }
 

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -459,6 +459,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         RemoteWorkspacePolicy::RemoteUnsupported,
     ),
     (
+        "reveal_external_source_location",
+        RemoteWorkspacePolicy::RemoteUnsupported,
+    ),
+    (
         "get_file_change_history",
         RemoteWorkspacePolicy::LegacyUnaudited,
     ),

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -936,6 +936,7 @@ pub async fn run() {
             api::editor_ai_api::editor_ai_stream,
             api::editor_ai_api::editor_ai_cancel,
             get_external_source_snapshot,
+            reveal_external_source_location,
             update_external_integration_policy_command,
             set_external_source_enabled_command,
             set_external_source_conflict_choice_command,

--- a/src/crates/assembly/core/src/external_sources.rs
+++ b/src/crates/assembly/core/src/external_sources.rs
@@ -2074,6 +2074,22 @@ impl WorkspaceExternalSourceService {
         lock_snapshot(&self.snapshot).clone()
     }
 
+    fn source_location(&self, stable_key: &str) -> Result<PathBuf, String> {
+        let command_snapshot = lock_coordinator(&self.coordinator).snapshot();
+        let tool_snapshot = lock_tool_coordinator(&self.tool_coordinator).snapshot();
+        let subagent_snapshot = lock_subagent_coordinator(&self.subagent_coordinator).snapshot();
+        let mcp_snapshot = lock_mcp_coordinator(&self.mcp_coordinator).snapshot();
+        resolve_external_source_location(
+            stable_key,
+            command_snapshot
+                .sources
+                .iter()
+                .chain(tool_snapshot.sources.iter())
+                .chain(subagent_snapshot.sources.iter())
+                .chain(mcp_snapshot.sources.iter()),
+        )
+    }
+
     async fn set_source_enabled(
         self: &Arc<Self>,
         stable_key: &str,
@@ -3177,6 +3193,29 @@ fn relative_display_path(location: &str, root: &Path) -> Option<String> {
     (prefix.eq_ignore_ascii_case(root) && relative.starts_with('/'))
         .then(|| relative.trim_start_matches('/').to_string())
         .or_else(|| (prefix.eq_ignore_ascii_case(root) && relative.is_empty()).then(String::new))
+}
+
+fn resolve_external_source_location<'a>(
+    stable_key: &str,
+    sources: impl IntoIterator<Item = &'a ExternalSourceCatalogEntry>,
+) -> Result<PathBuf, String> {
+    let location = sources
+        .into_iter()
+        .find(|source| source.stable_key == stable_key)
+        .map(|source| source.record.location.trim())
+        .filter(|location| !location.is_empty())
+        .ok_or_else(|| {
+            missing_candidate_error(format!(
+                "External source '{stable_key}' is no longer available"
+            ))
+        })?;
+    let path = PathBuf::from(location);
+    if !path.is_absolute() {
+        return Err(invalid_operation_error(
+            "External source location is not an absolute host path",
+        ));
+    }
+    Ok(path)
 }
 
 pub(super) fn safe_external_source_location(
@@ -4916,6 +4955,17 @@ pub async fn external_source_snapshot(
     }
 }
 
+/// Resolves an opaque source identity to its host-local location for a host
+/// action. The raw path must not be serialized into the public snapshot.
+pub async fn external_source_location_for_host_action(
+    workspace_root: Option<&Path>,
+    stable_key: &str,
+) -> Result<PathBuf, String> {
+    service_for(workspace_root)
+        .await?
+        .source_location(stable_key)
+}
+
 /// Returns a static, sanitized projection for Hosts that may inspect external
 /// configuration but must never load external code or alter runtime routes.
 pub async fn external_source_read_only_snapshot(
@@ -5411,6 +5461,41 @@ mod tests {
             .sources
             .iter()
             .all(|source| source.record.location == "<remote>/.config/opencode/opencode.json"));
+    }
+
+    #[test]
+    fn reveal_location_uses_stable_identity_and_keeps_the_raw_path_private() {
+        let raw_location = std::env::current_dir()
+            .unwrap()
+            .join(".opencode")
+            .join("opencode.json");
+        let source = ExternalSourceCatalogEntry {
+            stable_key: "opencode-project".to_string(),
+            presentation_group_id: Some("opencode-project".to_string()),
+            record: ExternalSourceRecord {
+                key: SourceKey::new("opencode.commands", "project").unwrap(),
+                ecosystem_id: EcosystemId::new("opencode").unwrap(),
+                display_name: "OpenCode project configuration".to_string(),
+                source_kind: "configuration".to_string(),
+                scope: ExternalSourceScope::Project,
+                location: raw_location.to_string_lossy().into_owned(),
+                execution_domain_id: ExecutionDomainId::new("local-user").unwrap(),
+                health: bitfun_product_domains::external_sources::ExternalSourceHealth::Available,
+                content_version: "source-v1".to_string(),
+                diagnostics: Vec::new(),
+            },
+            lifecycle: ExternalSourceLifecycleState::Available,
+        };
+
+        let resolved =
+            resolve_external_source_location("opencode-project", std::iter::once(&source)).unwrap();
+
+        assert_eq!(resolved, raw_location);
+        assert!(resolve_external_source_location(
+            "<workspace>/.opencode",
+            std::iter::once(&source)
+        )
+        .is_err());
     }
 
     struct DelayedProvider {

--- a/src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.test.ts
@@ -37,6 +37,20 @@ describe('ExternalSourcesAPI', () => {
     });
   });
 
+  it('reveals a source by stable identity without sending its display location', async () => {
+    await externalSourcesAPI.revealSourceLocation(
+      'D:/workspace/project',
+      'opencode.commands:project',
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('reveal_external_source_location', {
+      request: {
+        workspacePath: 'D:/workspace/project',
+        sourceKey: 'opencode.commands:project',
+      },
+    });
+  });
+
   it('sends policy scope and optimistic revision as one atomic mutation', async () => {
     await externalSourcesAPI.updateIntegrationPolicy('D:/workspace/project', {
       expectedPreferenceRevision: 8,

--- a/src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts
@@ -626,6 +626,15 @@ export const externalSourcesAPI = {
     });
   },
 
+  revealSourceLocation(workspacePath: string | undefined, sourceKey: string) {
+    return invokeExternal<void>('reveal_external_source_location', {
+      request: {
+        workspacePath: normalizeOptionalWorkspacePath(workspacePath),
+        sourceKey,
+      },
+    });
+  },
+
   setSourceEnabled(
     workspacePath: string | undefined,
     sourceKey: string,

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
@@ -416,7 +416,7 @@
   }
 
   &__path-link {
-    color: var(--color-text-link);
+    color: var(--color-accent-500);
     text-decoration: underline;
     cursor: pointer;
     overflow-wrap: anywhere;
@@ -454,6 +454,13 @@
     gap: 4px;
     color: var(--color-text-secondary);
     font-size: 12px;
+
+    > div {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: var(--size-gap-2);
+    }
   }
 
   &__source-detail-toggle {
@@ -469,7 +476,7 @@
 
     code {
       font-size: 12px;
-      color: var(--color-text-tertiary);
+      color: var(--color-text-muted);
     }
   }
 

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
@@ -412,7 +412,65 @@
     display: grid;
     gap: 4px;
     color: var(--color-text-secondary);
-    font-size: 11px;
+    font-size: 13px;
+  }
+
+  &__path-link {
+    color: var(--color-text-link);
+    text-decoration: underline;
+    cursor: pointer;
+    overflow-wrap: anywhere;
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    &--disabled {
+      color: var(--color-text-secondary);
+      text-decoration: none;
+      cursor: not-allowed;
+    }
+  }
+
+  &__opencode-card {
+    padding: 12px 14px;
+    border: 1px solid var(--border-medium);
+    border-radius: 6px;
+    margin-bottom: 12px;
+  }
+
+  &__opencode-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    color: var(--color-text-secondary);
+    font-size: 13px;
+  }
+
+  &__opencode-locations {
+    margin-top: 8px;
+    display: grid;
+    gap: 4px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+  }
+
+  &__source-detail-toggle {
+    margin-top: 8px;
+  }
+
+  &__mcp-empty {
+    color: var(--color-text-secondary);
+    font-size: 13px;
+    display: grid;
+    gap: 8px;
+    padding: 12px 14px;
+
+    code {
+      font-size: 12px;
+      color: var(--color-text-tertiary);
+    }
   }
 
   &__tool-warning {

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
@@ -44,6 +44,11 @@ vi.mock('@/infrastructure/peer-device/PeerDeviceContext', () => ({
 }));
 
 vi.mock('@/infrastructure/runtime', () => ({ isTauriRuntime: () => true }));
+vi.mock('@/infrastructure/api/service-api/WorkspaceAPI', () => ({
+  workspaceAPI: {
+    revealInExplorer: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 vi.mock('@/shared/types', () => ({
   isRemoteWorkspace: () => false,
   WorkspaceKind: { Normal: 'normal', Assistant: 'assistant', Remote: 'remote' },
@@ -79,7 +84,7 @@ const snapshot = {
     record: {
       key: { providerId: 'opencode.commands', sourceId: 'project' },
       ecosystemId: 'opencode',
-      displayName: 'OpenCode project commands',
+      displayName: 'External project commands',
       sourceKind: 'prompt_commands',
       scope: 'project',
       location: '<workspace>/.opencode/commands',
@@ -100,7 +105,7 @@ const snapshot = {
     candidates: [{
       candidateId: 'candidate-opencode',
       source: { providerId: 'opencode.commands', sourceId: 'project' },
-      sourceDisplayName: 'OpenCode project commands',
+      sourceDisplayName: 'External project commands',
       ecosystemId: 'opencode',
       contentVersion: 'v1',
       commandDescription: 'Review with OpenCode',
@@ -349,7 +354,7 @@ describe('ExternalSourcesConfig', () => {
     expect(getSnapshotMock).toHaveBeenCalledWith('D:/workspace/project', false);
 
     const candidateButton = Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.includes('OpenCode project commands'));
+      button.textContent?.includes('External project commands'));
     expect(container.textContent).toContain('diagnostics.summary');
     expect(container.textContent).toContain('diagnostics.category.invalidSettings');
     expect(container.textContent).toContain('One command file could not be parsed.');
@@ -386,7 +391,7 @@ describe('ExternalSourcesConfig', () => {
       scope: 'user_global',
       location: '~\\.config\\opencode\\opencode.json',
       executionDomainId: 'local',
-      displayName: 'OpenCode user configuration',
+      displayName: 'External user configuration',
     };
     const groupedSnapshot = {
       ...snapshot,
@@ -454,7 +459,7 @@ describe('ExternalSourcesConfig', () => {
     expect(container.querySelectorAll(
       '.bitfun-external-sources-config__source-group',
     )).toHaveLength(1);
-    expect(container.textContent?.match(/OpenCode user configuration/g)).toHaveLength(1);
+    expect(container.textContent?.match(/External user configuration/g)).toHaveLength(1);
     expect(container.textContent).toContain('sources.commandCount:{"count":1}');
     expect(container.textContent).toContain('sources.agentCount:{"count":1}');
     expect(container.textContent).not.toContain('sources.toolCount:{"count":0}');
@@ -505,7 +510,7 @@ describe('ExternalSourcesConfig', () => {
 
     expect(container.textContent).not.toContain('sources.title');
     expect(container.textContent).not.toContain('sources.empty');
-    expect(container.textContent).not.toContain('OpenCode project commands');
+    expect(container.textContent).not.toContain('External project commands');
   });
 
   it('reviews MCP risk and binds approval and conflict choices to the visible versions', async () => {
@@ -903,7 +908,7 @@ describe('ExternalSourcesConfig', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(750);
     });
-    expect(container.textContent).toContain('OpenCode project commands');
+    expect(container.textContent).toContain('External project commands');
     expect(container.textContent).not.toContain('checkingNonBlocking');
   });
 
@@ -992,7 +997,7 @@ describe('ExternalSourcesConfig', () => {
     expect(getSnapshotMock).toHaveBeenCalledTimes(2);
     await act(async () => vi.advanceTimersByTimeAsync(1_500));
     expect(getSnapshotMock).toHaveBeenCalledTimes(3);
-    expect(container.textContent).toContain('OpenCode project commands');
+    expect(container.textContent).toContain('External project commands');
   });
 
   it('distinguishes initial load failures from uncertain mutation results', async () => {
@@ -1039,7 +1044,7 @@ describe('ExternalSourcesConfig', () => {
       await Promise.resolve();
     });
     expect(container.textContent).toContain('errors.refreshFailed');
-    expect(container.textContent).toContain('OpenCode project commands');
+    expect(container.textContent).toContain('External project commands');
     expect(container.textContent).not.toContain('refresh failed');
   });
 
@@ -1189,7 +1194,6 @@ describe('ExternalSourcesConfig', () => {
     expect(container.textContent).toContain('agentDiagnostics.invalidDefinition.reason');
     expect(container.textContent).toContain('agentConflicts.selectionApproves');
     expect(container.textContent).toContain('.opencode/agents/explore.md');
-    expect(container.textContent).toContain('sources.agentCount:{"count":2}');
     expect(container.textContent).not.toContain('D:/workspace/project/.opencode/agents');
     expect(container.innerHTML).not.toContain('D:');
     expect(container.innerHTML).not.toContain('D:/shared');
@@ -1669,7 +1673,7 @@ describe('ExternalSourcesConfig', () => {
     });
 
     expect(container.textContent).toContain('Other workspace commands');
-    expect(container.textContent).not.toContain('OpenCode project commands');
+    expect(container.textContent).not.toContain('External project commands');
   });
 
   it('isolates an in-flight response when the controlling Peer Host changes', async () => {
@@ -1711,7 +1715,7 @@ describe('ExternalSourcesConfig', () => {
     });
 
     expect(container.textContent).toContain('Peer B commands');
-    expect(container.textContent).not.toContain('OpenCode project commands');
+    expect(container.textContent).not.toContain('External project commands');
   });
 
   it('ignores a source mutation response from the previous workspace', async () => {
@@ -1757,7 +1761,7 @@ describe('ExternalSourcesConfig', () => {
     });
 
     expect(container.textContent).toContain('Other workspace commands');
-    expect(container.textContent).not.toContain('OpenCode project commands');
+    expect(container.textContent).not.toContain('External project commands');
   });
 
   it('keeps the latest mutation authoritative over a focus refresh', async () => {
@@ -2008,5 +2012,62 @@ describe('ExternalSourcesConfig', () => {
     expect(container.textContent).toContain('operationErrors.internal');
     expect(container.textContent).toContain('external-source-ref-7');
     expect(container.textContent).not.toContain('database connection string');
+  });
+
+  it('shows MCP empty state when no MCP servers found', async () => {
+    const emptyMcpSnapshot = {
+      ...snapshot,
+      mcpServers: [],
+      mcpApprovalRequests: [],
+      mcpConflicts: [],
+    };
+    getSnapshotMock.mockResolvedValue(emptyMcpSnapshot);
+
+    await act(async () => {
+      root.render(<ExternalSourcesConfig />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('mcp.empty');
+    expect(container.textContent).toContain('mcp.emptyGuidance');
+  });
+
+  it('renders subagent source locations as path links', async () => {
+    const agentSnapshot = {
+      ...snapshot,
+      commandConflicts: [],
+      subagents: [{
+        candidateId: 'agent-path-test',
+        logicalId: 'test',
+        displayName: 'Test Agent',
+        description: 'A test agent',
+        providerLabel: 'OpenCode',
+        scope: 'project',
+        sourceKeys: [{ providerId: 'opencode.agents', sourceId: 'user' }],
+        sourceLocationLabels: ['/path/to/source'],
+        sourceCount: 1,
+        effectiveModelLabel: 'gpt-4',
+        effectiveToolLabels: ['read'],
+        supportsFollowUp: false,
+        compatibilityState: 'ready',
+        diagnostics: [],
+        activationState: { state: 'approval_required' },
+        decisionKey: 'agent-path-key',
+      }],
+    };
+    getSnapshotMock.mockResolvedValue(agentSnapshot);
+
+    await act(async () => {
+      root.render(<ExternalSourcesConfig />);
+      await Promise.resolve();
+    });
+
+    const detailsButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'common.details',
+    );
+    await act(async () => detailsButton?.click());
+
+    const pathLink = container.querySelector('.bitfun-external-sources-config__path-link');
+    expect(pathLink).not.toBeNull();
   });
 });

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
@@ -15,6 +15,7 @@ const chooseSubagentConflictMock = vi.hoisted(() => vi.fn());
 const setMcpServerDecisionMock = vi.hoisted(() => vi.fn());
 const chooseMcpConflictMock = vi.hoisted(() => vi.fn());
 const updateIntegrationPolicyMock = vi.hoisted(() => vi.fn());
+const revealSourceLocationMock = vi.hoisted(() => vi.fn());
 const workspaceState = vi.hoisted(() => ({ path: 'D:/workspace/project', kind: 'normal' }));
 const peerState = vi.hoisted(() => ({ deviceId: '' }));
 
@@ -44,6 +45,15 @@ vi.mock('@/infrastructure/peer-device/PeerDeviceContext', () => ({
 }));
 
 vi.mock('@/infrastructure/runtime', () => ({ isTauriRuntime: () => true }));
+vi.mock('@/shared/utils/logger', () => {
+  const fn = () => vi.fn();
+  const contextLogger = { trace: fn(), debug: fn(), info: fn(), warn: fn(), error: fn() };
+  return {
+    createLogger: () => contextLogger,
+    logger: contextLogger,
+    log: contextLogger,
+  };
+});
 vi.mock('@/infrastructure/api/service-api/WorkspaceAPI', () => ({
   workspaceAPI: {
     revealInExplorer: vi.fn().mockResolvedValue(undefined),
@@ -65,6 +75,7 @@ vi.mock('@/infrastructure/api/service-api/ExternalSourcesAPI', () => ({
     setMcpServerDecision: setMcpServerDecisionMock,
     chooseMcpConflict: chooseMcpConflictMock,
     updateIntegrationPolicy: updateIntegrationPolicyMock,
+    revealSourceLocation: revealSourceLocationMock,
   },
 }));
 
@@ -83,8 +94,8 @@ const snapshot = {
     presentationGroupId: 'source-key',
     record: {
       key: { providerId: 'opencode.commands', sourceId: 'project' },
-      ecosystemId: 'opencode',
-      displayName: 'External project commands',
+      ecosystemId: 'other',
+      displayName: 'OpenCode project commands',
       sourceKind: 'prompt_commands',
       scope: 'project',
       location: '<workspace>/.opencode/commands',
@@ -105,7 +116,7 @@ const snapshot = {
     candidates: [{
       candidateId: 'candidate-opencode',
       source: { providerId: 'opencode.commands', sourceId: 'project' },
-      sourceDisplayName: 'External project commands',
+      sourceDisplayName: 'OpenCode project commands',
       ecosystemId: 'opencode',
       contentVersion: 'v1',
       commandDescription: 'Review with OpenCode',
@@ -241,6 +252,7 @@ describe('ExternalSourcesConfig', () => {
     setMcpServerDecisionMock.mockResolvedValue(snapshot);
     chooseMcpConflictMock.mockResolvedValue(snapshot);
     updateIntegrationPolicyMock.mockResolvedValue(snapshot);
+    revealSourceLocationMock.mockResolvedValue(undefined);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -354,7 +366,7 @@ describe('ExternalSourcesConfig', () => {
     expect(getSnapshotMock).toHaveBeenCalledWith('D:/workspace/project', false);
 
     const candidateButton = Array.from(container.querySelectorAll('button')).find((button) =>
-      button.textContent?.includes('External project commands'));
+      button.textContent?.includes('OpenCode project commands'));
     expect(container.textContent).toContain('diagnostics.summary');
     expect(container.textContent).toContain('diagnostics.category.invalidSettings');
     expect(container.textContent).toContain('One command file could not be parsed.');
@@ -387,11 +399,12 @@ describe('ExternalSourcesConfig', () => {
   it('combines duplicate physical sources and exposes honest capability-level controls', async () => {
     const sharedRecord = {
       ...snapshot.sources[0].record,
-      sourceKind: 'opencode_user_configuration',
+      ecosystemId: 'other',
+      sourceKind: 'other_user_configuration',
       scope: 'user_global',
-      location: '~\\.config\\opencode\\opencode.json',
+      location: '~\\.config\\other\\other.json',
       executionDomainId: 'local',
-      displayName: 'External user configuration',
+      displayName: 'Other user configuration',
     };
     const groupedSnapshot = {
       ...snapshot,
@@ -399,26 +412,26 @@ describe('ExternalSourcesConfig', () => {
       diagnostics: [],
       commandConflicts: [],
       sources: [{
-        stableKey: 'opencode-command-source',
-        presentationGroupId: 'opencode-user-config',
+        stableKey: 'other-command-source',
+        presentationGroupId: 'other-user-config',
         record: {
           ...sharedRecord,
-          key: { providerId: 'opencode.commands', sourceId: 'user-configuration' },
+          key: { providerId: 'other.commands', sourceId: 'user-configuration' },
         },
         lifecycle: 'available',
       }, {
-        stableKey: 'opencode-agent-source',
-        presentationGroupId: 'opencode-user-config',
+        stableKey: 'other-agent-source',
+        presentationGroupId: 'other-user-config',
         record: {
           ...sharedRecord,
-          key: { providerId: 'opencode.subagents', sourceId: 'user-configuration' },
+          key: { providerId: 'other.subagents', sourceId: 'user-configuration' },
         },
         lifecycle: 'suppressed',
       }],
       commands: [{
         definition: {
           id: {
-            source: { providerId: 'opencode.commands', sourceId: 'user-configuration' },
+            source: { providerId: 'other.commands', sourceId: 'user-configuration' },
             localId: 'smoke-command',
           },
           name: 'smoke-command',
@@ -432,10 +445,10 @@ describe('ExternalSourcesConfig', () => {
         logicalId: 'smoke-agent',
         displayName: 'Smoke agent',
         description: 'Smoke agent',
-        providerLabel: 'OpenCode',
+        providerLabel: 'Other',
         scope: 'user_global',
-        sourceKeys: [{ providerId: 'opencode.subagents', sourceId: 'user-configuration' }],
-        sourceLocationLabels: ['~/.config/opencode/opencode.json'],
+        sourceKeys: [{ providerId: 'other.subagents', sourceId: 'user-configuration' }],
+        sourceLocationLabels: ['~/.config/other/other.json'],
         sourceCount: 1,
         effectiveToolLabels: [],
         supportsFollowUp: false,
@@ -459,7 +472,7 @@ describe('ExternalSourcesConfig', () => {
     expect(container.querySelectorAll(
       '.bitfun-external-sources-config__source-group',
     )).toHaveLength(1);
-    expect(container.textContent?.match(/External user configuration/g)).toHaveLength(1);
+    expect(container.textContent?.match(/Other user configuration/g)).toHaveLength(1);
     expect(container.textContent).toContain('sources.commandCount:{"count":1}');
     expect(container.textContent).toContain('sources.agentCount:{"count":1}');
     expect(container.textContent).not.toContain('sources.toolCount:{"count":0}');
@@ -482,7 +495,7 @@ describe('ExternalSourcesConfig', () => {
     expect(setSourceEnabledMock).toHaveBeenCalledOnce();
     expect(setSourceEnabledMock).toHaveBeenCalledWith(
       'D:/workspace/project',
-      'opencode-command-source',
+      'other-command-source',
       false,
       7,
     );
@@ -510,7 +523,7 @@ describe('ExternalSourcesConfig', () => {
 
     expect(container.textContent).not.toContain('sources.title');
     expect(container.textContent).not.toContain('sources.empty');
-    expect(container.textContent).not.toContain('External project commands');
+    expect(container.textContent).not.toContain('OpenCode project commands');
   });
 
   it('reviews MCP risk and binds approval and conflict choices to the visible versions', async () => {
@@ -908,7 +921,7 @@ describe('ExternalSourcesConfig', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(750);
     });
-    expect(container.textContent).toContain('External project commands');
+    expect(container.textContent).toContain('OpenCode project commands');
     expect(container.textContent).not.toContain('checkingNonBlocking');
   });
 
@@ -997,7 +1010,7 @@ describe('ExternalSourcesConfig', () => {
     expect(getSnapshotMock).toHaveBeenCalledTimes(2);
     await act(async () => vi.advanceTimersByTimeAsync(1_500));
     expect(getSnapshotMock).toHaveBeenCalledTimes(3);
-    expect(container.textContent).toContain('External project commands');
+    expect(container.textContent).toContain('OpenCode project commands');
   });
 
   it('distinguishes initial load failures from uncertain mutation results', async () => {
@@ -1044,7 +1057,7 @@ describe('ExternalSourcesConfig', () => {
       await Promise.resolve();
     });
     expect(container.textContent).toContain('errors.refreshFailed');
-    expect(container.textContent).toContain('External project commands');
+    expect(container.textContent).toContain('OpenCode project commands');
     expect(container.textContent).not.toContain('refresh failed');
   });
 
@@ -1631,6 +1644,54 @@ describe('ExternalSourcesConfig', () => {
     expect(container.textContent?.match(/opencode\.configuration\.invalid/g)).toHaveLength(1);
   });
 
+  it('keeps grouped OpenCode diagnostics and lifecycle states visible', async () => {
+    const diagnostic = {
+      severity: 'warning',
+      code: 'opencode.configuration.invalid',
+      message: 'The configuration could not be parsed.',
+    };
+    getSnapshotMock.mockResolvedValue({
+      ...snapshot,
+      integrationPolicy,
+      diagnostics: [diagnostic],
+      commandConflicts: [],
+      sources: [{
+        ...snapshot.sources[0],
+        stableKey: 'opencode-project',
+        presentationGroupId: 'opencode-project',
+        lifecycle: 'degraded',
+        record: {
+          ...snapshot.sources[0].record,
+          ecosystemId: 'opencode',
+          diagnostics: [diagnostic],
+        },
+      }],
+    });
+
+    await act(async () => {
+      root.render(<ExternalSourcesConfig />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('lifecycle.degraded');
+    expect(container.textContent).toContain('opencode.configuration.invalid');
+    expect(container.querySelector(
+      '.bitfun-external-sources-config__opencode-card [data-external-attention="true"]',
+    )).not.toBeNull();
+    expect(container.textContent?.match(/opencode\.configuration\.invalid/g)).toHaveLength(1);
+    const sourceToggle = container.querySelector(
+      '.bitfun-external-sources-config__opencode-card input[aria-label^="sources.toggleLabel"]',
+    ) as HTMLInputElement;
+    expect(sourceToggle).not.toBeNull();
+    await act(async () => sourceToggle.click());
+    expect(setSourceEnabledMock).toHaveBeenCalledWith(
+      'D:/workspace/project',
+      'opencode-project',
+      false,
+      0,
+    );
+  });
+
   it('ignores an older workspace response after switching workspaces', async () => {
     let resolveProject: ((value: typeof snapshot) => void) | undefined;
     const projectRequest = new Promise<typeof snapshot>((resolve) => {
@@ -1673,7 +1734,7 @@ describe('ExternalSourcesConfig', () => {
     });
 
     expect(container.textContent).toContain('Other workspace commands');
-    expect(container.textContent).not.toContain('External project commands');
+    expect(container.textContent).not.toContain('OpenCode project commands');
   });
 
   it('isolates an in-flight response when the controlling Peer Host changes', async () => {
@@ -1715,7 +1776,7 @@ describe('ExternalSourcesConfig', () => {
     });
 
     expect(container.textContent).toContain('Peer B commands');
-    expect(container.textContent).not.toContain('External project commands');
+    expect(container.textContent).not.toContain('OpenCode project commands');
   });
 
   it('ignores a source mutation response from the previous workspace', async () => {
@@ -1761,7 +1822,7 @@ describe('ExternalSourcesConfig', () => {
     });
 
     expect(container.textContent).toContain('Other workspace commands');
-    expect(container.textContent).not.toContain('External project commands');
+    expect(container.textContent).not.toContain('OpenCode project commands');
   });
 
   it('keeps the latest mutation authoritative over a focus refresh', async () => {
@@ -2032,10 +2093,39 @@ describe('ExternalSourcesConfig', () => {
     expect(container.textContent).toContain('mcp.emptyGuidance');
   });
 
+  it('does not show the MCP empty state when the initial snapshot failed', async () => {
+    getSnapshotMock.mockRejectedValueOnce(new Error('initial load failed'));
+
+    await act(async () => {
+      root.render(<ExternalSourcesConfig />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('errors.loadFailed');
+    expect(container.textContent).not.toContain('mcp.empty');
+  });
+
   it('renders subagent source locations as path links', async () => {
     const agentSnapshot = {
       ...snapshot,
       commandConflicts: [],
+      sources: [{
+        ...snapshot.sources[0],
+        stableKey: 'opencode-agent-user',
+        record: {
+          ...snapshot.sources[0].record,
+          key: { providerId: 'opencode.agents', sourceId: 'user' },
+          location: '<workspace>/.opencode/agents/review.md',
+        },
+      }, {
+        ...snapshot.sources[0],
+        stableKey: 'opencode-agent-admin',
+        record: {
+          ...snapshot.sources[0].record,
+          key: { providerId: 'opencode.agents', sourceId: 'admin' },
+          location: '<workspace>/.opencode/agents/review.md',
+        },
+      }],
       subagents: [{
         candidateId: 'agent-path-test',
         logicalId: 'test',
@@ -2043,9 +2133,12 @@ describe('ExternalSourcesConfig', () => {
         description: 'A test agent',
         providerLabel: 'OpenCode',
         scope: 'project',
-        sourceKeys: [{ providerId: 'opencode.agents', sourceId: 'user' }],
-        sourceLocationLabels: ['/path/to/source'],
-        sourceCount: 1,
+        sourceKeys: [
+          { providerId: 'opencode.agents', sourceId: 'user' },
+          { providerId: 'opencode.agents', sourceId: 'admin' },
+        ],
+        sourceLocationLabels: ['<workspace>/.opencode/agents/review.md'],
+        sourceCount: 2,
         effectiveModelLabel: 'gpt-4',
         effectiveToolLabels: ['read'],
         supportsFollowUp: false,
@@ -2067,7 +2160,169 @@ describe('ExternalSourcesConfig', () => {
     );
     await act(async () => detailsButton?.click());
 
-    const pathLink = container.querySelector('.bitfun-external-sources-config__path-link');
-    expect(pathLink).not.toBeNull();
+    const pathLinks = container.querySelectorAll(
+      '.bitfun-external-sources-config__source-detail-toggle .bitfun-external-sources-config__path-link',
+    );
+    expect(pathLinks).toHaveLength(2);
+    await act(async () => {
+      (pathLinks[0] as HTMLAnchorElement).click();
+      (pathLinks[1] as HTMLAnchorElement).click();
+      await Promise.resolve();
+    });
+    expect(revealSourceLocationMock).toHaveBeenNthCalledWith(
+      1,
+      'D:/workspace/project',
+      'opencode-agent-user',
+    );
+    expect(revealSourceLocationMock).toHaveBeenNthCalledWith(
+      2,
+      'D:/workspace/project',
+      'opencode-agent-admin',
+    );
+  });
+
+  it('renders the OpenCode aggregation card with summary counts and config locations', async () => {
+    const opencodeSnapshot = {
+      ...snapshot,
+      integrationPolicy,
+      commandConflicts: [],
+      sources: [{
+        stableKey: 'opencode-source',
+        presentationGroupId: 'opencode-source',
+        record: {
+          key: { providerId: 'opencode.commands', sourceId: 'project' },
+          ecosystemId: 'opencode',
+          displayName: 'OpenCode project commands',
+          sourceKind: 'prompt_commands',
+          scope: 'project',
+          location: '<workspace>/.opencode/commands',
+          health: 'available',
+          contentVersion: 'v1',
+        },
+        lifecycle: 'suppressed',
+      }, {
+        stableKey: 'opencode-source-secondary',
+        presentationGroupId: 'opencode-source-secondary',
+        record: {
+          key: { providerId: 'opencode.commands', sourceId: 'user' },
+          ecosystemId: 'opencode',
+          displayName: 'OpenCode user commands',
+          sourceKind: 'prompt_commands',
+          scope: 'user_global',
+          location: '<workspace>/.opencode/commands',
+          health: 'available',
+          contentVersion: 'v2',
+        },
+        lifecycle: 'suppressed',
+      }],
+    };
+    getSnapshotMock.mockResolvedValue(opencodeSnapshot);
+
+    await act(async () => {
+      root.render(<ExternalSourcesConfig />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('opencode.title');
+    expect(container.querySelector(
+      '.bitfun-external-sources-config__opencode-card',
+    )).not.toBeNull();
+    expect(container.textContent).not.toContain('sources.title');
+
+    const expandButton = container.querySelector(
+      'button[aria-controls="external-capabilities-opencode"]',
+    );
+    expect(expandButton).not.toBeNull();
+    await act(async () => {
+      (expandButton as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(expandButton?.getAttribute('aria-expanded')).toBe('true');
+    const locationBlocks = container.querySelectorAll(
+      '.bitfun-external-sources-config__opencode-locations',
+    );
+    expect(locationBlocks).toHaveLength(2);
+    const expandedLinks = locationBlocks[1].querySelectorAll(
+      '.bitfun-external-sources-config__path-link',
+    );
+    expect(expandedLinks).toHaveLength(2);
+    await act(async () => {
+      (expandedLinks[1] as HTMLAnchorElement).click();
+      await Promise.resolve();
+    });
+    expect(revealSourceLocationMock).toHaveBeenLastCalledWith(
+      'D:/workspace/project',
+      'opencode-source-secondary',
+    );
+  });
+
+  it('labels all OpenCode scopes with supported translations and includes tools in the summary', async () => {
+    const opencodeSnapshot = {
+      ...snapshot,
+      integrationPolicy,
+      commandConflicts: [],
+      commands: [{
+        ...discoveredCommand,
+        definition: {
+          ...discoveredCommand.definition,
+          id: {
+            ...discoveredCommand.definition.id,
+            source: { providerId: 'opencode.commands', sourceId: 'user' },
+          },
+        },
+      }],
+      tools: [{
+        definition: {
+          id: {
+            target: {
+              source: { providerId: 'opencode.tools', sourceId: 'config-dir' },
+              localId: 'weather',
+            },
+            exportId: 'weather',
+          },
+          displayName: 'Weather',
+          description: 'Weather tool',
+          modulePath: '<workspace>/.opencode/tools/weather.js',
+          workingDirectory: '<workspace>',
+          runtimeKind: 'javascript',
+          capabilities: [],
+          contentVersion: 'v1',
+        },
+        activation: { state: 'disabled' },
+      }],
+      sources: [{
+        ...snapshot.sources[0],
+        stableKey: 'opencode-workspace',
+        presentationGroupId: 'opencode-workspace',
+        record: {
+          ...snapshot.sources[0].record,
+          key: { providerId: 'opencode.tools', sourceId: 'config-dir' },
+          ecosystemId: 'opencode',
+          scope: 'workspace_local',
+        },
+      }, {
+        ...snapshot.sources[0],
+        stableKey: 'opencode-user',
+        presentationGroupId: 'opencode-user',
+        record: {
+          ...snapshot.sources[0].record,
+          key: { providerId: 'opencode.commands', sourceId: 'user' },
+          ecosystemId: 'opencode',
+          scope: 'user_global',
+          location: '~/.config/opencode/opencode.json',
+        },
+      }],
+    };
+    getSnapshotMock.mockResolvedValue(opencodeSnapshot);
+
+    await act(async () => {
+      root.render(<ExternalSourcesConfig />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('shared:features.workspace');
+    expect(container.textContent).toContain('scope.user_global');
+    expect(container.textContent).not.toContain('scope.workspace_local');
+    expect(container.textContent).toContain('"tools":1');
   });
 });

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
@@ -21,9 +21,11 @@ import {
   Tooltip,
 } from '@/component-library';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
-import { workspaceAPI } from '@/infrastructure/api/service-api/WorkspaceAPI';
 import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/PeerDeviceContext';
 import { WorkspaceKind } from '@/shared/types';
+import { createLogger } from '@/shared/utils/logger';
+
+const logger = createLogger('ExternalSourcesConfig');
 import {
   externalSourcesAPI,
   type ExternalIntegrationAccess,
@@ -44,6 +46,7 @@ import {
   buildExternalSourcePresentationGroups,
   catalogDiagnosticsWithoutSourceDuplicates,
   externalSourceDiagnosticKey,
+  type ExternalSourcePresentationGroup,
 } from '../externalSourcePresentation';
 import { externalSourceRequestScopeKey } from './externalSourceRequestScope';
 import './ExternalSourcesConfig.scss';
@@ -109,6 +112,12 @@ function sourceDiagnosticCategory(code: string): string {
   }
   if (code.includes('failed')) return 'checkFailed';
   return 'sourceIssue';
+}
+
+function sourceScopeLabel(scope: string, t: TFunction): string {
+  return scope === 'workspace_local'
+    ? t('shared:features.workspace')
+    : t(`scope.${scope}`);
 }
 
 function externalAgentModelLabel(model: string | undefined, t: TFunction): string {
@@ -456,13 +465,19 @@ const ExternalSourcesConfig: React.FC = () => {
     [snapshot],
   );
   const opencodeGroups = useMemo(
-    () => sourceGroups.filter((group) => group.displayName.toLowerCase().includes('opencode')),
+    () => sourceGroups.filter((group) => group.ecosystemId === 'opencode'),
     [sourceGroups],
   );
   const nonOpencodeGroups = useMemo(
-    () => sourceGroups.filter((group) => !group.displayName.toLowerCase().includes('opencode')),
+    () => sourceGroups.filter((group) => group.ecosystemId !== 'opencode'),
     [sourceGroups],
   );
+  const opencodeScopeLabel = useMemo(() => {
+    const scopes = Array.from(new Set(opencodeGroups.flatMap((group) => group.scopes)));
+    return (scopes.length > 0 ? scopes : ['user_global'])
+      .map((scope) => sourceScopeLabel(scope, t))
+      .join(' + ');
+  }, [opencodeGroups, t]);
   const catalogDiagnostics = useMemo(
     () => snapshot ? catalogDiagnosticsWithoutSourceDuplicates(snapshot, sourceGroups) : [],
     [snapshot, sourceGroups],
@@ -739,7 +754,8 @@ const ExternalSourcesConfig: React.FC = () => {
     return accepted;
   }, [loadSnapshot, runMutation, snapshot, t, workspacePath]);
 
-  const isRemote = workspace?.workspaceKind === 'remote' || Boolean(workspace?.connectionId);
+  const isRemote = workspace?.workspaceKind === WorkspaceKind.Remote
+    || Boolean(workspace?.connectionId);
   const policy = snapshot?.integrationPolicy;
   const selectedPolicyEnabled = policyScope === 'workspace'
     ? policy?.workspaceOverride?.enabled ?? policy?.userDefaults.enabled ?? true
@@ -903,9 +919,16 @@ const ExternalSourcesConfig: React.FC = () => {
     target.focus();
   }, []);
 
-  const renderPathLink = useCallback((location: string) => {
+  const renderPathLink = useCallback((location: string, sourceKey?: string) => {
     const display = abbreviatedLocation(location);
-    if (isRemote) {
+    if (isRemote || !sourceKey) {
+      if (!isRemote) {
+        return (
+          <span className="bitfun-external-sources-config__path-link bitfun-external-sources-config__path-link--disabled">
+            {display}
+          </span>
+        );
+      }
       return (
         <Tooltip content={t('common.openInExplorerRemote')} placement="top">
           <span className="bitfun-external-sources-config__path-link bitfun-external-sources-config__path-link--disabled">
@@ -916,20 +939,68 @@ const ExternalSourcesConfig: React.FC = () => {
     }
     return (
       <a
+        href="#"
         className="bitfun-external-sources-config__path-link"
         title={location}
         translate="no"
         onClick={(event) => {
           event.preventDefault();
-          void workspaceAPI.revealInExplorer(location).catch(() => {
-            // silently ignore — do not block UI
+          void externalSourcesAPI.revealSourceLocation(workspacePath, sourceKey).catch((error) => {
+            logger.warn('Could not reveal external source location', { sourceKey, error });
           });
         }}
       >
         {display}
       </a>
     );
-  }, [isRemote, t]);
+  }, [isRemote, t, workspacePath]);
+
+  const renderSourceMembers = useCallback((group: ExternalSourcePresentationGroup) => (
+    <div
+      className="bitfun-external-sources-config__source-members"
+      role="group"
+      aria-label={t('sources.toggleLabel', { name: group.displayName })}
+    >
+      {group.members.map((member) => {
+        const capabilityLabel = member.capability === 'source'
+          ? group.displayName
+          : t(`policy.capability.${member.capability}`);
+        const scopeLabel = sourceScopeLabel(member.scope, t);
+        return (
+          <Switch
+            key={member.stableKey}
+            className="bitfun-external-sources-config__source-member"
+            size="small"
+            label={capabilityLabel}
+            description={group.scopes.length > 1 ? scopeLabel : undefined}
+            checked={member.enabled}
+            disabled={!policyCompatible
+              || !member.mutable
+              || !hostCapabilities.canManageSources}
+            loading={busyKey === member.stableKey}
+            aria-label={t('sources.toggleLabel', {
+              name: [
+                group.displayName,
+                capabilityLabel,
+                scopeLabel,
+                t(`lifecycle.${member.lifecycle}`),
+              ].join(' · '),
+            })}
+            onChange={(event) => void setEnabled(
+              member.stableKey,
+              event.currentTarget.checked,
+            )}
+          >
+            {member.lifecycle !== 'available' ? (
+              <span className={`bitfun-external-sources-config__state is-${member.lifecycle}`}>
+                {t(`lifecycle.${member.lifecycle}`)}
+              </span>
+            ) : null}
+          </Switch>
+        );
+      })}
+    </div>
+  ), [busyKey, hostCapabilities.canManageSources, policyCompatible, setEnabled, t]);
 
   if (loading && !snapshot) {
     return <ConfigPageLoading text={t('loading')} />;
@@ -1118,8 +1189,7 @@ const ExternalSourcesConfig: React.FC = () => {
                 </div>
 
                 {ecosystemPolicies.map((ecosystem) => {
-                  const isOpencode = ecosystem.descriptor.ecosystemId === 'opencode'
-                    || ecosystem.descriptor.displayName === 'OpenCode';
+                  const isOpencode = ecosystem.descriptor.ecosystemId === 'opencode';
                   if (isOpencode) {
                     return (
                       <React.Fragment key={ecosystem.ecosystemId}>
@@ -1130,6 +1200,7 @@ const ExternalSourcesConfig: React.FC = () => {
                               <span> · {t('opencode.summary', {
                                 agents: opencodeGroups.reduce((sum, g) => sum + g.counts.agents, 0),
                                 commands: opencodeGroups.reduce((sum, g) => sum + g.counts.commands, 0),
+                                tools: opencodeGroups.reduce((sum, g) => sum + g.counts.tools, 0),
                                 mcps: opencodeGroups.reduce((sum, g) => sum + g.counts.mcps, 0),
                               })}</span>
                             </div>
@@ -1184,6 +1255,47 @@ const ExternalSourcesConfig: React.FC = () => {
                               </Tooltip>
                             </div>
                           </div>
+                          {opencodeGroups.length > 0 ? (
+                            <div className="bitfun-external-sources-config__opencode-locations">
+                              {opencodeGroups.map((group) => (
+                                <div key={group.key}>
+                                  <span>{renderPathLink(
+                                    group.location,
+                                    group.members[0]?.stableKey,
+                                  )}</span>
+                                  <span>
+                                    {group.scopes.map((scope) => sourceScopeLabel(scope, t)).join(' + ')}
+                                  </span>
+                                  {renderSourceMembers(group)}
+                                  {group.diagnostics.length > 0 ? (
+                                    <details
+                                      className="bitfun-external-sources-config__notice"
+                                      data-external-attention="true"
+                                    >
+                                      <summary>
+                                        {t('diagnostics.sourceSummary', {
+                                          name: group.displayName,
+                                          count: group.diagnostics.length,
+                                        })}
+                                      </summary>
+                                      <ul className="bitfun-external-sources-config__diagnostics">
+                                        {group.diagnostics.map((diagnostic) => (
+                                          <li key={externalSourceDiagnosticKey(diagnostic)}>
+                                            <span>{t(`diagnostics.category.${sourceDiagnosticCategory(diagnostic.code)}`)}</span>
+                                            <details>
+                                              <summary>{t('common.technicalDetails')}</summary>
+                                              <code>{diagnostic.code}</code>
+                                              <div>{diagnostic.message}</div>
+                                            </details>
+                                          </li>
+                                        ))}
+                                      </ul>
+                                    </details>
+                                  ) : null}
+                                </div>
+                              ))}
+                            </div>
+                          ) : null}
                           {expandedEcosystems.has(ecosystem.ecosystemId) ? (
                             <div
                               id={`external-capabilities-${ecosystem.ecosystemId}`}
@@ -1198,6 +1310,8 @@ const ExternalSourcesConfig: React.FC = () => {
                                   || KNOWN_INTEGRATION_ACCESS.has(configuredAccess);
                                 const countKey = capabilityId === 'subagent' ? 'agents'
                                   : capabilityId === 'command' ? 'commands'
+                                  : capabilityId === 'mcp' ? 'mcps'
+                                  : capabilityId === 'tool' ? 'tools'
                                   : capabilityId;
                                 const count = opencodeGroups.reduce(
                                   (sum, g) => sum + (g.counts[countKey as keyof typeof g.counts] ?? 0),
@@ -1220,7 +1334,7 @@ const ExternalSourcesConfig: React.FC = () => {
                                       <span className="bitfun-external-sources-config__candidate-detail">
                                         {t(`opencode.capability.${capabilityId}.description`, {
                                           count,
-                                          scope: t('scope.user_global'),
+                                          scope: opencodeScopeLabel,
                                         })}
                                       </span>
                                       <span className="bitfun-external-sources-config__candidate-detail">
@@ -1275,8 +1389,11 @@ const ExternalSourcesConfig: React.FC = () => {
                               {opencodeGroups.length > 0 ? (
                                 <div className="bitfun-external-sources-config__opencode-locations">
                                   <span>{t('opencode.configLocations')}</span>
-                                  {Array.from(new Set(opencodeGroups.map((g) => g.location))).map((location) => (
-                                    <span key={location}>{renderPathLink(location)}</span>
+                                  {opencodeGroups.map((group) => (
+                                    <span key={group.key}>{renderPathLink(
+                                      group.location,
+                                      group.members[0]?.stableKey,
+                                    )}</span>
                                   ))}
                                 </div>
                               ) : null}
@@ -1502,9 +1619,7 @@ const ExternalSourcesConfig: React.FC = () => {
                       ) : null}
                       {source ? (
                         <span>{t('mcp.scope', {
-                          scope: source.record.scope === 'workspace_local'
-                            ? t('shared:features.workspace')
-                            : t(`scope.${source.record.scope}`),
+                          scope: sourceScopeLabel(source.record.scope, t),
                         })}</span>
                       ) : null}
                       <span>{t(`mcp.transport.${request.definition.transport}`)}</span>
@@ -1639,9 +1754,12 @@ const ExternalSourcesConfig: React.FC = () => {
                             })}</span>
                             {source ? (
                               <>
-                                <span>{t('mcp.sourceLocation')}: {renderPathLink(source.record.location)}</span>
+                                <span>{t('mcp.sourceLocation')}: {renderPathLink(
+                                  source.record.location,
+                                  source.stableKey,
+                                )}</span>
                                 <span>{t('mcp.scope', {
-                                  scope: t(`scope.${source.record.scope}`),
+                                  scope: sourceScopeLabel(source.record.scope, t),
                                 })}</span>
                               </>
                             ) : null}
@@ -1787,7 +1905,7 @@ const ExternalSourcesConfig: React.FC = () => {
                                       location: externalSource.record.location,
                                     })}</span>
                                     <span>{t('mcp.scope', {
-                                      scope: t(`scope.${externalSource.record.scope}`),
+                                      scope: sourceScopeLabel(externalSource.record.scope, t),
                                     })}</span>
                                   </>
                                 ) : null}
@@ -1866,7 +1984,7 @@ const ExternalSourcesConfig: React.FC = () => {
               </ConfigPageSection>
             ) : null}
 
-            {(snapshot?.mcpServers?.length ?? 0) === 0
+            {snapshot && (snapshot.mcpServers?.length ?? 0) === 0
               && (snapshot?.mcpApprovalRequests?.length ?? 0) === 0
               && mcpConflicts.length === 0
               && !snapshot?.discoveryPending ? (
@@ -1889,6 +2007,25 @@ const ExternalSourcesConfig: React.FC = () => {
                   const state = agent.activationState.state;
                   const canEnable = state === 'approval_required' || state === 'declined';
                   const canDisable = state === 'active';
+                  const matchingSources = Array.from(new Map(
+                    snapshot.sources
+                      .filter((source) => agent.sourceKeys.some((key) => (
+                        key.providerId === source.record.key.providerId
+                        && key.sourceId === source.record.key.sourceId
+                      )))
+                      .map((source) => [source.stableKey, source]),
+                  ).values());
+                  const sourceLocations = matchingSources.length > 0
+                    ? matchingSources.map((source) => ({
+                        key: source.stableKey,
+                        label: source.record.location,
+                        stableKey: source.stableKey,
+                      }))
+                    : agent.sourceLocationLabels.map((label, index) => ({
+                        key: `${index}:${label}`,
+                        label,
+                        stableKey: undefined,
+                      }));
                   return (
                     <React.Fragment key={agent.candidateId}>
                       <ConfigPageRow
@@ -1935,12 +2072,15 @@ const ExternalSourcesConfig: React.FC = () => {
                             <span>{t('agents.tools', { tools: agent.effectiveToolLabels.join(', ') || t('agents.noTools') })}</span>
                             <span>{t('agents.executionDomain')}</span>
                             <span>{t('agents.compatibility', { state: t(`agentCompatibility.${agent.compatibilityState}`) })}</span>
-                            {agent.sourceLocationLabels.length > 0 ? (
+                            {sourceLocations.length > 0 ? (
                               <details className="bitfun-external-sources-config__source-detail-toggle">
-                                <summary>{t('agents.sourceLocations', { count: agent.sourceLocationLabels.length })}</summary>
+                                <summary>{t('agents.sourceLocations', { count: sourceLocations.length })}</summary>
                                 <div className="bitfun-external-sources-config__tool-detail">
-                                  {agent.sourceLocationLabels.map((location) => (
-                                    <span key={location}>{renderPathLink(location)}</span>
+                                  {sourceLocations.map((location) => (
+                                    <span key={location.key}>{renderPathLink(
+                                      location.label,
+                                      location.stableKey,
+                                    )}</span>
                                   ))}
                                 </div>
                               </details>
@@ -2158,9 +2298,10 @@ const ExternalSourcesConfig: React.FC = () => {
                         ))}
                         <span>
                           {t('toolApprovals.scope', {
-                            scope: (source?.record.scope ?? request.sourceScope) === 'workspace_local'
-                              ? t('shared:features.workspace')
-                              : t(`scope.${source?.record.scope ?? request.sourceScope}`),
+                            scope: sourceScopeLabel(
+                              source?.record.scope ?? request.sourceScope,
+                              t,
+                            ),
                           })}
                         </span>
                         <span>
@@ -2247,9 +2388,7 @@ const ExternalSourcesConfig: React.FC = () => {
                                   <React.Fragment key={scope}>
                                     {index > 0 ? <span aria-hidden="true"> + </span> : null}
                                     <span>
-                                      {scope === 'workspace_local'
-                                        ? t('shared:features.workspace')
-                                        : t(`scope.${scope}`)}
+                                      {sourceScopeLabel(scope, t)}
                                     </span>
                                   </React.Fragment>
                                 ))}
@@ -2276,52 +2415,7 @@ const ExternalSourcesConfig: React.FC = () => {
                         )}
                         align="center"
                       >
-                        <div
-                          className="bitfun-external-sources-config__source-members"
-                          role="group"
-                          aria-label={t('sources.toggleLabel', { name: group.displayName })}
-                        >
-                          {group.members.map((member) => {
-                            const capabilityLabel = member.capability === 'source'
-                              ? group.displayName
-                              : t(`policy.capability.${member.capability}`);
-                            const scopeLabel = member.scope === 'workspace_local'
-                              ? t('shared:features.workspace')
-                              : t(`scope.${member.scope}`);
-                            return (
-                              <Switch
-                                key={member.stableKey}
-                                className="bitfun-external-sources-config__source-member"
-                                size="small"
-                                label={capabilityLabel}
-                                description={group.scopes.length > 1 ? scopeLabel : undefined}
-                                checked={member.enabled}
-                                disabled={!policyCompatible
-                                  || !member.mutable
-                                  || !hostCapabilities.canManageSources}
-                                loading={busyKey === member.stableKey}
-                                aria-label={t('sources.toggleLabel', {
-                                  name: [
-                                    group.displayName,
-                                    capabilityLabel,
-                                    scopeLabel,
-                                    t(`lifecycle.${member.lifecycle}`),
-                                  ].join(' · '),
-                                })}
-                                onChange={(event) => void setEnabled(
-                                  member.stableKey,
-                                  event.currentTarget.checked,
-                                )}
-                              >
-                                {member.lifecycle !== 'available' ? (
-                                  <span className={`bitfun-external-sources-config__state is-${member.lifecycle}`}>
-                                    {t(`lifecycle.${member.lifecycle}`)}
-                                  </span>
-                                ) : null}
-                              </Switch>
-                            );
-                          })}
-                        </div>
+                        {renderSourceMembers(group)}
                       </ConfigPageRow>
                       {group.diagnostics.length > 0 ? (
                         <details
@@ -2439,11 +2533,9 @@ const ExternalSourcesConfig: React.FC = () => {
                             </span>
                             <span>
                               {t('toolApprovals.scope', {
-                                scope: source?.record.scope === 'workspace_local'
-                                  ? t('shared:features.workspace')
-                                  : source?.record.scope
-                                    ? t(`scope.${source.record.scope}`)
-                                    : t('common.unknown'),
+                                scope: source?.record.scope
+                                  ? sourceScopeLabel(source.record.scope, t)
+                                  : t('common.unknown'),
                               })}
                             </span>
                             <span>
@@ -2574,9 +2666,7 @@ const ExternalSourcesConfig: React.FC = () => {
                             <div className="bitfun-external-sources-config__candidate-detail">
                               {candidate.commandDescription}
                               {' · '}
-                              {candidate.sourceScope === 'workspace_local'
-                                ? t('shared:features.workspace')
-                                : t(`scope.${candidate.sourceScope}`)}
+                              {sourceScopeLabel(candidate.sourceScope, t)}
                               {' · '}
                               <span title={candidate.sourceLocation}>
                                 {abbreviatedLocation(candidate.sourceLocation)}

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
@@ -21,6 +21,7 @@ import {
   Tooltip,
 } from '@/component-library';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { workspaceAPI } from '@/infrastructure/api/service-api/WorkspaceAPI';
 import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/PeerDeviceContext';
 import { WorkspaceKind } from '@/shared/types';
 import {
@@ -454,6 +455,14 @@ const ExternalSourcesConfig: React.FC = () => {
     () => snapshot ? buildExternalSourcePresentationGroups(snapshot) : [],
     [snapshot],
   );
+  const opencodeGroups = useMemo(
+    () => sourceGroups.filter((group) => group.displayName.toLowerCase().includes('opencode')),
+    [sourceGroups],
+  );
+  const nonOpencodeGroups = useMemo(
+    () => sourceGroups.filter((group) => !group.displayName.toLowerCase().includes('opencode')),
+    [sourceGroups],
+  );
   const catalogDiagnostics = useMemo(
     () => snapshot ? catalogDiagnosticsWithoutSourceDuplicates(snapshot, sourceGroups) : [],
     [snapshot, sourceGroups],
@@ -730,6 +739,7 @@ const ExternalSourcesConfig: React.FC = () => {
     return accepted;
   }, [loadSnapshot, runMutation, snapshot, t, workspacePath]);
 
+  const isRemote = workspace?.workspaceKind === 'remote' || Boolean(workspace?.connectionId);
   const policy = snapshot?.integrationPolicy;
   const selectedPolicyEnabled = policyScope === 'workspace'
     ? policy?.workspaceOverride?.enabled ?? policy?.userDefaults.enabled ?? true
@@ -892,6 +902,34 @@ const ExternalSourcesConfig: React.FC = () => {
     target.tabIndex = -1;
     target.focus();
   }, []);
+
+  const renderPathLink = useCallback((location: string) => {
+    const display = abbreviatedLocation(location);
+    if (isRemote) {
+      return (
+        <Tooltip content={t('common.openInExplorerRemote')} placement="top">
+          <span className="bitfun-external-sources-config__path-link bitfun-external-sources-config__path-link--disabled">
+            {display}
+          </span>
+        </Tooltip>
+      );
+    }
+    return (
+      <a
+        className="bitfun-external-sources-config__path-link"
+        title={location}
+        translate="no"
+        onClick={(event) => {
+          event.preventDefault();
+          void workspaceAPI.revealInExplorer(location).catch(() => {
+            // silently ignore — do not block UI
+          });
+        }}
+      >
+        {display}
+      </a>
+    );
+  }, [isRemote, t]);
 
   if (loading && !snapshot) {
     return <ConfigPageLoading text={t('loading')} />;
@@ -1079,7 +1117,176 @@ const ExternalSourcesConfig: React.FC = () => {
                   ) : null}
                 </div>
 
-                {ecosystemPolicies.map((ecosystem) => (
+                {ecosystemPolicies.map((ecosystem) => {
+                  const isOpencode = ecosystem.descriptor.ecosystemId === 'opencode'
+                    || ecosystem.descriptor.displayName === 'OpenCode';
+                  if (isOpencode) {
+                    return (
+                      <React.Fragment key={ecosystem.ecosystemId}>
+                        <div className="bitfun-external-sources-config__opencode-card">
+                          <div className="bitfun-external-sources-config__opencode-summary">
+                            <div>
+                              <strong>{t('opencode.title')}</strong>
+                              <span> · {t('opencode.summary', {
+                                agents: opencodeGroups.reduce((sum, g) => sum + g.counts.agents, 0),
+                                commands: opencodeGroups.reduce((sum, g) => sum + g.counts.commands, 0),
+                                mcps: opencodeGroups.reduce((sum, g) => sum + g.counts.mcps, 0),
+                              })}</span>
+                            </div>
+                            <div className="bitfun-external-sources-config__policy-actions">
+                              <Select
+                                size="small"
+                                value={ecosystem.mode}
+                                triggerAriaLabel={t('policy.modeLabel', {
+                                  ecosystem: ecosystem.descriptor.displayName,
+                                })}
+                                disabled={!policyCompatible || !hostCapabilities.canMutatePolicy
+                                  || !selectedPolicyEnabled || busyKey !== null}
+                                options={[
+                                  { value: 'recommended', label: t('policy.mode.recommended') },
+                                  { value: 'discover_only', label: t('policy.mode.discoverOnly') },
+                                  { value: 'disabled', label: t('policy.mode.disabled') },
+                                  ...(ecosystem.mode === 'custom'
+                                    ? [{ value: 'custom', label: t('policy.mode.custom'), disabled: true }]
+                                    : []),
+                                  ...(!KNOWN_INTEGRATION_MODES.has(ecosystem.mode)
+                                    ? [{
+                                        value: ecosystem.mode,
+                                        label: t('policy.unsupportedSafelyOff'),
+                                        disabled: true,
+                                      }]
+                                    : []),
+                                ]}
+                                onChange={(value) => void updatePolicy({
+                                  operation: 'set_ecosystem_mode',
+                                  ecosystemId: ecosystem.ecosystemId,
+                                  mode: String(Array.isArray(value) ? value[0] : value) as ExternalIntegrationMode,
+                                })}
+                              />
+                              <Tooltip content={t('policy.capabilitiesHint')} placement="top">
+                                <button
+                                  type="button"
+                                  className="bitfun-external-sources-config__icon-action"
+                                  aria-label={t('policy.capabilitiesFor', {
+                                    ecosystem: ecosystem.descriptor.displayName,
+                                  })}
+                                  aria-expanded={expandedEcosystems.has(ecosystem.ecosystemId)}
+                                  aria-controls={`external-capabilities-${ecosystem.ecosystemId}`}
+                                  onClick={() => setExpandedEcosystems((current) => {
+                                    const next = new Set(current);
+                                    if (next.has(ecosystem.ecosystemId)) next.delete(ecosystem.ecosystemId);
+                                    else next.add(ecosystem.ecosystemId);
+                                    return next;
+                                  })}
+                                >
+                                  <Settings2 size={16} aria-hidden="true" />
+                                </button>
+                              </Tooltip>
+                            </div>
+                          </div>
+                          {expandedEcosystems.has(ecosystem.ecosystemId) ? (
+                            <div
+                              id={`external-capabilities-${ecosystem.ecosystemId}`}
+                              className="bitfun-external-sources-config__capability-grid"
+                            >
+                              {ecosystem.descriptor.capabilities.map((capabilityDescriptor) => {
+                                const capabilityId = capabilityDescriptor.capabilityId;
+                                const limited = ecosystem.effective?.policyLimitedCapabilities
+                                  ?.includes(capabilityId);
+                                const configuredAccess = ecosystem.capabilityOverrides[capabilityId];
+                                const accessKnown = configuredAccess === undefined
+                                  || KNOWN_INTEGRATION_ACCESS.has(configuredAccess);
+                                const countKey = capabilityId === 'subagent' ? 'agents'
+                                  : capabilityId === 'command' ? 'commands'
+                                  : capabilityId;
+                                const count = opencodeGroups.reduce(
+                                  (sum, g) => sum + (g.counts[countKey as keyof typeof g.counts] ?? 0),
+                                  0,
+                                );
+                                const riskKey = `opencode.capability.${capabilityId}.risk`;
+                                const riskText = t(riskKey);
+                                return (
+                                  <div
+                                    className="bitfun-external-sources-config__capability-row"
+                                    key={capabilityId}
+                                  >
+                                    <div>
+                                      <span>{t(`policy.capability.${capabilityId}`)}</span>
+                                      {limited ? (
+                                        <span className="bitfun-external-sources-config__limited-badge">
+                                          {t('policy.safetyLimited')}
+                                        </span>
+                                      ) : null}
+                                      <span className="bitfun-external-sources-config__candidate-detail">
+                                        {t(`opencode.capability.${capabilityId}.description`, {
+                                          count,
+                                          scope: t('scope.user_global'),
+                                        })}
+                                      </span>
+                                      <span className="bitfun-external-sources-config__candidate-detail">
+                                        {t(`opencode.capability.${capabilityId}.effect`)}
+                                      </span>
+                                      {riskText && riskText !== riskKey ? (
+                                        <span className="bitfun-external-sources-config__tool-warning">
+                                          {riskText}
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                    <Select
+                                      size="small"
+                                      value={accessKnown
+                                        ? selectedCapabilityAccess(ecosystem, capabilityId)
+                                        : configuredAccess}
+                                      triggerAriaLabel={t('policy.capabilityAccessLabel', {
+                                        ecosystem: ecosystem.descriptor.displayName,
+                                        capability: t(`policy.capability.${capabilityId}`),
+                                      })}
+                                      disabled={!policyCompatible || !hostCapabilities.canMutatePolicy
+                                        || !selectedPolicyEnabled || busyKey !== null}
+                                      options={[
+                                        { value: 'disabled', label: t('policy.access.disabled') },
+                                        { value: 'discover_only', label: t('policy.access.discoverOnly') },
+                                        { value: 'ask_before_use', label: t('policy.access.askBeforeUse') },
+                                        ...(capabilityDescriptor.safetyCeiling === 'auto'
+                                          ? [{ value: 'auto', label: t('policy.access.auto') }]
+                                          : []),
+                                        ...(!accessKnown && configuredAccess
+                                          ? [{
+                                              value: configuredAccess,
+                                              label: t('policy.unsupportedSafelyOff'),
+                                              disabled: true,
+                                            }]
+                                          : []),
+                                      ]}
+                                      onChange={(value) => {
+                                        const access = String(
+                                          Array.isArray(value) ? value[0] : value,
+                                        ) as ExternalIntegrationAccess;
+                                        void updateCapabilityAccess(
+                                          ecosystem.ecosystemId,
+                                          capabilityId,
+                                          access,
+                                        );
+                                      }}
+                                    />
+                                  </div>
+                                );
+                              })}
+                              {opencodeGroups.length > 0 ? (
+                                <div className="bitfun-external-sources-config__opencode-locations">
+                                  <span>{t('opencode.configLocations')}</span>
+                                  {Array.from(new Set(opencodeGroups.map((g) => g.location))).map((location) => (
+                                    <span key={location}>{renderPathLink(location)}</span>
+                                  ))}
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
+                        </div>
+                      </React.Fragment>
+                    );
+                  }
+                  return (
                   <React.Fragment key={ecosystem.ecosystemId}>
                 <div className="bitfun-external-sources-config__ecosystem-card">
                   <div className="bitfun-external-sources-config__ecosystem-heading">
@@ -1216,7 +1423,8 @@ const ExternalSourcesConfig: React.FC = () => {
                   </div>
                 ) : null}
                   </React.Fragment>
-                ))}
+                  );
+                })}
               </ConfigPageSection>
             ) : null}
             {operationStatus ? (
@@ -1431,9 +1639,7 @@ const ExternalSourcesConfig: React.FC = () => {
                             })}</span>
                             {source ? (
                               <>
-                                <span>{t('mcp.sourceLocation', {
-                                  location: source.record.location,
-                                })}</span>
+                                <span>{t('mcp.sourceLocation')}: {renderPathLink(source.record.location)}</span>
                                 <span>{t('mcp.scope', {
                                   scope: t(`scope.${source.record.scope}`),
                                 })}</span>
@@ -1459,15 +1665,9 @@ const ExternalSourcesConfig: React.FC = () => {
                               })}</span>
                             ) : null}
                             {'reason' in server.activationState ? (
-                              <>
-                                <span>{t(server.activationState.state === 'runtime_unavailable'
-                                  ? 'mcp.runtimeUnavailableGuidance'
-                                  : 'mcp.unsupportedGuidance')}</span>
-                                <details>
-                                  <summary>{t('common.technicalDetails')}</summary>
-                                  <code>{server.activationState.reason}</code>
-                                </details>
-                              </>
+                              <span>{t(server.activationState.state === 'runtime_unavailable'
+                                ? 'mcp.runtimeUnavailableGuidance'
+                                : 'mcp.unsupportedGuidance')}</span>
                             ) : null}
                             <span>{t('mcp.changePolicy')}</span>
                           </div>
@@ -1666,6 +1866,22 @@ const ExternalSourcesConfig: React.FC = () => {
               </ConfigPageSection>
             ) : null}
 
+            {(snapshot?.mcpServers?.length ?? 0) === 0
+              && (snapshot?.mcpApprovalRequests?.length ?? 0) === 0
+              && mcpConflicts.length === 0
+              && !snapshot?.discoveryPending ? (
+              <ConfigPageSection title={t('mcp.title')}>
+                <div className="bitfun-external-sources-config__mcp-empty">
+                  <span>{t('mcp.empty')}</span>
+                  <span>{t('mcp.emptyGuidance')}</span>
+                  <span>· {t('mcp.emptyLocation.userGlobal')}</span>
+                  <span>· {t('mcp.emptyLocation.project')}</span>
+                  <span>· {t('mcp.emptyLocation.envConfig')}</span>
+                  <code>{t('mcp.emptyExample')}</code>
+                </div>
+              </ConfigPageSection>
+            ) : null}
+
             {(snapshot?.subagents?.length ?? 0) > 0 ? (
               <ConfigPageSection title={t('agents.title')}>
                 {snapshot?.subagents?.map((agent) => {
@@ -1719,10 +1935,16 @@ const ExternalSourcesConfig: React.FC = () => {
                             <span>{t('agents.tools', { tools: agent.effectiveToolLabels.join(', ') || t('agents.noTools') })}</span>
                             <span>{t('agents.executionDomain')}</span>
                             <span>{t('agents.compatibility', { state: t(`agentCompatibility.${agent.compatibilityState}`) })}</span>
-                            <span>{t('agents.sources', { count: agent.sourceCount })}</span>
-                            {agent.sourceLocationLabels.map((location) => (
-                              <span key={location}>{abbreviatedLocation(location)}</span>
-                            ))}
+                            {agent.sourceLocationLabels.length > 0 ? (
+                              <details className="bitfun-external-sources-config__source-detail-toggle">
+                                <summary>{t('agents.sourceLocations', { count: agent.sourceLocationLabels.length })}</summary>
+                                <div className="bitfun-external-sources-config__tool-detail">
+                                  {agent.sourceLocationLabels.map((location) => (
+                                    <span key={location}>{renderPathLink(location)}</span>
+                                  ))}
+                                </div>
+                              </details>
+                            ) : null}
                             {agent.diagnostics.map((diagnostic) => {
                                 const category = agentDiagnosticCategory(
                                   diagnostic.code,
@@ -1731,16 +1953,7 @@ const ExternalSourcesConfig: React.FC = () => {
                               return (
                                 <div key={diagnostic.code}>
                                   <span>{t(`agentDiagnostics.${category}.reason`)}</span>
-                                  <span>{t(`agentDiagnostics.${category}.impact`, {
-                                    impact: diagnostic.blocksActivation
-                                      ? t('agentDiagnostics.activationBlocked')
-                                      : t('agentDiagnostics.degradedOnly'),
-                                  })}</span>
                                   <span>{t(`agentDiagnostics.${category}.nextStep`)}</span>
-                                  <details>
-                                    <summary>{t('common.technicalDetails')}</summary>
-                                    <code>{diagnostic.code}</code>
-                                  </details>
                                 </div>
                               );
                             })}
@@ -2010,9 +2223,9 @@ const ExternalSourcesConfig: React.FC = () => {
               </ConfigPageSection>
             ) : null}
 
-            {sourceGroups.length > 0 ? (
+            {nonOpencodeGroups.length > 0 ? (
               <ConfigPageSection title={t('sources.title')}>
-                {sourceGroups.map((group) => {
+                {nonOpencodeGroups.map((group) => {
                   return (
                     <React.Fragment key={group.key}>
                       <ConfigPageRow

--- a/src/web-ui/src/infrastructure/config/externalSourcePresentation.test.ts
+++ b/src/web-ui/src/infrastructure/config/externalSourcePresentation.test.ts
@@ -124,6 +124,7 @@ describe('external source presentation', () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0]).toMatchObject({
+      ecosystemId: 'opencode',
       displayName: 'OpenCode user configuration',
       location: '~/.config/opencode/opencode.json',
       counts: { commands: 1, tools: 0, agents: 1, mcps: 1 },

--- a/src/web-ui/src/infrastructure/config/externalSourcePresentation.ts
+++ b/src/web-ui/src/infrastructure/config/externalSourcePresentation.ts
@@ -25,6 +25,7 @@ export interface ExternalSourcePresentationMember {
 
 export interface ExternalSourcePresentationGroup {
   key: string;
+  ecosystemId: string;
   scopes: ExternalSourceScope[];
   displayName: string;
   location: string;
@@ -272,6 +273,7 @@ export function buildExternalSourcePresentationGroups(
 
     groups.push({
       key,
+      ecosystemId: representative.record.ecosystemId,
       scopes,
       displayName: representative.record.displayName,
       location: normalizeLocation(representative.record.location),

--- a/src/web-ui/src/locales/en-US/settings/external-sources.json
+++ b/src/web-ui/src/locales/en-US/settings/external-sources.json
@@ -12,7 +12,9 @@
     "selected": "Currently used",
     "selectedUnavailable": "Selected, currently unavailable",
     "notSelected": "Not used",
-    "availableChoice": "Available choice"
+    "availableChoice": "Available choice",
+    "openInExplorer": "Open in file explorer",
+    "openInExplorerRemote": "Remote workspace paths cannot be opened in the local file manager"
   },
   "actions": {
     "refresh": "Refresh",
@@ -148,7 +150,8 @@
     "compatibility": "Status: {{state}}",
     "sources": "Combined from {{count}} configuration sources",
     "noDescription": "No description provided",
-    "noTools": "No tools"
+    "noTools": "No tools",
+    "sourceLocations": "Configuration sources ({{count}})"
   },
   "agentState": {
     "approval_required": "Confirmation required",
@@ -236,6 +239,14 @@
     "unsupportedGuidance": "Change this setting in the source application, then refresh.",
     "enable": "Enable server",
     "disable": "Disable",
+    "empty": "No MCP servers found.",
+    "emptyGuidance": "BitFun discovers MCP servers from OpenCode-compatible configurations. Supported locations:",
+    "emptyLocation": {
+      "userGlobal": "User global: ~/.config/opencode/opencode.json",
+      "project": "Project: .opencode/opencode.json",
+      "envConfig": "File pointed to by OPENCODE_CONFIG environment variable"
+    },
+    "emptyExample": "Add an \"mcp\" field to the config file, e.g.: { \"mcp\": { \"server-name\": { ... } } }",
     "transport": {
       "local_stdio": "Local process",
       "streamable_http": "Remote connection"
@@ -375,5 +386,34 @@
     "currentSelection": "The current source is used for this command. Choose another available source above to change it.",
     "currentSelectionUnavailable": "This command source is still selected, but it cannot run in its current state. Choose an available source or fix this source first.",
     "restricted": "Not supported in this version"
+  },
+  "opencode": {
+    "title": "OpenCode extensions",
+    "description": "External capabilities discovered from OpenCode-compatible configurations.",
+    "summary": "Found {{agents}} agents · {{commands}} commands · {{mcps}} MCP",
+    "configLocations": "Configuration locations",
+    "inherited": "Inherited from overall mode",
+    "capability": {
+      "subagent": {
+        "description": "{{count}} agents found · from {{scope}}",
+        "effect": "Allows calling agents defined in OpenCode.",
+        "risk": "Agents can make model calls; confirm the source is trusted."
+      },
+      "command": {
+        "description": "{{count}} commands found · from {{scope}}",
+        "effect": "Allows calling OpenCode commands in BitFun.",
+        "risk": ""
+      },
+      "mcp": {
+        "description": "{{count}} MCP servers found",
+        "effect": "Allows connecting to MCP servers configured in OpenCode.",
+        "risk": "MCP servers can start local processes or connect to remote addresses."
+      },
+      "tool": {
+        "description": "{{count}} tools found · from {{scope}}",
+        "effect": "Allows using tools defined in OpenCode.",
+        "risk": "Tool code runs with your user permissions, not in a sandbox."
+      }
+    }
   }
 }

--- a/src/web-ui/src/locales/en-US/settings/external-sources.json
+++ b/src/web-ui/src/locales/en-US/settings/external-sources.json
@@ -148,7 +148,6 @@
     "tools": "Tools: {{tools}}",
     "executionDomain": "Runs in: this computer and current workspace",
     "compatibility": "Status: {{state}}",
-    "sources": "Combined from {{count}} configuration sources",
     "noDescription": "No description provided",
     "noTools": "No tools",
     "sourceLocations": "Configuration sources ({{count}})"
@@ -390,7 +389,7 @@
   "opencode": {
     "title": "OpenCode extensions",
     "description": "External capabilities discovered from OpenCode-compatible configurations.",
-    "summary": "Found {{agents}} agents · {{commands}} commands · {{mcps}} MCP",
+    "summary": "Found {{agents}} agents · {{commands}} commands · {{tools}} tools · {{mcps}} MCP",
     "configLocations": "Configuration locations",
     "inherited": "Inherited from overall mode",
     "capability": {

--- a/src/web-ui/src/locales/zh-CN/settings/external-sources.json
+++ b/src/web-ui/src/locales/zh-CN/settings/external-sources.json
@@ -12,7 +12,9 @@
     "selected": "当前使用",
     "selectedUnavailable": "已选择，当前不可用",
     "notSelected": "未使用",
-    "availableChoice": "可选"
+    "availableChoice": "可选",
+    "openInExplorer": "在文件管理器中打开",
+    "openInExplorerRemote": "远程工作区路径无法在本地文件管理器中打开"
   },
   "actions": {
     "refresh": "刷新",
@@ -148,7 +150,8 @@
     "compatibility": "状态：{{state}}",
     "sources": "由 {{count}} 个配置来源共同定义",
     "noDescription": "未提供说明",
-    "noTools": "无工具"
+    "noTools": "无工具",
+    "sourceLocations": "配置来源（{{count}} 个）"
   },
   "agentState": {
     "approval_required": "待确认",
@@ -236,6 +239,14 @@
     "unsupportedGuidance": "请在来源应用中修改此配置，然后刷新。",
     "enable": "启用服务器",
     "disable": "停用",
+    "empty": "未发现 MCP 服务器。",
+    "emptyGuidance": "BitFun 当前从 OpenCode 兼容配置中发现 MCP 服务器，支持以下配置位置：",
+    "emptyLocation": {
+      "userGlobal": "用户全局：~/.config/opencode/opencode.json",
+      "project": "项目级：.opencode/opencode.json",
+      "envConfig": "环境变量 OPENCODE_CONFIG 指向的文件"
+    },
+    "emptyExample": "在配置文件中添加 \"mcp\" 字段即可，例如：{ \"mcp\": { \"server-name\": { ... } } }",
     "transport": {
       "local_stdio": "本地进程",
       "streamable_http": "远程连接"
@@ -375,5 +386,34 @@
     "currentSelection": "当前命令会使用已选来源。如需更改，请在上方选择其他可用来源。",
     "currentSelectionUnavailable": "仍保留此命令来源为当前选择，但它目前无法运行。请改选可用来源，或先修复此来源。",
     "restricted": "当前版本暂不支持"
+  },
+  "opencode": {
+    "title": "OpenCode 扩展",
+    "description": "从 OpenCode 兼容配置中发现的外部能力。",
+    "summary": "发现 {{agents}} 个 Agent · {{commands}} 个命令 · {{mcps}} 个 MCP",
+    "configLocations": "配置位置",
+    "inherited": "继承自整体模式",
+    "capability": {
+      "subagent": {
+        "description": "发现 {{count}} 个 Agent · 来自{{scope}}",
+        "effect": "启用后允许调用 OpenCode 中定义的 Agent。",
+        "risk": "Agent 可执行模型调用，请确认来源可信。"
+      },
+      "command": {
+        "description": "发现 {{count}} 个命令 · 来自{{scope}}",
+        "effect": "启用后可在 BitFun 中调用 OpenCode 命令。",
+        "risk": ""
+      },
+      "mcp": {
+        "description": "发现 {{count}} 个 MCP 服务器",
+        "effect": "启用后可连接 OpenCode 配置的 MCP 服务器。",
+        "risk": "MCP 服务器可启动本地进程或连接远程地址。"
+      },
+      "tool": {
+        "description": "发现 {{count}} 个工具 · 来自{{scope}}",
+        "effect": "启用后可使用 OpenCode 中定义的工具。",
+        "risk": "工具代码以你的用户权限运行，不在沙箱中隔离。"
+      }
+    }
   }
 }

--- a/src/web-ui/src/locales/zh-CN/settings/external-sources.json
+++ b/src/web-ui/src/locales/zh-CN/settings/external-sources.json
@@ -148,7 +148,6 @@
     "tools": "工具：{{tools}}",
     "executionDomain": "运行位置：本机和当前工作区",
     "compatibility": "状态：{{state}}",
-    "sources": "由 {{count}} 个配置来源共同定义",
     "noDescription": "未提供说明",
     "noTools": "无工具",
     "sourceLocations": "配置来源（{{count}} 个）"
@@ -390,7 +389,7 @@
   "opencode": {
     "title": "OpenCode 扩展",
     "description": "从 OpenCode 兼容配置中发现的外部能力。",
-    "summary": "发现 {{agents}} 个 Agent · {{commands}} 个命令 · {{mcps}} 个 MCP",
+    "summary": "发现 {{agents}} 个 Agent · {{commands}} 个命令 · {{tools}} 个工具 · {{mcps}} 个 MCP",
     "configLocations": "配置位置",
     "inherited": "继承自整体模式",
     "capability": {

--- a/src/web-ui/src/locales/zh-TW/settings/external-sources.json
+++ b/src/web-ui/src/locales/zh-TW/settings/external-sources.json
@@ -148,7 +148,6 @@
     "tools": "工具：{{tools}}",
     "executionDomain": "執行位置：本機與目前工作區",
     "compatibility": "狀態：{{state}}",
-    "sources": "由 {{count}} 個設定來源共同定義",
     "noDescription": "未提供說明",
     "noTools": "無工具",
     "sourceLocations": "設定來源（{{count}} 個）"
@@ -390,7 +389,7 @@
   "opencode": {
     "title": "OpenCode 擴充",
     "description": "從 OpenCode 相容設定中發現的外部能力。",
-    "summary": "發現 {{agents}} 個 Agent · {{commands}} 個命令 · {{mcps}} 個 MCP",
+    "summary": "發現 {{agents}} 個 Agent · {{commands}} 個命令 · {{tools}} 個工具 · {{mcps}} 個 MCP",
     "configLocations": "設定位置",
     "inherited": "繼承自整體模式",
     "capability": {

--- a/src/web-ui/src/locales/zh-TW/settings/external-sources.json
+++ b/src/web-ui/src/locales/zh-TW/settings/external-sources.json
@@ -12,7 +12,9 @@
     "selected": "目前使用",
     "selectedUnavailable": "已選擇，目前無法使用",
     "notSelected": "未使用",
-    "availableChoice": "可選"
+    "availableChoice": "可選",
+    "openInExplorer": "在檔案管理員中開啟",
+    "openInExplorerRemote": "遠端工作區路徑無法在本機檔案管理員中開啟"
   },
   "actions": {
     "refresh": "重新整理",
@@ -148,7 +150,8 @@
     "compatibility": "狀態：{{state}}",
     "sources": "由 {{count}} 個設定來源共同定義",
     "noDescription": "未提供說明",
-    "noTools": "無工具"
+    "noTools": "無工具",
+    "sourceLocations": "設定來源（{{count}} 個）"
   },
   "agentState": {
     "approval_required": "待確認",
@@ -236,6 +239,14 @@
     "unsupportedGuidance": "請在來源應用程式中修改此設定，然後重新整理。",
     "enable": "啟用伺服器",
     "disable": "停用",
+    "empty": "未發現 MCP 伺服器。",
+    "emptyGuidance": "BitFun 目前從 OpenCode 相容設定中發現 MCP 伺服器，支援以下設定位置：",
+    "emptyLocation": {
+      "userGlobal": "使用者全域：~/.config/opencode/opencode.json",
+      "project": "專案級：.opencode/opencode.json",
+      "envConfig": "環境變數 OPENCODE_CONFIG 指向的檔案"
+    },
+    "emptyExample": "在設定檔中加入 \"mcp\" 欄位即可，例如：{ \"mcp\": { \"server-name\": { ... } } }",
     "transport": {
       "local_stdio": "本機程序",
       "streamable_http": "遠端連線"
@@ -375,5 +386,34 @@
     "currentSelection": "目前命令會使用已選來源。若要變更，請在上方選擇其他可用來源。",
     "currentSelectionUnavailable": "仍保留此命令來源為目前選擇，但它目前無法執行。請改選可用來源，或先修復此來源。",
     "restricted": "目前版本暫不支援"
+  },
+  "opencode": {
+    "title": "OpenCode 擴充",
+    "description": "從 OpenCode 相容設定中發現的外部能力。",
+    "summary": "發現 {{agents}} 個 Agent · {{commands}} 個命令 · {{mcps}} 個 MCP",
+    "configLocations": "設定位置",
+    "inherited": "繼承自整體模式",
+    "capability": {
+      "subagent": {
+        "description": "發現 {{count}} 個 Agent · 來自{{scope}}",
+        "effect": "啟用後允許呼叫 OpenCode 中定義的 Agent。",
+        "risk": "Agent 可執行模型呼叫，請確認來源可信。"
+      },
+      "command": {
+        "description": "發現 {{count}} 個命令 · 來自{{scope}}",
+        "effect": "啟用後可在 BitFun 中呼叫 OpenCode 命令。",
+        "risk": ""
+      },
+      "mcp": {
+        "description": "發現 {{count}} 個 MCP 伺服器",
+        "effect": "啟用後可連接 OpenCode 設定的 MCP 伺服器。",
+        "risk": "MCP 伺服器可啟動本機行程或連接遠端位址。"
+      },
+      "tool": {
+        "description": "發現 {{count}} 個工具 · 來自{{scope}}",
+        "effect": "啟用後可使用 OpenCode 中定義的工具。",
+        "risk": "工具程式碼以你的使用者權限執行，不在沙箱中隔離。"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Improve the External AI applications settings UI while keeping external-source identity and host paths on their owning side of the boundary:

- make subagent details and source locations easier to inspect
- aggregate OpenCode configuration with lifecycle, diagnostics, scope, and capability controls intact
- explain the MCP empty state only after a successful snapshot
- reveal local source locations without sending raw or redacted display paths back from the frontend

## Changes

### Safe source-location actions

- The frontend sends only `workspacePath` plus the opaque source `stableKey`.
- The core resolves that identity against its private raw discovery snapshots; raw host paths remain absent from the public snapshot.
- The desktop adapter owns the actual file-manager reveal operation.
- Remote workspaces declare this command unsupported, and the UI renders location text as disabled there.
- Repeated redacted labels no longer merge distinct Subagent or OpenCode sources.

### OpenCode and source status

- Aggregate OpenCode sources into the dedicated card without dropping per-source lifecycle state, enable controls, or diagnostics.
- Show all represented scopes and include tool counts in the summary.
- Keep independently identified configuration locations separate even when their redacted labels match.
- Reuse the same source-member control renderer for OpenCode and other ecosystems.

### Empty, error, and presentation states

- Show MCP discovery guidance only when a snapshot loaded successfully and contains no MCP servers, approvals, or conflicts.
- Replace retired/undefined CSS variables with current theme tokens.
- Keep Subagent source locations collapsible and diagnostics localized.

## Compatibility and architecture impact

- Adds one narrow core host-action API for stable-key-to-local-path resolution and registers it in the core public API boundary rules.
- Adds one desktop Tauri command with an explicit `RemoteUnsupported` policy.
- No raw path is added to serialized DTOs, and no remote execution behavior changes.

## Verification

- `pnpm --dir src/web-ui run test:run src/infrastructure/api/service-api/ExternalSourcesAPI.test.ts src/infrastructure/config/externalSourcePresentation.test.ts src/infrastructure/config/components/ExternalSourcesConfig.test.tsx` — PASS (64/64)
- `pnpm run type-check:web` — PASS
- `pnpm run lint:web` — PASS (0 errors; pre-existing warnings only)
- `pnpm run i18n:audit` — PASS (0 warnings)
- `pnpm run theme:color-audit:all` — PASS
- `node scripts/check-core-boundaries.mjs` — PASS
- `pnpm run check:repo-hygiene` — PASS
- `pnpm run check:github-config` — PASS (7/7)
- `cargo check --workspace` — PASS
- `cargo test -p bitfun-core reveal_location_uses_stable_identity_and_keeps_the_raw_path_private` — PASS
- `cargo test -p bitfun-desktop remote_workspace_policy::tests` — PASS (2/2)
- `git diff --check gcwing/main..HEAD` — PASS
