### PR TITLE
feat: add permission mode selector visibility preference

### DIFF
--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -233,12 +233,38 @@ pub struct ModelExchangeTracingConfig {
 }
 
 /// FlowChat UI preferences.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AppFlowChatConfig {
     /// Optional user override for the default ChatInput mode id.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_mode_id: Option<String>,
+    /// Whether the chat input exposes the global permission-mode shortcut.
+    ///
+    /// The default is visible, but that value is omitted from persisted config
+    /// so existing config files remain unchanged until the user hides it.
+    #[serde(
+        default = "default_show_permission_mode_control",
+        skip_serializing_if = "is_permission_mode_control_visible"
+    )]
+    pub show_permission_mode_control: bool,
+}
+
+fn default_show_permission_mode_control() -> bool {
+    true
+}
+
+fn is_permission_mode_control_visible(value: &bool) -> bool {
+    *value
+}
+
+impl Default for AppFlowChatConfig {
+    fn default() -> Self {
+        Self {
+            default_mode_id: None,
+            show_permission_mode_control: default_show_permission_mode_control(),
+        }
+    }
 }
 
 /// A user-defined quick action for the FlowChat post-coding actions menu.
@@ -2392,6 +2418,40 @@ mod tests {
         assert_eq!(
             serialized["app"]["flow_chat"]["default_mode_id"],
             "PlannerPlus"
+        );
+    }
+
+    #[test]
+    fn app_flow_chat_permission_mode_control_defaults_to_visible_without_persisting_default() {
+        let default_config: GlobalConfig = serde_json::from_value(serde_json::json!({
+            "app": {
+                "flow_chat": {}
+            }
+        }))
+        .expect("flow chat config without visibility preference should deserialize");
+
+        assert!(default_config.app.flow_chat.show_permission_mode_control);
+        let default_serialized =
+            serde_json::to_value(&default_config).expect("config should serialize");
+        assert!(default_serialized["app"]["flow_chat"]
+            .get("show_permission_mode_control")
+            .is_none());
+
+        let hidden_config: GlobalConfig = serde_json::from_value(serde_json::json!({
+            "app": {
+                "flow_chat": {
+                    "show_permission_mode_control": false
+                }
+            }
+        }))
+        .expect("flow chat config with hidden permission control should deserialize");
+
+        assert!(!hidden_config.app.flow_chat.show_permission_mode_control);
+        let hidden_serialized =
+            serde_json::to_value(&hidden_config).expect("config should serialize");
+        assert_eq!(
+            hidden_serialized["app"]["flow_chat"]["show_permission_mode_control"],
+            false
         );
     }
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -394,6 +394,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     DEFAULT_TOOL_PERMISSION_CONFIG,
   );
   const [permissionModeSaving, setPermissionModeSaving] = useState(false);
+  const [showPermissionModeControl, setShowPermissionModeControl] = useState(true);
   const { addMessage: addToHistory, getSessionHistory } = useInputHistoryStore();
   
   const contexts = useContextStore(state => state.contexts);
@@ -1688,6 +1689,35 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, []);
 
   React.useEffect(() => {
+    const configPath = 'app.flow_chat.show_permission_mode_control';
+    let cancelled = false;
+    const applyVisibility = (value: unknown) => {
+      if (!cancelled) {
+        setShowPermissionModeControl(value !== false);
+      }
+    };
+    const loadVisibility = async () => {
+      try {
+        applyVisibility(await configManager.getConfig<boolean | undefined>(configPath));
+      } catch (error) {
+        log.warn('Failed to load permission mode control visibility preference', error);
+        applyVisibility(true);
+      }
+    };
+
+    void loadVisibility();
+    const unsubscribe = configManager.onConfigChange((path, _oldValue, value) => {
+      if (path === configPath) {
+        applyVisibility(value);
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  React.useEffect(() => {
     let cancelled = false;
     const applyConfig = (config: ToolPermissionConfig) => {
       if (!cancelled) {
@@ -1753,6 +1783,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       setPermissionModeSaving(false);
     }
   }, [isAcpTargetSession, permissionModeSaving, t, toolPermissionConfig]);
+
+  const handleHidePermissionModeControl = useCallback(async () => {
+    try {
+      await configManager.setConfig('app.flow_chat.show_permission_mode_control', false);
+    } catch (error) {
+      log.error('Failed to hide permission mode control', error);
+      notificationService.error(t('chatInput.permissionMode.hideControlFailed'));
+    }
+  }, [t]);
 
   React.useEffect(() => {
     if (!slashCommandState.isActive || slashCommandState.kind !== 'all' || derivedState?.isProcessing) {
@@ -5176,11 +5215,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         repositoryPath={chatStripRepositoryPath}
         workspaceLabel={chatStripWorkspaceLabel}
         deferPassiveGitRefresh={deferChatStripPassiveGitRefresh}
-        permissionControl={{
+        permissionControl={showPermissionModeControl ? {
           mode: permissionMode,
           saving: permissionModeSaving,
           onChange: isAcpTargetSession ? undefined : handlePermissionModeChange,
-        }}
+          onHide: isAcpTargetSession ? undefined : handleHidePermissionModeControl,
+        } : undefined}
         usageReport={
           effectiveTargetSessionId && effectiveTargetSession
             ? { visible: true, onOpen: handleToolbarUsageReport }

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
@@ -209,6 +209,12 @@
     gap: 2px;
   }
 
+  &__permission-menu-divider {
+    height: 1px;
+    margin: 6px 2px;
+    background: var(--border-subtle);
+  }
+
   &__permission-option {
     display: grid;
     grid-template-columns: minmax(0, 1fr) 16px;
@@ -266,6 +272,31 @@
     font-weight: 400;
     line-height: 1.35;
     white-space: normal;
+  }
+
+  &__permission-visibility-action {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    width: 100%;
+    min-height: 32px;
+    padding: 6px 8px;
+    border: 0;
+    border-radius: $size-radius-sm;
+    background: transparent;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-size: var(--flowchat-font-size-xs);
+    letter-spacing: 0;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      background: var(--element-bg-medium);
+      color: var(--color-text-primary);
+      outline: none;
+    }
   }
 
   &__goal-btn.icon-btn {

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
@@ -100,12 +100,13 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
 
   it('keeps an ask-mode permission entry visible and switches from its menu', async () => {
     const onChange = vi.fn();
+    const onHide = vi.fn();
     await act(async () => {
       root.render(
         <ChatInputWorkspaceStrip
           repositoryPath=""
           workspaceLabel=""
-          permissionControl={{ mode: 'ask', onChange }}
+          permissionControl={{ mode: 'ask', onChange, onHide }}
         />
       );
     });
@@ -125,6 +126,17 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onChange).toHaveBeenCalledWith('auto');
+    expect(container.querySelector('[data-testid="chat-input-permission-menu"]')).toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-input-permission-hide-control"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onHide).toHaveBeenCalledOnce();
     expect(container.querySelector('[data-testid="chat-input-permission-menu"]')).toBeNull();
   });
 

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Activity, Check, GitBranch, Shield, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { Activity, Check, EyeOff, GitBranch, Shield, ShieldAlert, ShieldCheck } from 'lucide-react';
 import { ThreadGoalStripButton } from './thread-goal/ThreadGoalStripButton';
 import type { ThreadGoalSnapshot } from '../services/goalService';
 import { Tooltip, IconButton } from '@/component-library';
@@ -32,6 +32,7 @@ export interface ChatInputWorkspaceStripProps {
     mode: ChatInputPermissionMode;
     saving?: boolean;
     onChange?: (mode: Exclude<ChatInputPermissionMode, 'acp'>) => void | Promise<void>;
+    onHide?: () => void | Promise<void>;
   };
   /** Keep the strip on cached Git state while historical content is still restoring. */
   deferPassiveGitRefresh?: boolean;
@@ -268,6 +269,25 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
                       );
                     })}
                   </div>
+                  {permissionControl.onHide ? (
+                    <>
+                      <div className="bitfun-chat-input-workspace-strip__permission-menu-divider" role="separator" />
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="bitfun-chat-input-workspace-strip__permission-visibility-action"
+                        data-testid="chat-input-permission-hide-control"
+                        onClick={event => {
+                          event.stopPropagation();
+                          setPermissionMenuOpen(false);
+                          void permissionControl.onHide?.();
+                        }}
+                      >
+                        <EyeOff size={14} strokeWidth={2} aria-hidden />
+                        <span>{t('chatInput.permissionMode.hideControl')}</span>
+                      </button>
+                    </>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -83,6 +83,7 @@ type ToolPermissionMode = 'ask' | 'auto' | 'full_access';
 
 const DEFAULT_SUBAGENT_BATCH_EXECUTION_POLICY: SubagentBatchExecutionPolicy = 'force_parallel';
 const DEFAULT_SUBAGENT_MAX_CONCURRENCY = 5;
+const SHOW_PERMISSION_MODE_CONTROL_CONFIG_PATH = 'app.flow_chat.show_permission_mode_control';
 
 function normalizeSubagentBatchExecutionPolicy(value: unknown): SubagentBatchExecutionPolicy {
   return value === 'force_parallel' || value === 'serial' || value === 'safe_only'
@@ -127,6 +128,8 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
   const [deferredToolLoadingConfigSaving, setDeferredToolLoadingConfigSaving] = useState(false);
   const [toolPermissionConfig, setToolPermissionConfig] = useState<ToolPermissionConfig>(DEFAULT_TOOL_PERMISSION_CONFIG);
   const [permissionConfigSaving, setPermissionConfigSaving] = useState(false);
+  const [showPermissionModeControl, setShowPermissionModeControl] = useState(true);
+  const [permissionModeControlVisibilitySaving, setPermissionModeControlVisibilitySaving] = useState(false);
   const [isGlobalPermissionRulesDialogOpen, setIsGlobalPermissionRulesDialogOpen] = useState(false);
 
   const [computerUseEnabled, setComputerUseEnabled] = useState(false);
@@ -231,6 +234,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
         computerUseCfg,
         browserControlPreferredBrowser,
         loadedToolPermissionConfig,
+        loadedPermissionModeControlVisibility,
         loadedCompanionPets,
       ] = await Promise.all([
         aiExperienceConfigService.getSettingsAsync(),
@@ -242,6 +246,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
         configManager.getConfig<boolean>('ai.computer_use_enabled'),
         configManager.getConfig<string>('ai.browser_control_preferred_browser'),
         permissionConfigService.getConfig(),
+        configManager.getConfig<boolean | undefined>(SHOW_PERMISSION_MODE_CONTROL_CONFIG_PATH),
         listAgentCompanionPets(),
       ]);
 
@@ -256,6 +261,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
       if (debugConfigData) setDebugConfig(debugConfigData);
       setPreferredBrowser(browserControlPreferredBrowser || DEFAULT_BROWSER_CONTROL_BROWSER);
       setToolPermissionConfig(normalizeToolPermissionConfig(loadedToolPermissionConfig));
+      setShowPermissionModeControl(loadedPermissionModeControlVisibility !== false);
 
       refreshDesktopStatus(computerUseCfg);
     } catch (error) {
@@ -330,6 +336,22 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
       { ...previousConfig, policy: { ...previousConfig.policy, rules } },
       previousConfig,
     );
+  };
+
+  const handlePermissionModeControlVisibilityChange = async (visible: boolean) => {
+    const previousVisibility = showPermissionModeControl;
+    setShowPermissionModeControl(visible);
+    setPermissionModeControlVisibilitySaving(true);
+    try {
+      await configManager.setConfig(SHOW_PERMISSION_MODE_CONTROL_CONFIG_PATH, visible);
+      notificationService.success(t('messages.saveSuccess'), { duration: 2000 });
+    } catch (error) {
+      log.error('Failed to save permission mode control visibility', error);
+      setShowPermissionModeControl(previousVisibility);
+      notificationService.error(t('messages.saveFailed'));
+    } finally {
+      setPermissionModeControlVisibilitySaving(false);
+    }
   };
 
   useEffect(() => {
@@ -1104,6 +1126,20 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
                 ]}
                 disabled={permissionConfigSaving}
                 onChange={handlePermissionModeChange}
+              />
+            </div>
+          </ConfigPageRow>
+          <ConfigPageRow
+            label={t('permissionPolicy.showInChatInput')}
+            description={t('permissionPolicy.showInChatInputDescription')}
+            align="center"
+          >
+            <div className="bitfun-func-agent-config__row-control">
+              <Switch
+                checked={showPermissionModeControl}
+                disabled={permissionModeControlVisibilitySaving}
+                onChange={event => void handlePermissionModeControlVisibilityChange(event.target.checked)}
+                size="small"
               />
             </div>
           </ConfigPageRow>

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -113,6 +113,7 @@ export interface AppLoggingConfig {
 
 export interface AppFlowChatConfig {
   default_mode_id?: string | null;
+  show_permission_mode_control?: boolean;
 }
 
 export interface SidebarConfig {
@@ -652,6 +653,7 @@ export type ConfigPath =
   | 'app.telemetry'
   | 'app.flow_chat'
   | 'app.flow_chat.default_mode_id'
+  | 'app.flow_chat.show_permission_mode_control'
   | 'app.sidebar'
   | 'app.sidebar.width'
   | 'app.sidebar.collapsed'

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -621,6 +621,8 @@
       "globalScope": "Global",
       "current": "Permissions: {{mode}}",
       "changeFailed": "Failed to change the permission mode.",
+      "hideControl": "Hide permission mode selector",
+      "hideControlFailed": "Failed to hide the permission mode selector.",
       "ask": {
         "label": "Ask",
         "description": "External access, file changes, and command execution require confirmation."

--- a/src/web-ui/src/locales/en-US/settings/session-config.json
+++ b/src/web-ui/src/locales/en-US/settings/session-config.json
@@ -59,6 +59,8 @@
     "cancel": "Cancel",
     "autoApprove": "Auto approve",
     "autoApproveDescription": "Automatically approve requests that require confirmation.",
+    "showInChatInput": "Show permission mode selector",
+    "showInChatInputDescription": "Show the selector below the chat input. Hiding it does not change the current permission mode.",
     "globalRules": "Global rules",
     "globalRulesDescription": "Define user-level rules that apply after the selected mode and before project and Agent rules.",
     "manageGlobalRules": "Manage rules",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -621,6 +621,8 @@
       "globalScope": "全局",
       "current": "权限：{{mode}}",
       "changeFailed": "切换权限模式失败。",
+      "hideControl": "隐藏权限模式选择器",
+      "hideControlFailed": "隐藏权限模式选择器失败。",
       "ask": {
         "label": "需要确认",
         "description": "外部访问，修改文件和执行命令需要确认。"

--- a/src/web-ui/src/locales/zh-CN/settings/session-config.json
+++ b/src/web-ui/src/locales/zh-CN/settings/session-config.json
@@ -59,6 +59,8 @@
     "cancel": "取消",
     "autoApprove": "自动批准",
     "autoApproveDescription": "自动批准需要确认的请求。",
+    "showInChatInput": "显示权限模式选择器",
+    "showInChatInputDescription": "在聊天输入框下方显示权限模式选择器。隐藏它不会更改当前权限模式。",
     "globalRules": "全局规则",
     "globalRulesDescription": "定义用户级规则；它们在所选模式之后、项目和 Agent 规则之前应用。",
     "manageGlobalRules": "管理规则",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -621,6 +621,8 @@
       "globalScope": "全域",
       "current": "權限：{{mode}}",
       "changeFailed": "切換權限模式失敗。",
+      "hideControl": "隱藏權限模式選擇器",
+      "hideControlFailed": "隱藏權限模式選擇器失敗。",
       "ask": {
         "label": "需要確認",
         "description": "外部存取、修改檔案和執行命令需要確認。"

--- a/src/web-ui/src/locales/zh-TW/settings/session-config.json
+++ b/src/web-ui/src/locales/zh-TW/settings/session-config.json
@@ -59,6 +59,8 @@
     "cancel": "取消",
     "autoApprove": "自動批准",
     "autoApproveDescription": "自動批准需要確認的請求。",
+    "showInChatInput": "顯示權限模式選擇器",
+    "showInChatInputDescription": "在聊天輸入框下方顯示權限模式選擇器。隱藏它不會變更目前權限模式。",
     "globalRules": "全域規則",
     "globalRulesDescription": "定義使用者級規則；它們在所選模式之後、專案和 Agent 規則之前套用。",
     "manageGlobalRules": "管理規則",


### PR DESCRIPTION
## Summary

- Add a global preference for showing the Flow Chat permission mode selector.
- Add a hide action in the native permission selector and a recovery toggle in Tool Permissions settings.
- Keep the default visible preference out of persisted config files.

Fixes #<issue-number>

## Type and Areas

Type: Feature / UI/UX

Areas: Rust core, Web UI, i18n

## Motivation / Impact

Users who keep Full Access enabled can hide the prominent permission mode selector without changing the active permission policy. The selector can be restored from Tool Permissions settings.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-core app_flow_chat_permission_mode_control_defaults_to_visible_without_persisting_default -- --nocapture`
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx`
- `pnpm run i18n:audit`
- `git diff --check`

All commands passed. Interactive verification was not run.

## Reviewer Notes

- `app.flow_chat.show_permission_mode_control` defaults to `true`.
- The default `true` value is omitted during serialization; only an explicit hidden state (`false`) is persisted.
- The preference controls visibility globally, including ACP sessions; ACP permission ownership remains unchanged.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.