### PR TITLE
ci(cli): add lightweight macOS test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,22 @@ permissions:
 jobs:
   # ── CLI: independent tests ─────────────────────────────────────────
   cli-test:
-    name: CLI Tests (ubuntu-latest)
-    runs-on: ubuntu-latest
+    name: CLI Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cache_key: ubuntu
+          - os: macos-15
+            cache_key: macos
     steps:
       - uses: actions/checkout@v5
 
       - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           sudo apt-get update
@@ -49,17 +58,24 @@ jobs:
 
       - uses: swatinem/rust-cache@v2
         with:
-          shared-key: "cli-ci-v2-ubuntu"
+          shared-key: "cli-ci-v2-${{ matrix.cache_key }}"
           cache-bin: false
           save-if: ${{ github.event_name != 'pull_request' }}
 
+      - name: Run CLI and ACP tests on macOS
+        if: runner.os == 'macOS'
+        run: cargo test --locked -p bitfun-cli -p bitfun-acp
+
       - name: Run CLI, ACP, and agent runtime tests
+        if: runner.os == 'Linux'
         run: cargo test --locked -p bitfun-cli -p bitfun-acp -p bitfun-agent-runtime
 
       - name: Run SDK Host tests
+        if: runner.os == 'Linux'
         run: cargo test --locked -p bitfun-sdk-host -p bitfun-sdk-host-app
 
       - name: Run SDK Host terminal cleanup regressions
+        if: runner.os == 'Linux'
         run: |
           cargo test --locked -p terminal-core shutdown_returns_only_after_process_exit_is_confirmed -- --test-threads=1
           cargo test --locked -p terminal-core shutdown_evicts_a_process_whose_controller_already_confirmed_exit -- --test-threads=1


### PR DESCRIPTION
## Summary

- expand the existing CLI test job into independent Ubuntu and macOS matrix entries
- preserve the full Ubuntu CLI, ACP, Agent Runtime, SDK Host, and terminal cleanup coverage
- add a lightweight `macos-15` gate that runs `bitfun-cli` and `bitfun-acp` tests
- isolate Rust caches per operating system while keeping pull-request caches read-only

## Why

The ordinary CI workflow only had a dedicated Ubuntu CLI gate. The workspace-wide macOS job checks compilation and broader Rust behavior, but it does not run the CLI and ACP test suites directly. This adds focused macOS CLI coverage without copying release packaging or the longer Ubuntu-only suites into the new job.

The new matrix entry starts immediately alongside the existing jobs, keeps the 15-minute timeout, and uses `fail-fast: false`, so it should not extend the current Windows-dominated CI critical path.

## Validation

- `pnpm run check:github-config`
- `pnpm run check:repo-hygiene`
- focused YAML structure and Ubuntu-equivalence contract check
- `git diff --check gcwing/main...HEAD`

## Impact

Pull requests and pushes to `main` gain a distinct `CLI Tests (macos-15)` check. The existing `CLI Tests (ubuntu-latest)` name, commands, cache key, and activation policy remain unchanged.

Repository branch protection or rulesets must list the new check as required if maintainers want it to block merges independently.
