### PR TITLE
ci: move SDK tests into CLI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,17 @@ jobs:
           cache-bin: false
           save-if: ${{ github.event_name != 'pull_request' }}
 
-      - name: Run CLI, ACP, SDK Host, and agent runtime tests
-        run: cargo test --locked -p bitfun-cli -p bitfun-acp -p bitfun-sdk-host -p bitfun-sdk-host-app -p bitfun-agent-runtime
+      - name: Run CLI, ACP, and agent runtime tests
+        run: cargo test --locked -p bitfun-cli -p bitfun-acp -p bitfun-agent-runtime
+
+      - name: Run SDK Host tests
+        run: cargo test --locked -p bitfun-sdk-host -p bitfun-sdk-host-app
+
+      - name: Run SDK Host terminal cleanup regressions
+        run: |
+          cargo test --locked -p terminal-core shutdown_returns_only_after_process_exit_is_confirmed -- --test-threads=1
+          cargo test --locked -p terminal-core shutdown_evicts_a_process_whose_controller_already_confirmed_exit -- --test-threads=1
+          cargo test --locked -p terminal-core background_only_binding_is_owned_by_the_session -- --test-threads=1
 
   # ── Rust: build check ─────────────────────────────────────────────
   rust-build-check:
@@ -136,18 +145,6 @@ jobs:
 
       - name: Check compilation
         run: cargo check --locked --workspace
-
-      - name: Run SDK Host terminal cleanup regressions
-        # This PR changes only the PTY/session shutdown path required by
-        # connection-scoped Session cleanup. Keep the gate scoped to those
-        # regressions instead of adopting unrelated terminal command tests.
-        run: |
-          cargo test --locked -p terminal-core shutdown_returns_only_after_process_exit_is_confirmed -- --test-threads=1
-          cargo test --locked -p terminal-core shutdown_evicts_a_process_whose_controller_already_confirmed_exit -- --test-threads=1
-          cargo test --locked -p terminal-core background_only_binding_is_owned_by_the_session -- --test-threads=1
-
-      - name: Run standalone SDK Host process smokes
-        run: cargo test --locked -p bitfun-sdk-host-app --test process_initialization --test stdio_process
 
       - name: Run Windows ConPTY CLI smoke test
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

- move SDK Host crate tests into the independent CLI job
- move SDK Host terminal cleanup regressions out of the three-platform Rust build matrix
- keep process smoke coverage through the full bitfun-sdk-host-app test suite

## Why

SDK-specific tests were duplicated in the long-running Rust matrix even though the CLI job already owns the SDK Host package tests. Keeping them in the CLI job shortens the matrix without dropping the test suites.

## Impact

SDK tests now run in the Ubuntu CLI job instead of being repeated across the Rust OS matrix. The matrix still compiles the full workspace on Linux, macOS, and Windows, and the Windows ConPTY CLI smoke remains platform-gated there.

## Validation

- SDK CI placement structural assertion
- pnpm run check:github-config
- git diff --check