### PR TITLE
fix(worktree): defer isolation until first prompt

### DIFF
--- a/src/apps/cli/src/agent/runtime_client.rs
+++ b/src/apps/cli/src/agent/runtime_client.rs
@@ -822,7 +822,9 @@ impl CliAgentRuntimeClient {
             original_message: None,
             turn_id: Some(turn_id.clone()),
             agent_type: agent_type.to_string(),
-            workspace_path: Some(self.workspace_path_string()),
+            // Dialog submission uses this path to locate persisted session
+            // state. Execution still comes from the session's resolved binding.
+            workspace_path: Some(self.project_workspace_path_string()),
             remote_connection_id: None,
             remote_ssh_host: None,
             policy: DialogSubmissionPolicy::for_source(AgentSubmissionSource::Cli),

--- a/src/apps/cli/src/chat_state.rs
+++ b/src/apps/cli/src/chat_state.rs
@@ -315,6 +315,9 @@ pub(crate) struct ChatState {
     is_git_repository: bool,
     /// Whether this runtime exposes session worktree lifecycle controls.
     worktree_control_available: bool,
+    /// Empty-session preference. The actual worktree is created only after the
+    /// user submits the first prompt.
+    worktree_isolation_requested: Option<bool>,
     /// Current model display name (shown in shortcuts bar)
     pub current_model_name: String,
     /// Effective Auto mode for permission results that evaluate to Ask.
@@ -375,6 +378,7 @@ impl ChatState {
             git_branch: None,
             is_git_repository: false,
             worktree_control_available: true,
+            worktree_isolation_requested: None,
             current_model_name: String::new(),
             auto_approve_ask: false,
             messages: Vec::new(),
@@ -411,12 +415,25 @@ impl ChatState {
         self.git_branch = branch.filter(|value| !value.trim().is_empty());
     }
 
-    pub(crate) fn is_worktree_enabled(&self) -> bool {
+    pub(crate) fn is_worktree_materialized(&self) -> bool {
         self.workspace_binding
             .as_ref()
             .and_then(|binding| binding.execution_target.as_ref())
             .and_then(|target| target.worktree_id.as_ref())
             .is_some()
+    }
+
+    pub(crate) fn is_worktree_enabled(&self) -> bool {
+        self.worktree_isolation_requested
+            .unwrap_or_else(|| self.is_worktree_materialized())
+    }
+
+    pub(crate) fn requested_worktree_enabled(&self) -> Option<bool> {
+        self.worktree_isolation_requested
+    }
+
+    pub(crate) fn set_worktree_isolation_requested(&mut self, requested: Option<bool>) {
+        self.worktree_isolation_requested = requested;
     }
 
     pub(crate) fn has_conversation_history(&self) -> bool {
@@ -445,7 +462,7 @@ impl ChatState {
             return branch.to_string();
         }
 
-        if self.is_worktree_enabled() {
+        if self.is_worktree_materialized() {
             if let Some(commit) = execution_target
                 .and_then(|target| target.base_commit.as_deref())
                 .map(str::trim)
@@ -465,6 +482,14 @@ impl ChatState {
     pub(crate) fn worktree_status_label(&self) -> &'static str {
         if !self.worktree_control_available {
             "unavailable"
+        } else if self.worktree_isolation_requested == Some(true)
+            && !self.is_worktree_materialized()
+        {
+            "pending-on"
+        } else if self.worktree_isolation_requested == Some(false)
+            && self.is_worktree_materialized()
+        {
+            "pending-off"
         } else if self.is_worktree_enabled() {
             "on"
         } else if self.is_git_repository {
@@ -1419,6 +1444,26 @@ mod tests {
 
         state.metadata.message_count = 1;
         assert!(state.has_conversation_history());
+    }
+
+    #[test]
+    fn worktree_preference_is_visible_before_materialization() {
+        let mut state = ChatState::new(
+            "session-1".to_string(),
+            "Session".to_string(),
+            "agentic".to_string(),
+            Some("/tmp/project".to_string()),
+        );
+        state.set_git_repository_status(true, Some("main".to_string()));
+        state.set_worktree_isolation_requested(Some(true));
+
+        assert!(state.is_worktree_enabled());
+        assert!(!state.is_worktree_materialized());
+        assert_eq!(state.worktree_status_label(), "pending-on");
+        assert_eq!(
+            state.workspace_context_label(),
+            "Branch: main | Worktree: pending-on"
+        );
     }
 
     #[test]

--- a/src/apps/cli/src/modes/chat/sessions.rs
+++ b/src/apps/cli/src/modes/chat/sessions.rs
@@ -109,7 +109,7 @@ impl ChatMode {
     /// Show skill list/configuration menu.
     /// Send a message to the agent programmatically (used by slash commands like /init)
     fn send_message_to_agent(
-        &self,
+        &mut self,
         message: String,
         chat_view: &mut ChatView,
         chat_state: &mut ChatState,
@@ -127,6 +127,13 @@ impl ChatMode {
         }
         if chat_state.is_processing {
             chat_state.add_system_message("Already processing, please wait.".to_string());
+            return;
+        }
+
+        if let Err(error) = self.materialize_requested_worktree(chat_view, chat_state, rt_handle) {
+            tracing::error!("Failed to prepare worktree for submitted prompt: {error}");
+            chat_view.set_status(Some(format!("Error: {error}")));
+            chat_state.add_system_message(error);
             return;
         }
 

--- a/src/apps/cli/src/modes/chat/worktree.rs
+++ b/src/apps/cli/src/modes/chat/worktree.rs
@@ -63,6 +63,73 @@ impl ChatMode {
         )
     }
 
+    /// Materialize the checkbox/slash-command preference only after the user
+    /// has submitted a prompt. Keeping this next to the shared binding adapter
+    /// gives interactive input, prompt commands, and future send paths one
+    /// transition implementation.
+    fn materialize_requested_worktree(
+        &mut self,
+        chat_view: &mut ChatView,
+        chat_state: &mut ChatState,
+        rt_handle: &tokio::runtime::Handle,
+    ) -> std::result::Result<(), String> {
+        let Some(enabled) = chat_state.requested_worktree_enabled() else {
+            return Ok(());
+        };
+        if enabled == chat_state.is_worktree_materialized() {
+            chat_state.set_worktree_isolation_requested(None);
+            return Ok(());
+        }
+
+        chat_view.set_status(Some(if enabled {
+            "Creating worktree after prompt submission...".to_string()
+        } else {
+            "Releasing worktree after prompt submission...".to_string()
+        }));
+        let project_workspace_path = chat_state.project_workspace_path().map(str::to_string);
+        let result = tokio::task::block_in_place(|| {
+            rt_handle.block_on(WorktreeService::bind_session(
+                WorktreeSessionBindingRequest {
+                    request_id: uuid::Uuid::new_v4().to_string(),
+                    session_id: chat_state.core_session_id.clone(),
+                    project_workspace_path,
+                    enabled,
+                },
+            ))
+        })
+        .map_err(|error| {
+            format!(
+                "Worktree isolation could not be prepared ({}): {}",
+                error.code.as_str(),
+                error.message
+            )
+        })?;
+
+        let previous_binding = chat_state.workspace_binding.as_ref();
+        let binding = AgentSessionWorkspaceBinding {
+            workspace_id: result.workspace_id,
+            workspace_path: result.workspace_path,
+            project_workspace_path: Some(result.project_workspace_path),
+            execution_target: Some(result.execution_target),
+            remote_connection_id: previous_binding
+                .and_then(|binding| binding.remote_connection_id.clone()),
+            remote_ssh_host: previous_binding.and_then(|binding| binding.remote_ssh_host.clone()),
+        };
+        self.agent.set_workspace_binding(&binding);
+        chat_state.apply_workspace_binding(binding);
+        chat_state.set_worktree_isolation_requested(None);
+        self.workspace = chat_state.workspace.clone();
+        self.refresh_workspace_git_status(chat_state, rt_handle);
+
+        if let Some(path) = result.retained_worktree_path {
+            chat_state.add_system_message(format!(
+                "The released worktree was kept because it may contain local or unpublished work: {}",
+                path
+            ));
+        }
+        Ok(())
+    }
+
     fn handle_worktree_command(
         &mut self,
         arguments: &str,
@@ -79,8 +146,8 @@ impl ChatMode {
             }
         };
 
-        self.refresh_workspace_git_status(chat_state, rt_handle);
         if command == WorktreeCommand::Status {
+            self.refresh_workspace_git_status(chat_state, rt_handle);
             let message = Self::worktree_status_message(chat_state);
             chat_view.set_status(Some(chat_state.workspace_context_label()));
             chat_state.add_system_message(message);
@@ -116,58 +183,12 @@ impl ChatMode {
             WorktreeCommand::Set(enabled) => enabled,
             WorktreeCommand::Status => unreachable!("status returned above"),
         };
-        chat_view.set_status(Some(if enabled {
-            "Enabling worktree isolation...".to_string()
-        } else {
-            "Disabling worktree isolation...".to_string()
-        }));
-
-        let project_workspace_path = chat_state.project_workspace_path().map(str::to_string);
-        let result = tokio::task::block_in_place(|| {
-            rt_handle.block_on(WorktreeService::bind_session(
-                WorktreeSessionBindingRequest {
-                    request_id: uuid::Uuid::new_v4().to_string(),
-                    session_id: chat_state.core_session_id.clone(),
-                    project_workspace_path,
-                    enabled,
-                },
-            ))
-        });
-
-        let result = match result {
-            Ok(result) => result,
-            Err(error) => {
-                let message = format!(
-                    "Worktree isolation could not be changed ({}): {}",
-                    error.code.as_str(),
-                    error.message
-                );
-                tracing::warn!("{}", message);
-                chat_view.set_status(Some(message.clone()));
-                chat_state.add_system_message(message);
-                return Ok(None);
-            }
-        };
-
-        let previous_binding = chat_state.workspace_binding.as_ref();
-        let binding = AgentSessionWorkspaceBinding {
-            workspace_id: result.workspace_id,
-            workspace_path: result.workspace_path,
-            project_workspace_path: Some(result.project_workspace_path),
-            execution_target: Some(result.execution_target),
-            remote_connection_id: previous_binding
-                .and_then(|binding| binding.remote_connection_id.clone()),
-            remote_ssh_host: previous_binding.and_then(|binding| binding.remote_ssh_host.clone()),
-        };
-        self.agent.set_workspace_binding(&binding);
-        chat_state.apply_workspace_binding(binding);
-        self.workspace = chat_state.workspace.clone();
-        self.refresh_workspace_git_status(chat_state, rt_handle);
-
+        chat_state.set_worktree_isolation_requested(Some(enabled));
         let status = if enabled {
-            "Worktree isolation enabled".to_string()
+            "Worktree isolation armed; it will be created after the first prompt is submitted"
+                .to_string()
         } else {
-            "Worktree isolation disabled".to_string()
+            "Worktree isolation disarmed; no Git work runs until a prompt is submitted".to_string()
         };
         chat_view.set_status(Some(format!(
             "{} ({})",
@@ -179,12 +200,6 @@ impl ChatMode {
             status,
             Self::worktree_status_message(chat_state)
         ));
-        if let Some(path) = result.retained_worktree_path {
-            chat_state.add_system_message(format!(
-                "The released worktree was kept because it may contain local or unpublished work: {}",
-                path
-            ));
-        }
 
         Ok(None)
     }

--- a/src/apps/cli/src/peer_host/commands/dialog.rs
+++ b/src/apps/cli/src/peer_host/commands/dialog.rs
@@ -40,7 +40,8 @@ pub(crate) async fn start_dialog_turn(
     let user_input = get_string(request, "userInput")?;
     let original_user_input = optional_string(request, "originalUserInput");
     let agent_type = get_string(request, "agentType")?;
-    let workspace_path = optional_string(request, "workspacePath");
+    let workspace_path = optional_string(request, "projectWorkspacePath")
+        .or_else(|| optional_string(request, "workspacePath"));
     let remote_connection_id = optional_string(request, "remoteConnectionId");
     let remote_ssh_host = optional_string(request, "remoteSshHost");
     let controller_lease = attached_controller_lease()?;

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -254,7 +254,13 @@ pub struct StartDialogTurnRequest {
     pub user_input: String,
     pub original_user_input: Option<String>,
     pub agent_type: String,
+    /// Concrete execution root retained for backward compatibility and
+    /// non-native transports.
     pub workspace_path: Option<String>,
+    /// Stable project root used to locate the session transcript when
+    /// execution happens in a managed worktree.
+    #[serde(default)]
+    pub project_workspace_path: Option<String>,
     pub remote_connection_id: Option<String>,
     pub remote_ssh_host: Option<String>,
     pub turn_id: Option<String>,
@@ -1739,6 +1745,7 @@ fn desktop_dialog_turn_request(
         original_user_input,
         agent_type,
         workspace_path,
+        project_workspace_path,
         remote_connection_id,
         remote_ssh_host,
         turn_id,
@@ -1762,7 +1769,7 @@ fn desktop_dialog_turn_request(
         original_message: original_user_input,
         turn_id,
         agent_type,
-        workspace_path,
+        workspace_path: project_workspace_path.or(workspace_path),
         remote_connection_id,
         remote_ssh_host,
         policy,
@@ -3167,7 +3174,8 @@ mod tests {
             "userInput": "resolved input",
             "originalUserInput": "original input",
             "agentType": "agentic",
-            "workspacePath": "/workspace/project",
+            "workspacePath": "/worktrees/session-1",
+            "projectWorkspacePath": "/workspace/project",
             "remoteConnectionId": "connection-1",
             "remoteSshHost": "host-1",
             "turnId": "turn-1",

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -104,6 +104,57 @@ const SESSION_REFERENCE_ARTIFACT_STEM_LENGTH: usize = 8;
 const SESSION_REFERENCE_ARTIFACT_STEM_EXTENSION_LENGTH: usize = 4;
 const SESSION_REFERENCE_NAME_CHAR_LIMIT: usize = 96;
 
+fn comparable_workspace_path(path: &str) -> String {
+    let path = path.trim();
+    let mut normalized = dunce::canonicalize(Path::new(path))
+        .unwrap_or_else(|_| PathBuf::from(path))
+        .to_string_lossy()
+        .replace('\\', "/");
+    while normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+    #[cfg(windows)]
+    {
+        normalized.make_ascii_lowercase();
+    }
+    normalized
+}
+
+/// Turn submission APIs historically carried a single `workspacePath`, even
+/// though a worktree session has two roots. Accept the persisted execution
+/// root as a legacy alias, but normalize it to the owning project root before
+/// any session-storage lookup. An unrelated requested workspace is preserved
+/// so the existing cross-workspace identity check still rejects it.
+pub(super) fn session_storage_workspace_locator(
+    requested_workspace_path: Option<&str>,
+    execution_workspace_path: Option<&str>,
+    project_workspace_path: Option<&str>,
+) -> Option<String> {
+    let requested_workspace_path = requested_workspace_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty());
+    let execution_workspace_path = execution_workspace_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty());
+    let project_workspace_path = project_workspace_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty());
+
+    match requested_workspace_path {
+        Some(requested)
+            if execution_workspace_path.is_some_and(|execution| {
+                comparable_workspace_path(requested) == comparable_workspace_path(execution)
+            }) =>
+        {
+            Some(project_workspace_path.unwrap_or(requested).to_string())
+        }
+        Some(requested) => Some(requested.to_string()),
+        None => project_workspace_path
+            .or(execution_workspace_path)
+            .map(str::to_string),
+    }
+}
+
 fn trimmed_model_id(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)
@@ -3557,7 +3608,17 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         mut additional_prepended_messages: Vec<Message>,
         suppress_session_title_generation: bool,
     ) -> BitFunResult<()> {
-        let requested_restore_path = match workspace_path.as_deref() {
+        let loaded_session = self.session_manager.get_session(&session_id);
+        let storage_workspace_path = session_storage_workspace_locator(
+            workspace_path.as_deref(),
+            loaded_session
+                .as_ref()
+                .and_then(|session| session.config.workspace_path.as_deref()),
+            loaded_session
+                .as_ref()
+                .and_then(|session| session.config.project_workspace_path.as_deref()),
+        );
+        let requested_restore_path = match storage_workspace_path.as_deref() {
             Some(workspace_path) => Some(
                 Self::resolve_session_restore_path(
                     workspace_path,
@@ -3572,7 +3633,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         // Get latest session, restoring from persistence on demand so every entry
         // point can use the same start_dialog_turn flow. A loaded session must keep
         // the same storage identity as this invocation.
-        let session = match self.session_manager.get_session(&session_id) {
+        let session = match loaded_session {
             Some(session) => {
                 if let Some(restore_path) = requested_restore_path.as_deref() {
                     self.session_manager
@@ -3766,9 +3827,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             );
             let restore_workspace_path = session
                 .config
-                .workspace_path
+                .project_workspace_path
                 .as_deref()
-                .or(workspace_path.as_deref())
+                .or(storage_workspace_path.as_deref())
                 .ok_or_else(|| {
                     BitFunError::Validation(format!(
                         "workspace_path is required when restoring session: {}",
@@ -9229,9 +9290,10 @@ mod tests {
         normalize_subagent_max_concurrency, resolve_agent_session_create_created_by,
         resolve_agent_submission_turn_id, resolve_subagent_model_selection,
         runtime_port_error_preserving_message, runtime_tool_restrictions_for_session_lifetime,
-        turn_review_manifest_for_agent, BackgroundSubagentWaitMode, ConversationCoordinator,
-        SessionMemoryMode, SessionReferenceLocator, SessionRelationshipKind,
-        SubagentExecutionRequest, TEST_AGENT_MODEL_DEFAULTS,
+        session_storage_workspace_locator, turn_review_manifest_for_agent,
+        BackgroundSubagentWaitMode, ConversationCoordinator, SessionMemoryMode,
+        SessionReferenceLocator, SessionRelationshipKind, SubagentExecutionRequest,
+        TEST_AGENT_MODEL_DEFAULTS,
     };
     use crate::agentic::coordination::coordination_store::{
         BackgroundTaskRegistration, RegisteredBackgroundTask,
@@ -9271,6 +9333,41 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn worktree_execution_root_is_a_legacy_alias_for_project_storage() {
+        assert_eq!(
+            session_storage_workspace_locator(
+                Some(r"D:\worktrees\session-1"),
+                Some("D:/worktrees/session-1"),
+                Some("D:/projects/BitFun"),
+            )
+            .as_deref(),
+            Some("D:/projects/BitFun")
+        );
+        assert_eq!(
+            session_storage_workspace_locator(
+                None,
+                Some("/worktrees/session-1"),
+                Some("/projects/BitFun"),
+            )
+            .as_deref(),
+            Some("/projects/BitFun")
+        );
+    }
+
+    #[test]
+    fn unrelated_workspace_is_not_rewritten_to_the_project_storage_root() {
+        assert_eq!(
+            session_storage_workspace_locator(
+                Some("/projects/other"),
+                Some("/worktrees/session-1"),
+                Some("/projects/BitFun"),
+            )
+            .as_deref(),
+            Some("/projects/other")
+        );
+    }
 
     #[test]
     fn btw_session_memory_mode_requires_both_generation_switches() {

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -149,9 +149,10 @@ pub(super) fn session_storage_workspace_locator(
             Some(project_workspace_path.unwrap_or(requested).to_string())
         }
         Some(requested) => Some(requested.to_string()),
-        None => project_workspace_path
-            .or(execution_workspace_path)
-            .map(str::to_string),
+        // An omitted locator means "use the already loaded session binding".
+        // Its indexed storage path stays authoritative even if ambient host
+        // storage settings have changed since the session was loaded.
+        None => None,
     }
 }
 
@@ -3829,6 +3830,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 .config
                 .project_workspace_path
                 .as_deref()
+                .or(session.config.workspace_path.as_deref())
                 .or(storage_workspace_path.as_deref())
                 .ok_or_else(|| {
                     BitFunError::Validation(format!(
@@ -9345,6 +9347,10 @@ mod tests {
             .as_deref(),
             Some("D:/projects/BitFun")
         );
+    }
+
+    #[test]
+    fn omitted_locator_reuses_the_loaded_session_storage_binding() {
         assert_eq!(
             session_storage_workspace_locator(
                 None,
@@ -9352,7 +9358,7 @@ mod tests {
                 Some("/projects/BitFun"),
             )
             .as_deref(),
-            Some("/projects/BitFun")
+            None
         );
     }
 

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -11,7 +11,8 @@
 //! - Queue cleared on unrecoverable failure
 
 use super::coordinator::{
-    ConversationCoordinator, DialogTriggerSource, HiddenSubagentExecutionRequest, SubagentResult,
+    session_storage_workspace_locator, ConversationCoordinator, DialogTriggerSource,
+    HiddenSubagentExecutionRequest, SubagentResult,
 };
 use super::turn_outcome::TurnOutcome;
 use super::turn_settlement::TurnSettlementRegistration;
@@ -988,9 +989,16 @@ impl DialogScheduler {
         &self,
         session_id: String,
         resolved_turn_id: String,
-        queued_turn: QueuedTurn,
+        mut queued_turn: QueuedTurn,
         reject_if_busy: bool,
     ) -> Result<DialogSubmitOutcome, SchedulerSubmitError> {
+        if let Some(session) = self.session_manager.get_session(&session_id) {
+            queued_turn.workspace_path = session_storage_workspace_locator(
+                queued_turn.workspace_path.as_deref(),
+                session.config.workspace_path.as_deref(),
+                session.config.project_workspace_path.as_deref(),
+            );
+        }
         if let Some(workspace_path) = queued_turn.workspace_path.as_deref() {
             let requested_storage_path = Self::resolve_session_restore_path(
                 workspace_path,

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -47,7 +47,6 @@ import {
   type SlashActionId,
 } from '../utils/slashActionSelection';
 import { notificationService } from '@/shared/notification-system';
-import { worktreeAPI } from '@/infrastructure/api/service-api/WorktreeAPI';
 import { useI18n } from '@/infrastructure/i18n';
 import { inputReducer, initialInputState, type InputAction } from '../reducers/inputReducer';
 import { modeReducer, initialModeState } from '../reducers/modeReducer';
@@ -82,6 +81,7 @@ import { isReviewSlashCommand } from '../deep-review/launch/commandParser';
 import { createLogger } from '@/shared/utils/logger';
 import { isSamePath } from '@/shared/utils/pathUtils';
 import {
+  isSessionWorktreeIsolationEnabled,
   isSessionWorktreeBindingLocked,
   sessionWorktreeBindingSubscriptionKey,
 } from '../utils/sessionWorktree';
@@ -834,15 +834,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     : currentWorkspaceName;
   const sessionBoundWorkspacePath = (
     (!hasRegisteredWorkspace && effectiveTargetSession?.workspacePath)
-    || workspacePath
-    || ''
-  ).trim();
-  const sessionProjectWorkspacePath = (
-    (!hasRegisteredWorkspace && (
-      effectiveTargetSession?.config.projectWorkspacePath
-      || effectiveTargetSession?.projectWorkspacePath
-      || effectiveTargetSession?.workspacePath
-    ))
     || workspacePath
     || ''
   ).trim();
@@ -1905,8 +1896,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [isAcpTargetSession, permissionModeSaving, t, toolPermissionConfig]);
 
   /**
-   * Worktree isolation is a property of where the session runs, so it can only
-   * move while the session is still empty. Remote sessions have no worktrees.
+   * Checking worktree isolation only arms the empty session. The first prompt
+   * materializes the worktree after it has visibly been submitted.
    */
   const worktreeControl = useMemo(() => {
     if (!effectiveTargetSessionId || !effectiveTargetSession) return undefined;
@@ -1919,8 +1910,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     );
 
     return {
+      enabled: isSessionWorktreeIsolationEnabled(effectiveTargetSession),
       locked,
-      onChange: async (enabled: boolean) => {
+      onChange: (enabled: boolean) => {
         const latestSession = FlowChatStore.getInstance()
           .getState()
           .sessions
@@ -1932,38 +1924,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
           notificationService.error(tWorktrees('strip.toggleLocked'));
           return;
         }
-        const latestProjectWorkspacePath = (
-          latestSession.config.projectWorkspacePath
-          || latestSession.projectWorkspacePath
-          || latestSession.workspacePath
-          || sessionProjectWorkspacePath
-        ).trim();
-        try {
-          const result = await worktreeAPI.bindSession(
-            effectiveTargetSessionId,
-            enabled,
-            globalThis.crypto?.randomUUID?.() ?? `worktree-${Date.now()}`,
-            latestProjectWorkspacePath,
-          );
-          FlowChatStore.getInstance().updateSessionExecutionTarget(effectiveTargetSessionId, {
-            workspacePath: result.workspacePath,
-            projectWorkspacePath: result.projectWorkspacePath,
-            workspaceId: result.workspaceId,
-            executionTarget: result.executionTarget,
-          });
-          if (result.retainedWorktreePath) {
-            notificationService.info(
-              tWorktrees('strip.retained', { path: result.retainedWorktreePath }),
-              { duration: 6000 },
-            );
-          }
-        } catch (error) {
-          log.error('Failed to toggle session worktree isolation', error);
-          notificationService.error(
-            error instanceof Error ? error.message : String(error),
-            { duration: 5000 },
-          );
-        }
+        FlowChatStore.getInstance().setSessionWorktreeIsolationRequested(
+          effectiveTargetSessionId,
+          enabled,
+        );
       },
     };
   }, [
@@ -1972,7 +1936,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     derivedState?.isProcessing,
     isAcpTargetSession,
     isSubagentInputTarget,
-    sessionProjectWorkspacePath,
     tWorktrees,
   ]);
 

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
@@ -167,7 +167,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
         <ChatInputWorkspaceStrip
           repositoryPath="/repo"
           workspaceLabel="repo"
-          worktreeControl={{ locked: false, onChange }}
+          worktreeControl={{ enabled: false, locked: false, onChange }}
         />
       );
     });
@@ -183,17 +183,14 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it('coalesces repeated clicks while a worktree transition is pending', async () => {
-    let finishTransition!: () => void;
-    const onChange = vi.fn(() => new Promise<void>(resolve => {
-      finishTransition = resolve;
-    }));
+  it('updates repeated clicks optimistically without waiting for Git work', async () => {
+    const onChange = vi.fn();
     await act(async () => {
       root.render(
         <ChatInputWorkspaceStrip
           repositoryPath="/repo"
           workspaceLabel="repo"
-          worktreeControl={{ locked: false, onChange }}
+          worktreeControl={{ enabled: false, locked: false, onChange }}
         />
       );
     });
@@ -204,10 +201,24 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
       toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenNthCalledWith(1, true);
+    expect(onChange).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it('shows an armed worktree as checked before it is materialized', async () => {
     await act(async () => {
-      finishTransition();
+      root.render(
+        <ChatInputWorkspaceStrip
+          repositoryPath="/repo"
+          workspaceLabel="repo"
+          worktreeControl={{ enabled: true, locked: false, onChange: vi.fn() }}
+        />
+      );
     });
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="chat-input-worktree-toggle"]');
+    expect(toggle?.dataset.worktreeEnabled).toBe('true');
+    expect(toggle?.dataset.worktreeMaterialized).toBe('false');
   });
 
   it('shows the toggle as on inside a worktree and asks to turn it off', async () => {
@@ -225,7 +236,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
             branch: 'bitfun/isolated',
             lifecycle: 'managed',
           }}
-          worktreeControl={{ locked: false, onChange }}
+          worktreeControl={{ enabled: true, locked: false, onChange }}
         />
       );
     });
@@ -247,7 +258,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
         <ChatInputWorkspaceStrip
           repositoryPath="/repo"
           workspaceLabel="repo"
-          worktreeControl={{ locked: true, onChange }}
+          worktreeControl={{ enabled: false, locked: true, onChange }}
         />
       );
     });
@@ -268,7 +279,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
         <ChatInputWorkspaceStrip
           repositoryPath="/repo"
           workspaceLabel="repo"
-          worktreeControl={{ locked: false, onChange }}
+          worktreeControl={{ enabled: false, locked: false, onChange }}
         />
       );
     });
@@ -285,7 +296,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
             rootPath: '/worktrees/wt-1',
             lifecycle: 'managed',
           }}
-          worktreeControl={{ locked: false, onChange }}
+          worktreeControl={{ enabled: true, locked: false, onChange }}
         />
       );
     });

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -8,7 +8,6 @@ import {
   Activity,
   Check,
   EyeOff,
-  Loader2,
   GitBranch,
   Shield,
   ShieldAlert,
@@ -56,9 +55,11 @@ export interface ChatInputWorkspaceStripProps {
    * Omitted when the session cannot host a worktree at all (remote, no session).
    */
   worktreeControl?: {
+    /** Desired state, including an armed worktree not created until first send. */
+    enabled: boolean;
     /** Locked once the session has a transcript — its history describes one directory. */
     locked: boolean;
-    onChange: (enabled: boolean) => void | Promise<void>;
+    onChange: (enabled: boolean) => void;
   };
 }
 
@@ -84,8 +85,6 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const { t: tWorktrees } = useI18n('worktrees');
   const permissionRootRef = useRef<HTMLDivElement>(null);
   const [permissionMenuOpen, setPermissionMenuOpen] = useState(false);
-  const [worktreePending, setWorktreePending] = useState(false);
-  const worktreePendingRef = useRef(false);
   const trimmedPath = repositoryPath.trim();
   const label = workspaceLabel.trim();
 
@@ -115,7 +114,11 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const showPermission = !!permissionControl;
   const showRightActions = showPermission || showUsage || showGoal;
   const isWorktree = !!executionTarget?.worktreeId;
-  const showWorktreeToggle = !!worktreeControl && (isRepository || isWorktree);
+  const worktreeEnabled = worktreeControl?.enabled ?? isWorktree;
+  const worktreeEnabledRef = useRef(worktreeEnabled);
+  worktreeEnabledRef.current = worktreeEnabled;
+  const showWorktreeToggle =
+    !!worktreeControl && (isRepository || isWorktree || worktreeEnabled);
   const permissionCopy = {
     ask: {
       label: t('chatInput.permissionMode.ask.label'),
@@ -178,12 +181,17 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
       : '—');
 
   const workspaceTooltipContent = trimmedPath || label;
-  const worktreeToggleDisabled = !!worktreeControl?.locked || worktreePending;
-  const worktreeTooltip = worktreeControl?.locked
-    ? tWorktrees('strip.toggleLocked')
-    : isWorktree
-      ? tWorktrees('strip.toggleOnDescription', { path: trimmedPath })
-      : tWorktrees('strip.toggleOffDescription');
+  const worktreeToggleDisabled = !!worktreeControl?.locked;
+  let worktreeTooltip = tWorktrees('strip.toggleOffDescription');
+  if (worktreeControl?.locked) {
+    worktreeTooltip = tWorktrees('strip.toggleLocked');
+  } else if (worktreeEnabled && !isWorktree) {
+    worktreeTooltip = tWorktrees('strip.togglePendingOnDescription');
+  } else if (!worktreeEnabled && isWorktree) {
+    worktreeTooltip = tWorktrees('strip.togglePendingOffDescription');
+  } else if (isWorktree) {
+    worktreeTooltip = tWorktrees('strip.toggleOnDescription', { path: trimmedPath });
+  }
   const permissionMode = permissionControl?.mode ?? 'ask';
   const permissionModeLabel = permissionCopy[permissionMode].label;
   const permissionTooltip = permissionMode === 'acp'
@@ -197,15 +205,12 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const showPermissionLabel = permissionMode !== 'acp';
 
   const handleWorktreeToggle = () => {
-    if (!worktreeControl || worktreeToggleDisabled || worktreePendingRef.current) {
+    if (!worktreeControl || worktreeToggleDisabled) {
       return;
     }
-    worktreePendingRef.current = true;
-    setWorktreePending(true);
-    void Promise.resolve(worktreeControl.onChange(!isWorktree)).finally(() => {
-      worktreePendingRef.current = false;
-      setWorktreePending(false);
-    });
+    const nextEnabled = !worktreeEnabledRef.current;
+    worktreeEnabledRef.current = nextEnabled;
+    worktreeControl.onChange(nextEnabled);
   };
 
   const split = !!label && showRightActions;
@@ -248,28 +253,22 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
               <button
                 type="button"
                 role="switch"
-                aria-checked={isWorktree}
+                aria-checked={worktreeEnabled}
                 aria-label={tWorktrees('strip.toggleLabel')}
                 className={[
                   'bitfun-chat-input-workspace-strip__chip',
                   'bitfun-chat-input-workspace-strip__chip--worktree',
-                  isWorktree && 'bitfun-chat-input-workspace-strip__chip--worktree-on',
+                  worktreeEnabled && 'bitfun-chat-input-workspace-strip__chip--worktree-on',
                 ]
                   .filter(Boolean)
                   .join(' ')}
                 disabled={worktreeToggleDisabled}
                 data-testid="chat-input-worktree-toggle"
-                data-worktree-enabled={isWorktree ? 'true' : 'false'}
+                data-worktree-enabled={worktreeEnabled ? 'true' : 'false'}
+                data-worktree-materialized={isWorktree ? 'true' : 'false'}
                 onClick={handleWorktreeToggle}
               >
-                {worktreePending ? (
-                  <Loader2
-                    className="bitfun-chat-input-workspace-strip__worktree-icon is-spinning"
-                    size={11}
-                    strokeWidth={2}
-                    aria-hidden
-                  />
-                ) : isWorktree ? (
+                {worktreeEnabled ? (
                   <SquareCheck
                     className="bitfun-chat-input-workspace-strip__worktree-icon"
                     size={11}

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -5,6 +5,7 @@
 
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { ACPClientAPI } from '@/infrastructure/api/service-api/ACPClientAPI';
+import { worktreeAPI } from '@/infrastructure/api/service-api/WorktreeAPI';
 import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import type { AIModelConfig, AgentModelDefaultsConfig, DefaultModelsConfig } from '@/infrastructure/config/types';
 import { notificationService } from '../../../shared/notification-system';
@@ -22,6 +23,8 @@ import {
   type FlowChatPinTurnToTopRequest,
 } from '../../events/flowchatNavigation';
 import { pendingQueueManager } from './PendingQueueModule';
+import { sessionProjectWorkspacePath } from '../../utils/sessionWorkspace';
+import { sessionWorktreeMaterializationPlan } from '../../utils/sessionWorktree';
 
 const log = createLogger('MessageModule');
 
@@ -269,16 +272,46 @@ export async function sendMessage(
       throw new Error(`Session is still busy finishing the previous turn (current state: ${currentState})`);
     }
 
-    if (isFirstMessage) {
-      handleTitleGeneration(context, sessionId, message);
-    }
-
     context.processingManager.registerStatus({
       sessionId: sessionId,
       status: 'thinking',
       message: '',
       metadata: { sessionId: sessionId, dialogTurnId }
     });
+
+    if (readySession.config.worktreeIsolationRequested !== undefined) {
+      const materialization = sessionWorktreeMaterializationPlan(readySession);
+      if (materialization) {
+        log.info('Materializing requested worktree after prompt submission', {
+          sessionId,
+          enabled: materialization.enabled,
+          projectWorkspacePath: materialization.projectWorkspacePath,
+        });
+        const result = await worktreeAPI.bindSession(
+          sessionId,
+          materialization.enabled,
+          globalThis.crypto?.randomUUID?.() ?? `worktree-first-turn-${Date.now()}`,
+          materialization.projectWorkspacePath,
+        );
+        context.flowChatStore.updateSessionExecutionTarget(sessionId, {
+          workspacePath: result.workspacePath,
+          projectWorkspacePath: result.projectWorkspacePath,
+          workspaceId: result.workspaceId,
+          executionTarget: result.executionTarget,
+        });
+        if (result.retainedWorktreePath) {
+          log.warn('Released worktree retained because it contains local work', {
+            sessionId,
+            retainedWorktreePath: result.retainedWorktreePath,
+          });
+        }
+      }
+      context.flowChatStore.setSessionWorktreeIsolationRequested(sessionId, undefined);
+    }
+
+    if (isFirstMessage) {
+      handleTitleGeneration(context, sessionId, message);
+    }
 
     if (!acpClientId) {
       await syncSessionModelSelection(context, sessionId, currentAgentType);
@@ -293,6 +326,7 @@ export async function sendMessage(
     context.activeTextItems.set(sessionId, new Map());
 
     const workspacePath = updatedSession.workspacePath;
+    const projectWorkspacePath = sessionProjectWorkspacePath(updatedSession);
     
     if (acpClientId) {
       await ACPClientAPI.startDialogTurn({
@@ -317,6 +351,7 @@ export async function sendMessage(
           turnId: dialogTurnId,
           agentType: currentAgentType,
           workspacePath,
+          projectWorkspacePath,
           remoteConnectionId: updatedSession.remoteConnectionId,
           remoteSshHost: updatedSession.remoteSshHost,
           imageContexts: options?.imageContexts,
@@ -339,6 +374,7 @@ export async function sendMessage(
             turnId: dialogTurnId,
             agentType: currentAgentType,
             workspacePath,
+            projectWorkspacePath,
             remoteConnectionId: updatedSession.remoteConnectionId,
             remoteSshHost: updatedSession.remoteSshHost,
             imageContexts: options?.imageContexts,

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -179,6 +179,41 @@ function resetStartupTraceEventsForTest(): void {
   trace.phaseRecords.length = 0;
 }
 
+describe('FlowChatStore lazy worktree preference', () => {
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('records and clears the desired state without changing the execution root', () => {
+    const session = createSession({
+      config: {
+        workspacePath: '/repo',
+        projectWorkspacePath: '/repo',
+        executionTarget: { kind: 'local', rootPath: '/repo' },
+      },
+      workspacePath: '/repo',
+      projectWorkspacePath: '/repo',
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    flowChatStore.setSessionWorktreeIsolationRequested(session.sessionId, true);
+    expect(flowChatStore.getState().sessions.get(session.sessionId)?.config).toMatchObject({
+      workspacePath: '/repo',
+      worktreeIsolationRequested: true,
+      executionTarget: { kind: 'local', rootPath: '/repo' },
+    });
+
+    flowChatStore.setSessionWorktreeIsolationRequested(session.sessionId, undefined);
+    expect(
+      flowChatStore.getState().sessions.get(session.sessionId)?.config
+        .worktreeIsolationRequested,
+    ).toBeUndefined();
+  });
+});
+
 describe('FlowChatStore metadata persistence callbacks', () => {
   afterEach(() => {
     resetStore();

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -2152,6 +2152,35 @@ export class FlowChatStore {
     });
   }
 
+  /**
+   * Record an empty session's desired isolation state without touching Git.
+   * MessageModule materializes this preference only after the user submits the
+   * first prompt.
+   */
+  public setSessionWorktreeIsolationRequested(
+    sessionId: string,
+    requested: boolean | undefined,
+  ): void {
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session) return prev;
+
+      const newSessions = new Map(prev.sessions);
+      const config = { ...session.config };
+      if (requested === undefined) {
+        delete config.worktreeIsolationRequested;
+      } else {
+        config.worktreeIsolationRequested = requested;
+      }
+      newSessions.set(sessionId, {
+        ...session,
+        config,
+        lastActiveAt: Date.now(),
+      });
+      return { ...prev, sessions: newSessions };
+    });
+  }
+
   public updateSessionFocusedReviewDisplayLabel(
     sessionId: string,
     focusedReviewDisplayLabel: Session['focusedReviewDisplayLabel'],

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -502,6 +502,12 @@ export interface SessionConfig {
   executionTargetRequest?: import('@/infrastructure/api/service-api/WorktreeAPI').SessionExecutionTargetRequest;
   /** Resolved target returned and persisted by the backend. */
   executionTarget?: import('@/infrastructure/api/service-api/WorktreeAPI').SessionExecutionTarget;
+  /**
+   * Composer-only preference for an empty session. The concrete worktree is
+   * materialized after the first prompt is submitted, not when the checkbox
+   * is clicked.
+   */
+  worktreeIsolationRequested?: boolean;
   /** Binds session to `WorkspaceInfo.id` (path alone is insufficient for remotes). */
   workspaceId?: string;
   /** Disambiguates sessions when multiple remote workspaces share the same `workspacePath`. */

--- a/src/web-ui/src/flow_chat/utils/sessionWorktree.test.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionWorktree.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { Session } from '../types/flow-chat';
 import {
+  isSessionWorktreeIsolationEnabled,
   isSessionWorktreeBindingLocked,
+  sessionWorktreeMaterializationPlan,
   sessionWorktreeBindingSubscriptionKey,
 } from './sessionWorktree';
 
@@ -34,8 +36,51 @@ describe('session worktree control', () => {
     expect(isSessionWorktreeBindingLocked(session({ totalTurnCount: 1 }), false)).toBe(true);
   });
 
+  it('shows an armed worktree before it has been materialized', () => {
+    const armed = session({
+      workspacePath: '/repo',
+      projectWorkspacePath: '/repo',
+      config: {
+        projectWorkspacePath: '/repo',
+        executionTarget: {
+          kind: 'local',
+          rootPath: '/repo',
+        },
+        worktreeIsolationRequested: true,
+      },
+    });
+
+    expect(isSessionWorktreeIsolationEnabled(armed)).toBe(true);
+    expect(sessionWorktreeMaterializationPlan(armed)).toEqual({
+      enabled: true,
+      projectWorkspacePath: '/repo',
+    });
+  });
+
+  it('does not materialize when no preference change is pending', () => {
+    expect(sessionWorktreeMaterializationPlan(session())).toBeUndefined();
+    expect(sessionWorktreeMaterializationPlan(session({
+      config: {
+        executionTarget: {
+          kind: 'local',
+          rootPath: '/repo',
+        },
+        worktreeIsolationRequested: false,
+      },
+    }))).toBeUndefined();
+  });
+
   it('invalidates the composer subscription after hydrate and rebind', () => {
     const initial = sessionWorktreeBindingSubscriptionKey(session());
+    const armed = sessionWorktreeBindingSubscriptionKey(session({
+      config: {
+        executionTarget: {
+          kind: 'local',
+          rootPath: '/repo',
+        },
+        worktreeIsolationRequested: true,
+      },
+    }));
     const hydrated = sessionWorktreeBindingSubscriptionKey(session({ totalTurnCount: 1 }));
     const rebound = sessionWorktreeBindingSubscriptionKey(session({
       workspacePath: '/worktrees/wt-1',
@@ -50,6 +95,7 @@ describe('session worktree control', () => {
       },
     }));
 
+    expect(armed).not.toBe(initial);
     expect(hydrated).not.toBe(initial);
     expect(rebound).not.toBe(initial);
   });

--- a/src/web-ui/src/flow_chat/utils/sessionWorktree.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionWorktree.ts
@@ -1,4 +1,5 @@
 import type { Session } from '../types/flow-chat';
+import { sessionProjectWorkspacePath } from './sessionWorkspace';
 
 type SessionWorktreeFacts = Pick<
   Session,
@@ -12,6 +13,48 @@ export function isSessionWorktreeBindingLocked(
   return session.dialogTurns.length > 0
     || (session.totalTurnCount ?? 0) > 0
     || isProcessing;
+}
+
+export function isSessionWorktreeMaterialized(
+  session: Pick<SessionWorktreeFacts, 'config'>,
+): boolean {
+  return !!session.config.executionTarget?.worktreeId;
+}
+
+/** Checkbox state, including an unmaterialized choice made before first send. */
+export function isSessionWorktreeIsolationEnabled(
+  session: Pick<SessionWorktreeFacts, 'config'>,
+): boolean {
+  return session.config.worktreeIsolationRequested
+    ?? isSessionWorktreeMaterialized(session);
+}
+
+export interface SessionWorktreeMaterializationPlan {
+  enabled: boolean;
+  projectWorkspacePath: string;
+}
+
+/**
+ * Resolve the one transition that must run after a prompt is submitted and
+ * before its backend turn starts. `undefined` means the checkbox has not
+ * requested a change, or the session is already materialized as requested.
+ */
+export function sessionWorktreeMaterializationPlan(
+  session: SessionWorktreeFacts,
+): SessionWorktreeMaterializationPlan | undefined {
+  const requested = session.config.worktreeIsolationRequested;
+  if (
+    requested === undefined
+    || requested === isSessionWorktreeMaterialized(session)
+  ) {
+    return undefined;
+  }
+
+  const projectWorkspacePath = sessionProjectWorkspacePath(session)?.trim();
+  if (!projectWorkspacePath) {
+    throw new Error('Project workspace path is required to prepare worktree isolation');
+  }
+  return { enabled: requested, projectWorkspacePath };
 }
 
 /**
@@ -30,5 +73,6 @@ export function sessionWorktreeBindingSubscriptionKey(session: SessionWorktreeFa
     session.config.executionTarget?.kind ?? '',
     session.config.executionTarget?.worktreeId ?? '',
     session.config.executionTarget?.rootPath ?? '',
+    session.config.worktreeIsolationRequested ?? '',
   ].join('|');
 }

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -85,7 +85,10 @@ export interface StartDialogTurnRequest {
   originalUserInput?: string;
   turnId?: string; 
   agentType: string; 
+  /** Concrete root where this session executes. */
   workspacePath?: string;
+  /** Stable project root used to locate persistence for worktree sessions. */
+  projectWorkspacePath?: string;
   remoteConnectionId?: string;
   remoteSshHost?: string;
   /** Optional multimodal image contexts (snake_case fields, aligned with backend ImageContextData). */

--- a/src/web-ui/src/infrastructure/api/service-api/WorktreeAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/WorktreeAPI.ts
@@ -261,8 +261,8 @@ export class WorktreeAPI {
   }
 
   /**
-   * Move a session into a managed worktree, or back to the project checkout.
-   * Only allowed while the session has no messages yet.
+   * Materialize an empty session's requested execution root. Composer controls
+   * call this only after the first prompt has been submitted.
    */
   bindSession(
     sessionId: string,

--- a/src/web-ui/src/locales/en-US/worktrees.json
+++ b/src/web-ui/src/locales/en-US/worktrees.json
@@ -6,6 +6,8 @@
     "toggleLabel": "worktree",
     "toggleOffDescription": "Run this session in its own Git worktree so parallel agents do not disturb each other.",
     "toggleOnDescription": "Running in an isolated worktree at {{path}}. Turn off to run in the project directory.",
+    "togglePendingOnDescription": "Worktree isolation is armed. The worktree will be created after you send the first message.",
+    "togglePendingOffDescription": "Worktree isolation will be turned off after you send the first message.",
     "toggleLocked": "Worktree isolation can only be changed before the session's first message.",
     "retained": "The worktree still held local work and was kept at {{path}}."
   },

--- a/src/web-ui/src/locales/zh-CN/worktrees.json
+++ b/src/web-ui/src/locales/zh-CN/worktrees.json
@@ -6,6 +6,8 @@
     "toggleLabel": "worktree",
     "toggleOffDescription": "让这个会话在独立的 Git worktree 中执行，多个 agent 并行跑任务时互不打扰。",
     "toggleOnDescription": "正在隔离的 worktree 中执行：{{path}}。关闭后会回到项目目录。",
+    "togglePendingOnDescription": "已开启 worktree 隔离；发送第一条消息后才会创建 worktree。",
+    "togglePendingOffDescription": "已关闭 worktree 隔离；发送第一条消息后会回到项目目录。",
     "toggleLocked": "只能在会话发出第一条消息之前切换 worktree 隔离。",
     "retained": "该 worktree 仍有本地工作，已保留在 {{path}}。"
   },

--- a/src/web-ui/src/locales/zh-TW/worktrees.json
+++ b/src/web-ui/src/locales/zh-TW/worktrees.json
@@ -6,6 +6,8 @@
     "toggleLabel": "worktree",
     "toggleOffDescription": "讓這個工作階段在獨立的 Git worktree 中執行，多個 agent 並行執行任務時互不干擾。",
     "toggleOnDescription": "正在隔離的 worktree 中執行：{{path}}。關閉後會回到專案目錄。",
+    "togglePendingOnDescription": "已開啟 worktree 隔離；傳送第一則訊息後才會建立 worktree。",
+    "togglePendingOffDescription": "已關閉 worktree 隔離；傳送第一則訊息後會回到專案目錄。",
     "toggleLocked": "只能在工作階段送出第一則訊息之前切換 worktree 隔離。",
     "retained": "該 worktree 仍有本機工作，已保留在 {{path}}。"
   },


### PR DESCRIPTION
## Summary

- make the Desktop checkbox and CLI `/worktree` command arm an empty-session preference without running Git I/O
- materialize or release the worktree only after the first prompt is visibly submitted, then start the backend turn in the resolved execution root
- keep the stable project root as the session persistence locator while the worktree remains the execution root, including legacy caller normalization
- expose pending worktree state in both the Desktop branch strip and CLI workspace status

## Type and Areas

Type: regression fix / UI/UX

Areas: Rust core, desktop/Tauri, Web UI, CLI/TUI, Peer Host adapter

## Motivation / Impact

Checking worktree isolation previously performed synchronous worktree creation. The following prompt then passed the worktree execution path as a session-storage locator, causing `Session ID is already bound to another workspace` and preventing the message from being sent.

After this change, checking the control is immediate. Worktree creation starts only after prompt submission, and session persistence continues to resolve through the owning project root on Windows, macOS, and Linux. Remote-workspace support remains explicitly unchanged.

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/flow_chat/utils/sessionWorktree.test.ts src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx src/flow_chat/store/FlowChatStore.test.ts` — 79 passed
- `pnpm run lint:web`
- `pnpm run i18n:audit` — 0 warnings
- `cargo check --workspace`
- `cargo test -p bitfun-core worktree_execution_root_is_a_legacy_alias_for_project_storage --lib`
- `cargo test -p bitfun-core unrelated_workspace_is_not_rewritten_to_the_project_storage_root --lib`
- `cargo test -p bitfun-core dialog_port_preserves_invalid_request_for_wrong_workspace --lib`
- `cargo test -p bitfun-cli` — all unit and integration tests passed
- `cargo test -p bitfun-desktop` — 226 passed, 2 pre-existing permission-gated tests ignored
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:repo-hygiene`
- `git diff --check`

## Reviewer Notes

The storage-locator fallback intentionally rewrites only the loaded session own execution root to its project root. Unrelated workspace paths are preserved and still rejected by the existing session identity guard. No screenshot is included because the UI shape is unchanged; the visible behavior change is that the checked state is immediate and reports a pending state until first send.

This change was AI-assisted and fully tested with the commands above.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.