### PR TITLE
fix(permission): honor full access for Bash commands

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -566,7 +566,10 @@ fn permission_intent_effect(
                         &rule.action,
                         PermissionResourceCaseSensitivity::Sensitive,
                     ) && match rule.effect {
-                        PermissionEffect::Allow => rule.resource == *resource,
+                        PermissionEffect::Allow => {
+                            rule.resource == *resource
+                                || (rule.action == "*" && rule.resource == "*")
+                        }
                         PermissionEffect::Ask | PermissionEffect::Deny => {
                             wildcard_matches(resource, &rule.resource, case_sensitivity)
                         }
@@ -2189,10 +2192,10 @@ mod tests {
     };
     use bitfun_runtime_ports::{
         ClockPort, PermissionAuditEvent, PermissionAuditRecord, PermissionAuditStorePort,
-        PermissionGrant, PermissionGrantKey, PermissionGrantStorePort, PermissionReplyStorePort,
-        PortResult, RoundInjection, RoundInjectionExecutionPolicy, RoundInjectionKind,
-        RoundInjectionTarget, RoundInjectionToolPreemption, RuntimeServiceCapability,
-        RuntimeServicePort,
+        PermissionGrant, PermissionGrantKey, PermissionGrantStorePort, PermissionPolicyPreset,
+        PermissionReplyStorePort, PortResult, RoundInjection, RoundInjectionExecutionPolicy,
+        RoundInjectionKind, RoundInjectionTarget, RoundInjectionToolPreemption,
+        RuntimeServiceCapability, RuntimeServicePort,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -2293,6 +2296,22 @@ mod tests {
                 PermissionResourceCaseSensitivity::Sensitive,
             ),
             PermissionEffect::Deny
+        );
+    }
+
+    #[test]
+    fn full_access_baseline_allows_bash_commands() {
+        let intent = PermissionIntent::new("bash", vec!["git status && rm -rf build".to_string()]);
+        let full_access_rules = PermissionPolicyPreset::FullAccess.baseline_rules();
+
+        assert_eq!(
+            permission_intent_effect(
+                &intent,
+                &full_access_rules,
+                &[],
+                PermissionResourceCaseSensitivity::Sensitive,
+            ),
+            PermissionEffect::Allow
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix Bash tools falling back to confirmation when the global permission mode is Full access.
- Preserve exact-command matching for custom Bash allow rules.
- Add a regression test for the Full access Bash baseline.

Fixes #

## Type and Areas

Type:

Regression fix

Areas:

Rust core

## Motivation / Impact

Full access resolves to a `*/* -> Allow` baseline, but the Bash-specific matcher previously ignored that rule and fell back to Ask. Bash commands now honor Full access while custom wildcard Bash allow rules remain non-authorizing for compound commands.

## Verification

- `cargo check -p bitfun-core --features product-full`
- `cargo test -p bitfun-core --features product-full --lib full_access_baseline_allows_bash_commands`
- Verified in the desktop development build: Full access resolved Bash, edit, read, and external-directory actions as Allow without a permission prompt.

## Reviewer Notes

- No migration or user-facing string changes.
- The special case only recognizes the global `*/* -> Allow` baseline; custom Bash Allow rules still require an exact command match.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.