### PR TITLE
chore: bump version to 0.2.14

### DIFF
--- a/BitFun-Installer/package-lock.json
+++ b/BitFun-Installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-installer",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "type": "module",
   "description": "BitFun Custom Installer - Modern branded installation experience",

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-installer"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Custom Installer - Modern branded installation experience"

--- a/BitFun-Installer/src/pages/LanguageSelect.tsx
+++ b/BitFun-Installer/src/pages/LanguageSelect.tsx
@@ -72,7 +72,7 @@ export function LanguageSelect({ onSelect }: LanguageSelectProps) {
             opacity: 0.6,
             letterSpacing: '0.5px',
           }}>
-            Version 0.2.13
+            Version 0.2.14
           </div>
         </div>
       </div>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ resolver = "2"
 
 # Shared package metadata — single source of truth for version
 [workspace.package]
-version = "0.2.13" # x-release-please-version
+version = "0.2.14" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "BitFun",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "BitFun",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "hasInstallScript": true,
       "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BitFun",
   "private": true,
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-server"
-version = "0.2.13" # x-release-please-version
+version = "0.2.14" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun standalone Remote Connect relay server"

--- a/src/crates/services/page-function-runtime/Cargo.toml
+++ b/src/crates/services/page-function-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-page-function-runtime"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Embedded JS Page Function runtime for BitFun Pages (rquickjs)"

--- a/src/crates/services/relay-service/Cargo.toml
+++ b/src/crates/services/relay-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-service"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Reusable relay runtime for BitFun Remote Connect"

--- a/src/crates/services/services-integrations/tests/announcement_contracts.rs
+++ b/src/crates/services/services-integrations/tests/announcement_contracts.rs
@@ -165,14 +165,14 @@ async fn announcement_state_store_round_trips_state_and_defaults_missing_file() 
 fn announcement_remote_fetch_request_preserves_legacy_query_shape() {
     let request = AnnouncementRemoteFetchRequest {
         endpoint_url: "https://announcements.example.com/cards".to_string(),
-        app_version: "0.2.13".to_string(),
+        app_version: "0.2.14".to_string(),
         locale: "zh-CN".to_string(),
         platform: "desktop".to_string(),
     };
 
     assert_eq!(
         request.request_url(),
-        "https://announcements.example.com/cards?app_version=0.2.13&locale=zh-CN&platform=desktop"
+        "https://announcements.example.com/cards?app_version=0.2.14&locale=zh-CN&platform=desktop"
     );
 }
 

--- a/src/mobile-web/package-lock.json
+++ b/src/mobile-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-mobile-web",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfun/web-ui",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": true,
   "description": "BitFun Web UI - 支持 Desktop 和 Server 两种部署方式",
   "type": "module",

--- a/src/web-ui/src/component-library/preview/PreviewApp.tsx
+++ b/src/web-ui/src/component-library/preview/PreviewApp.tsx
@@ -48,7 +48,7 @@ export const PreviewApp: React.FC = () => {
       <header className="preview-header">
         <div className="preview-logo">
           <h1>{t('componentLibrary.previewApp.title')}</h1>
-          <span className="preview-version">v0.2.13</span>
+          <span className="preview-version">v0.2.14</span>
         </div>
         <div className="preview-header-actions">
           <label className="preview-theme-selector">

--- a/src/web-ui/src/shared/utils/version.ts
+++ b/src/web-ui/src/shared/utils/version.ts
@@ -6,7 +6,7 @@ import { i18nService } from '@/infrastructure/i18n';
  
 const DEFAULT_VERSION_INFO: VersionInfo = {
   name: 'BitFun',
-  version: '0.2.13',
+  version: '0.2.14',
   buildDate: new Date().toISOString(),
   buildTimestamp: Date.now(),
   isDev: import.meta.env.DEV,


### PR DESCRIPTION
## Summary

- bump the BitFun product version from 0.2.13 to 0.2.14
- keep root, Web UI, mobile web, installer, Relay Server, Relay Service, and Page Function Runtime version metadata aligned
- update displayed fallback versions and the announcement request contract fixture

## Verification

- `pnpm run check:github-config`
- `pnpm run type-check:web`
- `pnpm --dir src/mobile-web run type-check`
- `pnpm --dir BitFun-Installer run type-check`
- `cargo metadata --no-deps --format-version 1`
- `cargo test -p bitfun-services-integrations --features announcement --test announcement_contracts announcement_remote_fetch_request_preserves_legacy_query_shape`
- `git diff --check`

`pnpm run check:repo-hygiene` is blocked by the pre-existing untracked `generate_intro_doc.cjs`, which contains a local absolute path; that unrelated file is not included in this PR.