### PR TITLE
feat(agents): add ACP agent subagent definition

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/definitions/subagents/acp_agent.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/subagents/acp_agent.rs
@@ -1,0 +1,77 @@
+//! ACP bridge agent — an AgentRegistry entry for every configured ACP client.
+//!
+//! Each ACP client (OpenCode, Claude Code, CodeBuddy, etc.) is represented as a
+//! `SubAgent` so it appears in the agent selector and can be targeted by
+//! `SessionControl` / `SessionMessage` for legion orchestration.
+
+use crate::agentic::agents::{Agent, UserContextPolicy};
+use async_trait::async_trait;
+
+/// A thin Agent wrapper around a single ACP client config.
+#[allow(dead_code)]
+pub struct AcpAgent {
+    agent_id: String,
+    display_name: String,
+    default_tools: Vec<String>,
+}
+
+impl AcpAgent {
+    pub fn new(client_id: String, display_name: String) -> Self {
+        let agent_id = Self::agent_id_for(&client_id);
+        Self {
+            // ACP prompt tool is registered in the global tool registry by
+            // register_configured_tools() — do NOT add it to default_tools
+            // here, or the tool name will appear twice in the model manifest.
+            default_tools: vec![
+                "Read".to_string(),
+                "Grep".to_string(),
+                "Glob".to_string(),
+                "LS".to_string(),
+            ],
+            agent_id,
+            display_name,
+        }
+    }
+
+    /// The agent registry id: `acp__<client_id>`
+    pub fn agent_id_for(client_id: &str) -> String {
+        format!("acp__{client_id}")
+    }
+}
+
+#[async_trait]
+impl Agent for AcpAgent {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn id(&self) -> &str {
+        &self.agent_id
+    }
+
+    fn name(&self) -> &str {
+        &self.display_name
+    }
+
+    fn description(&self) -> &str {
+        "ACP agent"
+    }
+
+    fn prompt_template_name(&self, _model_name: Option<&str>) -> &str {
+        "acp_agent"
+    }
+
+    fn default_tools(&self) -> Vec<String> {
+        self.default_tools.clone()
+    }
+
+    fn user_context_policy(&self) -> UserContextPolicy {
+        UserContextPolicy::empty()
+            .with_workspace_context()
+            .with_workspace_instructions()
+    }
+
+    fn is_readonly(&self) -> bool {
+        false
+    }
+}

--- a/src/crates/assembly/core/src/agentic/agents/definitions/subagents/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/subagents/mod.rs
@@ -1,9 +1,11 @@
+﻿mod acp_agent;
 mod computer_use;
 mod explore;
 mod file_finder;
 mod general_purpose;
 mod research_specialist;
 
+pub use acp_agent::AcpAgent;
 pub use computer_use::ComputerUseMode;
 pub use explore::ExploreAgent;
 pub use file_finder::FileFinderAgent;

--- a/src/crates/assembly/core/src/agentic/agents/prompts/acp_agent.md
+++ b/src/crates/assembly/core/src/agentic/agents/prompts/acp_agent.md
@@ -1,0 +1,17 @@
+You are a bridge to an external ACP agent running inside BitFun. A commander has delegated a task to you. Your job is to forward the task through your ACP tool and return the result, nothing more.
+
+## How You Work
+
+1. Read the task that was sent to you via SessionMessage.
+2. Call your ACP prompt tool with the task as the `prompt` parameter.
+3. Return the ACP agent's response exactly as received — do not summarise, reinterpret, or embellish.
+4. If the ACP tool returns an error, report the error with the original task context so the commander can decide how to proceed.
+
+## Constraints
+
+- You do NOT have file write or edit capabilities by default. Your only execution tool is the ACP bridge.
+- Do NOT ask the user questions. The commander is your only audience.
+- Be concise. The commander is managing many agents and needs clear, direct responses.
+- Do NOT pretend to perform work that should be delegated through the ACP tool.
+
+{LANGUAGE_PREFERENCE}


### PR DESCRIPTION
## 概述

新增 ACP（Agent Client Protocol）SubAgent——支持外部 AI Agent 编排。

## 变更

- acp_agent.rs — Agent trait 实现
- acp_agent.md — 提示词
- subagents/mod.rs — 注册

## 验证

- cargo check -p bitfun-core --offline 通过

@wsp1911
Ref: #1674