### PR TITLE
fix(release): fall back when minisign apt package is unavailable

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -324,6 +324,9 @@ jobs:
             --repo "GCWing/BitFun" \
             --out linux-release-assets/linux-binaries.json
 
+      - name: Setup Rust toolchain (minisign fallback)
+        uses: dtolnay/rust-toolchain@stable
+
       # The Tauri bundler signs the five updater artifacts during `tauri build`,
       # but the installers people download by hand from the release page — dmg,
       # deb, rpm, the Windows installer and the direct AppImages — shipped with

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -279,6 +279,9 @@ jobs:
             --repo "GCWing/BitFun" \
             --out linux-release-assets/linux-binaries.json
 
+      - name: Setup Rust toolchain (minisign fallback)
+        uses: dtolnay/rust-toolchain@stable
+
       # The Tauri bundler signs the five updater artifacts during `tauri build`,
       # but the installers people download by hand from the release page — dmg,
       # deb, rpm, the Windows installer and the direct AppImages — shipped with

--- a/scripts/sign-release-assets.sh
+++ b/scripts/sign-release-assets.sh
@@ -34,7 +34,18 @@ fi
 
 if ! command -v minisign >/dev/null 2>&1; then
   echo "[sign] Installing minisign..."
-  sudo apt-get install -y --no-install-recommends minisign >/dev/null
+  # Ubuntu's package is not available in the default repositories on every
+  # runner image (notably ubuntu-24.04-arm). Prefer it when present, then use
+  # the portable Rust distribution as a fallback.
+  if ! sudo apt-get install -y --no-install-recommends minisign >/dev/null 2>&1; then
+    if ! command -v cargo >/dev/null 2>&1; then
+      echo "[sign] ERROR: minisign is unavailable and cargo is not installed." >&2
+      exit 1
+    fi
+    MINISIGN_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/bitfun-minisign"
+    cargo install --registry crates-io --locked --root "$MINISIGN_ROOT" minisign >/dev/null
+    export PATH="$MINISIGN_ROOT/bin:$PATH"
+  fi
 fi
 
 WORK="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- fall back to installing `minisign` with Cargo when the runner apt repository does not provide it
- emit a clear error when neither `minisign` nor Cargo is available
- provision Rust in desktop and nightly publishing jobs so the fallback is available there too

This fixes signed Linux archive publishing on `ubuntu-24.04-arm`, where `apt-get install minisign` currently fails with `Unable to locate package minisign`. Fork builds without signing secrets continue to skip signing as before.

## Verification

- `bash -n scripts/sign-release-assets.sh`
- `pnpm run check:github-config`
- `node --test scripts/relay/package-contract.test.mjs scripts/check-github-config.test.mjs`
- `git diff --check`