### PR TITLE
fix(web-ui): make permission requests collapsible

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -1503,7 +1503,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
         {activePermissionBatch && (
           <PermissionRequestPanel
+            key={`${activePermissionBatch.sessionId}:${activePermissionBatch.roundId}`}
             requests={activePermissionBatch.requests}
+            totalPendingCount={permissionRequests.length}
             aboveChatInput={permissionPanelAboveChatInput}
             onRespond={respondPermission}
             onRespondBatch={respondPermissionBatch}

--- a/src/web-ui/src/flow_chat/components/modern/PermissionRequestPanel.scss
+++ b/src/web-ui/src/flow_chat/components/modern/PermissionRequestPanel.scss
@@ -1,4 +1,4 @@
-.permission-request-panel {
+.permission-request-anchor {
   --permission-request-panel-bottom: 20px;
 
   position: absolute;
@@ -6,6 +6,22 @@
   bottom: var(--permission-request-panel-bottom);
   z-index: 25;
   width: min(460px, calc(100% - 40px));
+  display: flex;
+  justify-content: flex-end;
+}
+
+.permission-request-anchor--above-chat-input {
+  // Match the visible ChatInput card: its 900px drop zone has 8px horizontal
+  // insets on both sides before the card itself begins.
+  right: auto;
+  left: 50%;
+  width: min(884px, calc(100% - 16px));
+  transform: translateX(-50%);
+}
+
+.permission-request-panel {
+  width: 100%;
+  box-sizing: border-box;
   display: grid;
   gap: 10px;
   padding: 14px;
@@ -14,15 +30,6 @@
   background: var(--color-bg-secondary);
   box-shadow: var(--shadow-lg);
   color: var(--color-text-primary);
-}
-
-.permission-request-panel--above-chat-input {
-  // Match the visible ChatInput card: its 900px drop zone has 8px horizontal
-  // insets on both sides before the card itself begins.
-  right: auto;
-  left: 50%;
-  width: min(884px, calc(100% - 16px));
-  transform: translateX(-50%);
 }
 
 .permission-request-panel__heading {
@@ -44,6 +51,13 @@
   gap: 9px;
 }
 
+.permission-request-panel__heading-actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 6px;
+}
+
 .permission-request-panel__heading h2 {
   font-size: var(--flowchat-font-size-base);
 }
@@ -57,6 +71,61 @@
 .permission-request-panel__count {
   margin: 0;
   flex: none;
+}
+
+.permission-request-panel__collapse,
+.permission-request-panel__collapsed-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
+  background: var(--color-bg-primary);
+  cursor: pointer;
+}
+
+.permission-request-panel__collapse {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 5px;
+}
+
+.permission-request-panel__collapse:hover,
+.permission-request-panel__collapsed-trigger:hover {
+  background: color-mix(in srgb, var(--color-warning) 14%, var(--color-bg-primary));
+}
+
+.permission-request-panel__collapse:focus-visible,
+.permission-request-panel__collapsed-trigger:focus-visible {
+  outline: 2px solid var(--color-warning);
+  outline-offset: 2px;
+}
+
+.permission-request-panel__collapsed-trigger {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  box-shadow: var(--shadow-lg);
+}
+
+.permission-request-panel__collapsed-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  box-sizing: border-box;
+  padding: 2px 5px;
+  border: 1px solid var(--color-bg-secondary);
+  border-radius: 10px;
+  color: var(--color-static-white);
+  background: var(--color-error);
+  font-size: var(--flowchat-font-size-xs);
+  font-weight: 700;
+  line-height: 1.15;
+  text-align: center;
 }
 
 .permission-request-panel__requests {

--- a/src/web-ui/src/flow_chat/components/modern/PermissionRequestPanel.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/PermissionRequestPanel.test.tsx
@@ -38,6 +38,12 @@ vi.mock('react-i18next', () => ({
       if (key === 'permission.risks.pageSave') {
         return `Save ${values?.slug} as ${values?.visibility} without deploying.`;
       }
+      if (key === 'permission.collapsePanel') {
+        return 'Collapse permission requests';
+      }
+      if (key === 'permission.expandPanel') {
+        return `Expand ${values?.count} pending permission requests`;
+      }
       return TRANSLATIONS[key] ?? key;
     },
   }),
@@ -245,5 +251,72 @@ describe('PermissionRequestPanel', () => {
 
     expect(onRespondBatch).toHaveBeenCalledWith(first.requestId, 'once', undefined);
     expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(2);
+  });
+
+  it('collapses to an anchored permission indicator and reopens it with the session pending count', () => {
+    act(() => {
+      root.render(
+        <PermissionRequestPanel
+          requests={[request(false)]}
+          totalPendingCount={3}
+          onRespond={vi.fn()}
+          onRespondBatch={vi.fn()}
+        />,
+      );
+    });
+
+    const collapseButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="permission-request-panel-collapse"]',
+    );
+    expect(collapseButton?.getAttribute('aria-expanded')).toBe('true');
+
+    act(() => collapseButton?.click());
+
+    expect(container.querySelector('.permission-request-panel')).toBeNull();
+    const expandButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="permission-request-panel-expand"]',
+    );
+    expect(expandButton?.textContent).toContain('3');
+    expect(expandButton?.getAttribute('aria-label')).toBe('Expand 3 pending permission requests');
+    expect(expandButton?.getAttribute('aria-expanded')).toBe('false');
+
+    act(() => expandButton?.click());
+
+    expect(container.querySelector('.permission-request-panel')).not.toBeNull();
+  });
+
+  it('expands again when a newly active permission batch replaces a collapsed one', () => {
+    const first = request(false);
+    const nextBatch = { ...first, requestId: 'next-request', roundId: 'next-round' };
+    act(() => {
+      root.render(
+        <PermissionRequestPanel
+          key={`${first.sessionId}:${first.roundId}`}
+          requests={[first]}
+          onRespond={vi.fn()}
+          onRespondBatch={vi.fn()}
+        />,
+      );
+    });
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="permission-request-panel-collapse"]',
+      )?.click();
+    });
+    expect(container.querySelector('[data-testid="permission-request-panel-expand"]')).not.toBeNull();
+
+    act(() => {
+      root.render(
+        <PermissionRequestPanel
+          key={`${nextBatch.sessionId}:${nextBatch.roundId}`}
+          requests={[nextBatch]}
+          onRespond={vi.fn()}
+          onRespondBatch={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.querySelector('.permission-request-panel')).not.toBeNull();
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/PermissionRequestPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/PermissionRequestPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, type CSSProperties } from 'react';
-import { Check, ShieldAlert, X } from 'lucide-react';
+import { Check, ChevronsDown, ShieldAlert, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@/component-library';
 import type {
@@ -17,6 +17,7 @@ interface PermissionRequestPanelProps {
   onRespond: (requestId: string, reply: PermissionReplyKind, feedback?: string) => Promise<void>;
   onRespondBatch: (requestId: string, reply: PermissionReplyKind, feedback?: string) => Promise<void>;
   aboveChatInput?: boolean;
+  totalPendingCount?: number;
 }
 
 const PERMISSION_ACTION_LABEL_KEYS: Record<string, string> = {
@@ -85,14 +86,17 @@ export function PermissionRequestPanel({
   onRespond,
   onRespondBatch,
   aboveChatInput = false,
+  totalPendingCount,
 }: PermissionRequestPanelProps) {
   const { t } = useTranslation('flow-chat');
   const [feedback, setFeedback] = useState('');
   const [responding, setResponding] = useState(false);
   const [error, setError] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const inputHeight = useChatInputState((state) => state.inputHeight);
   const request = requests[0];
   const risk = permissionRisk(request, t);
+  const pendingCount = Math.max(totalPendingCount ?? requests.length, requests.length);
 
   const alwaysAllowTooltip = request?.saveResources?.length
     ? request.projectPath?.trim()
@@ -135,99 +139,136 @@ export function PermissionRequestPanel({
   if (!request) return null;
 
   return (
-    <section
-      className={`permission-request-panel${aboveChatInput ? ' permission-request-panel--above-chat-input' : ''}`}
+    <div
+      className={`permission-request-anchor${aboveChatInput ? ' permission-request-anchor--above-chat-input' : ''}`}
       style={panelStyle}
-      aria-label={t('permission.title')}
     >
-      <div className="permission-request-panel__heading">
-        <div className="permission-request-panel__heading-title">
-          <ShieldAlert size={18} aria-hidden="true" />
-          <h2>{t('permission.title')}</h2>
-        </div>
-        <span className="permission-request-panel__count">
-          {t('permission.batchCount', { count: requests.length })}
-        </span>
-      </div>
-      <div className="permission-request-panel__requests" role="list">
-        {requests.map((item, index) => (
-          <div
-            className={`permission-request-panel__request${index === 0 ? ' permission-request-panel__request--active' : ''}`}
-            key={item.requestId}
-            role="listitem"
+      {isCollapsed ? (
+        <Tooltip content={t('permission.expandPanel', { count: pendingCount })} placement="top">
+          <button
+            type="button"
+            className="permission-request-panel__collapsed-trigger"
+            onClick={() => setIsCollapsed(false)}
+            aria-label={t('permission.expandPanel', { count: pendingCount })}
+            aria-expanded={false}
+            data-testid="permission-request-panel-expand"
           >
-            <div className="permission-request-panel__request-heading">
-              <div className="permission-request-panel__tool-identity">
-                <strong>{item.source.identity}</strong>
-                {item.delegation && (
-                  <span className="permission-request-panel__subagent">
-                    {t('permission.subagentOwner', { subagent: item.delegation.subagentType })}
-                  </span>
-                )}
-              </div>
-              <span>{index === 0 ? t('permission.current') : t('permission.pending')}</span>
+            <ShieldAlert size={21} aria-hidden="true" />
+            <span className="permission-request-panel__collapsed-badge" aria-hidden="true">
+              {pendingCount > 99 ? '99+' : pendingCount}
+            </span>
+          </button>
+        </Tooltip>
+      ) : (
+        <section
+          id="permission-request-panel"
+          className="permission-request-panel"
+          aria-label={t('permission.title')}
+        >
+          <div className="permission-request-panel__heading">
+            <div className="permission-request-panel__heading-title">
+              <ShieldAlert size={18} aria-hidden="true" />
+              <h2>{t('permission.title')}</h2>
             </div>
-            <div className="permission-request-panel__request-details">
-              <span className="permission-request-panel__action">
-                {permissionActionLabel(item.action, t)}
+            <div className="permission-request-panel__heading-actions">
+              <span className="permission-request-panel__count">
+                {t('permission.batchCount', { count: requests.length })}
               </span>
-              <span className="permission-request-panel__detail-separator" aria-hidden="true">·</span>
-              <Tooltip content={item.resources.join(', ')} placement="top">
-                <code className="permission-request-panel__resource-summary">
-                  {item.resources.join(', ')}
-                </code>
+              <Tooltip content={t('permission.collapsePanel')} placement="top">
+                <button
+                  type="button"
+                  className="permission-request-panel__collapse"
+                  onClick={() => setIsCollapsed(true)}
+                  aria-label={t('permission.collapsePanel')}
+                  aria-expanded={true}
+                  data-testid="permission-request-panel-collapse"
+                >
+                  <ChevronsDown size={17} aria-hidden="true" />
+                </button>
               </Tooltip>
             </div>
           </div>
-        ))}
-      </div>
-      {risk && <p className="permission-request-panel__risk">{risk}</p>}
-      {error && <p role="alert">{t('permission.responseFailed')}</p>}
-      <textarea
-        value={feedback}
-        onChange={(event) => setFeedback(event.target.value)}
-        placeholder={t('permission.feedbackPlaceholder')}
-        aria-label={t('permission.feedbackLabel')}
-        disabled={responding}
-        rows={2}
-      />
-      <div className="permission-request-panel__actions">
-        <div className="permission-request-panel__single-actions">
-          <button type="button" onClick={() => void respond('once')} disabled={responding}>
-            <Check size={15} aria-hidden="true" /> {t('permission.allowOnce')}
-          </button>
-          {!!request.saveResources?.length && (
-            <Tooltip content={alwaysAllowTooltip} placement="top">
-              <button type="button" onClick={() => void respond('always')} disabled={responding}>
-                <Check size={15} aria-hidden="true" /> {t('permission.allowAlways')}
-              </button>
-            </Tooltip>
-          )}
-          <button
-            type="button"
-            className="permission-request-panel__reject"
-            onClick={() => void respond('reject')}
-            disabled={responding}
-          >
-            <X size={15} aria-hidden="true" /> {t('permission.reject')}
-          </button>
-        </div>
-        {requests.length > 1 && (
-          <div className="permission-request-panel__batch-actions">
-          <button type="button" onClick={() => void respondBatch('once')} disabled={responding}>
-            <Check size={15} aria-hidden="true" /> {t('permission.allowCurrentAndFollowing')}
-          </button>
-          <button
-            type="button"
-            className="permission-request-panel__reject"
-            onClick={() => void respondBatch('reject')}
-            disabled={responding}
-          >
-            <X size={15} aria-hidden="true" /> {t('permission.rejectCurrentAndFollowing')}
-          </button>
+          <div className="permission-request-panel__requests" role="list">
+            {requests.map((item, index) => (
+              <div
+                className={`permission-request-panel__request${index === 0 ? ' permission-request-panel__request--active' : ''}`}
+                key={item.requestId}
+                role="listitem"
+              >
+                <div className="permission-request-panel__request-heading">
+                  <div className="permission-request-panel__tool-identity">
+                    <strong>{item.source.identity}</strong>
+                    {item.delegation && (
+                      <span className="permission-request-panel__subagent">
+                        {t('permission.subagentOwner', { subagent: item.delegation.subagentType })}
+                      </span>
+                    )}
+                  </div>
+                  <span>{index === 0 ? t('permission.current') : t('permission.pending')}</span>
+                </div>
+                <div className="permission-request-panel__request-details">
+                  <span className="permission-request-panel__action">
+                    {permissionActionLabel(item.action, t)}
+                  </span>
+                  <span className="permission-request-panel__detail-separator" aria-hidden="true">·</span>
+                  <Tooltip content={item.resources.join(', ')} placement="top">
+                    <code className="permission-request-panel__resource-summary">
+                      {item.resources.join(', ')}
+                    </code>
+                  </Tooltip>
+                </div>
+              </div>
+            ))}
           </div>
-        )}
-      </div>
-    </section>
+          {risk && <p className="permission-request-panel__risk">{risk}</p>}
+          {error && <p role="alert">{t('permission.responseFailed')}</p>}
+          <textarea
+            value={feedback}
+            onChange={(event) => setFeedback(event.target.value)}
+            placeholder={t('permission.feedbackPlaceholder')}
+            aria-label={t('permission.feedbackLabel')}
+            disabled={responding}
+            rows={2}
+          />
+          <div className="permission-request-panel__actions">
+            <div className="permission-request-panel__single-actions">
+              <button type="button" onClick={() => void respond('once')} disabled={responding}>
+                <Check size={15} aria-hidden="true" /> {t('permission.allowOnce')}
+              </button>
+              {!!request.saveResources?.length && (
+                <Tooltip content={alwaysAllowTooltip} placement="top">
+                  <button type="button" onClick={() => void respond('always')} disabled={responding}>
+                    <Check size={15} aria-hidden="true" /> {t('permission.allowAlways')}
+                  </button>
+                </Tooltip>
+              )}
+              <button
+                type="button"
+                className="permission-request-panel__reject"
+                onClick={() => void respond('reject')}
+                disabled={responding}
+              >
+                <X size={15} aria-hidden="true" /> {t('permission.reject')}
+              </button>
+            </div>
+            {requests.length > 1 && (
+              <div className="permission-request-panel__batch-actions">
+                <button type="button" onClick={() => void respondBatch('once')} disabled={responding}>
+                  <Check size={15} aria-hidden="true" /> {t('permission.allowCurrentAndFollowing')}
+                </button>
+                <button
+                  type="button"
+                  className="permission-request-panel__reject"
+                  onClick={() => void respondBatch('reject')}
+                  disabled={responding}
+                >
+                  <X size={15} aria-hidden="true" /> {t('permission.rejectCurrentAndFollowing')}
+                </button>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+    </div>
   );
 }

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -22,6 +22,8 @@
     },
     "reject": "Reject",
     "batchCount": "{{count}} permission requests",
+    "collapsePanel": "Collapse permission requests",
+    "expandPanel": "Expand {{count}} pending permission requests",
     "current": "Current",
     "pending": "Pending",
     "actions": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -22,6 +22,8 @@
     },
     "reject": "拒绝",
     "batchCount": "{{count}} 个权限请求",
+    "collapsePanel": "收起权限请求",
+    "expandPanel": "展开 {{count}} 个待处理的权限请求",
     "current": "当前",
     "pending": "等待中",
     "actions": {

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -22,6 +22,8 @@
     },
     "reject": "拒絕",
     "batchCount": "{{count}} 個授權請求",
+    "collapsePanel": "收起授權請求",
+    "expandPanel": "展開 {{count}} 個待處理的授權請求",
     "current": "目前",
     "pending": "等待中",
     "actions": {


### PR DESCRIPTION
## Summary

- Add a collapse control to the pending permission request panel.
- Replace the expanded panel with a shield-alert circular indicator and pending-request badge when collapsed.
- Keep the indicator anchored to the expanded panel’s lower-right position and reset to expanded for a new active permission batch.
- Add localized labels and interaction coverage.

Fixes #

## Type and Areas

Type:

UI/UX, bug fix

Areas:

Web UI

## Motivation / Impact

Long conversations can place pending tool cards at the bottom of the chat, where the permission panel previously obscured them. Users can now collapse the panel to keep those tool cards visible while retaining a clear, accessible pending-permission indicator.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/PermissionRequestPanel.test.tsx` — passed (8 tests)
- `pnpm run type-check:web` — passed
- `pnpm run i18n:audit` — passed
- `pnpm run theme:color-audit:all` — passed
- `git diff --check` — passed

## Reviewer Notes

The badge reports all pending permission requests in the current session, while the expanded panel continues to present the currently actionable batch. No migration or backend contract changes are required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.