### PR TITLE
fix(web): avoid forced layouts in mouse glow discovery

### DIFF
--- a/src/web-ui/src/infrastructure/mouse-glow/core/MouseGlowService.test.ts
+++ b/src/web-ui/src/infrastructure/mouse-glow/core/MouseGlowService.test.ts
@@ -112,6 +112,48 @@ describe('MouseGlowService', () => {
     surface.remove();
   });
 
+  it('only reads geometry for the selected surface', () => {
+    const surface = document.createElement('div');
+    surface.className = 'workspace-card';
+    surface.style.border = '1px solid black';
+    surface.style.borderRadius = '8px';
+    surface.style.background = 'black';
+    const readSurfaceGeometry = vi.fn(() => ({
+      bottom: 128,
+      height: 80,
+      left: 20,
+      right: 220,
+      top: 48,
+      width: 200,
+      x: 20,
+      y: 48,
+      toJSON: () => ({}),
+    }));
+    surface.getBoundingClientRect = readSurfaceGeometry;
+    const wrapper = document.createElement('div');
+    const content = document.createElement('code');
+    const readWrapperGeometry = vi.fn();
+    const readContentGeometry = vi.fn();
+    wrapper.getBoundingClientRect = readWrapperGeometry;
+    content.getBoundingClientRect = readContentGeometry;
+    wrapper.appendChild(content);
+    surface.appendChild(wrapper);
+    document.body.appendChild(surface);
+    service.initialize();
+
+    content.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true,
+      clientX: 72,
+      clientY: 68,
+    }));
+    nextFrame?.(0);
+
+    expect(readContentGeometry).not.toHaveBeenCalled();
+    expect(readWrapperGeometry).not.toHaveBeenCalled();
+    expect(readSurfaceGeometry).toHaveBeenCalledTimes(1);
+    surface.remove();
+  });
+
   it('keeps the glow up until the frame resolves where the pointer went', () => {
     const surface = document.createElement('div');
     surface.setAttribute('data-mouse-glow-surface', '');
@@ -249,6 +291,8 @@ describe('MouseGlowService', () => {
     const stackingHost = document.createElement('div');
     stackingHost.style.position = 'relative';
     stackingHost.style.zIndex = '1';
+    const readStackingHostGeometry = vi.fn();
+    stackingHost.getBoundingClientRect = readStackingHostGeometry;
     const surface = document.createElement('div');
     surface.setAttribute('data-mouse-glow-surface', '');
     surface.getBoundingClientRect = () => ({
@@ -295,7 +339,9 @@ describe('MouseGlowService', () => {
 
     const overlay = document.getElementById('bitfun-mouse-glow-overlay');
     expect(overlay?.hasAttribute('data-active')).toBe(true);
-    expect(overlay?.parentElement).toBe(stackingHost);
+    expect(overlay?.parentElement).toBe(document.body);
+    expect(overlay?.hasAttribute('data-local-position')).toBe(false);
+    expect(readStackingHostGeometry).not.toHaveBeenCalled();
     expect(Number(window.getComputedStyle(listbox).zIndex)).toBeGreaterThan(49);
 
     option.dispatchEvent(new MouseEvent('pointermove', {
@@ -359,7 +405,7 @@ describe('MouseGlowService', () => {
     transformedHost.style.position = 'absolute';
     transformedHost.style.zIndex = '100';
     transformedHost.style.transform = 'translateX(-50%)';
-    transformedHost.getBoundingClientRect = () => ({
+    const readTransformedHostGeometry = vi.fn(() => ({
       bottom: 700,
       height: 200,
       left: 100,
@@ -369,7 +415,8 @@ describe('MouseGlowService', () => {
       x: 100,
       y: 500,
       toJSON: () => ({}),
-    });
+    }));
+    transformedHost.getBoundingClientRect = readTransformedHostGeometry;
     const inputSurface = document.createElement('div');
     inputSurface.setAttribute('data-mouse-glow-surface', '');
     inputSurface.style.border = '1px solid black';
@@ -400,11 +447,12 @@ describe('MouseGlowService', () => {
     nextFrame?.(0);
 
     const overlay = document.getElementById('bitfun-mouse-glow-overlay');
-    expect(overlay?.parentElement).toBe(transformedHost);
-    expect(overlay?.hasAttribute('data-local-position')).toBe(true);
-    expect(overlay?.style.transform).toBe('translate3d(20px, 40px, 0)');
+    expect(overlay?.parentElement).toBe(document.body);
+    expect(overlay?.hasAttribute('data-local-position')).toBe(false);
+    expect(overlay?.style.transform).toBe('translate3d(120px, 540px, 0)');
     expect(overlay?.style.getPropertyValue('--mouse-glow-local-x')).toBe('60px');
     expect(overlay?.style.getPropertyValue('--mouse-glow-local-y')).toBe('20px');
+    expect(readTransformedHostGeometry).not.toHaveBeenCalled();
     transformedHost.remove();
   });
 

--- a/src/web-ui/src/infrastructure/mouse-glow/core/MouseGlowService.ts
+++ b/src/web-ui/src/infrastructure/mouse-glow/core/MouseGlowService.ts
@@ -279,7 +279,11 @@ export class MouseGlowService {
       overlayHost,
       style,
     );
-    const overlayPosition = this.getOverlayPosition(geometry, overlayHost);
+    const overlayPosition = this.getOverlayPosition(
+      geometry,
+      overlayHost,
+      overlayHost === surface ? rect : null,
+    );
     this.activeSurface = surface;
     overlay.toggleAttribute('data-divider', dividerGeometry !== null);
     overlay.toggleAttribute('data-local-position', overlayPosition.isLocal);
@@ -319,6 +323,7 @@ export class MouseGlowService {
   private getOverlayPosition(
     geometry: OverlayGeometry,
     host: HTMLElement,
+    knownHostRect: DOMRect | null,
   ): { isLocal: boolean; left: number; top: number } {
     if (host === document.body) {
       return { isLocal: false, left: geometry.left, top: geometry.top };
@@ -329,7 +334,7 @@ export class MouseGlowService {
       return { isLocal: false, left: geometry.left, top: geometry.top };
     }
 
-    const hostRect = host.getBoundingClientRect();
+    const hostRect = knownHostRect ?? host.getBoundingClientRect();
     const borderLeftWidth = parseFloat(hostStyle.borderLeftWidth) || 0;
     const borderTopWidth = parseFloat(hostStyle.borderTopWidth) || 0;
     return {
@@ -408,11 +413,6 @@ export class MouseGlowService {
       return false;
     }
 
-    const rect = element.getBoundingClientRect();
-    if (rect.width <= 0 || rect.height <= 0) {
-      return false;
-    }
-
     if (!this.isVisibleElement(style)) {
       return false;
     }
@@ -441,7 +441,6 @@ export class MouseGlowService {
       return false;
     }
 
-    const rect = element.getBoundingClientRect();
     if (!this.isVisibleElement(style)) {
       return false;
     }
@@ -451,7 +450,7 @@ export class MouseGlowService {
       return true;
     }
 
-    return this.hasDividerSemantics(element) && this.isLineLikeGeometry(rect);
+    return this.hasDividerSemantics(element);
   }
 
   private getDividerGeometry(
@@ -485,7 +484,7 @@ export class MouseGlowService {
       }
     }
 
-    if (this.hasDividerSemantics(element)) {
+    if (this.hasDividerSemantics(element) && this.isLineLikeGeometry(rect)) {
       return {
         height: Math.max(rect.height, 1),
         left: rect.left,
@@ -557,9 +556,6 @@ export class MouseGlowService {
       if (this.isFloatingLayer(current)) {
         return current;
       }
-      if (this.createsStackingContext(current)) {
-        return current;
-      }
       current = current.parentElement;
     }
     return document.body;
@@ -582,22 +578,6 @@ export class MouseGlowService {
       && Array.from(element.classList).some(className =>
         FLOATING_LAYER_CLASS_PATTERN.test(className)
       )
-    );
-  }
-
-  private createsStackingContext(element: HTMLElement): boolean {
-    const style = window.getComputedStyle(element);
-    const positionedWithZIndex =
-      style.position !== 'static' && style.zIndex !== 'auto';
-
-    return (
-      positionedWithZIndex
-      || style.position === 'fixed'
-      || style.position === 'sticky'
-      || style.isolation === 'isolate'
-      || (style.opacity !== '' && style.opacity !== '1')
-      || (style.mixBlendMode !== '' && style.mixBlendMode !== 'normal')
-      || style.willChange.includes('opacity')
     );
   }
 


### PR DESCRIPTION
## Summary

- Make MouseGlow automatic-surface and divider candidate discovery geometry-free.
- Measure only the final selected surface instead of every composed-path ancestor.
- Keep normal overlays fixed under `document.body`; retain local positioning for actual floating layers.
- Reuse the selected surface rect when a floating surface is its own overlay host.
- Add regression coverage for geometry reads and normal stacking/transformed hosts.

## Type and Areas

Type:

Regression fix

Areas:

Web UI, mouse-follow glow

## Motivation / Impact

BitFun 0.2.14 could crash its WebView2 renderer with
`STATUS_ACCESS_VIOLATION` when the mouse-follow glow was enabled and the user
repeatedly switched between the Session and Settings scenes. Disabling the
effect prevented reproduction.

The native dump ended in:

`requestAnimationFrame -> getBoundingClientRect -> Blink Flex layout -> OutOfFlowLayoutPart::LayoutCandidates`

`MouseGlowService.findSurface()` walked the full composed ancestor path on
pointer frames. For each candidate it could call `getBoundingClientRect()` in
both divider and automatic-surface detection, then measure the selected surface
and an ordinary stacking-context host again. Session mounting and virtualized
content updates made these synchronous layout reads enter unstable Blink flex
layout repeatedly.

The regression was introduced in `1ec22139` / PR #1743, which added
the pointer-follow glow and its geometry-based ancestor discovery and overlay
host selection. The follow-up `e3169ccf` / PR #1757 consolidated the
ancestor style scan, but retained the per-candidate geometry reads.

The fix classifies candidates using computed styles, attributes, roles, and
class semantics. Geometry validation is deferred until one surface has been
selected. Ordinary stacking contexts no longer become overlay hosts, avoiding
the final SceneViewport flex-host measurement. Dialogs, listboxes, popovers,
and other actual floating layers retain local hosting.

No functional change is intended for the glow setting or normal pointer
tracking. Users should see the same effect with less layout work and without
the renderer crash.

## Verification

- `pnpm --dir src/web-ui run test:run src/infrastructure/mouse-glow/core/MouseGlowService.test.ts`
  - 1 test file passed, 15 tests passed.
- `pnpm run type-check:web`
  - Passed.
- `git diff --cached --check`
  - Passed.
- Manual reproduction with mouse-follow glow enabled and repeated
  Session/Settings switching:
  - No crash reproduced after the fix.
- Post-fix instrumentation sample:
  - 1,097 log entries inspected.
  - 763 MouseGlow reads measured only the final surface.
  - 0 divider/automatic ancestor geometry reads.
  - 0 SceneViewport or workspace stacking-host geometry reads.
  - The only additional host read was for an actual closing floating menu.

## Reviewer Notes

Normal surfaces now use viewport coordinates with the fixed overlay hosted by
`document.body`, even when they are inside transformed or stacking-context
ancestors. Actual floating layers still use local coordinates so their clipping
and z-order behavior is preserved.

Divider line-shape validation now runs against the final selected rect instead
of during ancestor discovery.

All temporary runtime probes and the debug receiver were removed after manual
confirmation.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.