### PR TITLE
feat(agentic): add durable AgentWait background coordination

### DIFF
--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -7888,8 +7888,8 @@ export const requiredContentRules = [
         message: 'missing background subagent launch path',
       },
       {
-        regex: /\bbackground_task_id\b/,
-        message: 'missing background task id result contract',
+        regex: /\bbg_task_id\b/,
+        message: 'missing parent-scoped background task id result contract',
       },
     ],
   },

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -3358,7 +3358,7 @@ export function runManifestParserSelfTest({
       contracts: [
         'delegation_policy\\(\\)\\.spawn_child\\(\\)',
         'start_background_subagent',
-        'background_task_id',
+        'bg_task_id',
       ],
     },
     {

--- a/src/crates/assembly/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/multitask_mode_first_entry_reminder.md
@@ -7,7 +7,7 @@ Before starting work, check whether the task contains two or more orthogonal bra
 ## Subagent Delegation Strategy
 
 - Prefer background subagents (setting `run_in_background: true` on the Task call) whenever the branch is independent and does not block your immediate next step.
-- Background Task responses include a `background_task_id`. Results are not delivered automatically. Continue independent work, then call AgentWait with the relevant task IDs before ending a turn whose answer depends on them. Do not poll background work for status updates.
+- Background Task responses include a `bg_task_id`. Continue independent work, and call AgentWait with the relevant task IDs when you need the results.
 - Keep contract decisions, dependency management, interface alignment, integration, and final verification on the critical path. Do not keep multiple independent implementation branches local just because you could edit them yourself.
 
 ## Task Handoff Instructions

--- a/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
@@ -114,7 +114,6 @@ impl BackgroundSubagentOutcome {
 pub(crate) enum BackgroundSubagentWaitStatus {
     Completed,
     TimedOut,
-    Cancelled,
     NoMatchingTasks,
 }
 
@@ -123,8 +122,22 @@ impl BackgroundSubagentWaitStatus {
         match self {
             Self::Completed => "completed",
             Self::TimedOut => "timed_out",
-            Self::Cancelled => "cancelled",
             Self::NoMatchingTasks => "no_matching_tasks",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackgroundSubagentWaitMode {
+    Any,
+    All,
+}
+
+impl BackgroundSubagentWaitMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Any => "any",
+            Self::All => "all",
         }
     }
 }
@@ -215,25 +228,34 @@ impl BackgroundSubagentOutcomeStore {
     pub(crate) async fn wait_for(
         &self,
         parent_session_id: &str,
-        parent_dialog_turn_id: &str,
         requested_task_ids: &[String],
+        wait_mode: BackgroundSubagentWaitMode,
         timeout: Duration,
         cancellation_token: Option<&CancellationToken>,
     ) -> BitFunResult<BackgroundSubagentWaitResult> {
         self.hydrate_parent_session(parent_session_id).await?;
 
+        // A session-wide selector is resolved once so new Task calls cannot change this wait.
+        let requested_task_ids = self.resolve_wait_task_ids(parent_session_id, requested_task_ids);
+        if requested_task_ids.is_empty() {
+            return Ok(BackgroundSubagentWaitResult {
+                status: BackgroundSubagentWaitStatus::NoMatchingTasks,
+                outcomes: Vec::new(),
+                pending_background_task_ids: Vec::new(),
+            });
+        }
+
         let deadline = Instant::now() + timeout;
-        let mut collected = Vec::new();
         let mut debounce_deadline = None;
 
         loop {
             let notified = self.changes.notified();
             tokio::pin!(notified);
 
-            let claim = self
-                .claim_available(parent_session_id, parent_dialog_turn_id, requested_task_ids)
+            let available = self
+                .collect_available(parent_session_id, &requested_task_ids, false)
                 .await?;
-            if !claim.had_matching_tasks && collected.is_empty() {
+            if !available.had_matching_tasks {
                 return Ok(BackgroundSubagentWaitResult {
                     status: BackgroundSubagentWaitStatus::NoMatchingTasks,
                     outcomes: Vec::new(),
@@ -241,27 +263,52 @@ impl BackgroundSubagentOutcomeStore {
                 });
             }
 
-            collected.extend(claim.outcomes);
-            if !collected.is_empty() && claim.pending_background_task_ids.is_empty() {
-                return Ok(wait_result_for_outcomes(collected, Vec::new()));
+            if !available.outcomes.is_empty() && available.pending_background_task_ids.is_empty() {
+                if let Some(result) = self
+                    .claim_wait_result(
+                        parent_session_id,
+                        &requested_task_ids,
+                        BackgroundSubagentWaitStatus::Completed,
+                    )
+                    .await?
+                {
+                    return Ok(result);
+                }
+                debounce_deadline = None;
+                continue;
             }
-            if !collected.is_empty() && debounce_deadline.is_none() {
+            if wait_mode == BackgroundSubagentWaitMode::Any
+                && !available.outcomes.is_empty()
+                && debounce_deadline.is_none()
+            {
                 debounce_deadline = Some((Instant::now() + RESULT_DEBOUNCE).min(deadline));
             }
 
             let wake_at = debounce_deadline.unwrap_or(deadline);
             if Instant::now() >= wake_at {
-                if collected.is_empty() {
+                if available.outcomes.is_empty() {
                     return Ok(BackgroundSubagentWaitResult {
                         status: BackgroundSubagentWaitStatus::TimedOut,
                         outcomes: Vec::new(),
-                        pending_background_task_ids: claim.pending_background_task_ids,
+                        pending_background_task_ids: available.pending_background_task_ids,
                     });
                 }
-                return Ok(wait_result_for_outcomes(
-                    collected,
-                    claim.pending_background_task_ids,
-                ));
+                if let Some(result) = self
+                    .claim_wait_result(
+                        parent_session_id,
+                        &requested_task_ids,
+                        if wake_at == deadline {
+                            BackgroundSubagentWaitStatus::TimedOut
+                        } else {
+                            BackgroundSubagentWaitStatus::Completed
+                        },
+                    )
+                    .await?
+                {
+                    return Ok(result);
+                }
+                debounce_deadline = None;
+                continue;
             }
 
             match cancellation_token {
@@ -284,19 +331,49 @@ impl BackgroundSubagentOutcomeStore {
         }
     }
 
-    async fn claim_available(
+    async fn claim_wait_result(
         &self,
         parent_session_id: &str,
-        parent_dialog_turn_id: &str,
         requested_task_ids: &[String],
+        status: BackgroundSubagentWaitStatus,
+    ) -> BitFunResult<Option<BackgroundSubagentWaitResult>> {
+        let claim = self
+            .collect_available(parent_session_id, requested_task_ids, true)
+            .await?;
+        Ok((!claim.outcomes.is_empty()).then(|| {
+            wait_result_for_outcomes(status, claim.outcomes, claim.pending_background_task_ids)
+        }))
+    }
+
+    fn resolve_wait_task_ids(
+        &self,
+        parent_session_id: &str,
+        requested_task_ids: &[String],
+    ) -> Vec<String> {
+        if !requested_task_ids.is_empty() {
+            return requested_task_ids.to_vec();
+        }
+
+        self.outcomes
+            .iter()
+            .filter(|entry| {
+                entry.parent_session_id == parent_session_id && entry.consumed_at_ms.is_none()
+            })
+            .map(|entry| entry.background_task_id.clone())
+            .collect()
+    }
+
+    async fn collect_available(
+        &self,
+        parent_session_id: &str,
+        requested_task_ids: &[String],
+        consume_terminal_outcomes: bool,
     ) -> BitFunResult<OutcomeClaim> {
         let task_ids = if requested_task_ids.is_empty() {
             self.outcomes
                 .iter()
                 .filter(|entry| {
-                    entry.parent_session_id == parent_session_id
-                        && entry.parent_dialog_turn_id == parent_dialog_turn_id
-                        && entry.consumed_at_ms.is_none()
+                    entry.parent_session_id == parent_session_id && entry.consumed_at_ms.is_none()
                 })
                 .map(|entry| entry.background_task_id.clone())
                 .collect::<Vec<_>>()
@@ -331,10 +408,14 @@ impl BackgroundSubagentOutcomeStore {
             }
             claim.had_matching_tasks = true;
             if entry.status.is_terminal() {
-                entry.consumed_at_ms = Some(unix_time_ms());
+                if consume_terminal_outcomes {
+                    entry.consumed_at_ms = Some(unix_time_ms());
+                }
                 let outcome = entry.clone();
                 claim.outcomes.push(outcome.clone());
-                consumed.push(outcome);
+                if consume_terminal_outcomes {
+                    consumed.push(outcome);
+                }
             } else {
                 claim
                     .pending_background_task_ids
@@ -406,17 +487,10 @@ impl BackgroundSubagentOutcomeStore {
 }
 
 fn wait_result_for_outcomes(
+    status: BackgroundSubagentWaitStatus,
     outcomes: Vec<BackgroundSubagentOutcome>,
     pending_background_task_ids: Vec<String>,
 ) -> BackgroundSubagentWaitResult {
-    let status = if outcomes
-        .iter()
-        .all(|outcome| outcome.status == BackgroundSubagentOutcomeStatus::Cancelled)
-    {
-        BackgroundSubagentWaitStatus::Cancelled
-    } else {
-        BackgroundSubagentWaitStatus::Completed
-    };
     BackgroundSubagentWaitResult {
         status,
         outcomes,

--- a/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
@@ -1,112 +1,40 @@
+use super::coordination_store::{
+    BackgroundTaskRecord, BackgroundTaskRegistration, BackgroundTaskStatus, CoordinationStore,
+    RegisteredBackgroundTask,
+};
 use super::coordinator::{SubagentResult, SubagentResultStatus};
 use crate::agentic::session::SessionManager;
+use crate::service::session::TurnStatus;
 use crate::util::errors::{BitFunError, BitFunResult};
 use dashmap::DashMap;
 use log::warn;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
+use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Notify;
 use tokio::time::{sleep_until, Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
-const OUTCOME_METADATA_KEY_PREFIX: &str = "backgroundSubagentOutcome:";
 const RESULT_DEBOUNCE: Duration = Duration::from_secs(5);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum BackgroundSubagentOutcomeStatus {
-    Running,
-    Completed,
-    PartialTimeout,
-    Failed,
-    Cancelled,
-}
+pub(crate) type BackgroundSubagentOutcomeStatus = BackgroundTaskStatus;
 
-impl BackgroundSubagentOutcomeStatus {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Running => "running",
-            Self::Completed => "completed",
-            Self::PartialTimeout => "partial_timeout",
-            Self::Failed => "failed",
-            Self::Cancelled => "cancelled",
-        }
-    }
-
-    fn is_terminal(self) -> bool {
-        !matches!(self, Self::Running)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub(crate) struct BackgroundSubagentOutcome {
-    pub background_task_id: String,
-    pub parent_session_id: String,
-    pub parent_dialog_turn_id: String,
-    pub subagent_session_id: String,
-    pub subagent_dialog_turn_id: String,
-    pub subagent_type: String,
-    pub task_description: String,
+    task_pk: i64,
+    pub bg_task_id: String,
+    pub agent_id: String,
     pub status: BackgroundSubagentOutcomeStatus,
     pub content: Option<String>,
     pub error: Option<String>,
-    pub created_at_ms: u64,
-    pub completed_at_ms: Option<u64>,
-    pub consumed_at_ms: Option<u64>,
 }
 
 impl BackgroundSubagentOutcome {
-    pub(crate) fn running(
-        background_task_id: String,
-        parent_session_id: String,
-        parent_dialog_turn_id: String,
-        subagent_session_id: String,
-        subagent_dialog_turn_id: String,
-        subagent_type: String,
-        task_description: String,
-    ) -> Self {
-        Self {
-            background_task_id,
-            parent_session_id,
-            parent_dialog_turn_id,
-            subagent_session_id,
-            subagent_dialog_turn_id,
-            subagent_type,
-            task_description,
-            status: BackgroundSubagentOutcomeStatus::Running,
-            content: None,
-            error: None,
-            created_at_ms: unix_time_ms(),
-            completed_at_ms: None,
-            consumed_at_ms: None,
-        }
+    pub(crate) fn model_bg_task_id(&self) -> &str {
+        &self.bg_task_id
     }
 
-    fn complete_from_subagent_result(&mut self, result: &SubagentResult) {
-        self.status = match result.status {
-            SubagentResultStatus::Completed => BackgroundSubagentOutcomeStatus::Completed,
-            SubagentResultStatus::PartialTimeout => BackgroundSubagentOutcomeStatus::PartialTimeout,
-        };
-        self.content = Some(result.text.clone());
-        self.error = result.reason.clone();
-        self.completed_at_ms = Some(unix_time_ms());
-    }
-
-    fn fail(&mut self, error: &BitFunError) {
-        self.status = BackgroundSubagentOutcomeStatus::Failed;
-        self.content = None;
-        self.error = Some(error.to_string());
-        self.completed_at_ms = Some(unix_time_ms());
-    }
-
-    fn cancel(&mut self) {
-        self.status = BackgroundSubagentOutcomeStatus::Cancelled;
-        self.content = None;
-        self.error = Some("Background subagent task was cancelled".to_string());
-        self.completed_at_ms = Some(unix_time_ms());
+    pub(crate) fn model_agent_id(&self) -> &str {
+        &self.agent_id
     }
 }
 
@@ -146,105 +74,166 @@ impl BackgroundSubagentWaitMode {
 pub(crate) struct BackgroundSubagentWaitResult {
     pub status: BackgroundSubagentWaitStatus,
     pub outcomes: Vec<BackgroundSubagentOutcome>,
-    pub pending_background_task_ids: Vec<String>,
+    pub pending_bg_task_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LiveBackgroundResult {
+    status: BackgroundTaskStatus,
+    content: Option<String>,
+    error: Option<String>,
 }
 
 #[derive(Debug, Default)]
-struct OutcomeClaim {
-    had_matching_tasks: bool,
+struct AvailableOutcomes {
     outcomes: Vec<BackgroundSubagentOutcome>,
-    pending_background_task_ids: Vec<String>,
+    pending_bg_task_ids: Vec<String>,
 }
 
 pub(crate) struct BackgroundSubagentOutcomeStore {
-    outcomes: DashMap<String, BackgroundSubagentOutcome>,
+    live_results: DashMap<i64, LiveBackgroundResult>,
     changes: Notify,
     session_manager: Arc<SessionManager>,
+    coordination_store: Arc<CoordinationStore>,
 }
 
 impl BackgroundSubagentOutcomeStore {
-    pub(crate) fn new(session_manager: Arc<SessionManager>) -> Self {
+    pub(crate) fn new(
+        session_manager: Arc<SessionManager>,
+        coordination_store: Arc<CoordinationStore>,
+    ) -> Self {
         Self {
-            outcomes: DashMap::new(),
+            live_results: DashMap::new(),
             changes: Notify::new(),
             session_manager,
+            coordination_store,
         }
     }
 
-    pub(crate) async fn register(&self, outcome: BackgroundSubagentOutcome) -> BitFunResult<()> {
-        self.outcomes
-            .insert(outcome.background_task_id.clone(), outcome.clone());
-        if let Err(error) = self.persist(&outcome).await {
-            self.outcomes.remove(&outcome.background_task_id);
-            return Err(error);
-        }
+    pub(crate) async fn register(
+        &self,
+        registration: BackgroundTaskRegistration,
+    ) -> BitFunResult<RegisteredBackgroundTask> {
+        let registered = self
+            .coordination_store
+            .register_background_task(registration)
+            .await?;
         self.changes.notify_waiters();
-        Ok(())
+        Ok(registered)
     }
 
     pub(crate) async fn complete(
         &self,
-        background_task_id: &str,
+        task_pk: i64,
         result: Result<&SubagentResult, &BitFunError>,
     ) {
-        let outcome = {
-            let Some(mut entry) = self.outcomes.get_mut(background_task_id) else {
-                warn!(
-                    "Background subagent outcome record is missing at completion: background_task_id={}",
-                    background_task_id
-                );
-                return;
-            };
-            if entry.status == BackgroundSubagentOutcomeStatus::Cancelled {
-                return;
-            }
-            match result {
-                Ok(result) => entry.complete_from_subagent_result(result),
-                Err(error) => entry.fail(error),
-            }
-            entry.clone()
+        let live_result = match result {
+            Ok(result) => LiveBackgroundResult {
+                status: match result.status {
+                    SubagentResultStatus::Completed => BackgroundTaskStatus::Completed,
+                    SubagentResultStatus::PartialTimeout => BackgroundTaskStatus::PartialTimeout,
+                },
+                content: Some(result.text.clone()),
+                error: result.reason.clone(),
+            },
+            Err(error) => LiveBackgroundResult {
+                status: if matches!(error, BitFunError::Cancelled(_)) {
+                    BackgroundTaskStatus::Cancelled
+                } else {
+                    BackgroundTaskStatus::Failed
+                },
+                content: None,
+                error: Some(error.to_string()),
+            },
         };
-        self.persist_best_effort(&outcome).await;
+        match self
+            .coordination_store
+            .update_task_status(task_pk, live_result.status, None, live_result.error.clone())
+            .await
+        {
+            Ok(true) => {
+                self.live_results.insert(task_pk, live_result);
+                self.changes.notify_waiters();
+            }
+            Ok(false) => {}
+            Err(error) => {
+                warn!(
+                    "Failed to persist background subagent completion: task_pk={}, error={}",
+                    task_pk, error
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn cancel(&self, task_pks: &[i64]) {
+        for task_pk in task_pks {
+            match self
+                .coordination_store
+                .update_task_status(
+                    *task_pk,
+                    BackgroundTaskStatus::Cancelled,
+                    Some("cancelled".to_string()),
+                    Some("Background subagent task was cancelled".to_string()),
+                )
+                .await
+            {
+                Ok(true) => {
+                    self.live_results.insert(
+                        *task_pk,
+                        LiveBackgroundResult {
+                            status: BackgroundTaskStatus::Cancelled,
+                            content: None,
+                            error: Some("Background subagent task was cancelled".to_string()),
+                        },
+                    );
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        "Failed to persist background subagent cancellation: task_pk={}, error={}",
+                        task_pk, error
+                    );
+                }
+            }
+        }
         self.changes.notify_waiters();
     }
 
-    pub(crate) async fn cancel(&self, background_task_ids: &[String]) {
-        for background_task_id in background_task_ids {
-            let outcome = {
-                let Some(mut entry) = self.outcomes.get_mut(background_task_id) else {
-                    continue;
-                };
-                if entry.status.is_terminal() {
-                    continue;
-                }
-                entry.cancel();
-                entry.clone()
-            };
-            self.persist_best_effort(&outcome).await;
-        }
+    pub(crate) async fn discard(&self, task_pk: i64) -> BitFunResult<()> {
+        self.live_results.remove(&task_pk);
+        self.coordination_store
+            .delete_background_task(task_pk)
+            .await?;
         self.changes.notify_waiters();
+        Ok(())
     }
 
     pub(crate) async fn wait_for(
         &self,
         parent_session_id: &str,
-        requested_task_ids: &[String],
+        requested_bg_task_ids: &[String],
         wait_mode: BackgroundSubagentWaitMode,
         timeout: Duration,
+        delivered_parent_dialog_turn_id: &str,
         cancellation_token: Option<&CancellationToken>,
     ) -> BitFunResult<BackgroundSubagentWaitResult> {
-        self.hydrate_parent_session(parent_session_id).await?;
-
-        // A session-wide selector is resolved once so new Task calls cannot change this wait.
-        let requested_task_ids = self.resolve_wait_task_ids(parent_session_id, requested_task_ids);
-        if requested_task_ids.is_empty() {
-            return Ok(BackgroundSubagentWaitResult {
-                status: BackgroundSubagentWaitStatus::NoMatchingTasks,
-                outcomes: Vec::new(),
-                pending_background_task_ids: Vec::new(),
-            });
+        self.reconcile_stale_running_tasks(parent_session_id)
+            .await?;
+        let selected = self
+            .coordination_store
+            .wait_candidates(parent_session_id, requested_bg_task_ids)
+            .await?;
+        if selected.is_empty() {
+            return Ok(wait_result(
+                BackgroundSubagentWaitStatus::NoMatchingTasks,
+                Vec::new(),
+                Vec::new(),
+            ));
         }
-
+        let selected_task_pks = selected
+            .iter()
+            .map(|record| record.task_pk)
+            .collect::<Vec<_>>();
         let deadline = Instant::now() + timeout;
         let mut debounce_deadline = None;
 
@@ -252,23 +241,14 @@ impl BackgroundSubagentOutcomeStore {
             let notified = self.changes.notified();
             tokio::pin!(notified);
 
-            let available = self
-                .collect_available(parent_session_id, &requested_task_ids, false)
-                .await?;
-            if !available.had_matching_tasks {
-                return Ok(BackgroundSubagentWaitResult {
-                    status: BackgroundSubagentWaitStatus::NoMatchingTasks,
-                    outcomes: Vec::new(),
-                    pending_background_task_ids: Vec::new(),
-                });
-            }
-
-            if !available.outcomes.is_empty() && available.pending_background_task_ids.is_empty() {
+            let available = self.collect_available(&selected_task_pks).await?;
+            if !available.outcomes.is_empty() && available.pending_bg_task_ids.is_empty() {
                 if let Some(result) = self
-                    .claim_wait_result(
+                    .claim_result(
                         parent_session_id,
-                        &requested_task_ids,
+                        delivered_parent_dialog_turn_id,
                         BackgroundSubagentWaitStatus::Completed,
+                        available,
                     )
                     .await?
                 {
@@ -287,21 +267,22 @@ impl BackgroundSubagentOutcomeStore {
             let wake_at = debounce_deadline.unwrap_or(deadline);
             if Instant::now() >= wake_at {
                 if available.outcomes.is_empty() {
-                    return Ok(BackgroundSubagentWaitResult {
-                        status: BackgroundSubagentWaitStatus::TimedOut,
-                        outcomes: Vec::new(),
-                        pending_background_task_ids: available.pending_background_task_ids,
-                    });
+                    return Ok(wait_result(
+                        BackgroundSubagentWaitStatus::TimedOut,
+                        Vec::new(),
+                        available.pending_bg_task_ids,
+                    ));
                 }
                 if let Some(result) = self
-                    .claim_wait_result(
+                    .claim_result(
                         parent_session_id,
-                        &requested_task_ids,
+                        delivered_parent_dialog_turn_id,
                         if wake_at == deadline {
                             BackgroundSubagentWaitStatus::TimedOut
                         } else {
                             BackgroundSubagentWaitStatus::Completed
                         },
+                        available,
                     )
                     .await?
                 {
@@ -331,180 +312,339 @@ impl BackgroundSubagentOutcomeStore {
         }
     }
 
-    async fn claim_wait_result(
-        &self,
-        parent_session_id: &str,
-        requested_task_ids: &[String],
-        status: BackgroundSubagentWaitStatus,
-    ) -> BitFunResult<Option<BackgroundSubagentWaitResult>> {
-        let claim = self
-            .collect_available(parent_session_id, requested_task_ids, true)
+    async fn collect_available(&self, task_pks: &[i64]) -> BitFunResult<AvailableOutcomes> {
+        let records = self
+            .coordination_store
+            .records_by_task_pks(task_pks)
             .await?;
-        Ok((!claim.outcomes.is_empty()).then(|| {
-            wait_result_for_outcomes(status, claim.outcomes, claim.pending_background_task_ids)
-        }))
-    }
-
-    fn resolve_wait_task_ids(
-        &self,
-        parent_session_id: &str,
-        requested_task_ids: &[String],
-    ) -> Vec<String> {
-        if !requested_task_ids.is_empty() {
-            return requested_task_ids.to_vec();
-        }
-
-        self.outcomes
-            .iter()
-            .filter(|entry| {
-                entry.parent_session_id == parent_session_id && entry.consumed_at_ms.is_none()
-            })
-            .map(|entry| entry.background_task_id.clone())
-            .collect()
-    }
-
-    async fn collect_available(
-        &self,
-        parent_session_id: &str,
-        requested_task_ids: &[String],
-        consume_terminal_outcomes: bool,
-    ) -> BitFunResult<OutcomeClaim> {
-        let task_ids = if requested_task_ids.is_empty() {
-            self.outcomes
-                .iter()
-                .filter(|entry| {
-                    entry.parent_session_id == parent_session_id && entry.consumed_at_ms.is_none()
-                })
-                .map(|entry| entry.background_task_id.clone())
-                .collect::<Vec<_>>()
-        } else {
-            requested_task_ids.to_vec()
-        };
-
-        if task_ids.is_empty() {
-            return Ok(OutcomeClaim::default());
-        }
-
-        let mut claim = OutcomeClaim::default();
-        let mut consumed = Vec::new();
-        for background_task_id in task_ids {
-            let Some(mut entry) = self.outcomes.get_mut(&background_task_id) else {
-                if requested_task_ids.is_empty() {
-                    continue;
-                }
-                return Err(BitFunError::tool(format!(
-                    "Background task was not found: {}",
-                    background_task_id
-                )));
-            };
-            if entry.parent_session_id != parent_session_id {
-                return Err(BitFunError::tool(format!(
-                    "Background task does not belong to the current session: {}",
-                    background_task_id
-                )));
-            }
-            if entry.consumed_at_ms.is_some() {
+        let mut available = AvailableOutcomes::default();
+        for record in records {
+            if record.delivered_at_ms.is_some() {
                 continue;
             }
-            claim.had_matching_tasks = true;
-            if entry.status.is_terminal() {
-                if consume_terminal_outcomes {
-                    entry.consumed_at_ms = Some(unix_time_ms());
-                }
-                let outcome = entry.clone();
-                claim.outcomes.push(outcome.clone());
-                if consume_terminal_outcomes {
-                    consumed.push(outcome);
-                }
+            if record.status.is_terminal() {
+                available
+                    .outcomes
+                    .push(self.outcome_from_record(&record).await?);
             } else {
-                claim
-                    .pending_background_task_ids
-                    .push(entry.background_task_id.clone());
+                available.pending_bg_task_ids.push(record.bg_task_id);
             }
         }
-
-        for outcome in consumed {
-            self.persist_best_effort(&outcome).await;
-        }
-        Ok(claim)
+        Ok(available)
     }
 
-    async fn hydrate_parent_session(&self, parent_session_id: &str) -> BitFunResult<()> {
-        let Some(custom_metadata) = self
+    async fn claim_result(
+        &self,
+        parent_session_id: &str,
+        delivered_parent_dialog_turn_id: &str,
+        status: BackgroundSubagentWaitStatus,
+        available: AvailableOutcomes,
+    ) -> BitFunResult<Option<BackgroundSubagentWaitResult>> {
+        let task_pks = available
+            .outcomes
+            .iter()
+            .map(|outcome| outcome.task_pk)
+            .collect::<Vec<_>>();
+        let claimed = self
+            .coordination_store
+            .claim_terminal_tasks(
+                parent_session_id,
+                &task_pks,
+                delivered_parent_dialog_turn_id,
+            )
+            .await?;
+        let claimed_task_pks = claimed
+            .into_iter()
+            .map(|record| record.task_pk)
+            .collect::<HashSet<_>>();
+        let outcomes = available
+            .outcomes
+            .into_iter()
+            .filter(|outcome| claimed_task_pks.contains(&outcome.task_pk))
+            .collect::<Vec<_>>();
+        Ok((!outcomes.is_empty())
+            .then(|| wait_result(status, outcomes, available.pending_bg_task_ids)))
+    }
+
+    async fn outcome_from_record(
+        &self,
+        record: &BackgroundTaskRecord,
+    ) -> BitFunResult<BackgroundSubagentOutcome> {
+        if let Some(live) = self.live_results.get(&record.task_pk) {
+            return Ok(BackgroundSubagentOutcome {
+                task_pk: record.task_pk,
+                bg_task_id: record.bg_task_id.clone(),
+                agent_id: record.agent_id.clone(),
+                status: live.status,
+                content: live.content.clone(),
+                error: live.error.clone(),
+            });
+        }
+
+        let content = if matches!(
+            record.status,
+            BackgroundTaskStatus::Completed | BackgroundTaskStatus::PartialTimeout
+        ) {
+            self.load_persisted_result_text(record).await?
+        } else {
+            None
+        };
+        Ok(BackgroundSubagentOutcome {
+            task_pk: record.task_pk,
+            bg_task_id: record.bg_task_id.clone(),
+            agent_id: record.agent_id.clone(),
+            status: record.status,
+            content,
+            error: record.error_message.clone(),
+        })
+    }
+
+    async fn load_persisted_result_text(
+        &self,
+        record: &BackgroundTaskRecord,
+    ) -> BitFunResult<Option<String>> {
+        let turn = self
             .session_manager
-            .load_session_custom_metadata(parent_session_id)
+            .load_related_dialog_turn(
+                &record.parent_session_id,
+                &record.child_session_id,
+                &record.child_dialog_turn_id,
+            )
             .await?
-        else {
-            return Ok(());
-        };
-        let Some(metadata) = custom_metadata.as_object() else {
-            return Ok(());
-        };
-        for (key, value) in metadata {
-            if !key.starts_with(OUTCOME_METADATA_KEY_PREFIX) {
-                continue;
-            }
-            let Ok(outcome) = serde_json::from_value::<BackgroundSubagentOutcome>(value.clone())
-            else {
-                warn!(
-                    "Ignoring invalid persisted background subagent outcome: session_id={}, metadata_key={}",
-                    parent_session_id, key
-                );
-                continue;
+            .ok_or_else(|| {
+                BitFunError::tool(format!(
+                    "Persisted subagent result is unavailable for {}",
+                    record.bg_task_id
+                ))
+            })?;
+        Ok(turn
+            .model_rounds
+            .iter()
+            .rev()
+            .flat_map(|round| round.text_items.iter().rev())
+            .find(|item| !item.content.trim().is_empty())
+            .map(|item| item.content.clone()))
+    }
+
+    async fn reconcile_stale_running_tasks(&self, parent_session_id: &str) -> BitFunResult<()> {
+        let stale = self
+            .coordination_store
+            .stale_running_tasks(parent_session_id)
+            .await?;
+        for record in stale {
+            let turn = self
+                .session_manager
+                .load_related_dialog_turn(
+                    &record.parent_session_id,
+                    &record.child_session_id,
+                    &record.child_dialog_turn_id,
+                )
+                .await?;
+            let (status, error_code, error_message) = match turn.map(|turn| turn.status) {
+                Some(TurnStatus::Completed) => (BackgroundTaskStatus::Completed, None, None),
+                Some(TurnStatus::Error) => (
+                    BackgroundTaskStatus::Failed,
+                    Some("child_turn_failed".to_string()),
+                    Some("The persisted subagent turn failed".to_string()),
+                ),
+                Some(TurnStatus::Cancelled) => (
+                    BackgroundTaskStatus::Cancelled,
+                    Some("child_turn_cancelled".to_string()),
+                    Some("The persisted subagent turn was cancelled".to_string()),
+                ),
+                Some(TurnStatus::InProgress) | None => (
+                    BackgroundTaskStatus::Interrupted,
+                    Some("execution_interrupted".to_string()),
+                    Some("Background subagent execution was interrupted".to_string()),
+                ),
             };
-            if outcome.parent_session_id == parent_session_id {
-                self.outcomes
-                    .entry(outcome.background_task_id.clone())
-                    .or_insert(outcome);
-            }
+            let _ = self
+                .coordination_store
+                .update_task_status(record.task_pk, status, error_code, error_message)
+                .await?;
+        }
+        if !parent_session_id.is_empty() {
+            self.changes.notify_waiters();
         }
         Ok(())
     }
 
-    async fn persist(&self, outcome: &BackgroundSubagentOutcome) -> BitFunResult<()> {
-        let value = serde_json::to_value(outcome).map_err(|error| {
-            BitFunError::tool(format!(
-                "Failed to serialize background task outcome: {}",
-                error
-            ))
-        })?;
-        self.session_manager
-            .merge_session_custom_metadata(
-                &outcome.parent_session_id,
-                json!({ outcome_metadata_key(&outcome.background_task_id): value }),
-            )
+    pub(crate) async fn agent_id_for_session(
+        &self,
+        parent_session_id: &str,
+        child_session_id: &str,
+    ) -> BitFunResult<String> {
+        self.coordination_store
+            .agent_id_for_session(parent_session_id, child_session_id)
             .await
     }
 
-    async fn persist_best_effort(&self, outcome: &BackgroundSubagentOutcome) {
-        if let Err(error) = self.persist(outcome).await {
-            warn!(
-                "Failed to persist background subagent outcome: background_task_id={}, parent_session_id={}, error={}",
-                outcome.background_task_id, outcome.parent_session_id, error
-            );
+    pub(crate) async fn resolve_agent_id(
+        &self,
+        parent_session_id: &str,
+        agent_id: &str,
+    ) -> BitFunResult<String> {
+        self.coordination_store
+            .resolve_agent_id(parent_session_id, agent_id)
+            .await
+    }
+
+    pub(crate) async fn delete_session_references(&self, session_id: &str) -> BitFunResult<()> {
+        let deleted_task_pks = self
+            .coordination_store
+            .delete_session_references(session_id)
+            .await?;
+        for task_pk in deleted_task_pks {
+            self.live_results.remove(&task_pk);
         }
+        self.changes.notify_waiters();
+        Ok(())
+    }
+
+    pub(crate) async fn rollback_parent_turns(
+        &self,
+        parent_session_id: &str,
+        parent_dialog_turn_ids: &[String],
+    ) -> BitFunResult<()> {
+        let deleted_task_pks = self
+            .coordination_store
+            .rollback_parent_turns(parent_session_id, parent_dialog_turn_ids)
+            .await?;
+        for task_pk in deleted_task_pks {
+            self.live_results.remove(&task_pk);
+        }
+        self.changes.notify_waiters();
+        Ok(())
+    }
+
+    pub(crate) async fn initialize_fork(
+        &self,
+        source_parent_session_id: &str,
+        target_parent_session_id: &str,
+    ) -> BitFunResult<()> {
+        self.coordination_store
+            .initialize_fork(source_parent_session_id, target_parent_session_id)
+            .await
     }
 }
 
-fn wait_result_for_outcomes(
+fn wait_result(
     status: BackgroundSubagentWaitStatus,
     outcomes: Vec<BackgroundSubagentOutcome>,
-    pending_background_task_ids: Vec<String>,
+    pending_bg_task_ids: Vec<String>,
 ) -> BackgroundSubagentWaitResult {
     BackgroundSubagentWaitResult {
         status,
         outcomes,
-        pending_background_task_ids,
+        pending_bg_task_ids,
     }
 }
 
-fn outcome_metadata_key(background_task_id: &str) -> String {
-    format!("{}{}", OUTCOME_METADATA_KEY_PREFIX, background_task_id)
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agentic::core::{SessionConfig, TurnStats};
+    use crate::agentic::persistence::PersistenceManager;
+    use crate::agentic::session::{PromptCachePolicy, SessionContextStore, SessionManagerConfig};
+    use crate::infrastructure::PathManager;
 
-fn unix_time_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
+    #[tokio::test]
+    async fn restart_recovers_completed_result_from_child_turn_history() {
+        let root = tempfile::tempdir().expect("background outcome temp directory");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        let path_manager = Arc::new(PathManager::with_user_root_for_tests(
+            root.path().join("config"),
+        ));
+        let session_manager = Arc::new(SessionManager::new(
+            Arc::new(SessionContextStore::new()),
+            Arc::new(PersistenceManager::new(path_manager.clone()).expect("persistence manager")),
+            SessionManagerConfig {
+                max_active_sessions: 10,
+                session_idle_timeout: Duration::from_secs(3600),
+                auto_save_interval: Duration::from_secs(300),
+                enable_persistence: true,
+                prompt_cache_policy: PromptCachePolicy::default(),
+            },
+        ));
+        let config = SessionConfig {
+            workspace_path: Some(workspace.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        session_manager
+            .create_session_with_id(
+                Some("parent-session".to_string()),
+                "Parent".to_string(),
+                "agentic".to_string(),
+                config.clone(),
+            )
+            .await
+            .expect("create parent session");
+        session_manager
+            .create_session_with_id(
+                Some("child-session".to_string()),
+                "Child".to_string(),
+                "GeneralPurpose".to_string(),
+                config,
+            )
+            .await
+            .expect("create child session");
+        session_manager
+            .start_dialog_turn(
+                "child-session",
+                "GeneralPurpose".to_string(),
+                "Inspect implementation".to_string(),
+                Some("child-turn".to_string()),
+                None,
+                None,
+            )
+            .await
+            .expect("start child turn");
+        session_manager
+            .complete_dialog_turn(
+                "child-session",
+                "child-turn",
+                "persisted child result".to_string(),
+                &[],
+                TurnStats::default(),
+            )
+            .await
+            .expect("complete child turn");
+
+        let db_path = path_manager.agent_coordination_database_file();
+        let previous_owner = CoordinationStore::new(db_path.clone());
+        let registered = previous_owner
+            .register_background_task(BackgroundTaskRegistration {
+                parent_session_id: "parent-session".to_string(),
+                requested_agent_id: None,
+                child_session_id: "child-session".to_string(),
+                parent_dialog_turn_id: "parent-turn".to_string(),
+                parent_tool_call_id: "task-tool".to_string(),
+                child_dialog_turn_id: "child-turn".to_string(),
+            })
+            .await
+            .expect("register task for previous owner");
+        let recovered = BackgroundSubagentOutcomeStore::new(
+            session_manager,
+            Arc::new(CoordinationStore::new(db_path)),
+        )
+        .wait_for(
+            "parent-session",
+            &[],
+            BackgroundSubagentWaitMode::All,
+            Duration::from_millis(50),
+            "wait-turn",
+            None,
+        )
+        .await
+        .expect("recover persisted background result");
+
+        assert_eq!(recovered.status, BackgroundSubagentWaitStatus::Completed);
+        assert_eq!(recovered.outcomes.len(), 1);
+        assert_eq!(recovered.outcomes[0].bg_task_id, registered.bg_task_id);
+        assert_eq!(
+            recovered.outcomes[0].content.as_deref(),
+            Some("persisted child result")
+        );
+    }
 }

--- a/src/crates/assembly/core/src/agentic/coordination/coordination_store.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordination_store.rs
@@ -1,0 +1,1108 @@
+use crate::util::errors::{BitFunError, BitFunResult};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::OnceCell;
+use tokio::task;
+use uuid::Uuid;
+
+const SCHEMA_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackgroundTaskStatus {
+    Running,
+    Completed,
+    PartialTimeout,
+    Failed,
+    Cancelled,
+    Interrupted,
+}
+
+impl BackgroundTaskStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::PartialTimeout => "partial_timeout",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Interrupted => "interrupted",
+        }
+    }
+
+    pub(crate) fn is_terminal(self) -> bool {
+        self != Self::Running
+    }
+
+    fn parse(value: &str) -> BitFunResult<Self> {
+        match value {
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "partial_timeout" => Ok(Self::PartialTimeout),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            "interrupted" => Ok(Self::Interrupted),
+            _ => Err(BitFunError::service(format!(
+                "Invalid background task status in coordination database: {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BackgroundTaskRegistration {
+    pub parent_session_id: String,
+    pub requested_agent_id: Option<String>,
+    pub child_session_id: String,
+    pub parent_dialog_turn_id: String,
+    pub parent_tool_call_id: String,
+    pub child_dialog_turn_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RegisteredBackgroundTask {
+    pub task_pk: i64,
+    pub agent_id: String,
+    pub bg_task_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BackgroundTaskRecord {
+    pub task_pk: i64,
+    pub parent_session_id: String,
+    pub agent_id: String,
+    pub bg_task_id: String,
+    pub child_session_id: String,
+    pub parent_dialog_turn_id: String,
+    pub parent_tool_call_id: String,
+    pub child_dialog_turn_id: String,
+    pub status: BackgroundTaskStatus,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub execution_owner_token: String,
+    pub delivered_at_ms: Option<u64>,
+}
+
+pub(crate) struct CoordinationStore {
+    db_path: PathBuf,
+    connection: OnceCell<Arc<Mutex<Connection>>>,
+    execution_owner_token: String,
+}
+
+impl CoordinationStore {
+    pub(crate) fn new(db_path: PathBuf) -> Self {
+        Self {
+            db_path,
+            connection: OnceCell::new(),
+            execution_owner_token: Uuid::new_v4().to_string(),
+        }
+    }
+
+    async fn connection(&self) -> BitFunResult<Arc<Mutex<Connection>>> {
+        let db_path = self.db_path.clone();
+        self.connection
+            .get_or_try_init(|| async move {
+                task::spawn_blocking(move || open_connection(db_path))
+                    .await
+                    .map_err(|error| {
+                        BitFunError::service(format!(
+                            "Agent coordination database initialization task failed: {error}"
+                        ))
+                    })?
+            })
+            .await
+            .cloned()
+    }
+
+    async fn with_connection<T, F>(&self, operation: F) -> BitFunResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> BitFunResult<T> + Send + 'static,
+    {
+        let connection = self.connection().await?;
+        task::spawn_blocking(move || {
+            let mut connection = connection.lock().map_err(|_| {
+                BitFunError::service("Agent coordination database lock was poisoned".to_string())
+            })?;
+            operation(&mut connection)
+        })
+        .await
+        .map_err(|error| {
+            BitFunError::service(format!("Agent coordination database task failed: {error}"))
+        })?
+    }
+
+    pub(crate) async fn agent_id_for_session(
+        &self,
+        parent_session_id: &str,
+        child_session_id: &str,
+    ) -> BitFunResult<String> {
+        let parent_session_id = parent_session_id.to_string();
+        let child_session_id = child_session_id.to_string();
+        self.with_connection(move |connection| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(db_error)?;
+            let (_, agent_id) =
+                get_or_create_agent(&transaction, &parent_session_id, &child_session_id, None)?;
+            transaction.commit().map_err(db_error)?;
+            Ok(agent_id)
+        })
+        .await
+    }
+
+    pub(crate) async fn resolve_agent_id(
+        &self,
+        parent_session_id: &str,
+        agent_id: &str,
+    ) -> BitFunResult<String> {
+        let parent_session_id = parent_session_id.to_string();
+        let agent_id = agent_id.to_string();
+        self.with_connection(move |connection| {
+            connection
+                .query_row(
+                    "SELECT child_session_id FROM agents WHERE parent_session_id = ?1 AND agent_id = ?2 AND state = 'active'",
+                    params![parent_session_id, agent_id],
+                    |row| row.get::<_, Option<String>>(0),
+                )
+                .optional()
+                .map_err(db_error)?
+                .flatten()
+                .ok_or_else(|| BitFunError::tool(format!("Agent was not found: {agent_id}")))
+        })
+        .await
+    }
+
+    pub(crate) async fn register_background_task(
+        &self,
+        registration: BackgroundTaskRegistration,
+    ) -> BitFunResult<RegisteredBackgroundTask> {
+        let execution_owner_token = self.execution_owner_token.clone();
+        self.with_connection(move |connection| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(db_error)?;
+            let (agent_pk, agent_id) = get_or_create_agent(
+                &transaction,
+                &registration.parent_session_id,
+                &registration.child_session_id,
+                registration.requested_agent_id.as_deref(),
+            )?;
+            let next_bg_seq = transaction
+                .query_row(
+                    "SELECT next_bg_seq FROM agents WHERE agent_pk = ?1",
+                    params![agent_pk],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(db_error)?;
+            let bg_task_id = format!("{agent_id}_bg{next_bg_seq}");
+            transaction
+                .execute(
+                    "UPDATE agents SET next_bg_seq = ?1 WHERE agent_pk = ?2",
+                    params![next_bg_seq.saturating_add(1), agent_pk],
+                )
+                .map_err(db_error)?;
+            transaction
+                .execute(
+                    r#"
+INSERT INTO background_tasks (
+    parent_session_id, agent_pk, bg_task_id, bg_ordinal,
+    parent_dialog_turn_id, parent_tool_call_id, child_dialog_turn_id,
+    status, execution_owner_token, created_at_ms
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'running', ?8, ?9)
+                    "#,
+                    params![
+                        registration.parent_session_id,
+                        agent_pk,
+                        bg_task_id,
+                        next_bg_seq,
+                        registration.parent_dialog_turn_id,
+                        registration.parent_tool_call_id,
+                        registration.child_dialog_turn_id,
+                        execution_owner_token,
+                        unix_time_ms() as i64,
+                    ],
+                )
+                .map_err(db_error)?;
+            let task_pk = transaction.last_insert_rowid();
+            transaction.commit().map_err(db_error)?;
+            Ok(RegisteredBackgroundTask {
+                task_pk,
+                agent_id,
+                bg_task_id,
+            })
+        })
+        .await
+    }
+
+    pub(crate) async fn update_task_status(
+        &self,
+        task_pk: i64,
+        status: BackgroundTaskStatus,
+        error_code: Option<String>,
+        error_message: Option<String>,
+    ) -> BitFunResult<bool> {
+        self.with_connection(move |connection| {
+            let changed = connection
+                .execute(
+                    r#"
+UPDATE background_tasks
+SET status = ?1, error_code = ?2, error_message = ?3, terminal_at_ms = ?4
+WHERE task_pk = ?5 AND status = 'running'
+                    "#,
+                    params![
+                        status.as_str(),
+                        error_code,
+                        error_message,
+                        status.is_terminal().then(|| unix_time_ms() as i64),
+                        task_pk,
+                    ],
+                )
+                .map_err(db_error)?;
+            Ok(changed > 0)
+        })
+        .await
+    }
+
+    pub(crate) async fn delete_background_task(&self, task_pk: i64) -> BitFunResult<()> {
+        self.with_connection(move |connection| {
+            connection
+                .execute(
+                    "DELETE FROM background_tasks WHERE task_pk = ?1",
+                    params![task_pk],
+                )
+                .map_err(db_error)?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn wait_candidates(
+        &self,
+        parent_session_id: &str,
+        requested_bg_task_ids: &[String],
+    ) -> BitFunResult<Vec<BackgroundTaskRecord>> {
+        let parent_session_id = parent_session_id.to_string();
+        let requested_bg_task_ids = requested_bg_task_ids.to_vec();
+        self.with_connection(move |connection| {
+            if requested_bg_task_ids.is_empty() {
+                let mut statement = connection
+                    .prepare(&format!(
+                        "{} WHERE tasks.parent_session_id = ?1 AND tasks.delivered_at_ms IS NULL ORDER BY tasks.task_pk",
+                        BACKGROUND_TASK_SELECT
+                    ))
+                    .map_err(db_error)?;
+                let rows = statement
+                    .query_map(params![parent_session_id], background_task_from_row)
+                    .map_err(db_error)?;
+                return collect_rows(rows);
+            }
+
+            let mut records = Vec::with_capacity(requested_bg_task_ids.len());
+            for bg_task_id in requested_bg_task_ids {
+                let record = connection
+                    .query_row(
+                        &format!(
+                            "{} WHERE tasks.parent_session_id = ?1 AND tasks.bg_task_id = ?2",
+                            BACKGROUND_TASK_SELECT
+                        ),
+                        params![parent_session_id, bg_task_id],
+                        background_task_from_row,
+                    )
+                    .optional()
+                    .map_err(db_error)?
+                    .ok_or_else(|| {
+                        BitFunError::tool(format!("Background task was not found: {bg_task_id}"))
+                    })?;
+                if record.delivered_at_ms.is_none() {
+                    records.push(record);
+                }
+            }
+            Ok(records)
+        })
+        .await
+    }
+
+    pub(crate) async fn records_by_task_pks(
+        &self,
+        task_pks: &[i64],
+    ) -> BitFunResult<Vec<BackgroundTaskRecord>> {
+        let task_pks = task_pks.to_vec();
+        self.with_connection(move |connection| {
+            let mut records = Vec::with_capacity(task_pks.len());
+            for task_pk in task_pks {
+                if let Some(record) = connection
+                    .query_row(
+                        &format!("{} WHERE tasks.task_pk = ?1", BACKGROUND_TASK_SELECT),
+                        params![task_pk],
+                        background_task_from_row,
+                    )
+                    .optional()
+                    .map_err(db_error)?
+                {
+                    records.push(record);
+                }
+            }
+            Ok(records)
+        })
+        .await
+    }
+
+    pub(crate) async fn claim_terminal_tasks(
+        &self,
+        parent_session_id: &str,
+        task_pks: &[i64],
+        delivered_parent_dialog_turn_id: &str,
+    ) -> BitFunResult<Vec<BackgroundTaskRecord>> {
+        let parent_session_id = parent_session_id.to_string();
+        let task_pks = task_pks.to_vec();
+        let delivered_parent_dialog_turn_id = delivered_parent_dialog_turn_id.to_string();
+        self.with_connection(move |connection| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(db_error)?;
+            let mut claimed = Vec::new();
+            for task_pk in task_pks {
+                let changed = transaction
+                    .execute(
+                        r#"
+UPDATE background_tasks
+SET delivered_at_ms = ?1, delivered_parent_dialog_turn_id = ?2
+WHERE task_pk = ?3
+  AND parent_session_id = ?4
+  AND status != 'running'
+  AND delivered_at_ms IS NULL
+                        "#,
+                        params![
+                            unix_time_ms() as i64,
+                            delivered_parent_dialog_turn_id,
+                            task_pk,
+                            parent_session_id,
+                        ],
+                    )
+                    .map_err(db_error)?;
+                if changed == 0 {
+                    continue;
+                }
+                claimed.push(
+                    transaction
+                        .query_row(
+                            &format!("{} WHERE tasks.task_pk = ?1", BACKGROUND_TASK_SELECT),
+                            params![task_pk],
+                            background_task_from_row,
+                        )
+                        .map_err(db_error)?,
+                );
+            }
+            transaction.commit().map_err(db_error)?;
+            Ok(claimed)
+        })
+        .await
+    }
+
+    pub(crate) async fn stale_running_tasks(
+        &self,
+        parent_session_id: &str,
+    ) -> BitFunResult<Vec<BackgroundTaskRecord>> {
+        let parent_session_id = parent_session_id.to_string();
+        let execution_owner_token = self.execution_owner_token.clone();
+        self.with_connection(move |connection| {
+            let mut statement = connection
+                .prepare(&format!(
+                    "{} WHERE tasks.parent_session_id = ?1 AND tasks.status = 'running' AND tasks.execution_owner_token != ?2",
+                    BACKGROUND_TASK_SELECT
+                ))
+                .map_err(db_error)?;
+            let rows = statement
+                .query_map(
+                    params![parent_session_id, execution_owner_token],
+                    background_task_from_row,
+                )
+                .map_err(db_error)?;
+            collect_rows(rows)
+        })
+        .await
+    }
+
+    pub(crate) async fn delete_session_references(
+        &self,
+        session_id: &str,
+    ) -> BitFunResult<Vec<i64>> {
+        let session_id = session_id.to_string();
+        self.with_connection(move |connection| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(db_error)?;
+            let deleted_task_pks = {
+                let mut statement = transaction
+                    .prepare(
+                        "SELECT task_pk FROM background_tasks WHERE parent_session_id = ?1 OR agent_pk IN (SELECT agent_pk FROM agents WHERE child_session_id = ?1)",
+                    )
+                    .map_err(db_error)?;
+                let task_pks = statement
+                    .query_map(params![session_id], |row| row.get::<_, i64>(0))
+                    .map_err(db_error)?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+                    .map_err(db_error)?;
+                task_pks
+            };
+            transaction
+                .execute(
+                    "DELETE FROM background_tasks WHERE parent_session_id = ?1 OR agent_pk IN (SELECT agent_pk FROM agents WHERE child_session_id = ?1)",
+                    params![session_id],
+                )
+                .map_err(db_error)?;
+            transaction
+                .execute(
+                    "DELETE FROM agents WHERE parent_session_id = ?1 OR child_session_id = ?1",
+                    params![session_id],
+                )
+                .map_err(db_error)?;
+            transaction
+                .execute(
+                    "DELETE FROM coordination_sessions WHERE parent_session_id = ?1",
+                    params![session_id],
+                )
+                .map_err(db_error)?;
+            transaction.commit().map_err(db_error)?;
+            Ok(deleted_task_pks)
+        })
+        .await
+    }
+
+    pub(crate) async fn rollback_parent_turns(
+        &self,
+        parent_session_id: &str,
+        parent_dialog_turn_ids: &[String],
+    ) -> BitFunResult<Vec<i64>> {
+        let parent_session_id = parent_session_id.to_string();
+        let parent_dialog_turn_ids = parent_dialog_turn_ids.to_vec();
+        self.with_connection(move |connection| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(db_error)?;
+            let mut deleted_task_pks = Vec::new();
+            for turn_id in parent_dialog_turn_ids {
+                {
+                    let mut statement = transaction
+                        .prepare(
+                            "SELECT task_pk FROM background_tasks WHERE parent_session_id = ?1 AND parent_dialog_turn_id = ?2",
+                        )
+                        .map_err(db_error)?;
+                    deleted_task_pks.extend(
+                        statement
+                            .query_map(params![parent_session_id, turn_id], |row| {
+                                row.get::<_, i64>(0)
+                            })
+                            .map_err(db_error)?
+                            .collect::<rusqlite::Result<Vec<_>>>()
+                            .map_err(db_error)?,
+                    );
+                }
+                transaction
+                    .execute(
+                        "DELETE FROM background_tasks WHERE parent_session_id = ?1 AND parent_dialog_turn_id = ?2",
+                        params![parent_session_id, turn_id],
+                    )
+                    .map_err(db_error)?;
+                transaction
+                    .execute(
+                        "UPDATE background_tasks SET delivered_at_ms = NULL, delivered_parent_dialog_turn_id = NULL WHERE parent_session_id = ?1 AND delivered_parent_dialog_turn_id = ?2",
+                        params![parent_session_id, turn_id],
+                    )
+                    .map_err(db_error)?;
+            }
+            transaction.commit().map_err(db_error)?;
+            Ok(deleted_task_pks)
+        })
+        .await
+    }
+
+    pub(crate) async fn initialize_fork(
+        &self,
+        source_parent_session_id: &str,
+        target_parent_session_id: &str,
+    ) -> BitFunResult<()> {
+        let source_parent_session_id = source_parent_session_id.to_string();
+        let target_parent_session_id = target_parent_session_id.to_string();
+        self.with_connection(move |connection| {
+            let transaction = connection
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(db_error)?;
+            let next_auto_agent_seq = transaction
+                .query_row(
+                    "SELECT next_auto_agent_seq FROM coordination_sessions WHERE parent_session_id = ?1",
+                    params![source_parent_session_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .map_err(db_error)?
+                .unwrap_or(1);
+            transaction
+                .execute(
+                    "INSERT OR IGNORE INTO coordination_sessions (parent_session_id, next_auto_agent_seq, updated_at_ms) VALUES (?1, ?2, ?3)",
+                    params![target_parent_session_id, next_auto_agent_seq, unix_time_ms() as i64],
+                )
+                .map_err(db_error)?;
+
+            let reservations = {
+                let mut statement = transaction
+                    .prepare(
+                        "SELECT agent_id, next_bg_seq FROM agents WHERE parent_session_id = ?1 ORDER BY agent_pk",
+                    )
+                    .map_err(db_error)?;
+                let rows = statement
+                    .query_map(params![source_parent_session_id], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                    })
+                    .map_err(db_error)?;
+                rows.collect::<rusqlite::Result<Vec<_>>>()
+                    .map_err(db_error)?
+            };
+            for (agent_id, next_bg_seq) in reservations {
+                transaction
+                    .execute(
+                        "INSERT OR IGNORE INTO agents (parent_session_id, agent_id, child_session_id, next_bg_seq, state, created_at_ms) VALUES (?1, ?2, NULL, ?3, 'historical', ?4)",
+                        params![target_parent_session_id, agent_id, next_bg_seq, unix_time_ms() as i64],
+                    )
+                    .map_err(db_error)?;
+            }
+            transaction.commit().map_err(db_error)?;
+            Ok(())
+        })
+        .await
+    }
+}
+
+const BACKGROUND_TASK_SELECT: &str = r#"
+SELECT
+    tasks.task_pk,
+    tasks.parent_session_id,
+    agents.agent_id,
+    tasks.bg_task_id,
+    agents.child_session_id,
+    tasks.parent_dialog_turn_id,
+    tasks.parent_tool_call_id,
+    tasks.child_dialog_turn_id,
+    tasks.status,
+    tasks.error_code,
+    tasks.error_message,
+    tasks.execution_owner_token,
+    tasks.delivered_at_ms
+FROM background_tasks AS tasks
+JOIN agents ON agents.agent_pk = tasks.agent_pk
+"#;
+
+fn background_task_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<BackgroundTaskRecord> {
+    let status = row.get::<_, String>(8)?;
+    let status = BackgroundTaskStatus::parse(&status).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            8,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                error.to_string(),
+            )),
+        )
+    })?;
+    let delivered_at_ms = row
+        .get::<_, Option<i64>>(12)?
+        .and_then(|value| u64::try_from(value).ok());
+    Ok(BackgroundTaskRecord {
+        task_pk: row.get(0)?,
+        parent_session_id: row.get(1)?,
+        agent_id: row.get(2)?,
+        bg_task_id: row.get(3)?,
+        child_session_id: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+        parent_dialog_turn_id: row.get(5)?,
+        parent_tool_call_id: row.get(6)?,
+        child_dialog_turn_id: row.get(7)?,
+        status,
+        error_code: row.get(9)?,
+        error_message: row.get(10)?,
+        execution_owner_token: row.get(11)?,
+        delivered_at_ms,
+    })
+}
+
+fn collect_rows(
+    rows: rusqlite::MappedRows<
+        '_,
+        impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<BackgroundTaskRecord>,
+    >,
+) -> BitFunResult<Vec<BackgroundTaskRecord>> {
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(db_error)
+}
+
+fn get_or_create_agent(
+    transaction: &Transaction<'_>,
+    parent_session_id: &str,
+    child_session_id: &str,
+    requested_agent_id: Option<&str>,
+) -> BitFunResult<(i64, String)> {
+    if let Some(existing) = transaction
+        .query_row(
+            "SELECT agent_pk, agent_id FROM agents WHERE parent_session_id = ?1 AND child_session_id = ?2",
+            params![parent_session_id, child_session_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()
+        .map_err(db_error)?
+    {
+        if requested_agent_id.is_some_and(|requested_agent_id| existing.1 != requested_agent_id) {
+            return Err(BitFunError::tool(format!(
+                "Subagent session is already registered as agent_id={}",
+                existing.1
+            )));
+        }
+        return Ok(existing);
+    }
+
+    transaction
+        .execute(
+            "INSERT OR IGNORE INTO coordination_sessions (parent_session_id, next_auto_agent_seq, updated_at_ms) VALUES (?1, 1, ?2)",
+            params![parent_session_id, unix_time_ms() as i64],
+        )
+        .map_err(db_error)?;
+
+    let agent_id = match requested_agent_id {
+        Some(agent_id) => {
+            validate_agent_id(agent_id)?;
+            agent_id.to_string()
+        }
+        None => loop {
+            let next = transaction
+                .query_row(
+                    "SELECT next_auto_agent_seq FROM coordination_sessions WHERE parent_session_id = ?1",
+                    params![parent_session_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(db_error)?;
+            transaction
+                .execute(
+                    "UPDATE coordination_sessions SET next_auto_agent_seq = ?1, updated_at_ms = ?2 WHERE parent_session_id = ?3",
+                    params![next.saturating_add(1), unix_time_ms() as i64, parent_session_id],
+                )
+                .map_err(db_error)?;
+            let candidate = format!("a{next}");
+            let exists = transaction
+                .query_row(
+                    "SELECT 1 FROM agents WHERE parent_session_id = ?1 AND agent_id = ?2",
+                    params![parent_session_id, candidate],
+                    |_row| Ok(()),
+                )
+                .optional()
+                .map_err(db_error)?
+                .is_some();
+            if !exists {
+                break candidate;
+            }
+        },
+    };
+
+    transaction
+        .execute(
+            "INSERT INTO agents (parent_session_id, agent_id, child_session_id, next_bg_seq, state, created_at_ms) VALUES (?1, ?2, ?3, 1, 'active', ?4)",
+            params![parent_session_id, agent_id, child_session_id, unix_time_ms() as i64],
+        )
+        .map_err(|error| {
+            BitFunError::tool(format!(
+                "Failed to register agent_id={agent_id} for the parent session: {error}"
+            ))
+        })?;
+    Ok((transaction.last_insert_rowid(), agent_id))
+}
+
+fn validate_agent_id(agent_id: &str) -> BitFunResult<()> {
+    let valid = !agent_id.is_empty()
+        && agent_id.len() <= 32
+        && agent_id
+            .bytes()
+            .enumerate()
+            .all(|(index, byte)| match byte {
+                b'a'..=b'z' => true,
+                b'0'..=b'9' | b'_' | b'-' => index > 0,
+                _ => false,
+            });
+    if valid {
+        Ok(())
+    } else {
+        Err(BitFunError::tool(
+            "agent_id must match [a-z][a-z0-9_-]{0,31}".to_string(),
+        ))
+    }
+}
+
+fn open_connection(db_path: PathBuf) -> BitFunResult<Arc<Mutex<Connection>>> {
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            BitFunError::io(format!(
+                "Failed to create agent coordination database directory {}: {error}",
+                parent.display()
+            ))
+        })?;
+    }
+    let connection = Connection::open(&db_path).map_err(|error| {
+        BitFunError::io(format!(
+            "Failed to open agent coordination database {}: {error}",
+            db_path.display()
+        ))
+    })?;
+    connection
+        .busy_timeout(Duration::from_secs(5))
+        .map_err(db_error)?;
+    connection
+        .execute_batch(
+            r#"
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+PRAGMA synchronous = NORMAL;
+            "#,
+        )
+        .map_err(db_error)?;
+    initialize_schema(&connection)?;
+    Ok(Arc::new(Mutex::new(connection)))
+}
+
+fn initialize_schema(connection: &Connection) -> BitFunResult<()> {
+    let version = connection
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+        .map_err(db_error)?;
+    if version > SCHEMA_VERSION {
+        return Err(BitFunError::service(format!(
+            "Agent coordination database schema {version} is newer than supported schema {SCHEMA_VERSION}"
+        )));
+    }
+    if version == SCHEMA_VERSION {
+        return Ok(());
+    }
+    connection
+        .execute_batch(
+            r#"
+CREATE TABLE coordination_sessions (
+    parent_session_id TEXT PRIMARY KEY,
+    next_auto_agent_seq INTEGER NOT NULL DEFAULT 1,
+    updated_at_ms INTEGER NOT NULL
+);
+
+CREATE TABLE agents (
+    agent_pk INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_session_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    child_session_id TEXT,
+    next_bg_seq INTEGER NOT NULL DEFAULT 1,
+    state TEXT NOT NULL CHECK (state IN ('active', 'historical')),
+    created_at_ms INTEGER NOT NULL,
+    UNIQUE(parent_session_id, agent_id),
+    UNIQUE(parent_session_id, child_session_id)
+);
+
+CREATE TABLE background_tasks (
+    task_pk INTEGER PRIMARY KEY AUTOINCREMENT,
+    parent_session_id TEXT NOT NULL,
+    agent_pk INTEGER NOT NULL,
+    bg_task_id TEXT NOT NULL,
+    bg_ordinal INTEGER NOT NULL,
+    parent_dialog_turn_id TEXT NOT NULL,
+    parent_tool_call_id TEXT NOT NULL,
+    child_dialog_turn_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN ('running', 'completed', 'partial_timeout', 'failed', 'cancelled', 'interrupted')
+    ),
+    error_code TEXT,
+    error_message TEXT,
+    execution_owner_token TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    terminal_at_ms INTEGER,
+    delivered_at_ms INTEGER,
+    delivered_parent_dialog_turn_id TEXT,
+    UNIQUE(parent_session_id, bg_task_id),
+    UNIQUE(agent_pk, bg_ordinal),
+    FOREIGN KEY(agent_pk) REFERENCES agents(agent_pk) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_background_tasks_wait
+    ON background_tasks(parent_session_id, delivered_at_ms, status, task_pk);
+CREATE INDEX idx_background_tasks_parent_turn
+    ON background_tasks(parent_session_id, parent_dialog_turn_id);
+
+PRAGMA user_version = 1;
+            "#,
+        )
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn db_error(error: rusqlite::Error) -> BitFunError {
+    BitFunError::io(format!("Agent coordination database error: {error}"))
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_store() -> (tempfile::TempDir, CoordinationStore) {
+        let root = tempfile::tempdir().expect("coordination store temp directory");
+        let store = CoordinationStore::new(root.path().join("coordination.sqlite"));
+        (root, store)
+    }
+
+    fn registration(
+        parent_session_id: &str,
+        child_session_id: &str,
+        parent_dialog_turn_id: &str,
+        requested_agent_id: Option<&str>,
+    ) -> BackgroundTaskRegistration {
+        BackgroundTaskRegistration {
+            parent_session_id: parent_session_id.to_string(),
+            requested_agent_id: requested_agent_id.map(str::to_string),
+            child_session_id: child_session_id.to_string(),
+            parent_dialog_turn_id: parent_dialog_turn_id.to_string(),
+            parent_tool_call_id: format!("tool-{parent_dialog_turn_id}"),
+            child_dialog_turn_id: format!("turn-{child_session_id}-{parent_dialog_turn_id}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn model_ids_are_parent_scoped_and_task_ids_are_agent_scoped() {
+        let (_root, store) = test_store();
+
+        let first = store
+            .register_background_task(registration("parent-1", "child-1", "parent-turn-1", None))
+            .await
+            .expect("register first task");
+        let second = store
+            .register_background_task(registration("parent-1", "child-1", "parent-turn-2", None))
+            .await
+            .expect("register second task");
+        let named = store
+            .register_background_task(registration(
+                "parent-1",
+                "child-reviewer",
+                "parent-turn-3",
+                Some("reviewer"),
+            ))
+            .await
+            .expect("register named agent task");
+        let other_parent = store
+            .register_background_task(registration("parent-2", "child-2", "parent-turn-1", None))
+            .await
+            .expect("register task for another parent");
+
+        assert_eq!(
+            (first.agent_id.as_str(), first.bg_task_id.as_str()),
+            ("a1", "a1_bg1")
+        );
+        assert_eq!(
+            (second.agent_id.as_str(), second.bg_task_id.as_str()),
+            ("a1", "a1_bg2")
+        );
+        assert_eq!(
+            (named.agent_id.as_str(), named.bg_task_id.as_str()),
+            ("reviewer", "reviewer_bg1")
+        );
+        assert_eq!(
+            (
+                other_parent.agent_id.as_str(),
+                other_parent.bg_task_id.as_str()
+            ),
+            ("a1", "a1_bg1")
+        );
+        assert_eq!(
+            store
+                .resolve_agent_id("parent-1", "reviewer")
+                .await
+                .expect("resolve named agent"),
+            "child-reviewer"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_transition_and_delivery_claim_are_single_winner() {
+        let (_root, store) = test_store();
+        let task = store
+            .register_background_task(registration("parent", "child", "spawn-turn", None))
+            .await
+            .expect("register task");
+
+        assert!(store
+            .update_task_status(task.task_pk, BackgroundTaskStatus::Completed, None, None)
+            .await
+            .expect("complete task"));
+        assert!(!store
+            .update_task_status(
+                task.task_pk,
+                BackgroundTaskStatus::Cancelled,
+                Some("late_cancel".to_string()),
+                Some("late cancellation".to_string()),
+            )
+            .await
+            .expect("late terminal transition"));
+
+        let first_claim = store
+            .claim_terminal_tasks("parent", &[task.task_pk], "wait-turn-1")
+            .await
+            .expect("claim completed task");
+        let second_claim = store
+            .claim_terminal_tasks("parent", &[task.task_pk], "wait-turn-2")
+            .await
+            .expect("repeat claim");
+        assert_eq!(first_claim.len(), 1);
+        assert_eq!(first_claim[0].status, BackgroundTaskStatus::Completed);
+        assert!(second_claim.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stale_running_tasks_can_only_be_reconciled_once() {
+        let root = tempfile::tempdir().expect("coordination store temp directory");
+        let db_path = root.path().join("coordination.sqlite");
+        let first_owner = CoordinationStore::new(db_path.clone());
+        let task = first_owner
+            .register_background_task(registration("parent", "child", "spawn-turn", None))
+            .await
+            .expect("register running task");
+        let second_owner = CoordinationStore::new(db_path);
+
+        let stale = second_owner
+            .stale_running_tasks("parent")
+            .await
+            .expect("load stale running tasks");
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].task_pk, task.task_pk);
+        assert!(second_owner
+            .update_task_status(
+                task.task_pk,
+                BackgroundTaskStatus::Interrupted,
+                Some("execution_interrupted".to_string()),
+                Some("execution interrupted".to_string()),
+            )
+            .await
+            .expect("reconcile stale task"));
+        assert!(!first_owner
+            .update_task_status(task.task_pk, BackgroundTaskStatus::Completed, None, None)
+            .await
+            .expect("late original owner completion"));
+    }
+
+    #[tokio::test]
+    async fn rollback_deletes_spawned_tasks_and_restores_rolled_back_deliveries() {
+        let (_root, store) = test_store();
+        let delivered = store
+            .register_background_task(registration("parent", "child-1", "spawn-turn-1", None))
+            .await
+            .expect("register delivered task");
+        let removed = store
+            .register_background_task(registration("parent", "child-2", "spawn-turn-2", None))
+            .await
+            .expect("register removable task");
+        assert!(store
+            .update_task_status(
+                delivered.task_pk,
+                BackgroundTaskStatus::Completed,
+                None,
+                None,
+            )
+            .await
+            .expect("complete delivered task"));
+        store
+            .claim_terminal_tasks("parent", &[delivered.task_pk], "delivery-turn")
+            .await
+            .expect("claim delivered task");
+
+        let deleted = store
+            .rollback_parent_turns(
+                "parent",
+                &["spawn-turn-2".to_string(), "delivery-turn".to_string()],
+            )
+            .await
+            .expect("rollback parent turns");
+        assert_eq!(deleted, vec![removed.task_pk]);
+        let candidates = store
+            .wait_candidates("parent", &[])
+            .await
+            .expect("load restored candidates");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].task_pk, delivered.task_pk);
+        assert!(candidates[0].delivered_at_ms.is_none());
+    }
+
+    #[tokio::test]
+    async fn fork_preserves_id_reservations_without_copying_tasks() {
+        let (_root, store) = test_store();
+        let first = store
+            .register_background_task(registration("source", "child-1", "spawn-turn-1", None))
+            .await
+            .expect("register first source agent");
+        store
+            .agent_id_for_session("source", "child-2")
+            .await
+            .expect("reserve second source agent");
+        store
+            .initialize_fork("source", "target")
+            .await
+            .expect("initialize fork reservations");
+
+        assert!(store
+            .wait_candidates("target", &[])
+            .await
+            .expect("load fork tasks")
+            .is_empty());
+        let target = store
+            .register_background_task(registration("target", "target-child", "spawn-turn", None))
+            .await
+            .expect("register target task");
+        assert_eq!(first.agent_id, "a1");
+        assert_eq!(target.agent_id, "a3");
+        assert_eq!(target.bg_task_id, "a3_bg1");
+        assert!(store
+            .register_background_task(registration(
+                "target",
+                "explicit-child",
+                "explicit-turn",
+                Some("a1"),
+            ))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn deleting_a_parent_or_child_removes_their_tasks() {
+        let (_root, store) = test_store();
+        let first = store
+            .register_background_task(registration("parent", "child-1", "spawn-turn-1", None))
+            .await
+            .expect("register first child task");
+        let second = store
+            .register_background_task(registration("parent", "child-2", "spawn-turn-2", None))
+            .await
+            .expect("register second child task");
+
+        assert_eq!(
+            store
+                .delete_session_references("child-1")
+                .await
+                .expect("delete child references"),
+            vec![first.task_pk]
+        );
+        assert_eq!(
+            store
+                .delete_session_references("parent")
+                .await
+                .expect("delete parent references"),
+            vec![second.task_pk]
+        );
+        assert!(store
+            .wait_candidates("parent", &[])
+            .await
+            .expect("load remaining tasks")
+            .is_empty());
+    }
+}

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -9,7 +9,8 @@ use super::{
     },
     turn_outcome::TurnOutcome,
     turn_settlement::TurnSettlementTracker,
-    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitResult,
+    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitMode,
+    BackgroundSubagentWaitResult,
 };
 use crate::agentic::agents::get_agent_registry;
 use crate::agentic::context_profile::ContextProfilePolicy;
@@ -6838,16 +6839,16 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     pub(crate) async fn wait_for_background_subagent_outcomes(
         &self,
         parent_session_id: &str,
-        parent_dialog_turn_id: &str,
         background_task_ids: &[String],
+        wait_mode: BackgroundSubagentWaitMode,
         timeout: Duration,
         cancellation_token: Option<&CancellationToken>,
     ) -> BitFunResult<BackgroundSubagentWaitResult> {
         self.background_subagent_outcomes
             .wait_for(
                 parent_session_id,
-                parent_dialog_turn_id,
                 background_task_ids,
+                wait_mode,
                 timeout,
                 cancellation_token,
             )
@@ -8361,8 +8362,8 @@ mod tests {
         resolve_agent_session_create_created_by, resolve_agent_submission_turn_id,
         resolve_subagent_model_selection, runtime_port_error_preserving_message,
         should_require_tool_confirmation, turn_review_manifest_for_agent,
-        BackgroundSubagentOutcome, ConversationCoordinator, SubagentExecutionRequest,
-        TEST_AGENT_MODEL_DEFAULTS,
+        BackgroundSubagentOutcome, BackgroundSubagentWaitMode, ConversationCoordinator,
+        SubagentExecutionRequest, TEST_AGENT_MODEL_DEFAULTS,
     };
     use crate::agentic::core::{
         InternalReminderKind, Message, MessageContent, MessageRole, MessageSemanticKind,
@@ -8875,8 +8876,8 @@ mod tests {
         let result = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                "parent-turn",
                 std::slice::from_ref(&background_task_id),
+                BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
                 None,
             )
@@ -8891,8 +8892,8 @@ mod tests {
         let second = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                "parent-turn",
                 std::slice::from_ref(&background_task_id),
+                BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
                 None,
             )
@@ -8900,6 +8901,200 @@ mod tests {
             .expect("a consumed outcome should not be delivered twice");
         assert_eq!(second.status.as_str(), "no_matching_tasks");
         assert!(second.outcomes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_wait_without_task_ids_collects_unconsumed_session_outcomes() {
+        let (coordinator, _) = test_coordinator();
+        let background_task_id = "background-task-earlier-turn".to_string();
+        coordinator
+            .background_subagent_outcomes
+            .register(BackgroundSubagentOutcome::running(
+                background_task_id.clone(),
+                "parent-session".to_string(),
+                "earlier-parent-turn".to_string(),
+                "subagent-session".to_string(),
+                "subagent-turn".to_string(),
+                "GeneralPurpose".to_string(),
+                "Inspect implementation".to_string(),
+            ))
+            .await
+            .expect("register outcome");
+        let completed = super::SubagentResult::completed("done".to_string());
+        coordinator
+            .background_subagent_outcomes
+            .complete(&background_task_id, Ok(&completed))
+            .await;
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                &[],
+                BackgroundSubagentWaitMode::Any,
+                Duration::from_millis(10),
+                None,
+            )
+            .await
+            .expect("AgentWait should collect a prior-turn outcome in the same session");
+
+        assert_eq!(result.status.as_str(), "completed");
+        assert_eq!(result.outcomes.len(), 1);
+        assert_eq!(result.outcomes[0].background_task_id, background_task_id);
+        assert!(result.pending_background_task_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn agent_wait_all_times_out_with_returned_partial_results() {
+        let (coordinator, _) = test_coordinator();
+        let completed_task_id = "background-task-completed".to_string();
+        let pending_task_id = "background-task-pending".to_string();
+        for background_task_id in [&completed_task_id, &pending_task_id] {
+            coordinator
+                .background_subagent_outcomes
+                .register(BackgroundSubagentOutcome::running(
+                    background_task_id.clone(),
+                    "parent-session".to_string(),
+                    "parent-turn".to_string(),
+                    format!("subagent-session-{background_task_id}"),
+                    format!("subagent-turn-{background_task_id}"),
+                    "GeneralPurpose".to_string(),
+                    "Inspect implementation".to_string(),
+                ))
+                .await
+                .expect("register outcome");
+        }
+        let completed = super::SubagentResult::completed("done".to_string());
+        coordinator
+            .background_subagent_outcomes
+            .complete(&completed_task_id, Ok(&completed))
+            .await;
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                &[],
+                BackgroundSubagentWaitMode::All,
+                Duration::from_millis(1),
+                None,
+            )
+            .await
+            .expect("all selector timeout should return partial results");
+
+        assert_eq!(result.status.as_str(), "timed_out");
+        assert_eq!(result.outcomes.len(), 1);
+        assert_eq!(result.outcomes[0].background_task_id, completed_task_id);
+        assert_eq!(result.pending_background_task_ids, vec![pending_task_id]);
+
+        let retry = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                std::slice::from_ref(&completed_task_id),
+                BackgroundSubagentWaitMode::All,
+                Duration::from_millis(10),
+                None,
+            )
+            .await
+            .expect("returned results should be consumed");
+        assert_eq!(retry.status.as_str(), "no_matching_tasks");
+    }
+
+    #[tokio::test]
+    async fn agent_wait_any_returns_partial_results_after_debounce() {
+        let (coordinator, _) = test_coordinator();
+        let completed_task_id = "background-task-completed".to_string();
+        let pending_task_id = "background-task-pending".to_string();
+        for background_task_id in [&completed_task_id, &pending_task_id] {
+            coordinator
+                .background_subagent_outcomes
+                .register(BackgroundSubagentOutcome::running(
+                    background_task_id.clone(),
+                    "parent-session".to_string(),
+                    "parent-turn".to_string(),
+                    format!("subagent-session-{background_task_id}"),
+                    format!("subagent-turn-{background_task_id}"),
+                    "GeneralPurpose".to_string(),
+                    "Inspect implementation".to_string(),
+                ))
+                .await
+                .expect("register outcome");
+        }
+        let completed = super::SubagentResult::completed("done".to_string());
+        coordinator
+            .background_subagent_outcomes
+            .complete(&completed_task_id, Ok(&completed))
+            .await;
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                &[],
+                BackgroundSubagentWaitMode::Any,
+                Duration::from_secs(6),
+                None,
+            )
+            .await
+            .expect("any selector should return after the result debounce");
+
+        assert_eq!(result.status.as_str(), "completed");
+        assert_eq!(result.outcomes.len(), 1);
+        assert_eq!(result.outcomes[0].background_task_id, completed_task_id);
+        assert_eq!(result.pending_background_task_ids, vec![pending_task_id]);
+    }
+
+    #[tokio::test]
+    async fn cancelled_agent_wait_keeps_collected_outcomes_available() {
+        let (coordinator, _) = test_coordinator();
+        let completed_task_id = "background-task-completed".to_string();
+        let pending_task_id = "background-task-pending".to_string();
+        for background_task_id in [&completed_task_id, &pending_task_id] {
+            coordinator
+                .background_subagent_outcomes
+                .register(BackgroundSubagentOutcome::running(
+                    background_task_id.clone(),
+                    "parent-session".to_string(),
+                    "parent-turn".to_string(),
+                    format!("subagent-session-{background_task_id}"),
+                    format!("subagent-turn-{background_task_id}"),
+                    "GeneralPurpose".to_string(),
+                    "Inspect implementation".to_string(),
+                ))
+                .await
+                .expect("register outcome");
+        }
+        let completed = super::SubagentResult::completed("done".to_string());
+        coordinator
+            .background_subagent_outcomes
+            .complete(&completed_task_id, Ok(&completed))
+            .await;
+
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let requested_task_ids = vec![completed_task_id.clone(), pending_task_id];
+        let error = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                &requested_task_ids,
+                BackgroundSubagentWaitMode::All,
+                Duration::from_secs(10),
+                Some(&cancellation),
+            )
+            .await
+            .expect_err("cancelled AgentWait should not return a partial result");
+        assert!(error.to_string().contains("AgentWait was cancelled"));
+
+        let retry = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                std::slice::from_ref(&completed_task_id),
+                BackgroundSubagentWaitMode::All,
+                Duration::from_millis(10),
+                None,
+            )
+            .await
+            .expect("a cancelled wait must not consume the completed outcome");
+
+        assert_eq!(retry.outcomes.len(), 1);
+        assert_eq!(retry.outcomes[0].background_task_id, completed_task_id);
     }
 
     #[tokio::test]
@@ -8923,8 +9118,8 @@ mod tests {
         let result = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                "parent-turn",
                 std::slice::from_ref(&background_task_id),
+                BackgroundSubagentWaitMode::All,
                 Duration::from_millis(1),
                 None,
             )

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -171,25 +171,6 @@ fn is_review_agent_type(agent_type: &str) -> bool {
     )
 }
 
-pub(crate) async fn validate_background_subagent_delivery(
-    agent_type: &str,
-    workspace_root: Option<&Path>,
-    allow_review_follow_up: bool,
-) -> BitFunResult<()> {
-    let is_review = get_agent_registry()
-        .get_subagent_is_review_for_workspace(agent_type, workspace_root)
-        .await
-        .unwrap_or(false);
-    if !is_review || allow_review_follow_up {
-        return Ok(());
-    }
-
-    Err(BitFunError::Validation(
-        "Reviews wait for results by default so one final review can be returned. Retry without run_in_background. Only when the user explicitly asked not to wait, retry with run_in_background=true and allow_review_follow_up=true."
-            .to_string(),
-    ))
-}
-
 fn turn_review_manifest_for_agent(
     metadata: Option<&serde_json::Value>,
     agent_type: &str,
@@ -727,9 +708,6 @@ pub struct ConversationCoordinator {
     background_subagent_tasks: Arc<DashMap<String, BackgroundSubagentTaskControl>>,
     /// Parent-owned terminal outcomes consumed only through AgentWait.
     background_subagent_outcomes: Arc<BackgroundSubagentOutcomeStore>,
-    /// Cancelled deliveries consumed by the scheduler after it acquires the
-    /// parent session's operation lock.
-    background_subagent_delivery_suppressions: Arc<DashMap<String, ()>>,
     /// Notifies DialogScheduler of turn outcomes; injected after construction
     scheduler_notify_tx: OnceLock<mpsc::Sender<(String, TurnOutcome)>>,
     /// Round-boundary user steering source (mid-turn user message injection); injected after construction
@@ -1289,7 +1267,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             active_subagent_executions: Arc::new(DashMap::new()),
             background_subagent_tasks: Arc::new(DashMap::new()),
             background_subagent_outcomes,
-            background_subagent_delivery_suppressions: Arc::new(DashMap::new()),
             scheduler_notify_tx: OnceLock::new(),
             round_injection_source: OnceLock::new(),
             active_turns_per_session: Arc::new(DashMap::new()),
@@ -6150,7 +6127,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         &self,
         target_session_id: &str,
         parent_session_id: &str,
-        background_allow_review_follow_up: Option<bool>,
     ) -> BitFunResult<Session> {
         let session = match self.session_manager.get_session(target_session_id) {
             Some(session) => session,
@@ -6180,79 +6156,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         "subagent_follow_up_unsupported: this subagent session is fresh-only; start a new Task invocation"
                             .to_string(),
                     ));
-                }
-                if let Some(allow_review_follow_up) = background_allow_review_follow_up {
-                    let metadata = persisted_metadata.ok_or_else(|| {
-                        BitFunError::NotFound(format!(
-                            "Session metadata not found: {}",
-                            target_session_id
-                        ))
-                    })?;
-                    if !metadata.is_subagent() {
-                        return Err(BitFunError::Validation(format!(
-                            "Subagent execution target must be a subagent session: {}",
-                            target_session_id
-                        )));
-                    }
-                    let created_by_marker = format!("session-{parent_session_id}");
-                    let owned_subagent = session_lineage_matches_parent(
-                        metadata.relationship.as_ref(),
-                        parent_session_id,
-                    ) || metadata.created_by.as_deref()
-                        == Some(created_by_marker.as_str());
-                    if !owned_subagent {
-                        return Err(BitFunError::Validation(format!(
-                            "Subagent session '{}' was not created by parent session '{}'",
-                            target_session_id, parent_session_id
-                        )));
-                    }
-                    validate_background_subagent_delivery(
-                        &metadata.agent_type,
-                        metadata
-                            .workspace_path
-                            .as_deref()
-                            .map(Path::new)
-                            .or(Some(binding.root_path())),
-                        allow_review_follow_up,
-                    )
-                    .await?;
-
-                    let (session_view, _, _, _) = self
-                        .session_manager
-                        .restore_internal_session_view_from_storage_path_tail_timed(
-                            &binding.session_storage_dir(),
-                            target_session_id,
-                            0,
-                        )
-                        .await?;
-                    if session_view.kind != SessionKind::Subagent {
-                        return Err(BitFunError::Validation(format!(
-                            "Subagent execution target must be a subagent session: {}",
-                            target_session_id
-                        )));
-                    }
-                    if !session_created_by_parent(&session_view, parent_session_id)
-                        && !session_lineage_matches_parent(
-                            metadata.relationship.as_ref(),
-                            parent_session_id,
-                        )
-                    {
-                        return Err(BitFunError::Validation(format!(
-                            "Subagent session '{}' was not created by parent session '{}'",
-                            target_session_id, parent_session_id
-                        )));
-                    }
-                    validate_background_subagent_delivery(
-                        &session_view.agent_type,
-                        session_view
-                            .config
-                            .workspace_path
-                            .as_deref()
-                            .map(Path::new)
-                            .or(Some(binding.root_path())),
-                        allow_review_follow_up,
-                    )
-                    .await?;
                 }
                 self.session_manager
                     .restore_internal_session_from_storage_path(
@@ -6292,15 +6195,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 "Subagent session is in error state and cannot be reused: {}",
                 target_session_id
             )));
-        }
-
-        if let Some(allow_review_follow_up) = background_allow_review_follow_up {
-            validate_background_subagent_delivery(
-                &session.agent_type,
-                session.config.workspace_path.as_deref().map(Path::new),
-                allow_review_follow_up,
-            )
-            .await?;
         }
 
         Ok(session)
@@ -6454,7 +6348,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     async fn resolve_hidden_subagent_execution_request(
         &self,
         request: SubagentExecutionRequest,
-        background_allow_review_follow_up: Option<bool>,
     ) -> BitFunResult<HiddenSubagentExecutionRequest> {
         let task_description = request.task_description.trim().to_string();
         if task_description.is_empty() {
@@ -6506,7 +6399,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         .ensure_subagent_session_loaded_for_reuse(
                             target_session_id,
                             &parent_session_id,
-                            background_allow_review_follow_up,
                         )
                         .await?;
                     let requested_model_id = if inherit_parent_model {
@@ -6577,14 +6469,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                             .to_string(),
                     )
                 })?;
-                if let Some(allow_review_follow_up) = background_allow_review_follow_up {
-                    validate_background_subagent_delivery(
-                        &agent_type,
-                        Some(Path::new(&workspace_path)),
-                        allow_review_follow_up,
-                    )
-                    .await?;
-                }
                 let resolved_model_id = if matches!(
                     request.model_binding_policy,
                     SessionModelBindingPolicy::ApprovedImmutable
@@ -6670,14 +6554,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 let snapshot = self
                     .capture_fork_agent_context_snapshot(&request.subagent_parent_info.session_id)
                     .await?;
-                if let Some(allow_review_follow_up) = background_allow_review_follow_up {
-                    validate_background_subagent_delivery(
-                        &snapshot.parent_agent_type,
-                        Some(Path::new(&snapshot.workspace_path)),
-                        allow_review_follow_up,
-                    )
-                    .await?;
-                }
                 let defaults = Self::agent_model_defaults().await;
                 let parent_model_id = if inherit_parent_model
                     || (model_id.is_none()
@@ -6839,7 +6715,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         request: SubagentExecutionRequest,
     ) -> BitFunResult<HiddenSubagentExecutionRequest> {
         let request = self
-            .resolve_hidden_subagent_execution_request(request, None)
+            .resolve_hidden_subagent_execution_request(request)
             .await?;
         self.prepare_hidden_subagent_execution_request(request)
             .await
@@ -6914,32 +6790,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         );
     }
 
-    #[cfg(test)]
-    pub(crate) fn has_background_subagent_task_for_test(&self, background_task_id: &str) -> bool {
-        self.background_subagent_tasks
-            .contains_key(background_task_id)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn suppress_background_subagent_task_for_test(
-        &self,
-        background_task_id: &str,
-    ) -> bool {
-        self.background_subagent_tasks
-            .remove_if(background_task_id, |task_id, control| {
-                control.suppress_delivery.store(true, Ordering::SeqCst);
-                self.mark_background_subagent_delivery_suppression(task_id.clone());
-                true
-            })
-            .is_some()
-    }
-
     pub(crate) async fn cancel_background_subagents_for_parent(
         &self,
         parent_session_id: &str,
         subagent_session_id: &str,
     ) -> BitFunResult<usize> {
-        self.ensure_subagent_session_loaded_for_reuse(subagent_session_id, parent_session_id, None)
+        self.ensure_subagent_session_loaded_for_reuse(subagent_session_id, parent_session_id)
             .await?;
 
         let controls = self.claim_background_subagent_controls(|control| {
@@ -6998,46 +6854,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .await
     }
 
-    pub(crate) fn take_background_subagent_delivery_suppression(
-        &self,
-        background_task_id: &str,
-    ) -> bool {
-        self.background_subagent_delivery_suppressions
-            .remove(background_task_id)
-            .is_some()
-    }
-
-    pub(crate) fn mark_background_subagent_delivery_suppression(&self, background_task_id: String) {
-        self.background_subagent_delivery_suppressions
-            .insert(background_task_id, ());
-    }
-
-    pub(crate) fn finish_background_subagent_delivery(&self, background_task_id: &str) {
-        self.background_subagent_tasks.remove(background_task_id);
-        self.background_subagent_delivery_suppressions
-            .remove(background_task_id);
-    }
-
-    pub(crate) fn background_subagent_control_available_for_injection(
-        &self,
-        background_task_id: &str,
-    ) -> bool {
-        self.background_subagent_tasks
-            .get(background_task_id)
-            .is_some_and(|control| !control.suppress_delivery.load(Ordering::SeqCst))
-    }
-
-    pub(crate) fn claim_background_subagent_control_for_injection(
-        &self,
-        background_task_id: &str,
-    ) -> bool {
-        self.background_subagent_tasks
-            .remove_if(background_task_id, |_, control| {
-                !control.suppress_delivery.load(Ordering::SeqCst)
-            })
-            .is_some()
-    }
-
     fn claim_background_subagent_controls(
         &self,
         matches: impl Fn(&BackgroundSubagentTaskControl) -> bool,
@@ -7051,15 +6867,16 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         candidate_ids
             .into_iter()
             .filter_map(|background_task_id| {
-                self.background_subagent_tasks
-                    .remove_if(&background_task_id, |task_id, control| {
+                self.background_subagent_tasks.remove_if(
+                    &background_task_id,
+                    |_task_id, control| {
                         if !matches(control) {
                             return false;
                         }
                         control.suppress_delivery.store(true, Ordering::SeqCst);
-                        self.mark_background_subagent_delivery_suppression(task_id.clone());
                         true
-                    })
+                    },
+                )
             })
             .collect()
     }
@@ -7192,7 +7009,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         timeout_seconds: Option<u64>,
     ) -> BitFunResult<BackgroundSubagentStartResult> {
         let request = self
-            .resolve_hidden_subagent_execution_request(request, None)
+            .resolve_hidden_subagent_execution_request(request)
             .await?;
         let mut request = self
             .prepare_hidden_subagent_execution_request(request)
@@ -7292,8 +7109,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 BackgroundSubagentCancelTarget::Scheduler(cancel_handle.clone()),
             );
             let background_subagent_tasks = self.background_subagent_tasks.clone();
-            let background_delivery_suppressions =
-                self.background_subagent_delivery_suppressions.clone();
             let background_subagent_outcomes = self.background_subagent_outcomes.clone();
 
             tokio::spawn(async move {
@@ -7318,17 +7133,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 };
                 if suppress_delivery.load(Ordering::SeqCst) {
                     background_subagent_tasks.remove(&background_task_id_for_delivery);
-                    background_delivery_suppressions.remove(&background_task_id_for_delivery);
-                    debug!(
-                        "Suppressing cancelled background subagent result delivery: background_task_id={}, parent_session_id={}",
-                        background_task_id_for_delivery, subagent_parent_info.session_id
-                    );
-                    return;
-                }
-
-                if suppress_delivery.load(Ordering::SeqCst) {
-                    background_subagent_tasks.remove(&background_task_id_for_delivery);
-                    background_delivery_suppressions.remove(&background_task_id_for_delivery);
                     debug!(
                         "Suppressing cancelled background subagent result delivery: background_task_id={}, parent_session_id={}",
                         background_task_id_for_delivery, subagent_parent_info.session_id
@@ -7340,7 +7144,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     .complete(&background_task_id_for_delivery, result.as_ref())
                     .await;
                 background_subagent_tasks.remove(&background_task_id_for_delivery);
-                background_delivery_suppressions.remove(&background_task_id_for_delivery);
             });
 
             return Ok(BackgroundSubagentStartResult {
@@ -7376,8 +7179,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             BackgroundSubagentCancelTarget::Direct(background_cancel_token),
         );
         let background_subagent_tasks = self.background_subagent_tasks.clone();
-        let background_delivery_suppressions =
-            self.background_subagent_delivery_suppressions.clone();
         let background_subagent_outcomes = self.background_subagent_outcomes.clone();
 
         tokio::spawn(async move {
@@ -7391,17 +7192,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             cancel_bridge_handle.abort();
             if suppress_delivery.load(Ordering::SeqCst) {
                 background_subagent_tasks.remove(&background_task_id_for_delivery);
-                background_delivery_suppressions.remove(&background_task_id_for_delivery);
-                debug!(
-                    "Suppressing cancelled background subagent result delivery: background_task_id={}, parent_session_id={}",
-                    background_task_id_for_delivery, subagent_parent_info.session_id
-                );
-                return;
-            }
-
-            if suppress_delivery.load(Ordering::SeqCst) {
-                background_subagent_tasks.remove(&background_task_id_for_delivery);
-                background_delivery_suppressions.remove(&background_task_id_for_delivery);
                 debug!(
                     "Suppressing cancelled background subagent result delivery: background_task_id={}, parent_session_id={}",
                     background_task_id_for_delivery, subagent_parent_info.session_id
@@ -7413,7 +7203,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 .complete(&background_task_id_for_delivery, result.as_ref())
                 .await;
             background_subagent_tasks.remove(&background_task_id_for_delivery);
-            background_delivery_suppressions.remove(&background_task_id_for_delivery);
         });
 
         Ok(BackgroundSubagentStartResult {
@@ -8572,12 +8361,11 @@ mod tests {
         resolve_agent_session_create_created_by, resolve_agent_submission_turn_id,
         resolve_subagent_model_selection, runtime_port_error_preserving_message,
         should_require_tool_confirmation, turn_review_manifest_for_agent,
-        validate_background_subagent_delivery, BackgroundSubagentOutcome, ConversationCoordinator,
-        SubagentExecutionRequest, TEST_AGENT_MODEL_DEFAULTS,
+        BackgroundSubagentOutcome, ConversationCoordinator, SubagentExecutionRequest,
+        TEST_AGENT_MODEL_DEFAULTS,
     };
-    use crate::agentic::agents::{CustomSubagent, CustomSubagentKind, UserContextPolicy};
     use crate::agentic::core::{
-        InternalReminderKind, Message, MessageContent, MessageRole, MessageSemanticKind, Session,
+        InternalReminderKind, Message, MessageContent, MessageRole, MessageSemanticKind,
         SessionConfig, SessionContinuationPolicy, SessionKind, SessionModelBindingPolicy,
     };
     use crate::agentic::events::{EventQueue, EventQueueConfig, EventRouter};
@@ -9167,68 +8955,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_background_control_cannot_be_claimed_for_late_cancellation() {
-        let (coordinator, _) = test_coordinator();
-        coordinator.register_background_subagent_task(
-            "background-task".to_string(),
-            "parent-session".to_string(),
-            "subagent-session".to_string(),
-            super::BackgroundSubagentCancelTarget::Direct(
-                tokio_util::sync::CancellationToken::new(),
-            ),
-        );
-        coordinator.finish_background_subagent_delivery("background-task");
-
-        let claimed = coordinator.claim_background_subagent_controls(|control| {
-            control.parent_session_id == "parent-session"
-                && control.subagent_session_id == "subagent-session"
-        });
-
-        assert!(claimed.is_empty());
-        assert!(!coordinator.take_background_subagent_delivery_suppression("background-task"));
-    }
-
-    #[tokio::test]
-    async fn injection_and_cancellation_claim_the_same_background_control_once() {
-        let (coordinator, _) = test_coordinator();
-        coordinator.register_background_subagent_task(
-            "delivery-wins".to_string(),
-            "parent-session".to_string(),
-            "subagent-session".to_string(),
-            super::BackgroundSubagentCancelTarget::Direct(
-                tokio_util::sync::CancellationToken::new(),
-            ),
-        );
-        assert!(coordinator.claim_background_subagent_control_for_injection("delivery-wins"));
-        assert!(coordinator
-            .claim_background_subagent_controls(|control| {
-                control.parent_session_id == "parent-session"
-                    && control.subagent_session_id == "subagent-session"
-            })
-            .is_empty());
-
-        coordinator.register_background_subagent_task(
-            "cancellation-wins".to_string(),
-            "parent-session".to_string(),
-            "subagent-session".to_string(),
-            super::BackgroundSubagentCancelTarget::Direct(
-                tokio_util::sync::CancellationToken::new(),
-            ),
-        );
-        assert_eq!(
-            coordinator
-                .claim_background_subagent_controls(|control| {
-                    control.parent_session_id == "parent-session"
-                        && control.subagent_session_id == "subagent-session"
-                })
-                .len(),
-            1
-        );
-        assert!(!coordinator.claim_background_subagent_control_for_injection("cancellation-wins"));
-        assert!(coordinator.take_background_subagent_delivery_suppression("cancellation-wins"));
-    }
-
-    #[tokio::test]
     async fn coordinator_test_fixture_injects_terminal_port() {
         let (coordinator, _) = test_coordinator();
 
@@ -9241,397 +8967,6 @@ mod tests {
         assert_eq!(normalize_subagent_max_concurrency(0), 1);
         assert_eq!(normalize_subagent_max_concurrency(5), 5);
         assert_eq!(normalize_subagent_max_concurrency(usize::MAX), 64);
-    }
-
-    #[tokio::test]
-    async fn review_background_delivery_requires_explicit_follow_up_permission() {
-        let error = validate_background_subagent_delivery("CodeReview", None, false)
-            .await
-            .expect_err("review background delivery should require explicit follow-up permission");
-
-        assert!(error.to_string().contains("one final review"));
-        assert!(error.to_string().contains("allow_review_follow_up=true"));
-        assert!(
-            validate_background_subagent_delivery("CodeReview", None, true)
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn explicit_review_follow_up_allows_fresh_background_resolution() {
-        let (coordinator, _) = test_coordinator();
-        let workspace_path = std::env::temp_dir().join(format!(
-            "bitfun-review-follow-up-fresh-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&workspace_path).expect("workspace dir should exist");
-        let request = SubagentExecutionRequest {
-            task_description: "Review the current diff later".to_string(),
-            context_mode: SubagentContextMode::Fresh,
-            target_session_id: None,
-            subagent_type: Some("CodeReview".to_string()),
-            logical_subagent_type: None,
-            continuation_policy: SessionContinuationPolicy::Reusable,
-            model_binding_policy: SessionModelBindingPolicy::Mutable,
-            workspace_path: Some(workspace_path.to_string_lossy().into_owned()),
-            model_id: None,
-            inherit_parent_model: false,
-            subagent_parent_info: SubagentParentInfo {
-                session_id: "parent-session".to_string(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            },
-            context: HashMap::new(),
-            delegation_policy: DelegationPolicy::top_level().spawn_child(),
-            external_generation_lease: None,
-        };
-
-        let resolved = coordinator
-            .resolve_hidden_subagent_execution_request(request, Some(true))
-            .await
-            .expect("explicit review follow-up should resolve a fresh background request");
-
-        assert_eq!(resolved.agent_type, "CodeReview");
-        assert!(resolved.target_session_id.is_none());
-        let _ = std::fs::remove_dir_all(workspace_path);
-    }
-
-    #[tokio::test]
-    async fn explicit_review_follow_up_allows_reused_background_resolution() {
-        let (coordinator, _) = test_coordinator();
-        let workspace_path = std::env::temp_dir().join(format!(
-            "bitfun-review-follow-up-reuse-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&workspace_path).expect("workspace dir should exist");
-        let review_session = coordinator
-            .create_hidden_agent_session(
-                None,
-                "Reusable review".to_string(),
-                "CodeReview".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace_path.to_string_lossy().into_owned()),
-                    ..Default::default()
-                },
-                Some("session-parent-session".to_string()),
-                SessionKind::Subagent,
-            )
-            .await
-            .expect("review session should be created");
-        let request = SubagentExecutionRequest {
-            task_description: "Continue the review later".to_string(),
-            context_mode: SubagentContextMode::Fresh,
-            target_session_id: Some(review_session.session_id.clone()),
-            subagent_type: None,
-            logical_subagent_type: None,
-            continuation_policy: SessionContinuationPolicy::Reusable,
-            model_binding_policy: SessionModelBindingPolicy::Mutable,
-            workspace_path: None,
-            model_id: None,
-            inherit_parent_model: false,
-            subagent_parent_info: SubagentParentInfo {
-                session_id: "parent-session".to_string(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            },
-            context: HashMap::new(),
-            delegation_policy: DelegationPolicy::top_level().spawn_child(),
-            external_generation_lease: None,
-        };
-
-        let resolved = coordinator
-            .resolve_hidden_subagent_execution_request(request, Some(true))
-            .await
-            .expect("explicit review follow-up should resolve a reused background request");
-
-        assert_eq!(
-            resolved.target_session_id.as_deref(),
-            Some(review_session.session_id.as_str())
-        );
-        let _ = std::fs::remove_dir_all(workspace_path);
-    }
-
-    #[tokio::test]
-    async fn non_review_background_delivery_preserves_existing_behavior() {
-        assert!(
-            validate_background_subagent_delivery("GeneralPurpose", None, false)
-                .await
-                .is_ok()
-        );
-        assert!(
-            validate_background_subagent_delivery("ReviewFixer", None, false)
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn cold_review_session_is_rejected_before_full_restore() {
-        let (coordinator, session_manager) = test_coordinator();
-        let workspace_path = std::env::temp_dir().join(format!(
-            "bitfun-cold-review-background-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&workspace_path).expect("workspace dir should exist");
-        let parent_session = session_manager
-            .create_session(
-                "Parent".to_string(),
-                "agentic".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace_path.to_string_lossy().into_owned()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("parent session should be created");
-        let storage_binding = session_manager
-            .resolve_session_workspace_binding(&parent_session.session_id)
-            .await
-            .expect("parent workspace binding should resolve");
-        let review_session_id = format!("session-cold-review-{}", uuid::Uuid::new_v4());
-        let mut metadata = SessionMetadata::new(
-            review_session_id.clone(),
-            "Cold review".to_string(),
-            "CodeReview".to_string(),
-            "primary".to_string(),
-        );
-        metadata.session_kind = SessionKind::Subagent;
-        metadata.created_by = Some(format!("session-{}", parent_session.session_id));
-        metadata.workspace_path = Some(workspace_path.to_string_lossy().into_owned());
-        metadata.relationship = Some(super::build_subagent_session_relationship(
-            Some(&SubagentParentInfo {
-                session_id: parent_session.session_id.clone(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            }),
-            "CodeReview",
-            SessionContinuationPolicy::Reusable,
-        ));
-        session_manager
-            .save_session_metadata(&storage_binding.session_storage_dir(), &metadata)
-            .await
-            .expect("cold review metadata should be persisted");
-        assert!(session_manager.get_session(&review_session_id).is_none());
-
-        let request = SubagentExecutionRequest {
-            task_description: "Continue the cold review".to_string(),
-            context_mode: SubagentContextMode::Fresh,
-            target_session_id: Some(review_session_id.clone()),
-            subagent_type: None,
-            logical_subagent_type: None,
-            continuation_policy: SessionContinuationPolicy::Reusable,
-            model_binding_policy: SessionModelBindingPolicy::Mutable,
-            workspace_path: None,
-            model_id: Some("fast".to_string()),
-            inherit_parent_model: false,
-            subagent_parent_info: SubagentParentInfo {
-                session_id: parent_session.session_id.clone(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            },
-            context: HashMap::new(),
-            delegation_policy: DelegationPolicy::top_level().spawn_child(),
-            external_generation_lease: None,
-        };
-
-        let error = coordinator
-            .resolve_hidden_subagent_execution_request(request, Some(false))
-            .await
-            .expect_err("cold review should reject background delivery before restore");
-
-        assert!(error.to_string().contains("one final review"));
-        assert!(session_manager.get_session(&review_session_id).is_none());
-        let persisted = session_manager
-            .load_session_metadata(&storage_binding.session_storage_dir(), &review_session_id)
-            .await
-            .expect("cold review metadata should remain readable")
-            .expect("cold review metadata should remain present");
-        assert_eq!(persisted.model_name, "primary");
-        let _ = std::fs::remove_dir_all(workspace_path);
-    }
-
-    #[tokio::test]
-    async fn cold_subagent_owned_by_another_parent_is_rejected_before_restore() {
-        let (coordinator, session_manager) = test_coordinator();
-        let workspace_path = std::env::temp_dir().join(format!(
-            "bitfun-cold-foreign-subagent-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&workspace_path).expect("workspace dir should exist");
-        let parent_session = session_manager
-            .create_session(
-                "Parent".to_string(),
-                "agentic".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace_path.to_string_lossy().into_owned()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("parent session should be created");
-        let storage_binding = session_manager
-            .resolve_session_workspace_binding(&parent_session.session_id)
-            .await
-            .expect("parent workspace binding should resolve");
-        let review_session_id = format!("session-foreign-review-{}", uuid::Uuid::new_v4());
-        let mut metadata = SessionMetadata::new(
-            review_session_id.clone(),
-            "Foreign review".to_string(),
-            "CodeReview".to_string(),
-            "primary".to_string(),
-        );
-        metadata.session_kind = SessionKind::Subagent;
-        metadata.created_by = Some("session-another-parent".to_string());
-        metadata.workspace_path = Some(workspace_path.to_string_lossy().into_owned());
-        session_manager
-            .save_session_metadata(&storage_binding.session_storage_dir(), &metadata)
-            .await
-            .expect("foreign review metadata should be persisted");
-
-        let request = SubagentExecutionRequest {
-            task_description: "Continue a foreign review".to_string(),
-            context_mode: SubagentContextMode::Fresh,
-            target_session_id: Some(review_session_id.clone()),
-            subagent_type: None,
-            logical_subagent_type: None,
-            continuation_policy: SessionContinuationPolicy::Reusable,
-            model_binding_policy: SessionModelBindingPolicy::Mutable,
-            workspace_path: None,
-            model_id: None,
-            inherit_parent_model: false,
-            subagent_parent_info: SubagentParentInfo {
-                session_id: parent_session.session_id.clone(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            },
-            context: HashMap::new(),
-            delegation_policy: DelegationPolicy::top_level().spawn_child(),
-            external_generation_lease: None,
-        };
-
-        let error = coordinator
-            .resolve_hidden_subagent_execution_request(request, Some(false))
-            .await
-            .expect_err("foreign subagent should fail ownership preflight");
-
-        assert!(error
-            .to_string()
-            .contains("was not created by parent session"));
-        assert!(session_manager.get_session(&review_session_id).is_none());
-        let _ = std::fs::remove_dir_all(workspace_path);
-    }
-
-    #[tokio::test]
-    async fn cold_review_uses_read_only_session_workspace_before_restore() {
-        let (coordinator, session_manager) = test_coordinator();
-        let workspace_path = std::env::temp_dir().join(format!(
-            "bitfun-cold-review-workspace-preflight-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let review_workspace = workspace_path.join("review-workspace");
-        let reviewer_path = review_workspace
-            .join(".bitfun")
-            .join("agents")
-            .join("cold-reviewer.md");
-        std::fs::create_dir_all(
-            reviewer_path
-                .parent()
-                .expect("reviewer path should have a parent"),
-        )
-        .expect("review agent directory should exist");
-        let mut reviewer = CustomSubagent::new_with_id(
-            "ColdWorkspaceReviewer".to_string(),
-            "ColdWorkspaceReviewer".to_string(),
-            "Project review subagent".to_string(),
-            vec!["Read".to_string()],
-            "Review the relevant files.".to_string(),
-            true,
-            reviewer_path.to_string_lossy().into_owned(),
-            CustomSubagentKind::Project,
-            "fast".to_string(),
-            UserContextPolicy::empty().with_workspace_instructions(),
-        );
-        reviewer.data.review = true;
-        reviewer
-            .save_to_file(None)
-            .expect("project review subagent should save");
-
-        let parent_session = session_manager
-            .create_session(
-                "Parent".to_string(),
-                "agentic".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace_path.to_string_lossy().into_owned()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("parent session should be created");
-        let storage_binding = session_manager
-            .resolve_session_workspace_binding(&parent_session.session_id)
-            .await
-            .expect("parent workspace binding should resolve");
-        let review_session_id = format!("session-workspace-review-{}", uuid::Uuid::new_v4());
-        let mut persisted_session = Session::new_with_id(
-            review_session_id.clone(),
-            "Workspace review".to_string(),
-            "ColdWorkspaceReviewer".to_string(),
-            SessionConfig {
-                workspace_path: Some(review_workspace.to_string_lossy().into_owned()),
-                ..Default::default()
-            },
-        );
-        persisted_session.kind = SessionKind::Subagent;
-        persisted_session.created_by = Some(format!("session-{}", parent_session.session_id));
-        let persistence_manager = PersistenceManager::new(Arc::new(
-            PathManager::new().expect("path manager should initialize"),
-        ))
-        .expect("persistence manager should initialize");
-        persistence_manager
-            .save_session(&storage_binding.session_storage_dir(), &persisted_session)
-            .await
-            .expect("cold review session should be persisted");
-        let mut metadata = session_manager
-            .load_session_metadata(&storage_binding.session_storage_dir(), &review_session_id)
-            .await
-            .expect("cold review metadata should load")
-            .expect("cold review metadata should exist");
-        metadata.workspace_path = Some(workspace_path.to_string_lossy().into_owned());
-        session_manager
-            .save_session_metadata(&storage_binding.session_storage_dir(), &metadata)
-            .await
-            .expect("metadata workspace should be overridden for the mismatch fixture");
-
-        let request = SubagentExecutionRequest {
-            task_description: "Continue the workspace review".to_string(),
-            context_mode: SubagentContextMode::Fresh,
-            target_session_id: Some(review_session_id.clone()),
-            subagent_type: None,
-            logical_subagent_type: None,
-            continuation_policy: SessionContinuationPolicy::Reusable,
-            model_binding_policy: SessionModelBindingPolicy::Mutable,
-            workspace_path: None,
-            model_id: None,
-            inherit_parent_model: false,
-            subagent_parent_info: SubagentParentInfo {
-                session_id: parent_session.session_id.clone(),
-                dialog_turn_id: "parent-turn".to_string(),
-                tool_call_id: "task-tool".to_string(),
-            },
-            context: HashMap::new(),
-            delegation_policy: DelegationPolicy::top_level().spawn_child(),
-            external_generation_lease: None,
-        };
-
-        let error = coordinator
-            .resolve_hidden_subagent_execution_request(request, Some(false))
-            .await
-            .expect_err("stored review workspace should be checked before full restore");
-
-        assert!(error.to_string().contains("one final review"));
-        assert!(session_manager.get_session(&review_session_id).is_none());
-        let _ = std::fs::remove_dir_all(workspace_path);
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -3,14 +3,14 @@
 //! Top-level component that integrates all subsystems and provides a unified interface
 
 use super::{
+    coordination_store::{BackgroundTaskRegistration, CoordinationStore},
     scheduler::{
         abort_thread_goal_continuation_for_session, clear_thread_goal_continuation_abort,
         get_global_scheduler, DialogSubmissionPolicy, HiddenSubagentQueueCancelHandle,
     },
     turn_outcome::TurnOutcome,
     turn_settlement::TurnSettlementTracker,
-    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitMode,
-    BackgroundSubagentWaitResult,
+    BackgroundSubagentOutcomeStore, BackgroundSubagentWaitMode, BackgroundSubagentWaitResult,
 };
 use crate::agentic::agents::get_agent_registry;
 use crate::agentic::context_profile::ContextProfilePolicy;
@@ -324,8 +324,8 @@ impl SubagentResult {
 
 #[derive(Debug, Clone)]
 pub struct BackgroundSubagentStartResult {
-    pub background_task_id: String,
-    pub session_id: String,
+    pub bg_task_id: String,
+    pub agent_id: String,
 }
 
 fn build_subagent_session_relationship(
@@ -705,8 +705,8 @@ pub struct ConversationCoordinator {
     subagent_timeout_registry: Arc<RwLock<HashMap<String, Arc<SubagentTimeoutHandle>>>>,
     /// Active subagent executions keyed by subagent session id.
     active_subagent_executions: Arc<DashMap<String, ActiveSubagentExecution>>,
-    /// Background Task runs keyed by background_task_id.
-    background_subagent_tasks: Arc<DashMap<String, BackgroundSubagentTaskControl>>,
+    /// Background Task runs keyed by the coordination database task primary key.
+    background_subagent_tasks: Arc<DashMap<i64, BackgroundSubagentTaskControl>>,
     /// Parent-owned terminal outcomes consumed only through AgentWait.
     background_subagent_outcomes: Arc<BackgroundSubagentOutcomeStore>,
     /// Notifies DialogScheduler of turn outcomes; injected after construction
@@ -1253,8 +1253,31 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         event_queue: Arc<EventQueue>,
         event_router: Arc<EventRouter>,
     ) -> Self {
+        let coordination_database_file = session_manager
+            .path_manager()
+            .agent_coordination_database_file();
+        Self::new_with_coordination_database_file(
+            session_manager,
+            execution_engine,
+            tool_pipeline,
+            event_queue,
+            event_router,
+            coordination_database_file,
+        )
+    }
+
+    fn new_with_coordination_database_file(
+        session_manager: Arc<SessionManager>,
+        execution_engine: Arc<ExecutionEngine>,
+        tool_pipeline: Arc<ToolPipeline>,
+        event_queue: Arc<EventQueue>,
+        event_router: Arc<EventRouter>,
+        coordination_database_file: PathBuf,
+    ) -> Self {
+        let coordination_store = Arc::new(CoordinationStore::new(coordination_database_file));
         let background_subagent_outcomes = Arc::new(BackgroundSubagentOutcomeStore::new(
             Arc::clone(&session_manager),
+            coordination_store,
         ));
         Self {
             session_manager,
@@ -4257,6 +4280,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         self.session_manager
             .delete_session(workspace_path, session_id)
             .await?;
+        self.background_subagent_outcomes
+            .delete_session_references(session_id)
+            .await?;
         self.emit_event(AgenticEvent::SessionDeleted {
             session_id: session_id.to_string(),
         })
@@ -4278,6 +4304,11 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             )
             .await?;
 
+        let rolled_back_turn_ids = parent_dialog_turn_ids.iter().cloned().collect::<Vec<_>>();
+        self.background_subagent_outcomes
+            .rollback_parent_turns(parent_session_id, &rolled_back_turn_ids)
+            .await?;
+
         let mut deleted_session_ids = Vec::new();
 
         for session_id in session_ids {
@@ -4287,6 +4318,16 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
 
         Ok(deleted_session_ids)
+    }
+
+    pub(crate) async fn initialize_fork_coordination(
+        &self,
+        source_session_id: &str,
+        target_session_id: &str,
+    ) -> BitFunResult<()> {
+        self.background_subagent_outcomes
+            .initialize_fork(source_session_id, target_session_id)
+            .await
     }
 
     pub(crate) async fn collect_hidden_subagent_sessions_for_parent_turns(
@@ -6758,14 +6799,14 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
     fn register_background_subagent_task(
         &self,
-        background_task_id: String,
+        task_pk: i64,
         parent_session_id: String,
         subagent_session_id: String,
         cancel_target: BackgroundSubagentCancelTarget,
     ) -> Arc<AtomicBool> {
         let suppress_delivery = Arc::new(AtomicBool::new(false));
         self.background_subagent_tasks.insert(
-            background_task_id,
+            task_pk,
             BackgroundSubagentTaskControl {
                 parent_session_id,
                 subagent_session_id,
@@ -6779,12 +6820,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     #[cfg(test)]
     pub(crate) fn register_background_subagent_task_for_test(
         &self,
-        background_task_id: &str,
+        task_pk: i64,
         parent_session_id: &str,
         subagent_session_id: &str,
     ) {
         self.register_background_subagent_task(
-            background_task_id.to_string(),
+            task_pk,
             parent_session_id.to_string(),
             subagent_session_id.to_string(),
             BackgroundSubagentCancelTarget::Direct(CancellationToken::new()),
@@ -6803,14 +6844,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             control.parent_session_id == parent_session_id
                 && control.subagent_session_id == subagent_session_id
         });
-        let background_task_ids = controls
+        let task_pks = controls
             .iter()
-            .map(|(background_task_id, _)| background_task_id.clone())
+            .map(|(task_pk, _)| *task_pk)
             .collect::<Vec<_>>();
         let cancelled = self.cancel_background_subagent_controls(controls).await?;
-        self.background_subagent_outcomes
-            .cancel(&background_task_ids)
-            .await;
+        self.background_subagent_outcomes.cancel(&task_pks).await;
         Ok(cancelled)
     }
 
@@ -6825,71 +6864,89 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             .iter()
             .map(|(_, control)| control.subagent_session_id.clone())
             .collect::<Vec<_>>();
-        let background_task_ids = controls
+        let task_pks = controls
             .iter()
-            .map(|(background_task_id, _)| background_task_id.clone())
+            .map(|(task_pk, _)| *task_pk)
             .collect::<Vec<_>>();
         self.cancel_background_subagent_controls(controls).await?;
-        self.background_subagent_outcomes
-            .cancel(&background_task_ids)
-            .await;
+        self.background_subagent_outcomes.cancel(&task_pks).await;
         Ok(subagent_session_ids)
     }
 
     pub(crate) async fn wait_for_background_subagent_outcomes(
         &self,
         parent_session_id: &str,
-        background_task_ids: &[String],
+        bg_task_ids: &[String],
         wait_mode: BackgroundSubagentWaitMode,
         timeout: Duration,
+        delivered_parent_dialog_turn_id: &str,
         cancellation_token: Option<&CancellationToken>,
     ) -> BitFunResult<BackgroundSubagentWaitResult> {
         self.background_subagent_outcomes
             .wait_for(
                 parent_session_id,
-                background_task_ids,
+                bg_task_ids,
                 wait_mode,
                 timeout,
+                delivered_parent_dialog_turn_id,
                 cancellation_token,
             )
+            .await
+    }
+
+    pub(crate) async fn agent_id_for_subagent_session(
+        &self,
+        parent_session_id: &str,
+        subagent_session_id: &str,
+    ) -> BitFunResult<String> {
+        self.background_subagent_outcomes
+            .agent_id_for_session(parent_session_id, subagent_session_id)
+            .await
+    }
+
+    pub(crate) async fn resolve_agent_id(
+        &self,
+        parent_session_id: &str,
+        agent_id: &str,
+    ) -> BitFunResult<String> {
+        self.background_subagent_outcomes
+            .resolve_agent_id(parent_session_id, agent_id)
             .await
     }
 
     fn claim_background_subagent_controls(
         &self,
         matches: impl Fn(&BackgroundSubagentTaskControl) -> bool,
-    ) -> Vec<(String, BackgroundSubagentTaskControl)> {
+    ) -> Vec<(i64, BackgroundSubagentTaskControl)> {
         let candidate_ids = self
             .background_subagent_tasks
             .iter()
             .filter(|entry| matches(entry.value()))
-            .map(|entry| entry.key().clone())
+            .map(|entry| *entry.key())
             .collect::<Vec<_>>();
         candidate_ids
             .into_iter()
-            .filter_map(|background_task_id| {
-                self.background_subagent_tasks.remove_if(
-                    &background_task_id,
-                    |_task_id, control| {
+            .filter_map(|task_pk| {
+                self.background_subagent_tasks
+                    .remove_if(&task_pk, |_task_pk, control| {
                         if !matches(control) {
                             return false;
                         }
                         control.suppress_delivery.store(true, Ordering::SeqCst);
                         true
-                    },
-                )
+                    })
             })
             .collect()
     }
 
     async fn cancel_background_subagent_controls(
         &self,
-        controls: Vec<(String, BackgroundSubagentTaskControl)>,
+        controls: Vec<(i64, BackgroundSubagentTaskControl)>,
     ) -> BitFunResult<usize> {
-        for (background_task_id, control) in &controls {
+        for (task_pk, control) in &controls {
             debug!(
-                "Cancelling background subagent task: background_task_id={}, parent_session_id={}, subagent_session_id={}",
-                background_task_id, control.parent_session_id, control.subagent_session_id
+                "Cancelling background subagent task: task_pk={}, parent_session_id={}, subagent_session_id={}",
+                task_pk, control.parent_session_id, control.subagent_session_id
             );
             match &control.cancel_target {
                 BackgroundSubagentCancelTarget::Scheduler(handle) => {
@@ -6897,8 +6954,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         scheduler.request_hidden_subagent_cancellation(handle).await;
                     } else {
                         warn!(
-                            "Cannot cancel scheduler-backed background subagent because scheduler is unavailable: background_task_id={}, subagent_session_id={}",
-                            background_task_id, control.subagent_session_id
+                            "Cannot cancel scheduler-backed background subagent because scheduler is unavailable: task_pk={}, subagent_session_id={}",
+                            task_pk, control.subagent_session_id
                         );
                     }
                 }
@@ -7024,7 +7081,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 )
             })?
             .to_string();
-        let logical_agent_type = request.logical_agent_type.clone();
         let subagent_parent_info = match request.subagent_parent_info.clone() {
             Some(info) => info,
             None => {
@@ -7050,9 +7106,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 )));
             }
         };
-        let background_task_id = format!("bg-subagent-{}", uuid::Uuid::new_v4());
-        let background_task_id_for_delivery = background_task_id.clone();
-        let task_description = request.user_input_text.clone();
         let coordinator = match get_global_coordinator() {
             Some(coordinator) => coordinator,
             None => {
@@ -7063,23 +7116,28 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 ));
             }
         };
-        if let Err(error) = self
+        let registered_task = match self
             .background_subagent_outcomes
-            .register(BackgroundSubagentOutcome::running(
-                background_task_id.clone(),
-                subagent_parent_info.session_id.clone(),
-                subagent_parent_info.dialog_turn_id.clone(),
-                subagent_session_id.clone(),
-                subagent_dialog_turn_id.clone(),
-                logical_agent_type.clone(),
-                task_description.clone(),
-            ))
+            .register(BackgroundTaskRegistration {
+                parent_session_id: subagent_parent_info.session_id.clone(),
+                requested_agent_id: None,
+                child_session_id: subagent_session_id.clone(),
+                parent_dialog_turn_id: subagent_parent_info.dialog_turn_id.clone(),
+                parent_tool_call_id: subagent_parent_info.tool_call_id.clone(),
+                child_dialog_turn_id: subagent_dialog_turn_id.clone(),
+            })
             .await
         {
-            self.cleanup_prepared_hidden_subagent_session_if_unsubmitted(&request)
-                .await;
-            return Err(error);
-        }
+            Ok(registered_task) => registered_task,
+            Err(error) => {
+                self.cleanup_prepared_hidden_subagent_session_if_unsubmitted(&request)
+                    .await;
+                return Err(error);
+            }
+        };
+        let task_pk = registered_task.task_pk;
+        let bg_task_id = registered_task.bg_task_id;
+        let agent_id = registered_task.agent_id;
         let parent_cancel_token = self
             .execution_engine
             .cancel_token_for_dialog_turn(&subagent_parent_info.dialog_turn_id)
@@ -7092,9 +7150,14 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             {
                 Ok(submit_result) => submit_result,
                 Err(error) => {
-                    self.background_subagent_outcomes
-                        .cancel(std::slice::from_ref(&background_task_id))
-                        .await;
+                    if let Err(discard_error) =
+                        self.background_subagent_outcomes.discard(task_pk).await
+                    {
+                        warn!(
+                            "Failed to discard unsubmitted background task: task_pk={}, error={}",
+                            task_pk, discard_error
+                        );
+                    }
                     self.cleanup_prepared_hidden_subagent_session_if_unsubmitted(&request)
                         .await;
                     return Err(BitFunError::tool(error));
@@ -7104,7 +7167,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             let cancel_handle = submit_result.cancel_handle.clone();
             let scheduler_for_cancel = scheduler.clone();
             let suppress_delivery = self.register_background_subagent_task(
-                background_task_id.clone(),
+                task_pk,
                 subagent_parent_info.session_id.clone(),
                 subagent_session_id.clone(),
                 BackgroundSubagentCancelTarget::Scheduler(cancel_handle.clone()),
@@ -7133,23 +7196,23 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     None => Self::await_hidden_subagent_receiver(receiver).await,
                 };
                 if suppress_delivery.load(Ordering::SeqCst) {
-                    background_subagent_tasks.remove(&background_task_id_for_delivery);
+                    background_subagent_tasks.remove(&task_pk);
                     debug!(
-                        "Suppressing cancelled background subagent result delivery: background_task_id={}, parent_session_id={}",
-                        background_task_id_for_delivery, subagent_parent_info.session_id
+                        "Suppressing cancelled background subagent result delivery: task_pk={}, parent_session_id={}",
+                        task_pk, subagent_parent_info.session_id
                     );
                     return;
                 }
 
                 background_subagent_outcomes
-                    .complete(&background_task_id_for_delivery, result.as_ref())
+                    .complete(task_pk, result.as_ref())
                     .await;
-                background_subagent_tasks.remove(&background_task_id_for_delivery);
+                background_subagent_tasks.remove(&task_pk);
             });
 
             return Ok(BackgroundSubagentStartResult {
-                background_task_id,
-                session_id: subagent_session_id,
+                bg_task_id,
+                agent_id,
             });
         }
 
@@ -7174,7 +7237,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             }),
         };
         let suppress_delivery = self.register_background_subagent_task(
-            background_task_id.clone(),
+            task_pk,
             subagent_parent_info.session_id.clone(),
             subagent_session_id.clone(),
             BackgroundSubagentCancelTarget::Direct(background_cancel_token),
@@ -7192,23 +7255,23 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 .await;
             cancel_bridge_handle.abort();
             if suppress_delivery.load(Ordering::SeqCst) {
-                background_subagent_tasks.remove(&background_task_id_for_delivery);
+                background_subagent_tasks.remove(&task_pk);
                 debug!(
-                    "Suppressing cancelled background subagent result delivery: background_task_id={}, parent_session_id={}",
-                    background_task_id_for_delivery, subagent_parent_info.session_id
+                    "Suppressing cancelled background subagent result delivery: task_pk={}, parent_session_id={}",
+                    task_pk, subagent_parent_info.session_id
                 );
                 return;
             }
 
             background_subagent_outcomes
-                .complete(&background_task_id_for_delivery, result.as_ref())
+                .complete(task_pk, result.as_ref())
                 .await;
-            background_subagent_tasks.remove(&background_task_id_for_delivery);
+            background_subagent_tasks.remove(&task_pk);
         });
 
         Ok(BackgroundSubagentStartResult {
-            background_task_id,
-            session_id: subagent_session_id,
+            bg_task_id,
+            agent_id,
         })
     }
 
@@ -8362,8 +8425,11 @@ mod tests {
         resolve_agent_session_create_created_by, resolve_agent_submission_turn_id,
         resolve_subagent_model_selection, runtime_port_error_preserving_message,
         should_require_tool_confirmation, turn_review_manifest_for_agent,
-        BackgroundSubagentOutcome, BackgroundSubagentWaitMode, ConversationCoordinator,
-        SubagentExecutionRequest, TEST_AGENT_MODEL_DEFAULTS,
+        BackgroundSubagentWaitMode, ConversationCoordinator, SubagentExecutionRequest,
+        TEST_AGENT_MODEL_DEFAULTS,
+    };
+    use crate::agentic::coordination::coordination_store::{
+        BackgroundTaskRegistration, RegisteredBackgroundTask,
     };
     use crate::agentic::core::{
         InternalReminderKind, Message, MessageContent, MessageRole, MessageSemanticKind,
@@ -8736,6 +8802,9 @@ mod tests {
         max_active_sessions: usize,
     ) -> (ConversationCoordinator, Arc<SessionManager>) {
         let event_queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
+        let coordination_database_file = std::env::temp_dir()
+            .join(format!("bitfun-coordinator-test-{}", uuid::Uuid::new_v4()))
+            .join("coordination.sqlite");
         let session_manager = Arc::new(SessionManager::new(
             Arc::new(SessionContextStore::new()),
             Arc::new(
@@ -8766,12 +8835,13 @@ mod tests {
             Arc::new(ContextCompressor::new(CompressionConfig::default())),
             ExecutionEngineConfig::default(),
         ));
-        let coordinator = ConversationCoordinator::new(
+        let coordinator = ConversationCoordinator::new_with_coordination_database_file(
             session_manager.clone(),
             execution_engine,
             tool_pipeline,
             event_queue,
             Arc::new(EventRouter::new()),
+            coordination_database_file,
         );
         coordinator.set_terminal_port(
             bitfun_runtime_services::test_support::FakeRuntimeServicesProvider::terminal_port(),
@@ -8785,6 +8855,26 @@ mod tests {
 
     fn test_coordinator() -> (ConversationCoordinator, Arc<SessionManager>) {
         test_coordinator_with_max_active_sessions(100)
+    }
+
+    async fn register_test_background_task(
+        coordinator: &ConversationCoordinator,
+        parent_session_id: &str,
+        parent_dialog_turn_id: &str,
+        child_session_id: &str,
+    ) -> RegisteredBackgroundTask {
+        coordinator
+            .background_subagent_outcomes
+            .register(BackgroundTaskRegistration {
+                parent_session_id: parent_session_id.to_string(),
+                requested_agent_id: None,
+                child_session_id: child_session_id.to_string(),
+                parent_dialog_turn_id: parent_dialog_turn_id.to_string(),
+                parent_tool_call_id: format!("tool-{child_session_id}"),
+                child_dialog_turn_id: format!("turn-{child_session_id}"),
+            })
+            .await
+            .expect("register background task")
     }
 
     #[test]
@@ -8853,32 +8943,28 @@ mod tests {
     #[tokio::test]
     async fn background_subagent_outcome_is_consumed_only_by_agent_wait() {
         let (coordinator, _) = test_coordinator();
-        let background_task_id = "background-task".to_string();
-        coordinator
-            .background_subagent_outcomes
-            .register(BackgroundSubagentOutcome::running(
-                background_task_id.clone(),
-                "parent-session".to_string(),
-                "parent-turn".to_string(),
-                "subagent-session".to_string(),
-                "subagent-turn".to_string(),
-                "GeneralPurpose".to_string(),
-                "Inspect implementation".to_string(),
-            ))
-            .await
-            .expect("register outcome");
+        let registered = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session",
+        )
+        .await;
+        assert_eq!(registered.agent_id, "a1");
+        assert_eq!(registered.bg_task_id, "a1_bg1");
         let completed = super::SubagentResult::completed("done".to_string());
         coordinator
             .background_subagent_outcomes
-            .complete(&background_task_id, Ok(&completed))
+            .complete(registered.task_pk, Ok(&completed))
             .await;
 
         let result = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                std::slice::from_ref(&background_task_id),
+                std::slice::from_ref(&registered.bg_task_id),
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
+                "wait-turn-1",
                 None,
             )
             .await
@@ -8887,14 +8973,17 @@ mod tests {
         assert_eq!(result.status.as_str(), "completed");
         assert_eq!(result.outcomes.len(), 1);
         assert_eq!(result.outcomes[0].content.as_deref(), Some("done"));
-        assert!(result.pending_background_task_ids.is_empty());
+        assert_eq!(result.outcomes[0].model_bg_task_id(), "a1_bg1");
+        assert_eq!(result.outcomes[0].model_agent_id(), "a1");
+        assert!(result.pending_bg_task_ids.is_empty());
 
         let second = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                std::slice::from_ref(&background_task_id),
+                std::slice::from_ref(&registered.bg_task_id),
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
+                "wait-turn-2",
                 None,
             )
             .await
@@ -8904,26 +8993,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn model_facing_subagent_ids_are_stable_and_parent_scoped() {
+        let (coordinator, _) = test_coordinator();
+
+        let first_agent = coordinator
+            .agent_id_for_subagent_session("parent-1", "subagent-session-1")
+            .await
+            .expect("allocate first agent id");
+        let repeated_agent = coordinator
+            .agent_id_for_subagent_session("parent-1", "subagent-session-1")
+            .await
+            .expect("reuse first agent id");
+        let second_agent = coordinator
+            .agent_id_for_subagent_session("parent-1", "subagent-session-2")
+            .await
+            .expect("allocate second agent id");
+        let other_parent_agent = coordinator
+            .agent_id_for_subagent_session("parent-2", "subagent-session-3")
+            .await
+            .expect("allocate agent id for another parent");
+
+        assert_eq!(first_agent, "a1");
+        assert_eq!(repeated_agent, "a1");
+        assert_eq!(second_agent, "a2");
+        assert_eq!(other_parent_agent, "a1");
+        assert_eq!(
+            coordinator
+                .resolve_agent_id("parent-1", "a2")
+                .await
+                .expect("resolve agent id"),
+            "subagent-session-2"
+        );
+
+        let first_bg_task = register_test_background_task(
+            &coordinator,
+            "parent-1",
+            "parent-turn-1",
+            "subagent-session-1",
+        )
+        .await;
+        let second_bg_task = register_test_background_task(
+            &coordinator,
+            "parent-1",
+            "parent-turn-2",
+            "subagent-session-1",
+        )
+        .await;
+        assert_eq!(first_bg_task.bg_task_id, "a1_bg1");
+        assert_eq!(second_bg_task.bg_task_id, "a1_bg2");
+
+        let custom = coordinator
+            .background_subagent_outcomes
+            .register(BackgroundTaskRegistration {
+                parent_session_id: "parent-1".to_string(),
+                requested_agent_id: Some("reviewer".to_string()),
+                child_session_id: "reviewer-session".to_string(),
+                parent_dialog_turn_id: "parent-turn-3".to_string(),
+                parent_tool_call_id: "tool-reviewer".to_string(),
+                child_dialog_turn_id: "turn-reviewer".to_string(),
+            })
+            .await
+            .expect("register caller-named agent");
+        assert_eq!(custom.agent_id, "reviewer");
+        assert_eq!(custom.bg_task_id, "reviewer_bg1");
+        assert_eq!(
+            coordinator
+                .resolve_agent_id("parent-1", "reviewer")
+                .await
+                .expect("resolve caller-named agent"),
+            "reviewer-session"
+        );
+    }
+
+    #[tokio::test]
     async fn agent_wait_without_task_ids_collects_unconsumed_session_outcomes() {
         let (coordinator, _) = test_coordinator();
-        let background_task_id = "background-task-earlier-turn".to_string();
-        coordinator
-            .background_subagent_outcomes
-            .register(BackgroundSubagentOutcome::running(
-                background_task_id.clone(),
-                "parent-session".to_string(),
-                "earlier-parent-turn".to_string(),
-                "subagent-session".to_string(),
-                "subagent-turn".to_string(),
-                "GeneralPurpose".to_string(),
-                "Inspect implementation".to_string(),
-            ))
-            .await
-            .expect("register outcome");
+        let registered = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "earlier-parent-turn",
+            "subagent-session",
+        )
+        .await;
         let completed = super::SubagentResult::completed("done".to_string());
         coordinator
             .background_subagent_outcomes
-            .complete(&background_task_id, Ok(&completed))
+            .complete(registered.task_pk, Ok(&completed))
             .await;
 
         let result = coordinator
@@ -8932,6 +9087,7 @@ mod tests {
                 &[],
                 BackgroundSubagentWaitMode::Any,
                 Duration::from_millis(10),
+                "wait-turn",
                 None,
             )
             .await
@@ -8939,34 +9095,31 @@ mod tests {
 
         assert_eq!(result.status.as_str(), "completed");
         assert_eq!(result.outcomes.len(), 1);
-        assert_eq!(result.outcomes[0].background_task_id, background_task_id);
-        assert!(result.pending_background_task_ids.is_empty());
+        assert_eq!(result.outcomes[0].bg_task_id, registered.bg_task_id);
+        assert!(result.pending_bg_task_ids.is_empty());
     }
 
     #[tokio::test]
     async fn agent_wait_all_times_out_with_returned_partial_results() {
         let (coordinator, _) = test_coordinator();
-        let completed_task_id = "background-task-completed".to_string();
-        let pending_task_id = "background-task-pending".to_string();
-        for background_task_id in [&completed_task_id, &pending_task_id] {
-            coordinator
-                .background_subagent_outcomes
-                .register(BackgroundSubagentOutcome::running(
-                    background_task_id.clone(),
-                    "parent-session".to_string(),
-                    "parent-turn".to_string(),
-                    format!("subagent-session-{background_task_id}"),
-                    format!("subagent-turn-{background_task_id}"),
-                    "GeneralPurpose".to_string(),
-                    "Inspect implementation".to_string(),
-                ))
-                .await
-                .expect("register outcome");
-        }
+        let completed_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-completed",
+        )
+        .await;
+        let pending_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-pending",
+        )
+        .await;
         let completed = super::SubagentResult::completed("done".to_string());
         coordinator
             .background_subagent_outcomes
-            .complete(&completed_task_id, Ok(&completed))
+            .complete(completed_task.task_pk, Ok(&completed))
             .await;
 
         let result = coordinator
@@ -8975,6 +9128,7 @@ mod tests {
                 &[],
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(1),
+                "wait-turn-1",
                 None,
             )
             .await
@@ -8982,15 +9136,16 @@ mod tests {
 
         assert_eq!(result.status.as_str(), "timed_out");
         assert_eq!(result.outcomes.len(), 1);
-        assert_eq!(result.outcomes[0].background_task_id, completed_task_id);
-        assert_eq!(result.pending_background_task_ids, vec![pending_task_id]);
+        assert_eq!(result.outcomes[0].bg_task_id, completed_task.bg_task_id);
+        assert_eq!(result.pending_bg_task_ids, vec![pending_task.bg_task_id]);
 
         let retry = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                std::slice::from_ref(&completed_task_id),
+                std::slice::from_ref(&completed_task.bg_task_id),
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
+                "wait-turn-2",
                 None,
             )
             .await
@@ -9001,27 +9156,24 @@ mod tests {
     #[tokio::test]
     async fn agent_wait_any_returns_partial_results_after_debounce() {
         let (coordinator, _) = test_coordinator();
-        let completed_task_id = "background-task-completed".to_string();
-        let pending_task_id = "background-task-pending".to_string();
-        for background_task_id in [&completed_task_id, &pending_task_id] {
-            coordinator
-                .background_subagent_outcomes
-                .register(BackgroundSubagentOutcome::running(
-                    background_task_id.clone(),
-                    "parent-session".to_string(),
-                    "parent-turn".to_string(),
-                    format!("subagent-session-{background_task_id}"),
-                    format!("subagent-turn-{background_task_id}"),
-                    "GeneralPurpose".to_string(),
-                    "Inspect implementation".to_string(),
-                ))
-                .await
-                .expect("register outcome");
-        }
+        let completed_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-completed",
+        )
+        .await;
+        let pending_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-pending",
+        )
+        .await;
         let completed = super::SubagentResult::completed("done".to_string());
         coordinator
             .background_subagent_outcomes
-            .complete(&completed_task_id, Ok(&completed))
+            .complete(completed_task.task_pk, Ok(&completed))
             .await;
 
         let result = coordinator
@@ -9030,6 +9182,7 @@ mod tests {
                 &[],
                 BackgroundSubagentWaitMode::Any,
                 Duration::from_secs(6),
+                "wait-turn",
                 None,
             )
             .await
@@ -9037,45 +9190,46 @@ mod tests {
 
         assert_eq!(result.status.as_str(), "completed");
         assert_eq!(result.outcomes.len(), 1);
-        assert_eq!(result.outcomes[0].background_task_id, completed_task_id);
-        assert_eq!(result.pending_background_task_ids, vec![pending_task_id]);
+        assert_eq!(result.outcomes[0].bg_task_id, completed_task.bg_task_id);
+        assert_eq!(result.pending_bg_task_ids, vec![pending_task.bg_task_id]);
     }
 
     #[tokio::test]
     async fn cancelled_agent_wait_keeps_collected_outcomes_available() {
         let (coordinator, _) = test_coordinator();
-        let completed_task_id = "background-task-completed".to_string();
-        let pending_task_id = "background-task-pending".to_string();
-        for background_task_id in [&completed_task_id, &pending_task_id] {
-            coordinator
-                .background_subagent_outcomes
-                .register(BackgroundSubagentOutcome::running(
-                    background_task_id.clone(),
-                    "parent-session".to_string(),
-                    "parent-turn".to_string(),
-                    format!("subagent-session-{background_task_id}"),
-                    format!("subagent-turn-{background_task_id}"),
-                    "GeneralPurpose".to_string(),
-                    "Inspect implementation".to_string(),
-                ))
-                .await
-                .expect("register outcome");
-        }
+        let completed_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-completed",
+        )
+        .await;
+        let pending_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-pending",
+        )
+        .await;
         let completed = super::SubagentResult::completed("done".to_string());
         coordinator
             .background_subagent_outcomes
-            .complete(&completed_task_id, Ok(&completed))
+            .complete(completed_task.task_pk, Ok(&completed))
             .await;
 
         let cancellation = tokio_util::sync::CancellationToken::new();
         cancellation.cancel();
-        let requested_task_ids = vec![completed_task_id.clone(), pending_task_id];
+        let requested_task_ids = vec![
+            completed_task.bg_task_id.clone(),
+            pending_task.bg_task_id.clone(),
+        ];
         let error = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
                 &requested_task_ids,
                 BackgroundSubagentWaitMode::All,
                 Duration::from_secs(10),
+                "cancelled-wait-turn",
                 Some(&cancellation),
             )
             .await
@@ -9085,42 +9239,37 @@ mod tests {
         let retry = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                std::slice::from_ref(&completed_task_id),
+                std::slice::from_ref(&completed_task.bg_task_id),
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
+                "retry-wait-turn",
                 None,
             )
             .await
             .expect("a cancelled wait must not consume the completed outcome");
 
         assert_eq!(retry.outcomes.len(), 1);
-        assert_eq!(retry.outcomes[0].background_task_id, completed_task_id);
+        assert_eq!(retry.outcomes[0].bg_task_id, completed_task.bg_task_id);
     }
 
     #[tokio::test]
     async fn agent_wait_timeout_keeps_background_outcome_pending_without_follow_up() {
         let (coordinator, _) = test_coordinator();
-        let background_task_id = "background-task-timeout".to_string();
-        coordinator
-            .background_subagent_outcomes
-            .register(BackgroundSubagentOutcome::running(
-                background_task_id.clone(),
-                "parent-session".to_string(),
-                "parent-turn".to_string(),
-                "subagent-session".to_string(),
-                "subagent-turn".to_string(),
-                "GeneralPurpose".to_string(),
-                "Inspect implementation".to_string(),
-            ))
-            .await
-            .expect("register outcome");
+        let registered = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session",
+        )
+        .await;
 
         let result = coordinator
             .wait_for_background_subagent_outcomes(
                 "parent-session",
-                std::slice::from_ref(&background_task_id),
+                std::slice::from_ref(&registered.bg_task_id),
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(1),
+                "wait-turn",
                 None,
             )
             .await
@@ -9128,7 +9277,7 @@ mod tests {
 
         assert_eq!(result.status.as_str(), "timed_out");
         assert!(result.outcomes.is_empty());
-        assert_eq!(result.pending_background_task_ids, vec![background_task_id]);
+        assert_eq!(result.pending_bg_task_ids, vec![registered.bg_task_id]);
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/mod.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/mod.rs
@@ -3,6 +3,7 @@
 //! Top-level component that integrates all subsystems
 
 mod background_outcomes;
+mod coordination_store;
 pub mod coordinator;
 pub mod scheduler;
 pub mod state_manager;

--- a/src/crates/assembly/core/src/agentic/coordination/mod.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/mod.rs
@@ -15,7 +15,8 @@ pub use state_manager::*;
 pub use turn_outcome::*;
 
 pub(crate) use background_outcomes::{
-    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitResult,
+    BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitMode,
+    BackgroundSubagentWaitResult,
 };
 
 pub use coordinator::get_global_coordinator;

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -43,14 +43,14 @@ use uuid::Uuid;
 
 use bitfun_agent_runtime::scheduler::{
     build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
-    is_background_result_injection, resolve_agent_session_reply_action,
-    resolve_background_delivery_action, resolve_background_delivery_injection,
-    resolve_background_delivery_injection_for_turn, resolve_dialog_start_route,
-    resolve_dialog_steering_action, resolve_turn_outcome_lifecycle_plan, ActiveDialogTurn,
-    ActiveDialogTurnStore, ActiveDialogTurnTakeResult, AgentSessionReplyAction,
-    AgentSessionReplyPlan, BackgroundDeliveryAction, BackgroundDeliveryFacts,
-    BackgroundInjectionKind, DialogReplySuppressionSet, DialogStartRoute, DialogStartRouteFacts,
-    DialogSteeringAction, DialogTurnQueue, GoalContinuationAfterTurnAction, SessionAbortFlags,
+    resolve_agent_session_reply_action, resolve_background_delivery_action,
+    resolve_background_delivery_injection, resolve_background_delivery_injection_for_turn,
+    resolve_dialog_start_route, resolve_dialog_steering_action,
+    resolve_turn_outcome_lifecycle_plan, ActiveDialogTurn, ActiveDialogTurnStore,
+    ActiveDialogTurnTakeResult, AgentSessionReplyAction, AgentSessionReplyPlan,
+    BackgroundDeliveryAction, BackgroundDeliveryFacts, BackgroundInjectionKind,
+    DialogReplySuppressionSet, DialogStartRoute, DialogStartRouteFacts, DialogSteeringAction,
+    DialogTurnQueue, GoalContinuationAfterTurnAction, SessionAbortFlags,
     ThreadGoalDeliveryReminder, ThreadGoalDeliveryReminderKind, TurnOutcomeQueueAction,
     TurnOutcomeStatus,
 };
@@ -109,41 +109,6 @@ fn remove_queued_turn_by_id(
     turn_id: &str,
 ) -> Option<QueuedTurn> {
     queues.remove_first_matching(session_id, |turn| turn.turn_id.as_deref() == Some(turn_id))
-}
-
-fn background_task_id_from_metadata(metadata: Option<&serde_json::Value>) -> Option<&str> {
-    let metadata = metadata.and_then(serde_json::Value::as_object)?;
-    (metadata.get("kind").and_then(serde_json::Value::as_str) == Some("background_result")
-        && metadata
-            .get("sourceKind")
-            .and_then(serde_json::Value::as_str)
-            == Some("subagent"))
-    .then(|| {
-        metadata
-            .get("backgroundTaskId")
-            .and_then(serde_json::Value::as_str)
-    })
-    .flatten()
-}
-
-fn background_result_injection_id(background_task_id: Option<String>) -> String {
-    background_task_id.unwrap_or_else(|| Uuid::new_v4().to_string())
-}
-
-fn remove_queued_background_result_by_task_id(
-    queues: &DialogTurnQueue<QueuedTurn>,
-    session_id: &str,
-    background_task_id: &str,
-) -> Option<QueuedTurn> {
-    queues.remove_first_matching(session_id, |turn| {
-        queued_background_task_id(turn) == Some(background_task_id)
-    })
-}
-
-fn queued_background_task_id(turn: &QueuedTurn) -> Option<&str> {
-    (turn.policy.trigger_source == DialogTriggerSource::AgentSession)
-        .then(|| background_task_id_from_metadata(turn.user_message_metadata.as_ref()))
-        .flatten()
 }
 
 #[derive(Debug)]
@@ -284,7 +249,7 @@ enum ActiveInternalTurn {
 }
 
 #[derive(Clone)]
-struct PendingBackgroundResultDelivery {
+struct BackgroundResultDelivery {
     session_id: String,
     agent_type: String,
     workspace_path: Option<String>,
@@ -297,8 +262,6 @@ struct PendingBackgroundResultDelivery {
 
 struct SchedulerRoundInjectionSource {
     buffer: Arc<SessionRoundInjectionBuffer>,
-    coordinator: Arc<ConversationCoordinator>,
-    pending_background_results: Arc<dashmap::DashMap<String, PendingBackgroundResultDelivery>>,
 }
 
 impl DialogRoundInjectionSource for SchedulerRoundInjectionSource {
@@ -316,45 +279,16 @@ impl DialogRoundInjectionSource for SchedulerRoundInjectionSource {
     }
 
     fn take_pending(&self, session_id: &str, turn_id: &str) -> Vec<RoundInjection> {
-        self.buffer
-            .drain_for_turn(session_id, turn_id)
-            .into_iter()
-            .filter(|injection| {
-                if !is_background_result_injection(injection.kind)
-                    || !self.pending_background_results.contains_key(&injection.id)
-                {
-                    return true;
-                }
-                if self
-                    .coordinator
-                    .claim_background_subagent_control_for_injection(&injection.id)
-                {
-                    return true;
-                }
-                self.pending_background_results.remove(&injection.id);
-                self.coordinator
-                    .finish_background_subagent_delivery(&injection.id);
-                false
-            })
-            .collect()
+        self.buffer.drain_for_turn(session_id, turn_id)
     }
 
     fn acknowledge_consumed(
         &self,
         _session_id: &str,
         _turn_id: &str,
-        injection_id: &str,
-        kind: RoundInjectionKind,
+        _injection_id: &str,
+        _kind: RoundInjectionKind,
     ) {
-        if is_background_result_injection(kind)
-            && self
-                .pending_background_results
-                .remove(injection_id)
-                .is_some()
-        {
-            self.coordinator
-                .finish_background_subagent_delivery(injection_id);
-        }
     }
 }
 
@@ -391,13 +325,10 @@ pub struct DialogScheduler {
     /// by the engine and injected into the running dialog turn.
     round_injection_buffer: Arc<SessionRoundInjectionBuffer>,
     round_injection_source: Arc<SchedulerRoundInjectionSource>,
-    pending_background_results: Arc<dashmap::DashMap<String, PendingBackgroundResultDelivery>>,
     /// Child sessions already cancelled for a parent maintenance attempt but
     /// not yet observed as drained. Retain them across retryable timeouts even
     /// after their one-shot cancellation controls have been claimed.
     maintenance_background_sessions: Arc<dashmap::DashMap<String, HashSet<String>>>,
-    #[cfg(test)]
-    background_delivery_before_lock: std::sync::Mutex<Option<oneshot::Sender<()>>>,
 }
 
 /// Holds the scheduler's exclusive session-operation boundary while a caller
@@ -448,11 +379,8 @@ impl DialogScheduler {
     ) -> Arc<Self> {
         let (outcome_tx, outcome_rx) = mpsc::channel(128);
         let round_injection_buffer = Arc::new(SessionRoundInjectionBuffer::default());
-        let pending_background_results = Arc::new(dashmap::DashMap::new());
         let round_injection_source = Arc::new(SchedulerRoundInjectionSource {
             buffer: round_injection_buffer.clone(),
-            coordinator: coordinator.clone(),
-            pending_background_results: pending_background_results.clone(),
         });
 
         let scheduler = Arc::new(Self {
@@ -468,10 +396,7 @@ impl DialogScheduler {
             outcome_tx,
             round_injection_buffer,
             round_injection_source,
-            pending_background_results,
             maintenance_background_sessions: Arc::new(dashmap::DashMap::new()),
-            #[cfg(test)]
-            background_delivery_before_lock: std::sync::Mutex::new(None),
         });
 
         let scheduler_for_handler = Arc::clone(&scheduler);
@@ -494,40 +419,6 @@ impl DialogScheduler {
     /// Pass to [`ConversationCoordinator::set_round_injection_source`](super::coordinator::ConversationCoordinator::set_round_injection_source).
     pub fn round_injection_monitor(&self) -> Arc<dyn DialogRoundInjectionSource> {
         self.round_injection_source.clone()
-    }
-
-    #[cfg(test)]
-    fn install_background_delivery_before_lock_signal(&self) -> oneshot::Receiver<()> {
-        let (tx, rx) = oneshot::channel();
-        *self
-            .background_delivery_before_lock
-            .lock()
-            .expect("background delivery test hook") = Some(tx);
-        rx
-    }
-
-    #[cfg(test)]
-    fn signal_background_delivery_before_lock(&self) {
-        if let Some(tx) = self
-            .background_delivery_before_lock
-            .lock()
-            .expect("background delivery test hook")
-            .take()
-        {
-            let _ = tx.send(());
-        }
-    }
-
-    pub(crate) fn active_turn_requires_tool_confirmation(
-        &self,
-        session_id: &str,
-        turn_id: &str,
-    ) -> bool {
-        self.active_turns.user_message_metadata_bool_for_turn(
-            session_id,
-            turn_id,
-            "require_tool_confirmation",
-        ) == Some(true)
     }
 
     /// Submit a user "steering" message into the currently running dialog turn.
@@ -729,23 +620,9 @@ impl DialogScheduler {
         display_content: Option<String>,
         user_message_metadata: Option<serde_json::Value>,
     ) -> Result<(), String> {
-        #[cfg(test)]
-        self.signal_background_delivery_before_lock();
         let _operation_guard = self.lock_session_operation(&session_id).await;
-        let background_task_id =
-            background_task_id_from_metadata(user_message_metadata.as_ref()).map(str::to_string);
-        if background_task_id
-            .as_deref()
-            .is_some_and(|background_task_id| {
-                self.coordinator
-                    .take_background_subagent_delivery_suppression(background_task_id)
-            })
-        {
-            return Ok(());
-        }
-
         let display = display_content.unwrap_or_else(|| content.clone());
-        let delivery = PendingBackgroundResultDelivery {
+        let delivery = BackgroundResultDelivery {
             session_id: session_id.clone(),
             agent_type,
             workspace_path,
@@ -768,17 +645,6 @@ impl DialogScheduler {
             ),
         }) {
             BackgroundDeliveryAction::InjectIntoRunningTurn => {
-                if background_task_id.as_deref().is_some_and(|task_id| {
-                    !self
-                        .coordinator
-                        .background_subagent_control_available_for_injection(task_id)
-                }) {
-                    if let Some(task_id) = background_task_id.as_deref() {
-                        self.coordinator
-                            .take_background_subagent_delivery_suppression(task_id);
-                    }
-                    return Ok(());
-                }
                 let Some(current_turn_id) = state.as_ref().and_then(|state| match state {
                     SessionState::Processing {
                         current_turn_id, ..
@@ -789,7 +655,7 @@ impl DialogScheduler {
                         "Background result resolved to injection without an active turn: session_id={session_id}"
                     ));
                 };
-                let injection_id = background_result_injection_id(background_task_id.clone());
+                let injection_id = Uuid::new_v4().to_string();
                 let injection = resolve_background_delivery_injection_for_turn(
                     BackgroundInjectionKind::BackgroundResult,
                     injection_id.clone(),
@@ -798,10 +664,6 @@ impl DialogScheduler {
                     SystemTime::now(),
                     current_turn_id,
                 );
-                if background_task_id.is_some() {
-                    self.pending_background_results
-                        .insert(injection_id, delivery);
-                }
                 self.round_injection_buffer.push(&session_id, injection);
                 Ok(())
             }
@@ -821,13 +683,10 @@ impl DialogScheduler {
 
     async fn submit_background_result_follow_up_locked(
         &self,
-        delivery: PendingBackgroundResultDelivery,
+        delivery: BackgroundResultDelivery,
         queue_priority: DialogQueuePriority,
         skip_tool_confirmation: bool,
     ) -> Result<(), String> {
-        let background_task_id =
-            background_task_id_from_metadata(delivery.user_message_metadata.as_ref())
-                .map(str::to_string);
         let resolved_turn_id = Uuid::new_v4().to_string();
         let queued_turn = QueuedTurn {
             user_input: delivery.content,
@@ -850,15 +709,6 @@ impl DialogScheduler {
             _settlement_registration: None,
             execution: QueuedTurnExecution::Standard,
         };
-        if background_task_id
-            .as_deref()
-            .is_some_and(|background_task_id| {
-                self.coordinator
-                    .take_background_subagent_delivery_suppression(background_task_id)
-            })
-        {
-            return Ok(());
-        }
         let result = self
             .submit_queued_turn_locked(
                 delivery.session_id.clone(),
@@ -873,9 +723,6 @@ impl DialogScheduler {
             {
                 self.finish_removed_queued_turn(&delivery.session_id, removed_turn)
                     .await;
-            } else if let Some(background_task_id) = background_task_id.as_deref() {
-                self.coordinator
-                    .finish_background_subagent_delivery(background_task_id);
             }
         }
         result.map(|_| ()).map_err(|error| error.to_string())
@@ -1279,7 +1126,6 @@ impl DialogScheduler {
     }
 
     async fn finish_removed_queued_turn(&self, session_id: &str, removed_turn: QueuedTurn) {
-        let background_task_id = queued_background_task_id(&removed_turn).map(str::to_string);
         match removed_turn.execution {
             QueuedTurnExecution::Standard => {
                 if let Some(turn_id) = removed_turn.turn_id {
@@ -1303,125 +1149,6 @@ impl DialogScheduler {
                 )));
             }
         }
-        if let Some(background_task_id) = background_task_id.as_deref() {
-            self.coordinator
-                .finish_background_subagent_delivery(background_task_id);
-        }
-    }
-
-    fn discard_drained_background_results(&self, drained: Vec<RoundInjection>) {
-        for injection in drained {
-            if !is_background_result_injection(injection.kind) {
-                continue;
-            }
-            if self
-                .pending_background_results
-                .remove(&injection.id)
-                .is_some()
-            {
-                self.coordinator
-                    .finish_background_subagent_delivery(&injection.id);
-            }
-        }
-    }
-
-    async fn recover_drained_background_results(
-        &self,
-        status: TurnOutcomeStatus,
-        drained: Vec<RoundInjection>,
-    ) {
-        for injection in drained {
-            if !is_background_result_injection(injection.kind) {
-                continue;
-            }
-            let Some((background_task_id, delivery)) =
-                self.pending_background_results.remove(&injection.id)
-            else {
-                continue;
-            };
-            if status == TurnOutcomeStatus::Cancelled {
-                self.coordinator
-                    .finish_background_subagent_delivery(&background_task_id);
-                continue;
-            }
-            let policy = DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession);
-            let _operation_guard = self.lock_session_operation(&delivery.session_id).await;
-            let result = self
-                .submit_background_result_follow_up_locked(
-                    delivery.clone(),
-                    policy.queue_priority,
-                    policy.skip_tool_confirmation,
-                )
-                .await;
-            if let Err(error) = result {
-                self.coordinator
-                    .finish_background_subagent_delivery(&background_task_id);
-                warn!(
-                    "Failed to recover an unconsumed background result after turn {}: background_task_id={}, session_id={}, error={}",
-                    status, background_task_id, delivery.session_id, error
-                );
-            }
-        }
-    }
-
-    pub(crate) async fn cancel_background_result_delivery(
-        &self,
-        session_id: &str,
-        background_task_id: &str,
-    ) -> Result<bool, String> {
-        let _operation_guard = self.lock_session_operation(session_id).await;
-        let pending_matches_session = self
-            .pending_background_results
-            .get(background_task_id)
-            .is_some_and(|delivery| delivery.session_id == session_id);
-        if pending_matches_session
-            && self
-                .round_injection_buffer
-                .remove_by_id(session_id, background_task_id)
-                .is_some()
-        {
-            self.pending_background_results.remove(background_task_id);
-            self.coordinator
-                .finish_background_subagent_delivery(background_task_id);
-            return Ok(true);
-        }
-        if let Some(removed_turn) =
-            remove_queued_background_result_by_task_id(&self.queues, session_id, background_task_id)
-        {
-            self.finish_removed_queued_turn(session_id, removed_turn)
-                .await;
-            return Ok(true);
-        }
-
-        let Some(turn_id) = self
-            .active_turns
-            .turn_id_for_background_subagent_delivery(session_id, background_task_id)
-        else {
-            return Ok(false);
-        };
-        self.coordinator
-            .cancel_dialog_turn(session_id, &turn_id)
-            .await?;
-        Ok(true)
-    }
-
-    pub(crate) async fn cancel_background_result_deliveries(
-        &self,
-        session_id: &str,
-        background_task_ids: &[String],
-    ) -> Result<(), String> {
-        let mut first_error = None;
-        for background_task_id in background_task_ids {
-            if let Err(error) = self
-                .cancel_background_result_delivery(session_id, background_task_id)
-                .await
-            {
-                if first_error.is_none() {
-                    first_error = Some(error);
-                }
-            }
-        }
-        first_error.map_or(Ok(()), Err)
     }
 
     /// Cancel one queued or active turn without allowing it to cross the
@@ -1606,17 +1333,11 @@ impl DialogScheduler {
         let Some(active_turn) = self.active_turns.remove(session_id) else {
             return;
         };
-        if let Some(background_task_id) = active_turn.background_subagent_task_id() {
-            self.coordinator
-                .finish_background_subagent_delivery(background_task_id);
-        }
         let turn_id = active_turn.turn_id().to_string();
         self.retired_maintenance_outcomes.mark(session_id, &turn_id);
         self.active_internal_turns.remove(session_id);
-        let drained = self
-            .round_injection_buffer
+        self.round_injection_buffer
             .drain_for_turn(session_id, &turn_id);
-        self.discard_drained_background_results(drained);
         self.take_suppressed_cancelled_reply(session_id, &turn_id);
         debug!(
             "Retired active turn before destructive session maintenance: session_id={}, turn_id={}",
@@ -1651,7 +1372,6 @@ impl DialogScheduler {
         let cleared_turns = self.queues.clear(session_id);
         let count = cleared_turns.len();
         for queued_turn in cleared_turns {
-            let background_task_id = queued_background_task_id(&queued_turn).map(str::to_string);
             match queued_turn.execution {
                 QueuedTurnExecution::Standard => {
                     if let Some(turn_id) = queued_turn.turn_id {
@@ -1681,10 +1401,6 @@ impl DialogScheduler {
                         )));
                     });
                 }
-            }
-            if let Some(background_task_id) = background_task_id.as_deref() {
-                self.coordinator
-                    .finish_background_subagent_delivery(background_task_id);
             }
         }
         if count > 0 {
@@ -2073,10 +1789,8 @@ impl DialogScheduler {
                     &session_id,
                     outcome.turn_id(),
                 ) else {
-                    let drained = self
-                        .round_injection_buffer
+                    self.round_injection_buffer
                         .drain_for_turn(&session_id, outcome.turn_id());
-                    self.discard_drained_background_results(drained);
                     self.take_suppressed_cancelled_reply(&session_id, outcome.turn_id());
                     debug!(
                         "Ignoring outcome retired by session deletion: session_id={}, turn_id={}",
@@ -2089,10 +1803,8 @@ impl DialogScheduler {
                     ActiveDialogTurnTakeResult::Matched(turn) => Some(turn),
                     ActiveDialogTurnTakeResult::Absent => None,
                     ActiveDialogTurnTakeResult::DifferentTurn => {
-                        let drained = self
-                            .round_injection_buffer
+                        self.round_injection_buffer
                             .drain_for_turn(&session_id, outcome.turn_id());
-                        self.discard_drained_background_results(drained);
                         self.take_suppressed_cancelled_reply(&session_id, outcome.turn_id());
                         debug!(
                             "Ignoring stale turn outcome: session_id={}, turn_id={}",
@@ -2102,13 +1814,6 @@ impl DialogScheduler {
                         continue;
                     }
                 };
-                if let Some(background_task_id) = active_turn
-                    .as_ref()
-                    .and_then(ActiveDialogTurn::background_subagent_task_id)
-                {
-                    self.coordinator
-                        .finish_background_subagent_delivery(background_task_id);
-                }
                 let active_internal_turn = active_turn.as_ref().and_then(|_| {
                     self.active_internal_turns
                         .remove(&session_id)
@@ -2134,11 +1839,8 @@ impl DialogScheduler {
             // outcome is processed (race window between turn finalize and the
             // next turn starting). Targeting by turn_id keeps those alive.
             if lifecycle_plan.drain_finished_turn_injections {
-                let drained = self
-                    .round_injection_buffer
+                self.round_injection_buffer
                     .drain_for_turn(&session_id, outcome.turn_id());
-                self.recover_drained_background_results(status, drained)
-                    .await;
             }
             let suppressed_cancelled_reply =
                 self.take_suppressed_cancelled_reply(&session_id, outcome.turn_id());
@@ -2758,6 +2460,62 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn background_bash_result_injects_into_its_running_parent_turn() {
+        let (scheduler, session_manager, _, root) = test_scheduler();
+        let session_id = "parent-session";
+        let turn_id = "parent-turn";
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        session_manager
+            .create_session_with_id(
+                Some(session_id.to_string()),
+                "Parent".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create parent session");
+        session_manager
+            .update_session_state(
+                session_id,
+                SessionState::Processing {
+                    current_turn_id: turn_id.to_string(),
+                    phase: ProcessingPhase::Thinking,
+                },
+            )
+            .await
+            .expect("mark parent turn active");
+
+        scheduler
+            .deliver_background_result(
+                session_id.to_string(),
+                "agentic".to_string(),
+                None,
+                None,
+                None,
+                "Background Bash command completed".to_string(),
+                None,
+                Some(serde_json::json!({
+                    "kind": "background_result",
+                    "sourceKind": "bash_command",
+                    "parentSessionId": session_id,
+                    "parentDialogTurnId": turn_id,
+                })),
+            )
+            .await
+            .expect("inject background Bash result");
+
+        let pending = scheduler
+            .round_injection_monitor()
+            .take_pending(session_id, turn_id);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(scheduler.queue_depth(session_id), 0);
+    }
+
     fn standard_queued_turn(turn_id: &str) -> QueuedTurn {
         QueuedTurn {
             user_input: "queued".to_string(),
@@ -2892,408 +2650,6 @@ mod tests {
         assert!(!scheduler
             .maintenance_background_sessions
             .contains_key(parent_session_id));
-    }
-
-    #[tokio::test]
-    async fn background_delivery_rechecks_suppression_after_waiting_for_session_lock() {
-        let (scheduler, _, event_queue, _root) = test_scheduler();
-        let mut events = event_queue.subscribe();
-        let operation_guard = scheduler.lock_session_operation("parent-session").await;
-        let delivery_reached_lock = scheduler.install_background_delivery_before_lock_signal();
-        let delivery_scheduler = scheduler.clone();
-        let delivery = tokio::spawn(async move {
-            delivery_scheduler
-                .deliver_background_result(
-                    "parent-session".to_string(),
-                    "agentic".to_string(),
-                    None,
-                    None,
-                    None,
-                    "background result".to_string(),
-                    None,
-                    Some(serde_json::json!({
-                        "kind": "background_result",
-                        "sourceKind": "subagent",
-                        "backgroundTaskId": "background-task",
-                    })),
-                )
-                .await
-        });
-        delivery_reached_lock
-            .await
-            .expect("delivery should reach the session lock");
-        scheduler
-            .coordinator
-            .mark_background_subagent_delivery_suppression("background-task".to_string());
-
-        drop(operation_guard);
-        delivery
-            .await
-            .expect("delivery task")
-            .expect("suppressed delivery");
-
-        assert_eq!(scheduler.queue_depth("parent-session"), 0);
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), events.recv())
-                .await
-                .is_err()
-        );
-        assert!(!scheduler
-            .coordinator
-            .take_background_subagent_delivery_suppression("background-task"));
-    }
-
-    #[tokio::test]
-    async fn background_injection_claims_control_only_when_the_turn_consumes_it() {
-        let (scheduler, session_manager, _, root) = test_scheduler();
-        let session_id = "parent-session";
-        let workspace = root.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("workspace");
-        session_manager
-            .create_session_with_id(
-                Some(session_id.to_string()),
-                "Parent".to_string(),
-                "agentic".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace.to_string_lossy().to_string()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("create parent session");
-        session_manager
-            .update_session_state(
-                session_id,
-                SessionState::Processing {
-                    current_turn_id: "peer-turn".to_string(),
-                    phase: ProcessingPhase::Thinking,
-                },
-            )
-            .await
-            .expect("mark peer turn active");
-        scheduler
-            .coordinator
-            .register_background_subagent_task_for_test(
-                "background-task",
-                session_id,
-                "subagent-session",
-            );
-
-        scheduler
-            .deliver_background_result(
-                session_id.to_string(),
-                "agentic".to_string(),
-                None,
-                None,
-                None,
-                "background result".to_string(),
-                None,
-                Some(serde_json::json!({
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "background-task",
-                    "parentSessionId": session_id,
-                    "parentDialogTurnId": "peer-turn",
-                })),
-            )
-            .await
-            .expect("buffer background delivery");
-
-        assert!(scheduler
-            .coordinator
-            .has_background_subagent_task_for_test("background-task"));
-        assert!(scheduler
-            .pending_background_results
-            .contains_key("background-task"));
-
-        let source = scheduler.round_injection_monitor();
-        let pending = source.take_pending(session_id, "peer-turn");
-        assert_eq!(pending.len(), 1);
-        assert!(!scheduler
-            .coordinator
-            .has_background_subagent_task_for_test("background-task"));
-        assert!(scheduler
-            .pending_background_results
-            .contains_key("background-task"));
-
-        source.acknowledge_consumed(session_id, "peer-turn", "background-task", pending[0].kind);
-        assert!(!scheduler
-            .pending_background_results
-            .contains_key("background-task"));
-    }
-
-    #[tokio::test]
-    async fn cancellation_removes_a_pending_background_injection_without_recovery() {
-        let (scheduler, _, _, _root) = test_scheduler();
-        let session_id = "parent-session";
-        scheduler
-            .coordinator
-            .register_background_subagent_task_for_test(
-                "background-task",
-                session_id,
-                "subagent-session",
-            );
-        scheduler.pending_background_results.insert(
-            "background-task".to_string(),
-            PendingBackgroundResultDelivery {
-                session_id: session_id.to_string(),
-                agent_type: "agentic".to_string(),
-                workspace_path: None,
-                remote_connection_id: None,
-                remote_ssh_host: None,
-                content: "background result".to_string(),
-                display_content: Some("background result".to_string()),
-                user_message_metadata: Some(serde_json::json!({
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "background-task",
-                })),
-            },
-        );
-        let injection = resolve_background_delivery_injection_for_turn(
-            BackgroundInjectionKind::BackgroundResult,
-            "background-task".to_string(),
-            "background result".to_string(),
-            None,
-            SystemTime::now(),
-            "peer-turn".to_string(),
-        );
-        scheduler.round_injection_buffer.push(session_id, injection);
-        assert!(scheduler
-            .coordinator
-            .suppress_background_subagent_task_for_test("background-task"));
-
-        assert!(scheduler
-            .cancel_background_result_delivery(session_id, "background-task")
-            .await
-            .expect("cancel pending injection"));
-
-        assert_eq!(
-            scheduler.round_injection_buffer.pending_count(session_id),
-            0
-        );
-        assert!(!scheduler
-            .pending_background_results
-            .contains_key("background-task"));
-        assert!(!scheduler
-            .coordinator
-            .take_background_subagent_delivery_suppression("background-task"));
-    }
-
-    #[tokio::test]
-    async fn finished_turn_recovers_an_unconsumed_background_result_as_a_follow_up() {
-        let (scheduler, session_manager, _, root) = test_scheduler();
-        let session_id = "parent-session";
-        let workspace = root.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("workspace");
-        session_manager
-            .create_session_with_id(
-                Some(session_id.to_string()),
-                "Parent".to_string(),
-                "agentic".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace.to_string_lossy().to_string()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("create parent session");
-        session_manager
-            .update_session_state(
-                session_id,
-                SessionState::Processing {
-                    current_turn_id: "peer-turn".to_string(),
-                    phase: ProcessingPhase::Thinking,
-                },
-            )
-            .await
-            .expect("mark peer turn active");
-        scheduler
-            .coordinator
-            .register_background_subagent_task_for_test(
-                "background-task",
-                session_id,
-                "subagent-session",
-            );
-        scheduler
-            .deliver_background_result(
-                session_id.to_string(),
-                "agentic".to_string(),
-                None,
-                None,
-                None,
-                "background result".to_string(),
-                None,
-                Some(serde_json::json!({
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "background-task",
-                    "parentSessionId": session_id,
-                    "parentDialogTurnId": "peer-turn",
-                })),
-            )
-            .await
-            .expect("buffer background delivery");
-
-        let drained = scheduler
-            .round_injection_buffer
-            .drain_for_turn(session_id, "peer-turn");
-        session_manager
-            .update_session_state(
-                session_id,
-                SessionState::Processing {
-                    current_turn_id: "next-turn".to_string(),
-                    phase: ProcessingPhase::Thinking,
-                },
-            )
-            .await
-            .expect("mark next turn active");
-        scheduler
-            .recover_drained_background_results(TurnOutcomeStatus::Completed, drained)
-            .await;
-
-        assert_eq!(
-            scheduler.round_injection_buffer.pending_count(session_id),
-            0
-        );
-        assert!(!scheduler
-            .pending_background_results
-            .contains_key("background-task"));
-        assert_eq!(scheduler.queue_depth(session_id), 1);
-        assert!(scheduler
-            .coordinator
-            .has_background_subagent_task_for_test("background-task"));
-        assert!(remove_queued_background_result_by_task_id(
-            &scheduler.queues,
-            session_id,
-            "background-task"
-        )
-        .is_some());
-    }
-
-    #[tokio::test]
-    async fn background_delivery_queues_behind_an_unrelated_running_turn() {
-        let (scheduler, session_manager, _, root) = test_scheduler();
-        let session_id = "parent-session";
-        let workspace = root.path().join("workspace");
-        std::fs::create_dir_all(&workspace).expect("workspace");
-        session_manager
-            .create_session_with_id(
-                Some(session_id.to_string()),
-                "Parent".to_string(),
-                "agentic".to_string(),
-                SessionConfig {
-                    workspace_path: Some(workspace.to_string_lossy().to_string()),
-                    ..Default::default()
-                },
-            )
-            .await
-            .expect("create parent session");
-        session_manager
-            .update_session_state(
-                session_id,
-                SessionState::Processing {
-                    current_turn_id: "local-turn".to_string(),
-                    phase: ProcessingPhase::Thinking,
-                },
-            )
-            .await
-            .expect("mark unrelated turn active");
-        let mut spoofed_user_turn = standard_queued_turn("ordinary-turn");
-        spoofed_user_turn.policy = DialogSubmissionPolicy::new(
-            DialogTriggerSource::DesktopUi,
-            DialogQueuePriority::High,
-            false,
-        );
-        spoofed_user_turn.user_message_metadata = Some(serde_json::json!({
-            "kind": "background_result",
-            "sourceKind": "subagent",
-            "backgroundTaskId": "background-task",
-        }));
-        scheduler
-            .queues
-            .enqueue(session_id, spoofed_user_turn, DialogQueuePriority::High)
-            .expect("queue ordinary user turn with colliding metadata");
-
-        scheduler
-            .deliver_background_result(
-                session_id.to_string(),
-                "agentic".to_string(),
-                None,
-                None,
-                None,
-                "background result".to_string(),
-                None,
-                Some(serde_json::json!({
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "background-task",
-                    "parentSessionId": session_id,
-                    "parentDialogTurnId": "peer-turn",
-                })),
-            )
-            .await
-            .expect("queue background delivery");
-
-        assert_eq!(
-            scheduler.round_injection_buffer.pending_count(session_id),
-            0
-        );
-        assert_eq!(scheduler.queue_depth(session_id), 2);
-        assert!(scheduler
-            .cancel_background_result_delivery(session_id, "background-task")
-            .await
-            .expect("cancel exact queued background delivery"));
-        assert_eq!(scheduler.queue_depth(session_id), 1);
-        assert!(remove_queued_turn_by_id(&scheduler.queues, session_id, "ordinary-turn").is_some());
-    }
-
-    #[tokio::test]
-    async fn background_delivery_batch_cancellation_attempts_later_ids_after_an_error() {
-        let (scheduler, _, _, _root) = test_scheduler();
-        let session_id = "missing-parent-session";
-        scheduler.active_turns.insert(
-            session_id,
-            ActiveDialogTurn::new(
-                "active-background-turn".to_string(),
-                Some("/workspace".to_string()),
-                None,
-                None,
-                "agentic".to_string(),
-                "background result".to_string(),
-                Some(serde_json::json!({
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "background-active",
-                })),
-                DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
-                None,
-            ),
-        );
-        let mut queued = standard_queued_turn("queued-background-turn");
-        queued.policy = DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession);
-        queued.user_message_metadata = Some(serde_json::json!({
-            "kind": "background_result",
-            "sourceKind": "subagent",
-            "backgroundTaskId": "background-queued",
-        }));
-        scheduler
-            .queues
-            .enqueue(session_id, queued, DialogQueuePriority::Normal)
-            .expect("queue later background delivery");
-
-        scheduler
-            .cancel_background_result_deliveries(
-                session_id,
-                &[
-                    "background-active".to_string(),
-                    "background-queued".to_string(),
-                ],
-            )
-            .await
-            .expect_err("the active cancellation should fail for a missing session");
-
-        assert_eq!(scheduler.queue_depth(session_id), 0);
     }
 
     #[test]
@@ -3678,14 +3034,6 @@ mod tests {
             .expect_err("missing settlement evidence must not be treated as success");
 
         assert!(matches!(error, BitFunError::Service(_)), "{error}");
-    }
-
-    #[test]
-    fn background_result_injection_preserves_the_exact_task_id() {
-        assert_eq!(
-            background_result_injection_id(Some("background-task".to_string())),
-            "background-task"
-        );
     }
 
     fn desktop_active_turn(turn_id: &str) -> ActiveDialogTurn {

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -2608,11 +2608,7 @@ mod tests {
             .expect("parent storage binding");
         scheduler
             .coordinator
-            .register_background_subagent_task_for_test(
-                "background-task",
-                parent_session_id,
-                child_session_id,
-            );
+            .register_background_subagent_task_for_test(1, parent_session_id, child_session_id);
         scheduler
             .coordinator
             .set_active_turn_count_for_test(child_session_id, 1);

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -51,7 +51,7 @@ use bitfun_services_core::session::{
 };
 use dashmap::{mapref::entry::Entry, DashMap};
 use log::{debug, error, info, warn};
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -811,6 +811,37 @@ impl SessionManager {
     async fn effective_session_storage_path(&self, session_id: &str) -> Option<PathBuf> {
         let config = self.sessions.get(session_id)?.config.clone();
         self.effective_storage_path_for_config(&config).await
+    }
+
+    pub(crate) fn path_manager(&self) -> Arc<crate::infrastructure::PathManager> {
+        self.persistence_manager.path_manager().clone()
+    }
+
+    pub(crate) async fn load_related_dialog_turn(
+        &self,
+        parent_session_id: &str,
+        related_session_id: &str,
+        dialog_turn_id: &str,
+    ) -> BitFunResult<Option<DialogTurnData>> {
+        let storage_path = self
+            .effective_session_storage_path(parent_session_id)
+            .await
+            .or_else(|| {
+                self.session_storage_path_index
+                    .get(parent_session_id)
+                    .map(|entry| entry.value().path.clone())
+            })
+            .ok_or_else(|| {
+                BitFunError::NotFound(format!(
+                    "Session storage path not found: {parent_session_id}"
+                ))
+            })?;
+        Ok(self
+            .persistence_manager
+            .load_session_turns(&storage_path, related_session_id)
+            .await?
+            .into_iter()
+            .find(|turn| turn.turn_id == dialog_turn_id))
     }
 
     pub async fn create_compression_transcript_reference(
@@ -4637,22 +4668,6 @@ impl SessionManager {
             merge_session_custom_metadata_value(metadata, patch)
         })
         .await
-    }
-
-    pub(crate) async fn load_session_custom_metadata(
-        &self,
-        session_id: &str,
-    ) -> BitFunResult<Option<Value>> {
-        if !self.should_persist_session_id(session_id) {
-            return Ok(None);
-        }
-
-        let workspace_path = self.metadata_workspace_path_for_update(session_id).await?;
-        Ok(self
-            .persistence_manager
-            .load_session_metadata(&workspace_path, session_id)
-            .await?
-            .and_then(|metadata| metadata.custom_metadata))
     }
 
     pub async fn merge_session_relationship(

--- a/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
@@ -1,5 +1,6 @@
 use crate::agentic::coordination::{
-    get_global_coordinator, BackgroundSubagentOutcome, BackgroundSubagentWaitResult,
+    get_global_coordinator, BackgroundSubagentOutcome, BackgroundSubagentWaitMode,
+    BackgroundSubagentWaitResult,
 };
 use crate::agentic::tools::framework::{
     Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
@@ -15,6 +16,13 @@ const MAX_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
 
 pub struct AgentWaitTool;
 
+#[derive(Debug, PartialEq, Eq)]
+struct AgentWaitRequest {
+    background_task_ids: Vec<String>,
+    wait_mode: BackgroundSubagentWaitMode,
+    timeout_ms: u64,
+}
+
 impl Default for AgentWaitTool {
     fn default() -> Self {
         Self::new()
@@ -26,67 +34,73 @@ impl AgentWaitTool {
         Self
     }
 
-    fn parse_request(input: &Value) -> BitFunResult<(Vec<String>, u64)> {
+    fn parse_request(input: &Value) -> BitFunResult<AgentWaitRequest> {
         let object = input
             .as_object()
             .ok_or_else(|| BitFunError::tool("AgentWait input must be an object".to_string()))?;
-        for key in object.keys() {
-            if key != "background_task_ids" && key != "timeout_ms" {
-                return Err(BitFunError::tool(format!(
-                    "Unsupported AgentWait parameter: {}",
-                    key
-                )));
-            }
-        }
 
-        let background_task_ids = match object.get("background_task_ids") {
-            None => Vec::new(),
-            Some(Value::Array(values)) => {
-                let mut seen = HashSet::new();
-                values
-                    .iter()
-                    .map(|value| {
-                        let value = value.as_str().ok_or_else(|| {
-                            BitFunError::tool(
-                                "background_task_ids must contain strings".to_string(),
-                            )
-                        })?;
-                        let value = value.trim();
-                        if value.is_empty() {
-                            return Err(BitFunError::tool(
-                                "background_task_ids cannot contain empty values".to_string(),
-                            ));
-                        }
-                        if !seen.insert(value.to_string()) {
-                            return Err(BitFunError::tool(format!(
-                                "background_task_ids contains a duplicate task ID: {}",
-                                value
-                            )));
-                        }
-                        Ok(value.to_string())
-                    })
-                    .collect::<BitFunResult<Vec<_>>>()?
-            }
+        let (values, require_task_id) = match object.get("background_task_ids") {
+            None => (Vec::new(), false),
+            Some(value @ Value::String(_)) => (vec![value], true),
+            Some(Value::Array(values)) if values.is_empty() => (Vec::new(), false),
+            Some(Value::Array(values)) => (values.iter().collect::<Vec<_>>(), true),
             Some(_) => {
                 return Err(BitFunError::tool(
-                    "background_task_ids must be an array of strings".to_string(),
+                    "background_task_ids must be a string or an array".to_string(),
                 ));
             }
         };
 
-        let timeout_ms = match object.get("timeout_ms") {
-            None => DEFAULT_TIMEOUT_MS,
-            Some(value) => value.as_u64().ok_or_else(|| {
-                BitFunError::tool("timeout_ms must be a positive integer".to_string())
-            })?,
-        };
-        if timeout_ms == 0 || timeout_ms > MAX_TIMEOUT_MS {
-            return Err(BitFunError::tool(format!(
-                "timeout_ms must be between 1 and {}",
-                MAX_TIMEOUT_MS
-            )));
+        let mut seen = HashSet::new();
+        let background_task_ids = values
+            .into_iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .filter(|value| seen.insert((*value).to_string()))
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        if require_task_id && background_task_ids.is_empty() {
+            return Err(BitFunError::tool(
+                "background_task_ids must contain at least one non-empty string".to_string(),
+            ));
         }
-        Ok((background_task_ids, timeout_ms))
+
+        Ok(AgentWaitRequest {
+            background_task_ids,
+            wait_mode: Self::parse_wait_mode(object.get("wait_mode"))?,
+            timeout_ms: Self::parse_timeout_ms(object.get("timeout_ms")),
+        })
+    }
+
+    fn parse_wait_mode(wait_mode: Option<&Value>) -> BitFunResult<BackgroundSubagentWaitMode> {
+        let wait_mode = match wait_mode {
+            None => BackgroundSubagentWaitMode::All,
+            Some(Value::String(value)) => match value.trim() {
+                "any" => BackgroundSubagentWaitMode::Any,
+                "all" => BackgroundSubagentWaitMode::All,
+                value => {
+                    return Err(BitFunError::tool(format!(
+                        "wait_mode must be \"any\" or \"all\"; got: {}",
+                        value
+                    )));
+                }
+            },
+            Some(_) => {
+                return Err(BitFunError::tool(
+                    "wait_mode must be \"any\" or \"all\"".to_string(),
+                ));
+            }
+        };
+        Ok(wait_mode)
+    }
+
+    fn parse_timeout_ms(timeout_ms: Option<&Value>) -> u64 {
+        timeout_ms
+            .and_then(Value::as_u64)
+            .filter(|timeout_ms| *timeout_ms > 0)
+            .unwrap_or(DEFAULT_TIMEOUT_MS)
+            .min(MAX_TIMEOUT_MS)
     }
 
     fn outcome_json(outcome: &BackgroundSubagentOutcome) -> Value {
@@ -146,7 +160,10 @@ impl Tool for AgentWaitTool {
     }
 
     async fn description(&self) -> BitFunResult<String> {
-        Ok("Wait for background Task results that belong to the current parent turn. Provide exact background_task_ids when known, or omit the field to collect unconsumed background tasks created by this turn. Use this only when the unfinished answer depends on those results. The tool returns after matching tasks finish, after its timeout, or when the current turn is cancelled.".to_string())
+        Ok("Wait for background subagent results.
+Set wait_mode to `any` to return after any selected task completes, or `all` to wait for every selected task.
+Provide background_task_ids when known; omit it or pass [] to select all unconsumed background tasks.
+The selected task set is fixed when the call starts. wait_mode defaults to `all`; the tool also returns when `timeout_ms` has elapsed.".to_string())
     }
 
     fn short_description(&self) -> String {
@@ -160,13 +177,16 @@ impl Tool for AgentWaitTool {
                 "background_task_ids": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Optional exact background task IDs returned by Task. Omit to wait for any unconsumed background task created by the current turn."
+                    "description": "Optional background task IDs returned by Task tool. Omit this field or pass [] to select all unconsumed background subagent results."
+                },
+                "wait_mode": {
+                    "type": "string",
+                    "enum": ["any", "all"],
+                    "default": "all",
+                    "description": "Defaults to `all`."
                 },
                 "timeout_ms": {
                     "type": "integer",
-                    "minimum": 1,
-                    "maximum": MAX_TIMEOUT_MS,
-                    "default": DEFAULT_TIMEOUT_MS,
                     "description": "Maximum time to wait in milliseconds. Defaults to ten minutes."
                 }
             },
@@ -216,27 +236,25 @@ impl Tool for AgentWaitTool {
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
-        let (background_task_ids, timeout_ms) = Self::parse_request(input)?;
+        let request = Self::parse_request(input)?;
         let session_id = context
             .session_id
             .as_deref()
             .ok_or_else(|| BitFunError::tool("session_id is required in context".to_string()))?;
-        let dialog_turn_id = context.dialog_turn_id.as_deref().ok_or_else(|| {
-            BitFunError::tool("dialog_turn_id is required in context".to_string())
-        })?;
         let coordinator = get_global_coordinator()
             .ok_or_else(|| BitFunError::tool("coordinator not initialized".to_string()))?;
         let result = coordinator
             .wait_for_background_subagent_outcomes(
                 session_id,
-                dialog_turn_id,
-                &background_task_ids,
-                Duration::from_millis(timeout_ms),
+                &request.background_task_ids,
+                request.wait_mode,
+                Duration::from_millis(request.timeout_ms),
                 context.cancellation_token(),
             )
             .await?;
         let data = json!({
             "status": result.status.as_str(),
+            "wait_mode": request.wait_mode.as_str(),
             "results": result.outcomes.iter().map(Self::outcome_json).collect::<Vec<_>>(),
             "pending_background_task_ids": result.pending_background_task_ids,
         });
@@ -250,22 +268,96 @@ impl Tool for AgentWaitTool {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentWaitTool, DEFAULT_TIMEOUT_MS};
+    use super::{AgentWaitTool, DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS};
+    use crate::agentic::coordination::BackgroundSubagentWaitMode;
 
     #[test]
-    fn empty_input_uses_the_default_timeout_and_current_turn_selector() {
-        let (task_ids, timeout_ms) =
-            AgentWaitTool::parse_request(&serde_json::json!({})).expect("valid request");
-        assert!(task_ids.is_empty());
-        assert_eq!(timeout_ms, DEFAULT_TIMEOUT_MS);
+    fn empty_input_uses_the_default_timeout_and_session_selector() {
+        let request = AgentWaitTool::parse_request(&serde_json::json!({})).expect("valid request");
+        assert!(request.background_task_ids.is_empty());
+        assert_eq!(request.wait_mode, BackgroundSubagentWaitMode::All);
+        assert_eq!(request.timeout_ms, DEFAULT_TIMEOUT_MS);
     }
 
     #[test]
-    fn duplicate_task_ids_are_rejected() {
-        let error = AgentWaitTool::parse_request(&serde_json::json!({
-            "background_task_ids": ["bg-1", "bg-1"]
+    fn explicit_wait_mode_applies_to_session_and_exact_task_selectors() {
+        let any = AgentWaitTool::parse_request(&serde_json::json!({
+            "wait_mode": "any"
         }))
-        .expect_err("duplicate task IDs must fail");
-        assert!(error.to_string().contains("duplicate"));
+        .expect("any wait mode must be valid");
+        assert!(any.background_task_ids.is_empty());
+        assert_eq!(any.wait_mode, BackgroundSubagentWaitMode::Any);
+
+        let all = AgentWaitTool::parse_request(&serde_json::json!({
+            "wait_mode": "all"
+        }))
+        .expect("all wait mode must be valid");
+        assert!(all.background_task_ids.is_empty());
+        assert_eq!(all.wait_mode, BackgroundSubagentWaitMode::All);
+
+        let empty = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": [],
+            "wait_mode": "any"
+        }))
+        .expect("an empty selector must be valid");
+        assert_eq!(empty.wait_mode, BackgroundSubagentWaitMode::Any);
+
+        let exact = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": ["bg-1", "bg-2"],
+            "wait_mode": "any"
+        }))
+        .expect("exact task IDs must be valid");
+        assert_eq!(exact.wait_mode, BackgroundSubagentWaitMode::Any);
+        assert_eq!(exact.background_task_ids, ["bg-1", "bg-2"]);
+    }
+
+    #[test]
+    fn a_single_task_id_string_is_accepted() {
+        let request = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": " background-task "
+        }))
+        .expect("a single task ID string must be accepted");
+        assert_eq!(request.background_task_ids, ["background-task"]);
+        assert_eq!(request.wait_mode, BackgroundSubagentWaitMode::All);
+    }
+
+    #[test]
+    fn task_ids_filter_empty_values_and_deduplicate() {
+        let request = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": [" bg-1 ", "", null, 1, "bg-1", "bg-2", "   "]
+        }))
+        .expect("valid task IDs must be retained");
+        assert_eq!(request.background_task_ids, ["bg-1", "bg-2"]);
+    }
+
+    #[test]
+    fn task_ids_require_a_string_after_filtering_non_empty_inputs() {
+        let error = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": ["", null, 1]
+        }))
+        .expect_err("non-empty selectors without usable IDs must fail");
+        assert!(error.to_string().contains("at least one non-empty string"));
+    }
+
+    #[test]
+    fn timeout_and_unknown_parameters_are_tolerated() {
+        let defaulted = AgentWaitTool::parse_request(&serde_json::json!({
+            "timeout_ms": "invalid",
+            "unused": true
+        }))
+        .expect("invalid timeout and unknown parameters must be tolerated");
+        assert_eq!(defaulted.timeout_ms, DEFAULT_TIMEOUT_MS);
+
+        let capped = AgentWaitTool::parse_request(&serde_json::json!({
+            "timeout_ms": MAX_TIMEOUT_MS + 1
+        }))
+        .expect("large timeout must be capped");
+        assert_eq!(capped.timeout_ms, MAX_TIMEOUT_MS);
+
+        let zero = AgentWaitTool::parse_request(&serde_json::json!({
+            "timeout_ms": 0
+        }))
+        .expect("zero timeout must use the default");
+        assert_eq!(zero.timeout_ms, DEFAULT_TIMEOUT_MS);
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
@@ -18,7 +18,7 @@ pub struct AgentWaitTool;
 
 #[derive(Debug, PartialEq, Eq)]
 struct AgentWaitRequest {
-    background_task_ids: Vec<String>,
+    bg_task_ids: Vec<String>,
     wait_mode: BackgroundSubagentWaitMode,
     timeout_ms: u64,
 }
@@ -39,20 +39,23 @@ impl AgentWaitTool {
             .as_object()
             .ok_or_else(|| BitFunError::tool("AgentWait input must be an object".to_string()))?;
 
-        let (values, require_task_id) = match object.get("background_task_ids") {
+        let task_ids = object
+            .get("bg_task_ids")
+            .or_else(|| object.get("background_task_ids"));
+        let (values, require_task_id) = match task_ids {
             None => (Vec::new(), false),
             Some(value @ Value::String(_)) => (vec![value], true),
             Some(Value::Array(values)) if values.is_empty() => (Vec::new(), false),
             Some(Value::Array(values)) => (values.iter().collect::<Vec<_>>(), true),
             Some(_) => {
                 return Err(BitFunError::tool(
-                    "background_task_ids must be a string or an array".to_string(),
+                    "bg_task_ids must be a string or an array".to_string(),
                 ));
             }
         };
 
         let mut seen = HashSet::new();
-        let background_task_ids = values
+        let bg_task_ids = values
             .into_iter()
             .filter_map(Value::as_str)
             .map(str::trim)
@@ -60,14 +63,14 @@ impl AgentWaitTool {
             .filter(|value| seen.insert((*value).to_string()))
             .map(ToOwned::to_owned)
             .collect::<Vec<_>>();
-        if require_task_id && background_task_ids.is_empty() {
+        if require_task_id && bg_task_ids.is_empty() {
             return Err(BitFunError::tool(
-                "background_task_ids must contain at least one non-empty string".to_string(),
+                "bg_task_ids must contain at least one non-empty string".to_string(),
             ));
         }
 
         Ok(AgentWaitRequest {
-            background_task_ids,
+            bg_task_ids,
             wait_mode: Self::parse_wait_mode(object.get("wait_mode"))?,
             timeout_ms: Self::parse_timeout_ms(object.get("timeout_ms")),
         })
@@ -105,8 +108,8 @@ impl AgentWaitTool {
 
     fn outcome_json(outcome: &BackgroundSubagentOutcome) -> Value {
         json!({
-            "background_task_id": outcome.background_task_id,
-            "subagent_session_id": outcome.subagent_session_id,
+            "bg_task_id": outcome.model_bg_task_id(),
+            "agent_id": outcome.model_agent_id(),
             "outcome": outcome.status.as_str(),
             "content": outcome.content,
             "error": outcome.error,
@@ -118,16 +121,16 @@ impl AgentWaitTool {
             return format!(
                 "AgentWait finished with status {}. Pending background task IDs: {}.",
                 result.status.as_str(),
-                result.pending_background_task_ids.join(", ")
+                result.pending_bg_task_ids.join(", ")
             );
         }
 
         let mut message = format!("AgentWait finished with status {}.", result.status.as_str());
         for outcome in &result.outcomes {
             message.push_str(&format!(
-                "\n<background_subagent_result task_id=\"{}\" session_id=\"{}\" status=\"{}\">",
-                outcome.background_task_id,
-                outcome.subagent_session_id,
+                "\n<result bg_task_id=\"{}\" agent_id=\"{}\" status=\"{}\">",
+                outcome.model_bg_task_id(),
+                outcome.model_agent_id(),
                 outcome.status.as_str(),
             ));
             if let Some(content) = &outcome.content {
@@ -137,12 +140,12 @@ impl AgentWaitTool {
                 message.push_str("\nError: ");
                 message.push_str(error);
             }
-            message.push_str("</background_subagent_result>");
+            message.push_str("</result>");
         }
-        if !result.pending_background_task_ids.is_empty() {
+        if !result.pending_bg_task_ids.is_empty() {
             message.push_str(&format!(
                 "\nPending background task IDs: {}.",
-                result.pending_background_task_ids.join(", ")
+                result.pending_bg_task_ids.join(", ")
             ));
         }
         message
@@ -162,7 +165,7 @@ impl Tool for AgentWaitTool {
     async fn description(&self) -> BitFunResult<String> {
         Ok("Wait for background subagent results.
 Set wait_mode to `any` to return after any selected task completes, or `all` to wait for every selected task.
-Provide background_task_ids when known; omit it or pass [] to select all unconsumed background tasks.
+Provide bg_task_ids when known; omit it or pass [] to select all unconsumed background tasks.
 The selected task set is fixed when the call starts. wait_mode defaults to `all`; the tool also returns when `timeout_ms` has elapsed.".to_string())
     }
 
@@ -174,7 +177,7 @@ The selected task set is fixed when the call starts. wait_mode defaults to `all`
         json!({
             "type": "object",
             "properties": {
-                "background_task_ids": {
+                "bg_task_ids": {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Optional background task IDs returned by Task tool. Omit this field or pass [] to select all unconsumed background subagent results."
@@ -241,14 +244,18 @@ The selected task set is fixed when the call starts. wait_mode defaults to `all`
             .session_id
             .as_deref()
             .ok_or_else(|| BitFunError::tool("session_id is required in context".to_string()))?;
+        let dialog_turn_id = context.dialog_turn_id.as_deref().ok_or_else(|| {
+            BitFunError::tool("dialog_turn_id is required in context".to_string())
+        })?;
         let coordinator = get_global_coordinator()
             .ok_or_else(|| BitFunError::tool("coordinator not initialized".to_string()))?;
         let result = coordinator
             .wait_for_background_subagent_outcomes(
                 session_id,
-                &request.background_task_ids,
+                &request.bg_task_ids,
                 request.wait_mode,
                 Duration::from_millis(request.timeout_ms),
+                dialog_turn_id,
                 context.cancellation_token(),
             )
             .await?;
@@ -256,7 +263,7 @@ The selected task set is fixed when the call starts. wait_mode defaults to `all`
             "status": result.status.as_str(),
             "wait_mode": request.wait_mode.as_str(),
             "results": result.outcomes.iter().map(Self::outcome_json).collect::<Vec<_>>(),
-            "pending_background_task_ids": result.pending_background_task_ids,
+            "pending_bg_task_ids": result.pending_bg_task_ids,
         });
         Ok(vec![ToolResult::Result {
             data,
@@ -270,11 +277,20 @@ The selected task set is fixed when the call starts. wait_mode defaults to `all`
 mod tests {
     use super::{AgentWaitTool, DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS};
     use crate::agentic::coordination::BackgroundSubagentWaitMode;
+    use crate::agentic::tools::framework::Tool;
+
+    #[test]
+    fn schema_exposes_only_parent_scoped_background_task_ids() {
+        let schema = AgentWaitTool::new().input_schema();
+
+        assert_eq!(schema["properties"]["bg_task_ids"]["type"], "array");
+        assert!(schema["properties"].get("background_task_ids").is_none());
+    }
 
     #[test]
     fn empty_input_uses_the_default_timeout_and_session_selector() {
         let request = AgentWaitTool::parse_request(&serde_json::json!({})).expect("valid request");
-        assert!(request.background_task_ids.is_empty());
+        assert!(request.bg_task_ids.is_empty());
         assert_eq!(request.wait_mode, BackgroundSubagentWaitMode::All);
         assert_eq!(request.timeout_ms, DEFAULT_TIMEOUT_MS);
     }
@@ -285,55 +301,64 @@ mod tests {
             "wait_mode": "any"
         }))
         .expect("any wait mode must be valid");
-        assert!(any.background_task_ids.is_empty());
+        assert!(any.bg_task_ids.is_empty());
         assert_eq!(any.wait_mode, BackgroundSubagentWaitMode::Any);
 
         let all = AgentWaitTool::parse_request(&serde_json::json!({
             "wait_mode": "all"
         }))
         .expect("all wait mode must be valid");
-        assert!(all.background_task_ids.is_empty());
+        assert!(all.bg_task_ids.is_empty());
         assert_eq!(all.wait_mode, BackgroundSubagentWaitMode::All);
 
         let empty = AgentWaitTool::parse_request(&serde_json::json!({
-            "background_task_ids": [],
+            "bg_task_ids": [],
             "wait_mode": "any"
         }))
         .expect("an empty selector must be valid");
         assert_eq!(empty.wait_mode, BackgroundSubagentWaitMode::Any);
 
         let exact = AgentWaitTool::parse_request(&serde_json::json!({
-            "background_task_ids": ["bg-1", "bg-2"],
+            "bg_task_ids": ["bg1", "bg2"],
             "wait_mode": "any"
         }))
         .expect("exact task IDs must be valid");
         assert_eq!(exact.wait_mode, BackgroundSubagentWaitMode::Any);
-        assert_eq!(exact.background_task_ids, ["bg-1", "bg-2"]);
+        assert_eq!(exact.bg_task_ids, ["bg1", "bg2"]);
     }
 
     #[test]
     fn a_single_task_id_string_is_accepted() {
         let request = AgentWaitTool::parse_request(&serde_json::json!({
-            "background_task_ids": " background-task "
+            "bg_task_ids": " bg1 "
         }))
         .expect("a single task ID string must be accepted");
-        assert_eq!(request.background_task_ids, ["background-task"]);
+        assert_eq!(request.bg_task_ids, ["bg1"]);
         assert_eq!(request.wait_mode, BackgroundSubagentWaitMode::All);
+    }
+
+    #[test]
+    fn legacy_background_task_ids_are_tolerated_without_schema_exposure() {
+        let request = AgentWaitTool::parse_request(&serde_json::json!({
+            "background_task_ids": ["bg1"]
+        }))
+        .expect("legacy task IDs must remain unambiguous at runtime");
+        assert_eq!(request.bg_task_ids, ["bg1"]);
     }
 
     #[test]
     fn task_ids_filter_empty_values_and_deduplicate() {
         let request = AgentWaitTool::parse_request(&serde_json::json!({
-            "background_task_ids": [" bg-1 ", "", null, 1, "bg-1", "bg-2", "   "]
+            "bg_task_ids": [" bg1 ", "", null, 1, "bg1", "bg2", "   "]
         }))
         .expect("valid task IDs must be retained");
-        assert_eq!(request.background_task_ids, ["bg-1", "bg-2"]);
+        assert_eq!(request.bg_task_ids, ["bg1", "bg2"]);
     }
 
     #[test]
     fn task_ids_require_a_string_after_filtering_non_empty_inputs() {
         let error = AgentWaitTool::parse_request(&serde_json::json!({
-            "background_task_ids": ["", null, 1]
+            "bg_task_ids": ["", null, 1]
         }))
         .expect_err("non-empty selectors without usable IDs must fail");
         assert!(error.to_string().contains("at least one non-empty string"));

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/background.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/background.rs
@@ -2,12 +2,12 @@ use super::*;
 
 impl TaskTool {
     pub(super) fn background_subagent_started_assistant_message(
-        session_id: &str,
-        background_task_id: &str,
+        agent_id: &str,
+        bg_task_id: &str,
     ) -> String {
         format!(
-            "Background subagent started successfully.\nsession_id: \"{}\"\nbackground_task_id: \"{}\"\nUse AgentWait with this background_task_id when you need its result. The result will not be delivered automatically.",
-            session_id, background_task_id
+            "Background subagent started successfully.\nagent_id: \"{}\"\nbg_task_id: \"{}\"\nUse AgentWait with this bg_task_id when you need its result. The result will not be delivered automatically.",
+            agent_id, bg_task_id
         )
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/execution.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/execution.rs
@@ -136,25 +136,28 @@ impl TaskTool {
         parent_session_id: &str,
         invocation: TaskInvocation,
     ) -> BitFunResult<Vec<ToolResult>> {
-        let target_session_id = invocation.target_session_id.as_deref().ok_or_else(|| {
-            BitFunError::tool("session_id is required when action is cancel".to_string())
+        let agent_id = invocation.target_agent_id.as_deref().ok_or_else(|| {
+            BitFunError::tool("agent_id is required when action is cancel".to_string())
         })?;
         let coordinator = get_global_coordinator()
             .ok_or_else(|| BitFunError::tool("coordinator not initialized".to_string()))?;
+        let target_session_id = coordinator
+            .resolve_agent_id(parent_session_id, agent_id)
+            .await?;
         let cancelled_count = coordinator
-            .cancel_background_subagents_for_parent(parent_session_id, target_session_id)
+            .cancel_background_subagents_for_parent(parent_session_id, &target_session_id)
             .await?;
 
         Ok(vec![ToolResult::Result {
             data: json!({
                 "action": "cancel",
                 "status": "cancelled",
-                "session_id": target_session_id,
+                "agent_id": agent_id,
                 "cancelled_background_tasks": cancelled_count,
             }),
             result_for_assistant: Some(format!(
-                "Cancelled {} background Task run(s) for subagent session {}.\n<background_task status=\"cancelled\" session_id=\"{}\" cancelled_count=\"{}\">Cancelled background runs will not deliver results back to you.</background_task>",
-                cancelled_count, target_session_id, target_session_id, cancelled_count
+                "Cancelled {} background Task run(s) for agent {}.\n<background_task status=\"cancelled\" agent_id=\"{}\" cancelled_count=\"{}\">Cancelled background runs will not deliver results back to you.</background_task>",
+                cancelled_count, agent_id, agent_id, cancelled_count
             )),
             image_attachments: None,
         }])
@@ -169,6 +172,8 @@ impl TaskTool {
         session_id: String,
     ) -> BitFunResult<Vec<ToolResult>> {
         Self::ensure_delegation_allowed(context)?;
+        let coordinator = get_global_coordinator()
+            .ok_or_else(|| BitFunError::tool("coordinator not initialized".to_string()))?;
 
         let description = invocation.description.clone();
         let mut prompt = invocation.prompt.clone().ok_or_else(|| {
@@ -177,7 +182,10 @@ impl TaskTool {
             )
         })?;
         let context_mode = invocation.context_mode;
-        let target_session_id = invocation.target_session_id.clone();
+        let target_session_id = match invocation.target_agent_id.as_deref() {
+            Some(agent_id) => Some(coordinator.resolve_agent_id(&session_id, agent_id).await?),
+            None => None,
+        };
         let model_id = invocation.model_id.clone();
         let inherit_parent_model = invocation.inherit_parent_model;
         let mut timeout_seconds = invocation.timeout_seconds;
@@ -199,7 +207,7 @@ impl TaskTool {
                 } else {
                     let subagent_type = invocation.subagent_type.clone().ok_or_else(|| {
                         BitFunError::tool(
-                            "subagent_type is required when fork_context is false or omitted and session_id is not provided"
+                            "subagent_type is required when fork_context is false or omitted and agent_id is not provided"
                                 .to_string(),
                         )
                     })?;
@@ -278,9 +286,6 @@ impl TaskTool {
         let mut deep_review_retry_scope_files: Option<Vec<String>> = None;
         let mut deep_review_subagent_role: Option<DeepReviewSubagentRole> = None;
         let mut deep_review_run_manifest: Option<Value> = None;
-        let coordinator = get_global_coordinator()
-            .ok_or_else(|| BitFunError::tool("coordinator not initialized".to_string()))?;
-
         if is_deep_review_parent {
             let subagent_type = subagent_type.as_deref().ok_or_else(|| {
                 BitFunError::tool("subagent_type is required for DeepReview Task calls".to_string())
@@ -688,12 +693,12 @@ impl TaskTool {
                 "context_mode": context_mode.as_str(),
                 "status": "started",
                 "run_in_background": true,
-                "background_task_id": background_result.background_task_id.clone(),
-                "session_id": background_result.session_id.clone(),
+                "bg_task_id": background_result.bg_task_id.clone(),
+                "agent_id": background_result.agent_id.clone(),
             }),
             result_for_assistant: Some(Self::background_subagent_started_assistant_message(
-                &background_result.session_id,
-                &background_result.background_task_id,
+                &background_result.agent_id,
+                &background_result.bg_task_id,
             )),
             image_attachments: None,
         }])
@@ -1045,10 +1050,13 @@ impl TaskTool {
             );
         if supports_follow_up {
             if let Some(subagent_session_id) = result.session_id() {
-                data["session_id"] = json!(subagent_session_id);
+                let agent_id = coordinator
+                    .agent_id_for_subagent_session(&session_id, subagent_session_id)
+                    .await?;
+                data["agent_id"] = json!(agent_id.clone());
                 result_for_assistant.push_str(&format!(
-                "\n<subagent_session id=\"{}\">Use this session_id to continue the same subagent session.</subagent_session>",
-                subagent_session_id
+                "\n<subagent id=\"{}\">Use this agent_id to continue the same subagent.</subagent>",
+                agent_id
             ));
             }
         }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/input.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/input.rs
@@ -40,14 +40,14 @@ impl TaskAction {
             return None;
         }
 
-        let has_session_id = value.get("session_id").is_some();
+        let has_agent_id = value.get("agent_id").is_some();
         let has_subagent_type = value.get("subagent_type").is_some();
         let has_fork_context = value.get("fork_context").is_some();
 
-        if !has_session_id && (has_subagent_type || has_fork_context) {
+        if !has_agent_id && (has_subagent_type || has_fork_context) {
             return Some(Self::Spawn);
         }
-        if has_session_id && !has_subagent_type && !has_fork_context {
+        if has_agent_id && !has_subagent_type && !has_fork_context {
             return Some(Self::SendInput);
         }
 
@@ -69,7 +69,7 @@ pub(super) struct TaskInvocation {
     pub(super) description: Option<String>,
     pub(super) prompt: Option<String>,
     pub(super) context_mode: SubagentContextMode,
-    pub(super) target_session_id: Option<String>,
+    pub(super) target_agent_id: Option<String>,
     pub(super) subagent_type: Option<String>,
     pub(super) model_id: Option<String>,
     pub(super) inherit_parent_model: bool,
@@ -97,7 +97,7 @@ impl TaskTool {
                     "action is not supported for DeepReview Task calls".to_string(),
                 ));
             }
-            for field in ["fork_context", "session_id", "run_in_background"] {
+            for field in ["fork_context", "agent_id", "run_in_background"] {
                 if input.get(field).is_some() {
                     return Err(BitFunError::tool(format!(
                         "{field} is not allowed for DeepReview Task calls"
@@ -112,7 +112,7 @@ impl TaskTool {
                 description: Self::string_field(input, "description", "DeepReview Task calls")?,
                 prompt: Self::string_field(input, "prompt", "DeepReview Task calls")?,
                 context_mode: SubagentContextMode::Fresh,
-                target_session_id: None,
+                target_agent_id: None,
                 subagent_type: Self::string_field(input, "subagent_type", "DeepReview Task calls")?,
                 model_id,
                 inherit_parent_model,
@@ -143,9 +143,9 @@ impl TaskTool {
             TaskAction::Spawn => {
                 let description = Self::required_string_for_action(input, "description", action)?;
                 let prompt = Self::required_string_for_action(input, "prompt", action)?;
-                if input.get("session_id").is_some() {
+                if input.get("agent_id").is_some() {
                     return Err(BitFunError::tool(
-                        "session_id is not allowed when action is spawn".to_string(),
+                        "agent_id is not allowed when action is spawn".to_string(),
                     ));
                 }
                 let context_mode = Self::context_mode_from_input(input)?;
@@ -180,7 +180,7 @@ impl TaskTool {
                     description,
                     prompt,
                     context_mode,
-                    target_session_id: None,
+                    target_agent_id: None,
                     subagent_type: Self::optional_trimmed_string(input, "subagent_type")?,
                     model_id,
                     inherit_parent_model,
@@ -191,8 +191,7 @@ impl TaskTool {
                 })
             }
             TaskAction::SendInput => {
-                let target_session_id =
-                    Self::required_string_for_action(input, "session_id", action)?;
+                let target_agent_id = Self::required_string_for_action(input, "agent_id", action)?;
                 let description = Self::required_string_for_action(input, "description", action)?;
                 let prompt = Self::required_string_for_action(input, "prompt", action)?;
                 Self::ensure_fields_absent(
@@ -214,7 +213,7 @@ impl TaskTool {
                     description,
                     prompt,
                     context_mode: SubagentContextMode::Fresh,
-                    target_session_id,
+                    target_agent_id,
                     subagent_type: None,
                     model_id,
                     inherit_parent_model,
@@ -225,8 +224,7 @@ impl TaskTool {
                 })
             }
             TaskAction::Cancel => {
-                let target_session_id =
-                    Self::required_string_for_action(input, "session_id", action)?;
+                let target_agent_id = Self::required_string_for_action(input, "agent_id", action)?;
                 Self::ensure_fields_absent(
                     input,
                     &[
@@ -247,7 +245,7 @@ impl TaskTool {
                     description: None,
                     prompt: None,
                     context_mode: SubagentContextMode::Fresh,
-                    target_session_id,
+                    target_agent_id,
                     subagent_type: None,
                     model_id: None,
                     inherit_parent_model: false,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/launch_review_agent.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/launch_review_agent.rs
@@ -108,7 +108,7 @@ impl LaunchReviewAgentTool {
     }
 
     fn parse_invocation(input: &Value) -> BitFunResult<LaunchReviewAgentInvocation> {
-        for field in ["action", "fork_context", "session_id", "run_in_background"] {
+        for field in ["action", "fork_context", "agent_id", "run_in_background"] {
             if input.get(field).is_some() {
                 return Err(BitFunError::tool(format!(
                     "{field} is not supported for LaunchReviewAgent"

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/launch_review_agent.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/launch_review_agent.rs
@@ -108,13 +108,7 @@ impl LaunchReviewAgentTool {
     }
 
     fn parse_invocation(input: &Value) -> BitFunResult<LaunchReviewAgentInvocation> {
-        for field in [
-            "action",
-            "fork_context",
-            "session_id",
-            "run_in_background",
-            "allow_review_follow_up",
-        ] {
+        for field in ["action", "fork_context", "session_id", "run_in_background"] {
             if input.get(field).is_some() {
                 return Err(BitFunError::tool(format!(
                     "{field} is not supported for LaunchReviewAgent"

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/mod.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/mod.rs
@@ -199,9 +199,9 @@ impl Tool for TaskTool {
     fn render_tool_use_message(&self, input: &Value, options: &ToolRenderOptions) -> String {
         match TaskAction::parse(input).ok() {
             Some(TaskAction::Cancel) => input
-                .get("session_id")
+                .get("agent_id")
                 .and_then(Value::as_str)
-                .map(|session_id| format!("Cancelling background task: {}", session_id))
+                .map(|agent_id| format!("Cancelling background task: {}", agent_id))
                 .unwrap_or_else(|| "Cancelling background task".to_string()),
             Some(TaskAction::SendInput) => input
                 .get("description")

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/schema.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/schema.rs
@@ -57,7 +57,7 @@ impl TaskTool {
             }),
         );
         properties.insert(
-            "session_id".to_string(),
+            "agent_id".to_string(),
             json!({
                 "type": "string",
                 "description": "Required for action='send_input' and action='cancel'."
@@ -88,9 +88,9 @@ When to use:
 - Use direct tools instead for focused lookups, known paths, single symbols, or code that can be inspected with a few reads or searches.
 
 Supported actions:
-- `spawn`: create and run a new subagent. The result contains a `session_id` for future `send_input` or `cancel`.
-- `send_input`: continue an existing subagent. Provide `session_id`, `description`, and `prompt`. Optionally provide `model_id` to switch the subagent model for this and later turns.
-- `cancel`: cancel a background subagent. Provide `session_id`.
+- `spawn`: create and run a new subagent. The result contains an `agent_id` for future `send_input` or `cancel`.
+- `send_input`: continue an existing subagent. Provide `agent_id`, `description`, and `prompt`. Optionally provide `model_id` to switch the subagent model for this and later turns.
+- `cancel`: cancel a background subagent. Provide `agent_id`.
 
 Two modes for action='spawn':
 The two modes are mutually exclusive: do not provide `subagent_type` when `fork_context=true`.
@@ -103,15 +103,14 @@ The two modes are mutually exclusive: do not provide `subagent_type` when `fork_
   - In this mode, the subagent inherits the full conversation history up to this point — all prior user messages, assistant responses, and tool results. You do not need to repeat information already covered in the conversation.
 
 `prompt` writing guidelines:
-- Do not put `action`, `subagent_type`, `session_id`, `description`, or `model_id` inside the prompt string.
+- Do not put `action`, `subagent_type`, `agent_id`, `description`, or `model_id` inside the prompt string.
 - Keep it under 180 lines / 16KB. For large delegations, split the work into multiple Task calls with clear ownership.
 - Pass file paths, symbols, constraints, and exact questions instead of pasting large file contents.
 - Clearly tell the agent whether you expect code changes or research only (searches, file reads, web fetches, etc.), because it does not know the user's intent unless you state it.
 
 `run_in_background` usage:
 - false: Wait for the agent to finish and return its result to you.
-- true: Run the agent in the background without blocking you. The response includes a `background_task_id`; use AgentWait when you need one or more background results. Completed background tasks never automatically create a follow-up turn.
-- When an unfinished answer depends on background work, call AgentWait before ending the current turn. If the result is no longer needed, finish normally without waiting.
+- true: Run the agent in the background without blocking you. The response includes a `bg_task_id`; use AgentWait when you need the results.
 
 `model_id` usage:
 - Set it only when the user requests a particular model.
@@ -132,8 +131,8 @@ Examples (assume "example-reviewer" is present in the agent listing):
 <examples>
 - Start a new specialized subagent: `{ "action": "spawn", "description": "Inspect parser flow", "subagent_type": "example-reviewer", "prompt": "Inspect the parser flow in src/parser.rs and report risks, key functions, and any missing tests." }`
 - Start by forking the current context: `{ "action": "spawn", "description": "Check migration impact", "fork_context": true, "prompt": "Using the current context, check whether the migration affects config loading. Stay read-only and report the answer with file references." }`
-- Continue an existing subagent with a specific model: `{ "action": "send_input", "description": "Continue parser review", "session_id": "subagent-session-123", "model_id": "fast", "prompt": "Continue from your prior parser review and focus on the error recovery paths." }`
-- Cancel a background subagent: `{ "action": "cancel", "session_id": "subagent-session-123" }`
+- Continue an existing subagent with a specific model: `{ "action": "send_input", "description": "Continue parser review", "agent_id": "a1", "model_id": "fast", "prompt": "Continue from your prior parser review and focus on the error recovery paths." }`
+- Cancel a background subagent: `{ "action": "cancel", "agent_id": "a1" }`
 </examples>
 "#
             .to_string()

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs
@@ -526,13 +526,7 @@ async fn validate_input_rejects_timeout_for_regular_parent() {
 #[tokio::test]
 async fn launch_review_agent_rejects_task_context_controls() {
     let context = test_tool_context("DeepReview");
-    for field in [
-        "action",
-        "fork_context",
-        "session_id",
-        "run_in_background",
-        "allow_review_follow_up",
-    ] {
+    for field in ["action", "fork_context", "session_id", "run_in_background"] {
         let mut input = json!({
             "description": "delegate",
             "prompt": "Review security-sensitive files",

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/tests.rs
@@ -115,6 +115,8 @@ fn task_schema_accepts_optional_model_id() {
     let schema = TaskTool::new().input_schema();
 
     assert_eq!(schema["properties"]["action"]["type"], "string");
+    assert_eq!(schema["properties"]["agent_id"]["type"], "string");
+    assert!(schema["properties"].get("session_id").is_none());
     assert_eq!(schema["properties"]["model_id"]["type"], "string");
     assert!(schema["required"]
         .as_array()
@@ -213,7 +215,7 @@ fn task_schema_describes_spawn_context_modes_as_exclusive() {
 }
 
 #[tokio::test]
-async fn launch_review_agent_schema_exposes_retry_without_session_or_fork_controls() {
+async fn launch_review_agent_schema_exposes_retry_without_agent_or_fork_controls() {
     let context = test_tool_context("DeepReview");
     let schema = LaunchReviewAgentTool::new()
         .input_schema_for_model_with_context(Some(&context))
@@ -227,7 +229,7 @@ async fn launch_review_agent_schema_exposes_retry_without_session_or_fork_contro
     assert_eq!(schema["properties"]["retry_coverage"]["type"], "object");
     assert_eq!(schema["properties"]["packet_id"]["type"], "string");
     assert!(schema["properties"].get("fork_context").is_none());
-    assert!(schema["properties"].get("session_id").is_none());
+    assert!(schema["properties"].get("agent_id").is_none());
     assert!(schema["properties"].get("run_in_background").is_none());
     assert!(schema["required"]
         .as_array()
@@ -297,14 +299,11 @@ async fn managed_review_agent_requires_an_exact_packet_id() {
 
 #[test]
 fn background_subagent_start_acknowledgement_exposes_agent_wait_task_id() {
-    let message = TaskTool::background_subagent_started_assistant_message(
-        "subagent-session-123",
-        "bg-subagent-123",
-    );
+    let message = TaskTool::background_subagent_started_assistant_message("a1", "bg1");
 
     assert!(message.starts_with("Background subagent started successfully."));
-    assert!(message.contains("session_id: \"subagent-session-123\""));
-    assert!(message.contains("background_task_id: \"bg-subagent-123\""));
+    assert!(message.contains("agent_id: \"a1\""));
+    assert!(message.contains("bg_task_id: \"bg1\""));
     assert!(message.contains("Use AgentWait"));
     assert!(!message.contains("GeneralPurpose"));
     assert!(!message.contains("<background_task"));
@@ -405,14 +404,14 @@ async fn validate_input_rejects_fork_context_with_subagent_type_as_mode_conflict
 }
 
 #[tokio::test]
-async fn validate_input_accepts_send_input_session_id_without_subagent_type() {
+async fn validate_input_accepts_send_input_agent_id_without_subagent_type() {
     let validation = TaskTool::new()
         .validate_input(
             &json!({
                 "action": "send_input",
                 "description": "continue",
                 "prompt": "Continue the previous analysis",
-                "session_id": "subagent-session-1"
+                "agent_id": "a1"
             }),
             None,
         )
@@ -429,7 +428,7 @@ async fn validate_input_accepts_send_input_with_model_id() {
                 "action": "send_input",
                 "description": "continue",
                 "prompt": "Continue the previous analysis",
-                "session_id": "subagent-session-1",
+                "agent_id": "a1",
                 "model_id": "fast"
             }),
             None,
@@ -440,13 +439,13 @@ async fn validate_input_accepts_send_input_with_model_id() {
 }
 
 #[tokio::test]
-async fn validate_input_infers_send_input_without_action_when_session_id_present() {
+async fn validate_input_infers_send_input_without_action_when_agent_id_present() {
     let validation = TaskTool::new()
         .validate_input(
             &json!({
                 "description": "continue",
                 "prompt": "Continue the previous analysis",
-                "session_id": "subagent-session-1"
+                "agent_id": "a1"
             }),
             None,
         )
@@ -463,7 +462,7 @@ async fn validate_input_rejects_send_input_with_subagent_type() {
                 "action": "send_input",
                 "description": "continue",
                 "prompt": "Continue the previous analysis",
-                "session_id": "subagent-session-1",
+                "agent_id": "a1",
                 "subagent_type": "Explore"
             }),
             None,
@@ -526,7 +525,7 @@ async fn validate_input_rejects_timeout_for_regular_parent() {
 #[tokio::test]
 async fn launch_review_agent_rejects_task_context_controls() {
     let context = test_tool_context("DeepReview");
-    for field in ["action", "fork_context", "session_id", "run_in_background"] {
+    for field in ["action", "fork_context", "agent_id", "run_in_background"] {
         let mut input = json!({
             "description": "delegate",
             "prompt": "Review security-sensitive files",
@@ -534,7 +533,7 @@ async fn launch_review_agent_rejects_task_context_controls() {
         });
         input[field] = match field {
             "action" => json!("spawn"),
-            "session_id" => json!("subagent-session-1"),
+            "agent_id" => json!("a1"),
             _ => json!(false),
         };
 
@@ -594,12 +593,12 @@ async fn launch_review_agent_rejects_non_string_model_id() {
 }
 
 #[tokio::test]
-async fn validate_input_accepts_cancel_with_session_id_only() {
+async fn validate_input_accepts_cancel_with_agent_id_only() {
     let validation = TaskTool::new()
         .validate_input(
             &json!({
                 "action": "cancel",
-                "session_id": "subagent-session-1"
+                "agent_id": "a1"
             }),
             None,
         )
@@ -614,7 +613,7 @@ async fn validate_input_accepts_cancel_with_description() {
         .validate_input(
             &json!({
                 "action": "cancel",
-                "session_id": "subagent-session-1",
+                "agent_id": "a1",
                 "description": "cancel task"
             }),
             None,
@@ -630,7 +629,7 @@ async fn validate_input_rejects_cancel_with_prompt() {
         .validate_input(
             &json!({
                 "action": "cancel",
-                "session_id": "subagent-session-1",
+                "agent_id": "a1",
                 "prompt": "Stop this work"
             }),
             None,
@@ -661,7 +660,7 @@ async fn validate_input_rejects_fork_context_conflicting_fields() {
                 "description": "delegate",
                 "prompt": "Continue with inherited context",
                 "fork_context": true,
-                "session_id": "subagent-session-1"
+                "agent_id": "a1"
             }),
             None,
         )
@@ -671,7 +670,7 @@ async fn validate_input_rejects_fork_context_conflicting_fields() {
     assert!(validation
         .message
         .as_deref()
-        .is_some_and(|message| message.contains("session_id is not allowed")));
+        .is_some_and(|message| message.contains("agent_id is not allowed")));
 }
 
 #[tokio::test]

--- a/src/crates/assembly/core/src/infrastructure/app_paths/path_manager.rs
+++ b/src/crates/assembly/core/src/infrastructure/app_paths/path_manager.rs
@@ -284,6 +284,13 @@ impl PathManager {
             .join("memories.sqlite")
     }
 
+    /// Get the durable agent coordination database file.
+    pub fn agent_coordination_database_file(&self) -> PathBuf {
+        self.user_data_dir()
+            .join("agent-runtime")
+            .join("coordination.sqlite")
+    }
+
     /// Get user memory workspace root directory: ~/.bitfun/memories/
     pub fn memories_root_dir(&self) -> PathBuf {
         self.bitfun_home_dir().join("memories")

--- a/src/crates/assembly/core/src/product_runtime.rs
+++ b/src/crates/assembly/core/src/product_runtime.rs
@@ -733,6 +733,7 @@ impl CoreSessionOperationsPort {
                 "source turn id is required",
             ));
         }
+        let source_session_id_for_coordination = source_session_id.clone();
         let result = self
             .persistence
             .branch_session(
@@ -744,6 +745,26 @@ impl CoreSessionOperationsPort {
             )
             .await
             .map_err(runtime_port_error)?;
+        if let Err(error) = self
+            .coordinator
+            .initialize_fork_coordination(&source_session_id_for_coordination, &result.session_id)
+            .await
+        {
+            if let Err(cleanup_error) = self
+                .persistence
+                .delete_session(storage_path, &result.session_id)
+                .await
+            {
+                return Err(PortError::new(
+                    PortErrorKind::CleanupRequired,
+                    format!(
+                        "Session fork coordination initialization failed and rollback did not complete: session_id={}, error={}, cleanup_error={}",
+                        result.session_id, error, cleanup_error
+                    ),
+                ));
+            }
+            return Err(runtime_port_error(error));
+        }
         Ok(AgentSessionForkResult {
             session_id: result.session_id,
             session_name: result.session_name,

--- a/src/crates/execution/agent-runtime/src/scheduler.rs
+++ b/src/crates/execution/agent-runtime/src/scheduler.rs
@@ -98,33 +98,6 @@ impl ActiveDialogTurn {
         self.user_message_metadata.as_ref()
     }
 
-    pub fn background_subagent_task_id(&self) -> Option<&str> {
-        if self.policy.trigger_source != DialogTriggerSource::AgentSession {
-            return None;
-        }
-        let Some(metadata) = self
-            .user_message_metadata()
-            .and_then(serde_json::Value::as_object)
-        else {
-            return None;
-        };
-        (metadata.get("kind").and_then(serde_json::Value::as_str) == Some("background_result")
-            && metadata
-                .get("sourceKind")
-                .and_then(serde_json::Value::as_str)
-                == Some("subagent"))
-        .then(|| {
-            metadata
-                .get("backgroundTaskId")
-                .and_then(serde_json::Value::as_str)
-        })
-        .flatten()
-    }
-
-    fn is_background_subagent_delivery(&self, background_task_id: &str) -> bool {
-        self.background_subagent_task_id() == Some(background_task_id)
-    }
-
     pub fn reply_route(&self) -> Option<&AgentSessionReplyRoute> {
         self.reply_route.as_ref()
     }
@@ -189,30 +162,6 @@ impl ActiveDialogTurnStore {
         self.inner
             .get(session_id)
             .is_some_and(|turn| turn.turn_id() == turn_id)
-    }
-
-    pub fn user_message_metadata_bool_for_turn(
-        &self,
-        session_id: &str,
-        turn_id: &str,
-        key: &str,
-    ) -> Option<bool> {
-        self.inner.get(session_id).and_then(|turn| {
-            (turn.turn_id() == turn_id)
-                .then(|| turn.user_message_metadata()?.get(key)?.as_bool())
-                .flatten()
-        })
-    }
-
-    pub fn turn_id_for_background_subagent_delivery(
-        &self,
-        session_id: &str,
-        background_task_id: &str,
-    ) -> Option<String> {
-        self.inner.get(session_id).and_then(|turn| {
-            turn.is_background_subagent_delivery(background_task_id)
-                .then(|| turn.turn_id().to_string())
-        })
     }
 
     pub fn suppression_key_for_requester(
@@ -1064,71 +1013,6 @@ mod tests {
             store.take_for_outcome("session-1", "turn-new"),
             ActiveDialogTurnTakeResult::Absent
         ));
-    }
-
-    #[test]
-    fn active_turn_metadata_lookup_is_bound_to_the_exact_turn() {
-        let store = ActiveDialogTurnStore::default();
-        store.insert(
-            "session-1",
-            ActiveDialogTurn::new(
-                "turn-current".to_string(),
-                None,
-                None,
-                None,
-                "agentic".to_string(),
-                "input".to_string(),
-                Some(serde_json::json!({
-                    "require_tool_confirmation": true,
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "spoofed-background-task"
-                })),
-                DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopUi),
-                None,
-            ),
-        );
-
-        assert_eq!(
-            store.user_message_metadata_bool_for_turn(
-                "session-1",
-                "turn-current",
-                "require_tool_confirmation"
-            ),
-            Some(true)
-        );
-        assert!(store
-            .user_message_metadata_bool_for_turn(
-                "session-1",
-                "turn-stale",
-                "require_tool_confirmation"
-            )
-            .is_none());
-        assert!(store
-            .turn_id_for_background_subagent_delivery("session-1", "spoofed-background-task")
-            .is_none());
-        store.insert(
-            "session-2",
-            ActiveDialogTurn::new(
-                "turn-background".to_string(),
-                None,
-                None,
-                None,
-                "agentic".to_string(),
-                "result".to_string(),
-                Some(serde_json::json!({
-                    "kind": "background_result",
-                    "sourceKind": "subagent",
-                    "backgroundTaskId": "background-task"
-                })),
-                DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession),
-                None,
-            ),
-        );
-        assert_eq!(
-            store.turn_id_for_background_subagent_delivery("session-2", "background-task"),
-            Some("turn-background".to_string())
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove legacy automatic subagent result injection and follow-up delivery while preserving generic background result handling for non-subagent callers.
- Add explicit `any` and `all` AgentWait modes over a frozen set of unconsumed background tasks.
- Persist background coordination in a global SQLite store instead of parent session metadata.
- Expose compact parent-scoped `agent_id` and `bg_task_id` values instead of model-facing global session identifiers.
- Add atomic result claims, restart recovery, cancellation, rollback, deletion, and fork ID reservation behavior.

## Type and Areas

Type:

Feature / refactor / test

Areas:

Rust core, Agent runtime, Task and AgentWait tool contracts, scheduler, session persistence, core boundary checks

## Motivation / Impact

Background subagent results previously depended on automatic scheduler injection and stored outcome state in parent session metadata. This added lifecycle complexity, polluted session metadata, and exposed long global session and task identifiers to the model.

Background work is now consumed explicitly through AgentWait. Models receive compact parent-scoped IDs, can choose whether to wait for any or all selected tasks, and can recover completed results after an application restart.

The selected task set is frozen when AgentWait begins. Empty or omitted `bg_task_ids` selects all currently unconsumed tasks, `wait_mode` defaults to `all`, and `any` retains its result debounce.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-core --lib coordination_store::tests -j 1 -- --nocapture` - 6 passed
- `cargo test -p bitfun-core --lib agent_wait -j 1 -- --nocapture` - 16 passed
- `cargo test -p bitfun-core --lib restart_recovers_completed_result_from_child_turn_history -j 1 -- --nocapture` - passed
- `cargo test -p bitfun-core --lib maintenance_does_not_release_parent_while_background_child_is_still_running -j 1 -- --nocapture` - passed
- `cargo check -p bitfun-core --tests -j 1`
- `cargo check --workspace -j 1`
- `node scripts/check-core-boundaries.mjs`
- `node --test scripts/core-boundaries/self-test.mjs`
- `git diff --check`

`cargo check --workspace -j 1` passed with two pre-existing CLI `dead_code` warnings.

## Reviewer Notes

- Coordination data is stored at `<user_data_dir>/agent-runtime/coordination.sqlite` using WAL mode.
- SQLite stores identity, lifecycle, ownership, and delivery facts; complete result text remains sourced from child session turn history.
- Results are marked delivered when AgentWait successfully constructs the returned result.
- Restart recovery reconciles running tasks owned by a previous runtime against persisted child turn status.
- Forks copy agent ID reservations and counter watermarks, but do not copy live background tasks.
- Existing legacy AgentWait fields in persisted session metadata are ignored and are not proactively removed.
- Model-facing Task fields change from `session_id` to `agent_id`; AgentWait uses `bg_task_ids`. Runtime parsing still tolerates legacy `background_task_ids`.
- Generic background Bash result delivery remains intact.
- No frontend UI or locale changes are included.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.