### PR TITLE
fix(external-sources): clarify MCP and agent reviews

### DIFF
--- a/src/crates/assembly/core/src/external_subagents.rs
+++ b/src/crates/assembly/core/src/external_subagents.rs
@@ -86,6 +86,7 @@ struct ResolvedExternalCandidate {
     model_label: String,
     model_configuration_fingerprint: String,
     tools: Vec<ResolvedToolFact>,
+    unavailable_tool_labels: Vec<String>,
     readonly: bool,
     activation_envelope: String,
     approval_key: String,
@@ -675,6 +676,7 @@ fn resolve_external_candidate(
     };
 
     let mut tools = Vec::new();
+    let mut unavailable_tool_labels = Vec::new();
     for selector in definition
         .requested_tools
         .selectors
@@ -689,6 +691,7 @@ fn resolve_external_candidate(
             Some(tool) => tools.push(tool.clone()),
             None => {
                 compatibility = ExternalSubagentCompatibilityState::Blocked;
+                unavailable_tool_labels.push(name.to_string());
                 diagnostics.push(ExternalSubagentDiagnosticSummary {
                     code: "external_subagent.tool_unavailable".to_string(),
                     blocks_activation: true,
@@ -698,6 +701,8 @@ fn resolve_external_candidate(
     }
     tools.sort_by(|left, right| left.name.cmp(&right.name));
     tools.dedup_by(|left, right| left.name == right.name);
+    unavailable_tool_labels.sort();
+    unavailable_tool_labels.dedup();
     diagnostics.sort_by(|left, right| left.code.cmp(&right.code));
     diagnostics.dedup_by(|left, right| left.code == right.code);
     let readonly = tools.iter().all(|tool| tool.readonly);
@@ -779,6 +784,7 @@ fn resolve_external_candidate(
         model_label: model.display_label,
         model_configuration_fingerprint: model.configuration_fingerprint,
         tools,
+        unavailable_tool_labels,
         readonly,
         activation_envelope,
         approval_key,
@@ -1002,6 +1008,7 @@ fn summary_for(
             .iter()
             .map(|tool| tool.name.clone())
             .collect(),
+        unavailable_tool_labels: candidate.unavailable_tool_labels.clone(),
         supports_follow_up: false,
         compatibility_state: candidate.compatibility,
         diagnostics: candidate.diagnostics.clone(),
@@ -1417,6 +1424,40 @@ mod tests {
             ExternalSubagentActivationState::Active
         );
         assert_eq!(recovered.registrations.len(), 1);
+    }
+
+    #[test]
+    fn unavailable_tool_labels_are_preserved_for_product_diagnostics() {
+        let empty_set = BTreeSet::new();
+        let empty_map = BTreeMap::new();
+        let mut definition_snapshot = snapshot("behavior-v1", "catalog-v1");
+        definition_snapshot.definitions[0]
+            .requested_tools
+            .selectors
+            .push(ExternalSubagentToolSelector {
+                source_name: "shell".to_string(),
+                canonical_host_name: Some("Shell".to_string()),
+                allowed: true,
+            });
+
+        let state = reconcile_with_facts(
+            Some(Path::new("C:/repo")),
+            "local-user",
+            &definition_snapshot,
+            ExternalSubagentDecisions {
+                active_ecosystems: test_active_ecosystems(),
+                approved_envelopes: &empty_set,
+                declined_decisions: &empty_map,
+                conflict_choices: &empty_map,
+                conflict_lineage_current_keys: &empty_map,
+            },
+            &facts(),
+        );
+
+        assert_eq!(state.summaries[0].unavailable_tool_labels, ["Shell"]);
+        assert!(state.summaries[0].diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "external_subagent.tool_unavailable" && diagnostic.blocks_activation
+        }));
     }
 
     #[test]

--- a/src/crates/contracts/product-domains/src/external_sources.rs
+++ b/src/crates/contracts/product-domains/src/external_sources.rs
@@ -1912,6 +1912,9 @@ impl ExternalSourcePublicSnapshot {
                 tool.activation = ExternalToolActivationState::Disabled;
             }
         }
+        for subagent in &mut self.subagents {
+            subagent.unavailable_tool_labels.clear();
+        }
         self
     }
 }

--- a/src/crates/contracts/product-domains/src/external_subagents.rs
+++ b/src/crates/contracts/product-domains/src/external_subagents.rs
@@ -516,6 +516,8 @@ pub struct ExternalSubagentSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effective_model_label: Option<String>,
     pub effective_tool_labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unavailable_tool_labels: Vec<String>,
     pub supports_follow_up: bool,
     pub compatibility_state: ExternalSubagentCompatibilityState,
     pub diagnostics: Vec<ExternalSubagentDiagnosticSummary>,

--- a/src/crates/contracts/product-domains/tests/external_source_contracts.rs
+++ b/src/crates/contracts/product-domains/tests/external_source_contracts.rs
@@ -584,6 +584,27 @@ fn legacy_public_snapshot_downprojects_new_tool_review_variants() {
             "approvalKey": "approval-v1",
             "decisionKey": "decision-v1",
             "activation": { "state": "declined" }
+        }],
+        "subagents": [{
+            "candidateId": "external-review",
+            "logicalId": "review",
+            "displayName": "External Review",
+            "description": "Review changes",
+            "providerLabel": "OpenCode",
+            "scope": "project",
+            "sourceKeys": [],
+            "sourceLocationLabels": [],
+            "sourceCount": 1,
+            "effectiveToolLabels": ["Read"],
+            "unavailableToolLabels": ["Shell"],
+            "supportsFollowUp": false,
+            "compatibilityState": "blocked",
+            "diagnostics": [{
+                "code": "external_subagent.tool_unavailable",
+                "blocksActivation": true
+            }],
+            "activationState": { "state": "blocked" },
+            "decisionKey": "agent-decision-v1"
         }]
     }))
     .expect("new public snapshot");
@@ -591,6 +612,9 @@ fn legacy_public_snapshot_downprojects_new_tool_review_variants() {
     let legacy =
         serde_json::to_value(snapshot.into_legacy_v0_compatible()).expect("legacy public snapshot");
     assert_eq!(legacy["tools"][0]["activation"]["state"], "disabled");
+    assert!(legacy["subagents"][0]
+        .get("unavailableToolLabels")
+        .is_none());
 }
 
 #[test]

--- a/src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts
@@ -211,6 +211,7 @@ export interface ExternalSubagentSummary {
   sourceCount: number;
   effectiveModelLabel?: string;
   effectiveToolLabels: string[];
+  unavailableToolLabels: string[];
   supportsFollowUp: boolean;
   compatibilityState: 'ready' | 'ready_with_degradation' | 'blocked' | 'invalid';
   diagnostics: Array<{ code: string; blocksActivation: boolean }>;
@@ -775,6 +776,7 @@ function normalizeSnapshot(value: unknown): ExternalSourceCatalogSnapshot {
       sourceKeys: normalizeOptionalArray(subagent.sourceKeys),
       sourceLocationLabels: normalizeOptionalArray(subagent.sourceLocationLabels),
       effectiveToolLabels: normalizeOptionalArray(subagent.effectiveToolLabels),
+      unavailableToolLabels: normalizeOptionalArray(subagent.unavailableToolLabels),
       diagnostics: normalizeOptionalArray(subagent.diagnostics),
     })),
     subagentConflicts: normalizeOptionalArray<ExternalSubagentConflict>(candidate.subagentConflicts).map((conflict) => ({

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
@@ -494,6 +494,41 @@
     font-size: 11px;
   }
 
+  &__review-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 12px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+  }
+
+  &__review-risk {
+    margin-top: 6px;
+  }
+
+  &__review-details {
+    margin-top: 8px;
+    color: var(--color-text-secondary);
+    font-size: 12px;
+
+    > summary {
+      width: fit-content;
+      color: var(--color-accent-500);
+      cursor: pointer;
+      user-select: none;
+    }
+
+    &[open] > summary {
+      margin-bottom: 8px;
+    }
+  }
+
+  &__diagnostic-code {
+    color: var(--color-text-muted);
+    font-size: 11px;
+    overflow-wrap: anywhere;
+  }
+
   &__tool-actions {
     display: flex;
     justify-content: flex-end;

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
@@ -726,6 +726,27 @@ describe('ExternalSourcesConfig', () => {
           behaviorVersion: 'behavior-v1',
           staticStatus: { state: 'ready' },
         },
+      }, {
+        candidateId: 'external-mcp-docs',
+        approvalKey: 'mcp-approval-v2',
+        decisionKey: 'mcp-decision-v2',
+        definition: {
+          id: {
+            source: { providerId: 'opencode.mcp', sourceId: 'project' },
+            localId: 'docs',
+          },
+          provenance: [{ providerId: 'opencode.mcp', sourceId: 'project' }],
+          name: 'docs',
+          transport: 'streamable_http',
+          remoteUrlPreview: 'https://mcp.example.test',
+          argumentCount: 0,
+          environmentKeys: [],
+          environmentReferenceNames: [],
+          headerNames: [],
+          sourceEnabled: true,
+          behaviorVersion: 'behavior-v2',
+          staticStatus: { state: 'ready' },
+        },
       }],
       mcpConflicts: [{
         conflictKey: 'mcp-conflict-v1',
@@ -770,6 +791,45 @@ describe('ExternalSourcesConfig', () => {
     expect(container.textContent).toContain('mcp.workingDirectory:{"location":"<workspace>"}');
     expect(container.textContent).toContain('GITHUB_TOKEN');
     expect(container.textContent).toContain('OPENCODE_TOKEN');
+
+    const approvalDetails = container.querySelector(
+      '.bitfun-external-sources-config__review-details',
+    ) as HTMLDetailsElement;
+    const approvalCard = approvalDetails.closest(
+      '.bitfun-external-sources-config__tool-card',
+    ) as HTMLElement;
+    const alwaysVisibleSummary = approvalCard.querySelector(
+      '.bitfun-external-sources-config__review-summary',
+    ) as HTMLElement;
+    const alwaysVisibleRisk = approvalCard.querySelector(
+      '.bitfun-external-sources-config__review-risk',
+    ) as HTMLElement;
+    expect(approvalDetails.open).toBe(false);
+    expect(alwaysVisibleSummary.textContent).toContain('mcp.command:{"command":"npx"}');
+    expect(alwaysVisibleRisk.textContent).toContain('mcpApprovals.compactWarning');
+    expect(approvalDetails.contains(alwaysVisibleSummary)).toBe(false);
+    expect(approvalDetails.contains(alwaysVisibleRisk)).toBe(false);
+    const approvalEnable = Array.from(approvalCard.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('mcpApprovals.enable')) as HTMLButtonElement;
+    expect(alwaysVisibleRisk.id).toBe('mcp-review-risk-mcp-decision-v1');
+    expect(approvalEnable.getAttribute('aria-describedby')).toBe(alwaysVisibleRisk.id);
+    const remoteSummary = Array.from(approvalCard.parentElement?.querySelectorAll(
+      '.bitfun-external-sources-config__review-summary',
+    ) ?? []).find((candidate) => candidate.textContent?.includes('mcp.url')) as HTMLElement;
+    const remoteDetails = remoteSummary.closest(
+      '.bitfun-external-sources-config__tool-card',
+    )?.querySelector('.bitfun-external-sources-config__review-details') as HTMLDetailsElement;
+    expect(remoteSummary.textContent).toContain(
+      'mcp.url:{"url":"https://mcp.example.test"}',
+    );
+    expect(remoteDetails.textContent).not.toContain(
+      'mcp.url:{"url":"https://mcp.example.test"}',
+    );
+    expect(approvalDetails.querySelector('summary')?.textContent)
+      .toContain('mcpApprovals.showDetails');
+    expect(container.textContent).toContain('mcpApprovals.enable');
+    await act(async () => approvalDetails.querySelector('summary')?.click());
+    expect(approvalDetails.open).toBe(true);
 
     const externalConflictCandidate = Array.from(
       container.querySelectorAll('.bitfun-external-sources-config__candidate'),
@@ -1256,13 +1316,23 @@ describe('ExternalSourcesConfig', () => {
         sourceCount: 1,
         effectiveModelLabel: 'fast',
         effectiveToolLabels: ['Read', 'Grep'],
+        unavailableToolLabels: ['Shell', 'Write'],
         supportsFollowUp: false,
         compatibilityState: 'ready',
         diagnostics: [{
           code: 'opencode_agent_prompt_not_imported',
           blocksActivation: true,
         }, {
+          code: 'external_subagent.tool_unavailable',
+          blocksActivation: true,
+        }, {
+          code: 'opencode_agent_permission_not_imported',
+          blocksActivation: true,
+        }, {
           code: 'opencode_default_permission_semantics_not_imported',
+          blocksActivation: false,
+        }, {
+          code: 'opencode_agent_temperature_not_imported',
           blocksActivation: false,
         }, {
           code: 'opencode_agent_definition_type_invalid',
@@ -1340,9 +1410,21 @@ describe('ExternalSourcesConfig', () => {
     expect(container.textContent).toContain('fast');
     expect(container.textContent).toContain('Read, Grep');
     expect(container.textContent).toContain('agents.executionDomain');
-    expect(container.textContent).toContain('agentDiagnostics.unsupportedBehavior.reason');
-    expect(container.textContent).toContain('agentDiagnostics.ignoredOption.reason');
+    expect(container.textContent).toContain(
+      'agentDiagnostics.toolUnavailable.reason:{"tools":"Shell, Write"}',
+    );
+    expect(container.textContent).toContain('agentDiagnostics.promptMissing.reason');
+    expect(container.textContent).toContain(
+      'agentDiagnostics.unsupportedSetting.reason:{"setting":"agentDiagnostics.settings.permissions"}',
+    );
+    expect(container.textContent).toContain(
+      'agentDiagnostics.ignoredSetting.reason:{"setting":"agentDiagnostics.settings.defaultPermissions"}',
+    );
+    expect(container.textContent).toContain(
+      'agentDiagnostics.ignoredSetting.reason:{"setting":"agentDiagnostics.settings.temperature"}',
+    );
     expect(container.textContent).toContain('agentDiagnostics.invalidDefinition.reason');
+    expect(container.textContent).toContain('opencode_agent_definition_type_invalid');
     expect(container.textContent).toContain('agentConflicts.selectionApproves');
     expect(container.textContent).toContain('.opencode/agents/explore.md');
     expect(container.textContent).not.toContain('D:/workspace/project/.opencode/agents');

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
@@ -61,6 +61,25 @@ const SOURCE_COUNT_LABELS = [
   ['mcps', 'sources.mcpCount'],
 ] as const;
 
+const AGENT_DIAGNOSTIC_SETTING_KEYS: Record<string, string> = {
+  opencode_unknown_agent_field: 'unknownField',
+  opencode_ambient_permission_not_imported: 'ambientPermissions',
+  opencode_agent_permission_not_imported: 'permissions',
+  opencode_agent_options_not_imported: 'options',
+  opencode_native_agent_overlay_not_imported: 'nativeAgentOverlay',
+  opencode_legacy_primary_mode_not_imported: 'legacyPrimaryMode',
+  opencode_primary_agent_not_imported: 'primaryAgentMode',
+  opencode_agent_tool_pattern_not_imported: 'toolPatterns',
+  opencode_default_permission_semantics_not_imported: 'defaultPermissions',
+  opencode_agent_variant_not_imported: 'variant',
+  opencode_agent_temperature_not_imported: 'temperature',
+  opencode_agent_top_p_not_imported: 'topP',
+  opencode_agent_steps_not_imported: 'steps',
+  opencode_agent_maxSteps_not_imported: 'maxSteps',
+  opencode_agent_color_not_imported: 'color',
+  opencode_primary_facet_not_imported: 'primaryFacet',
+};
+
 type SnapshotLoadResult =
   | { status: 'accepted'; snapshot: ExternalSourceCatalogSnapshot }
   | { status: 'ignored' }
@@ -84,11 +103,32 @@ function agentDiagnosticCategory(code: string, blocksActivation: boolean): strin
   if (code.includes('configuration_unavailable')) return 'configurationUnavailable';
   if (code.includes('model_unavailable')) return 'modelUnavailable';
   if (code.includes('tool_unavailable')) return 'toolUnavailable';
+  if (code === 'opencode_agent_prompt_not_imported') return 'promptMissing';
+  if (AGENT_DIAGNOSTIC_SETTING_KEYS[code]) {
+    return blocksActivation ? 'unsupportedSetting' : 'ignoredSetting';
+  }
   if (code.includes('type_invalid') || code.includes('definition_invalid')
     || code.endsWith('_invalid')) {
     return 'invalidDefinition';
   }
   return blocksActivation ? 'unsupportedBehavior' : 'ignoredOption';
+}
+
+function agentDiagnosticParams(
+  code: string,
+  category: string,
+  unavailableToolLabels: string[],
+  t: TFunction,
+): Record<string, string> | undefined {
+  if (category === 'toolUnavailable') {
+    return {
+      tools: unavailableToolLabels.join(', ') || t('agents.unavailableToolsUnknown'),
+    };
+  }
+  const settingKey = AGENT_DIAGNOSTIC_SETTING_KEYS[code];
+  return settingKey
+    ? { setting: t(`agentDiagnostics.settings.${settingKey}`) }
+    : undefined;
 }
 
 function sourceDiagnosticCategory(code: string): string {
@@ -1801,6 +1841,7 @@ const ExternalSourcesConfig: React.FC = () => {
                     candidate.record.key.providerId === request.definition.id.source.providerId
                     && candidate.record.key.sourceId === request.definition.id.source.sourceId
                   ));
+                  const reviewRiskId = `mcp-review-risk-${encodeURIComponent(request.decisionKey)}`;
                   return (
                     <div
                       className="bitfun-external-sources-config__tool-card"
@@ -1809,20 +1850,10 @@ const ExternalSourcesConfig: React.FC = () => {
                     <div className="bitfun-external-sources-config__conflict-title">
                       {request.definition.name}
                     </div>
-                    <div className="bitfun-external-sources-config__tool-detail">
+                    <div className="bitfun-external-sources-config__review-summary">
                       <span>{t('mcp.source', {
                         source: source?.record.displayName ?? t('mcp.externalSource'),
                       })}</span>
-                      {source ? (
-                        <span>{t('mcp.sourceLocation', {
-                          location: source.record.location,
-                        })}</span>
-                      ) : null}
-                      {source ? (
-                        <span>{t('mcp.scope', {
-                          scope: sourceScopeLabel(source.record.scope, t),
-                        })}</span>
-                      ) : null}
                       <span>{t(`mcp.transport.${request.definition.transport}`)}</span>
                       {request.definition.commandPreview ? (
                         <span>{t('mcp.command', { command: request.definition.commandPreview })}</span>
@@ -1830,39 +1861,64 @@ const ExternalSourcesConfig: React.FC = () => {
                       {request.definition.remoteUrlPreview ? (
                         <span>{t('mcp.url', { url: request.definition.remoteUrlPreview })}</span>
                       ) : null}
-                      {request.definition.workingDirectory ? (
-                        <span>{t('mcp.workingDirectory', {
-                          location: request.definition.workingDirectory,
-                        })}</span>
-                      ) : null}
-                      <span>{t('mcp.argumentCount', {
-                        count: request.definition.argumentCount,
-                      })}</span>
-                      <span>{t('mcp.environmentCount', {
-                        count: request.definition.environmentKeys.length,
-                      })}</span>
-                      {request.definition.environmentKeys.length > 0 ? (
-                        <span>{t('mcp.environmentNames', {
-                          names: request.definition.environmentKeys.join(', '),
-                        })}</span>
-                      ) : null}
-                      {(request.definition.environmentReferenceNames?.length ?? 0) > 0 ? (
-                        <span>{t('mcp.environmentReads', {
-                          names: (request.definition.environmentReferenceNames ?? []).join(', '),
-                        })}</span>
-                      ) : null}
-                      <span>{t('mcp.headerCount', {
-                        count: request.definition.headerNames.length,
-                      })}</span>
-                      {request.definition.headerNames.length > 0 ? (
-                        <span>{t('mcp.headerNames', {
-                          names: request.definition.headerNames.join(', '),
-                        })}</span>
-                      ) : null}
                     </div>
-                    <div className="bitfun-external-sources-config__tool-warning">
-                      {t('mcpApprovals.warning')}
+                    <div
+                      className={[
+                        'bitfun-external-sources-config__tool-warning',
+                        'bitfun-external-sources-config__review-risk',
+                      ].join(' ')}
+                      id={reviewRiskId}
+                      role="note"
+                    >
+                      {t('mcpApprovals.compactWarning')}
                     </div>
+                    <details className="bitfun-external-sources-config__review-details">
+                      <summary>{t('mcpApprovals.showDetails')}</summary>
+                      <div className="bitfun-external-sources-config__tool-detail">
+                        {source ? (
+                          <span>{t('mcp.sourceLocation', {
+                            location: source.record.location,
+                          })}</span>
+                        ) : null}
+                        {source ? (
+                          <span>{t('mcp.scope', {
+                            scope: sourceScopeLabel(source.record.scope, t),
+                          })}</span>
+                        ) : null}
+                        {request.definition.workingDirectory ? (
+                          <span>{t('mcp.workingDirectory', {
+                            location: request.definition.workingDirectory,
+                          })}</span>
+                        ) : null}
+                        <span>{t('mcp.argumentCount', {
+                          count: request.definition.argumentCount,
+                        })}</span>
+                        <span>{t('mcp.environmentCount', {
+                          count: request.definition.environmentKeys.length,
+                        })}</span>
+                        {request.definition.environmentKeys.length > 0 ? (
+                          <span>{t('mcp.environmentNames', {
+                            names: request.definition.environmentKeys.join(', '),
+                          })}</span>
+                        ) : null}
+                        {(request.definition.environmentReferenceNames?.length ?? 0) > 0 ? (
+                          <span>{t('mcp.environmentReads', {
+                            names: (request.definition.environmentReferenceNames ?? []).join(', '),
+                          })}</span>
+                        ) : null}
+                        <span>{t('mcp.headerCount', {
+                          count: request.definition.headerNames.length,
+                        })}</span>
+                        {request.definition.headerNames.length > 0 ? (
+                          <span>{t('mcp.headerNames', {
+                            names: request.definition.headerNames.join(', '),
+                          })}</span>
+                        ) : null}
+                      </div>
+                      <div className="bitfun-external-sources-config__tool-warning">
+                        {t('mcpApprovals.warning')}
+                      </div>
+                    </details>
                     <div className="bitfun-external-sources-config__tool-actions">
                       <Button
                         variant="secondary"
@@ -1880,6 +1936,7 @@ const ExternalSourcesConfig: React.FC = () => {
                       <Button
                         variant="primary"
                         size="small"
+                        aria-describedby={reviewRiskId}
                         disabled={!policyCompatible || busyKey !== null
                           || !hostCapabilities.canApproveRuntime}
                         onClick={() => void decideMcpServer(
@@ -2291,10 +2348,19 @@ const ExternalSourcesConfig: React.FC = () => {
                                   diagnostic.code,
                                   diagnostic.blocksActivation,
                                 );
+                                const params = agentDiagnosticParams(
+                                  diagnostic.code,
+                                  category,
+                                  agent.unavailableToolLabels ?? [],
+                                  t,
+                                );
                               return (
                                 <div key={diagnostic.code}>
-                                  <span>{t(`agentDiagnostics.${category}.reason`)}</span>
-                                  <span>{t(`agentDiagnostics.${category}.nextStep`)}</span>
+                                  <span>{t(`agentDiagnostics.${category}.reason`, params)}</span>
+                                  <code className="bitfun-external-sources-config__diagnostic-code">
+                                    {diagnostic.code}
+                                  </code>
+                                  <span>{t(`agentDiagnostics.${category}.nextStep`, params)}</span>
                                 </div>
                               );
                             })}
@@ -2409,15 +2475,25 @@ const ExternalSourcesConfig: React.FC = () => {
                                     diagnostic.code,
                                     diagnostic.blocksActivation,
                                   );
+                                  const params = agentDiagnosticParams(
+                                    diagnostic.code,
+                                    category,
+                                    externalAgent.unavailableToolLabels ?? [],
+                                    t,
+                                  );
                                   return (
                                     <span key={diagnostic.code}>
-                                      {t(`agentDiagnostics.${category}.reason`)}{' '}
+                                      {t(`agentDiagnostics.${category}.reason`, params)}{' '}
                                       {t(`agentDiagnostics.${category}.impact`, {
                                         impact: diagnostic.blocksActivation
                                           ? t('agentDiagnostics.activationBlocked')
                                           : t('agentDiagnostics.degradedOnly'),
+                                        ...params,
                                       })}{' '}
-                                      {t(`agentDiagnostics.${category}.nextStep`)}
+                                      <code className="bitfun-external-sources-config__diagnostic-code">
+                                        {diagnostic.code}
+                                      </code>{' '}
+                                      {t(`agentDiagnostics.${category}.nextStep`, params)}
                                     </span>
                                   );
                                 })}

--- a/src/web-ui/src/locales/en-US/settings/external-sources.json
+++ b/src/web-ui/src/locales/en-US/settings/external-sources.json
@@ -253,6 +253,7 @@
     "compatibility": "Status: {{state}}",
     "noDescription": "No description provided",
     "noTools": "No tools",
+    "unavailableToolsUnknown": "Names were not provided by this host",
     "sourceLocations": "Configuration sources ({{count}})"
   },
   "agentState": {
@@ -289,9 +290,42 @@
       "nextStep": "Choose an available model in the source application, or set an available fixed Sub-Agent model in BitFun, then refresh."
     },
     "toolUnavailable": {
-      "reason": "One or more requested tools are not available in BitFun.",
+      "reason": "Unavailable tools: {{tools}}.",
       "impact": "{{impact}}",
       "nextStep": "Remove or replace the unsupported tools in the source application, then refresh."
+    },
+    "promptMissing": {
+      "reason": "The agent prompt is missing or empty.",
+      "impact": "{{impact}}",
+      "nextStep": "Add a non-empty prompt in the source application, then refresh."
+    },
+    "unsupportedSetting": {
+      "reason": "BitFun does not currently support this agent's {{setting}} setting.",
+      "impact": "{{impact}}",
+      "nextStep": "Remove or change {{setting}} in the source application, then refresh."
+    },
+    "ignoredSetting": {
+      "reason": "BitFun will not apply this agent's {{setting}} setting.",
+      "impact": "{{impact}}",
+      "nextStep": "Review the effective model and tools above before enabling this agent."
+    },
+    "settings": {
+      "unknownField": "unknown field",
+      "ambientPermissions": "global permission",
+      "permissions": "permission",
+      "options": "options",
+      "nativeAgentOverlay": "built-in agent override",
+      "legacyPrimaryMode": "legacy primary mode",
+      "primaryAgentMode": "primary agent mode",
+      "toolPatterns": "tool wildcard",
+      "defaultPermissions": "default permission semantics",
+      "variant": "model variant",
+      "temperature": "temperature",
+      "topP": "top_p",
+      "steps": "step limit",
+      "maxSteps": "maxSteps limit",
+      "color": "display color",
+      "primaryFacet": "primary-agent facet"
     },
     "invalidDefinition": {
       "reason": "The agent settings have an invalid or missing required value.",
@@ -357,7 +391,9 @@
   "mcpApprovals": {
     "title": "MCP servers to review",
     "description": "BitFun found executable or network configuration from another AI application. It is not started or contacted until you confirm it.",
-    "warning": "Enabling can start a local process with your user permissions or connect to the shown remote service. The server can provide tools to the agent and can receive arguments sent to those tools.",
+    "compactWarning": "Enabling can run this command with your user permissions or connect to this service; the server can receive data sent in tool calls.",
+    "showDetails": "Show configuration and risk",
+    "warning": "Local commands can read the listed environment variables, and remote requests can send the listed headers. Review these details before enabling.",
     "keepDisabled": "Keep disabled",
     "enable": "Enable server"
   },

--- a/src/web-ui/src/locales/zh-CN/settings/external-sources.json
+++ b/src/web-ui/src/locales/zh-CN/settings/external-sources.json
@@ -253,6 +253,7 @@
     "compatibility": "状态：{{state}}",
     "noDescription": "未提供说明",
     "noTools": "无工具",
+    "unavailableToolsUnknown": "当前 Host 未提供工具名称",
     "sourceLocations": "配置来源（{{count}} 个）"
   },
   "agentState": {
@@ -289,9 +290,42 @@
       "nextStep": "请在来源应用中改用可用模型，或在 BitFun 中设置可用的固定 Sub-Agent 模型，然后刷新。"
     },
     "toolUnavailable": {
-      "reason": "该 Agent 请求的一个或多个工具在 BitFun 中不可用。",
+      "reason": "BitFun 中不可用的工具：{{tools}}。",
       "impact": "{{impact}}",
       "nextStep": "请在来源应用中移除或替换不支持的工具，然后刷新。"
+    },
+    "promptMissing": {
+      "reason": "该 Agent 缺少有效的 prompt。",
+      "impact": "{{impact}}",
+      "nextStep": "请在来源应用中补充非空 prompt，然后刷新。"
+    },
+    "unsupportedSetting": {
+      "reason": "BitFun 当前不支持该 Agent 的“{{setting}}”设置。",
+      "impact": "{{impact}}",
+      "nextStep": "请在来源应用中移除或修改“{{setting}}”，然后刷新。"
+    },
+    "ignoredSetting": {
+      "reason": "BitFun 不会应用该 Agent 的“{{setting}}”设置。",
+      "impact": "{{impact}}",
+      "nextStep": "启用前，请核对上方实际使用的模型和工具。"
+    },
+    "settings": {
+      "unknownField": "未知字段",
+      "ambientPermissions": "全局权限",
+      "permissions": "permission 权限",
+      "options": "options",
+      "nativeAgentOverlay": "内置 Agent 覆盖",
+      "legacyPrimaryMode": "旧版 primary 模式",
+      "primaryAgentMode": "primary Agent 模式",
+      "toolPatterns": "工具通配规则",
+      "defaultPermissions": "默认权限语义",
+      "variant": "模型 variant",
+      "temperature": "temperature 参数",
+      "topP": "top_p 参数",
+      "steps": "steps 步数限制",
+      "maxSteps": "maxSteps 步数限制",
+      "color": "显示颜色",
+      "primaryFacet": "primary Agent 能力"
     },
     "invalidDefinition": {
       "reason": "该 Agent 的配置缺少必填内容或包含无效内容。",
@@ -357,7 +391,9 @@
   "mcpApprovals": {
     "title": "待确认的 MCP 服务器",
     "description": "BitFun 从其他 AI 应用中发现了可执行命令或网络连接配置；确认前不会启动进程或访问远程地址。",
-    "warning": "启用后，BitFun 可能以你的用户权限启动本地进程，或连接到上方显示的远程服务。服务器可以向 Agent 提供工具，并接收调用这些工具时提交的参数。",
+    "compactWarning": "启用后，BitFun 可能以你的用户权限启动该命令或连接该服务；服务器可接收工具调用中发送的数据。",
+    "showDetails": "查看配置与风险",
+    "warning": "本地命令可读取列出的环境变量，远程请求可发送列出的请求头；启用前请核对这些详情。",
     "keepDisabled": "保持停用",
     "enable": "启用服务器"
   },

--- a/src/web-ui/src/locales/zh-TW/settings/external-sources.json
+++ b/src/web-ui/src/locales/zh-TW/settings/external-sources.json
@@ -253,6 +253,7 @@
     "compatibility": "狀態：{{state}}",
     "noDescription": "未提供說明",
     "noTools": "無工具",
+    "unavailableToolsUnknown": "目前 Host 未提供工具名稱",
     "sourceLocations": "設定來源（{{count}} 個）"
   },
   "agentState": {
@@ -289,9 +290,42 @@
       "nextStep": "請在來源應用中改用可用模型，或在 BitFun 中設定可用的固定 Sub-Agent 模型，然後重新整理。"
     },
     "toolUnavailable": {
-      "reason": "此 Agent 要求的一個或多個工具在 BitFun 中不可用。",
+      "reason": "BitFun 中不可用的工具：{{tools}}。",
       "impact": "{{impact}}",
       "nextStep": "請在來源應用中移除或替換不支援的工具，然後重新整理。"
+    },
+    "promptMissing": {
+      "reason": "此 Agent 缺少有效的 prompt。",
+      "impact": "{{impact}}",
+      "nextStep": "請在來源應用中補上非空白 prompt，然後重新整理。"
+    },
+    "unsupportedSetting": {
+      "reason": "BitFun 目前不支援此 Agent 的「{{setting}}」設定。",
+      "impact": "{{impact}}",
+      "nextStep": "請在來源應用中移除或修改「{{setting}}」，然後重新整理。"
+    },
+    "ignoredSetting": {
+      "reason": "BitFun 不會套用此 Agent 的「{{setting}}」設定。",
+      "impact": "{{impact}}",
+      "nextStep": "啟用前，請核對上方實際使用的模型與工具。"
+    },
+    "settings": {
+      "unknownField": "未知欄位",
+      "ambientPermissions": "全域權限",
+      "permissions": "permission 權限",
+      "options": "options",
+      "nativeAgentOverlay": "內建 Agent 覆寫",
+      "legacyPrimaryMode": "舊版 primary 模式",
+      "primaryAgentMode": "primary Agent 模式",
+      "toolPatterns": "工具萬用字元規則",
+      "defaultPermissions": "預設權限語意",
+      "variant": "模型 variant",
+      "temperature": "temperature 參數",
+      "topP": "top_p 參數",
+      "steps": "steps 步數限制",
+      "maxSteps": "maxSteps 步數限制",
+      "color": "顯示顏色",
+      "primaryFacet": "primary Agent 能力"
     },
     "invalidDefinition": {
       "reason": "此 Agent 的設定缺少必填內容或包含無效內容。",
@@ -357,7 +391,9 @@
   "mcpApprovals": {
     "title": "待確認的 MCP 伺服器",
     "description": "BitFun 從其他 AI 應用程式找到可執行命令或網路連線設定；確認前不會啟動程序或存取遠端位址。",
-    "warning": "啟用後，BitFun 可能以你的使用者權限啟動本機程序，或連線到上方顯示的遠端服務。伺服器可以向 Agent 提供工具，並接收呼叫這些工具時提交的參數。",
+    "compactWarning": "啟用後，BitFun 可能以你的使用者權限啟動該命令或連線至該服務；伺服器可接收工具呼叫中傳送的資料。",
+    "showDetails": "查看設定與風險",
+    "warning": "本機命令可讀取列出的環境變數，遠端請求可傳送列出的標頭；啟用前請核對這些詳細資訊。",
     "keepDisabled": "保持停用",
     "enable": "啟用伺服器"
   },


### PR DESCRIPTION
## Summary

- keep pending MCP reviews compact while leaving the command or remote URL and a concise execution/data risk warning visible before approval
- keep working directory, environment, header, and full configuration details behind an explicit disclosure, and associate the risk note with the enable action for assistive technology
- report exact unavailable tool names and setting-specific OpenCode agent diagnostics while preserving older host and snapshot compatibility

## Verification

- `cargo test -p bitfun-product-domains --features external-sources --test external_source_contracts` (36 passed)
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/ExternalSourcesConfig.test.tsx` (45 passed)
- `pnpm run type-check:web`
- `pnpm run i18n:audit`
- `pnpm run theme:color-audit:all`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check`

A broad workspace/Core compile was intentionally not run locally because this is a focused change; CI remains the compilation gate.