### PR TITLE
ci: move Windows CLI terminal tests to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,6 @@ jobs:
       - name: Check compilation
         run: cargo check --locked --workspace
 
-      - name: Run Windows ConPTY CLI smoke test
-        if: runner.os == 'Windows'
-        run: cargo test --locked -p bitfun-cli --test terminal_process_contracts
-
       - name: Run core and desktop Rust tests
         run: cargo test --locked -p bitfun-core -p bitfun-desktop
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -195,6 +195,16 @@ jobs:
           echo "package.json version: $(jq -r '.version' package.json)"
           echo "Cargo.toml version:   $(grep 'x-release-please-version' Cargo.toml)"
 
+      - name: Run Windows CLI terminal contracts
+        if: runner.os == 'Windows'
+        env:
+          CARGO_INCREMENTAL: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
+        run: |
+          cargo generate-lockfile
+          cargo test --locked -p bitfun-cli --test terminal_process_contracts
+
       - name: Build desktop app
         run: ${{ matrix.platform.build_command }}
 


### PR DESCRIPTION
## Summary

- remove the Windows CLI terminal process contracts from the daily CI Rust matrix
- run the same contracts in the Windows nightly package path
- disable incremental compilation and debug symbols for the nightly test profile to bound disk and link cost

## Why

The Windows ConPTY step in run 30193605654 took 4 minutes 17 seconds, while its five tests completed in 2.83 seconds; almost all of the time was a separate Windows test-profile compile and link. Keeping that step serialized in daily CI materially extends the Windows critical path.

Nightly retains the native Windows terminal coverage for resize, cancellation, Ctrl+C, and cleanup without making every pull request pay that cost.

## Impact

| Workflow | Before | After |
|---|---|---|
| Daily CI Windows | runs terminal_process_contracts on every PR and main push | keeps cross-platform workspace compilation but omits the Windows process suite |
| Nightly Windows | packages the Windows build without this process suite | runs terminal_process_contracts before packaging |
| Linux and macOS | unchanged | unchanged |

The observed daily Windows critical path should drop by roughly four minutes. The same cost moves to the weekday nightly Windows package job.

## Validation

- ConPTY workflow placement structural assertion
- pnpm run check:github-config
- git diff --check