### PR TITLE
refactor(web-ui): extract flow chat scroll stability helpers

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -5,6 +5,10 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  VirtualMessageList,
+  type VirtualMessageListRef,
+} from './VirtualMessageList';
+import {
   consumeBottomReservationForContentGrowth,
   getCanceledUnsettledStickyPinGrowthPx,
   resolveAutoCollapseAnchorScrollTop,
@@ -13,9 +17,7 @@ import {
   shouldSyncPhysicalBottom,
   shouldSuppressFollowingTailNegativeScrollBy,
   transferCollapseReservationToPin,
-  VirtualMessageList,
-  type VirtualMessageListRef,
-} from './VirtualMessageList';
+} from './flowChatScrollStability';
 import { activeSessionHistoryProjectionHandoff } from './historyProjectionHandoff';
 import type { Session } from '../../types/flow-chat';
 import type { VirtualItem } from '../../store/modernFlowChatStore';

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -65,13 +65,29 @@ import {
   setFlowChatSearchHighlight,
 } from './flowChatSearchDom';
 import {
+  areBottomReservationStatesEqual,
+  COMPENSATION_EPSILON_PX,
+  consumeBottomReservationForContentGrowth,
+  createInitialBottomReservationState,
+  getCanceledUnsettledStickyPinGrowthPx,
+  getReservationTotalPx,
+  resolveAutoCollapseAnchorScrollTop,
+  sanitizeBottomReservationState,
+  shouldBypassShrinkCompensationInTailFollow,
+  shouldPreserveCollapseReservationAfterIntent,
+  shouldSuppressFollowingTailNegativeScrollBy,
+  shouldSyncPhysicalBottom,
+  transferCollapseReservationToPin,
+  type BottomReservationState,
+  type PinBottomReservation,
+} from './flowChatScrollStability';
+import {
   canHandoffPinnedItemToTail,
   FlowChatViewportCoordinator,
   type FlowChatViewportRangeHost,
 } from './FlowChatViewportCoordinator';
 import './VirtualMessageList.scss';
 
-const COMPENSATION_EPSILON_PX = 0.5;
 const PINNED_TURN_VIEWPORT_OFFSET_PX = 57; // Keep in sync with `.message-list-header`.
 const TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX = 6;
 const USER_UPWARD_SCROLL_INTENT_WINDOW_MS = 800;
@@ -215,44 +231,6 @@ interface LatestEndAnchorRequestState {
   lastTargetBottom: number | null;
 }
 
-type BottomReservationKind = 'collapse' | 'pin';
-
-interface BottomReservationBase {
-  kind: BottomReservationKind;
-  px: number;
-  floorPx: number;
-}
-
-interface CollapseBottomReservation extends BottomReservationBase {
-  kind: 'collapse';
-}
-
-interface PinBottomReservation extends BottomReservationBase {
-  kind: 'pin';
-  mode: FlowChatPinTurnToTopMode;
-  targetTurnId: string | null;
-}
-
-interface BottomReservationState {
-  collapse: CollapseBottomReservation;
-  pin: PinBottomReservation;
-}
-
-export function transferCollapseReservationToPin(
-  currentState: BottomReservationState,
-  nextPinReservation: PinBottomReservation,
-): BottomReservationState {
-  return {
-    ...currentState,
-    collapse: {
-      ...currentState.collapse,
-      px: 0,
-      floorPx: 0,
-    },
-    pin: nextPinReservation,
-  };
-}
-
 interface ScrollerGeometrySnapshot {
   scrollTop: number;
   scrollHeight: number;
@@ -270,23 +248,6 @@ interface PendingTurnPinState {
 interface PendingStaticTurnPinState {
   turnId: string;
   behavior: ScrollBehavior;
-}
-
-function createInitialBottomReservationState(): BottomReservationState {
-  return {
-    collapse: {
-      kind: 'collapse',
-      px: 0,
-      floorPx: 0,
-    },
-    pin: {
-      kind: 'pin',
-      px: 0,
-      floorPx: 0,
-      mode: 'transient',
-      targetTurnId: null,
-    },
-  };
 }
 
 function sanitizeReservationPx(value: number): number {
@@ -361,39 +322,6 @@ function isPointerOnScrollbarGutter(
   return isWithinVerticalScrollbar || isWithinHorizontalScrollbar;
 }
 
-function sanitizeBottomReservationState(state: BottomReservationState): BottomReservationState {
-  const collapsePx = sanitizeReservationPx(state.collapse.px);
-  const collapseFloorPx = Math.min(collapsePx, sanitizeReservationPx(state.collapse.floorPx));
-  const pinPx = sanitizeReservationPx(state.pin.px);
-  const pinFloorPx = Math.min(pinPx, sanitizeReservationPx(state.pin.floorPx));
-
-  return {
-    collapse: {
-      kind: 'collapse',
-      px: collapsePx,
-      floorPx: collapseFloorPx,
-    },
-    pin: {
-      kind: 'pin',
-      px: pinPx,
-      floorPx: pinFloorPx,
-      mode: state.pin.mode ?? 'transient',
-      targetTurnId: state.pin.targetTurnId ?? null,
-    },
-  };
-}
-
-function areBottomReservationStatesEqual(left: BottomReservationState, right: BottomReservationState): boolean {
-  return (
-    Math.abs(left.collapse.px - right.collapse.px) <= COMPENSATION_EPSILON_PX &&
-    Math.abs(left.collapse.floorPx - right.collapse.floorPx) <= COMPENSATION_EPSILON_PX &&
-    Math.abs(left.pin.px - right.pin.px) <= COMPENSATION_EPSILON_PX &&
-    Math.abs(left.pin.floorPx - right.pin.floorPx) <= COMPENSATION_EPSILON_PX &&
-    left.pin.mode === right.pin.mode &&
-    left.pin.targetTurnId === right.pin.targetTurnId
-  );
-}
-
 function getVirtualItemStableKey(item: VirtualItem): string {
   switch (item.type) {
     case 'user-message':
@@ -425,128 +353,6 @@ function getPrependedVirtualItemCount(previousItems: VirtualItem[], nextItems: V
   }
 
   return prependedCount;
-}
-
-function getReservationTotalPx(reservation: BottomReservationBase): number {
-  return Math.max(0, reservation.px);
-}
-
-function getReservationConsumablePx(reservation: BottomReservationBase): number {
-  return Math.max(0, reservation.px - reservation.floorPx);
-}
-
-export function consumeBottomReservationForContentGrowth(
-  state: BottomReservationState,
-  amountPx: number,
-  consumeStickyPinFloor: boolean,
-  preserveCollapseReservation = false,
-): BottomReservationState {
-  let remaining = Math.max(0, amountPx);
-
-  const collapseConsumablePx = preserveCollapseReservation
-    ? 0
-    : getReservationConsumablePx(state.collapse);
-  const collapseConsumed = Math.min(collapseConsumablePx, remaining);
-  remaining -= collapseConsumed;
-
-  const pinConsumablePx = getReservationConsumablePx(state.pin);
-  const pinConsumed = Math.min(pinConsumablePx, remaining);
-  remaining -= pinConsumed;
-
-  const stickyPinFloorConsumed = consumeStickyPinFloor && state.pin.mode === 'sticky-latest'
-    ? Math.min(state.pin.floorPx, remaining)
-    : 0;
-
-  return sanitizeBottomReservationState({
-    collapse: {
-      ...state.collapse,
-      px: state.collapse.px - collapseConsumed,
-    },
-    pin: {
-      ...state.pin,
-      px: state.pin.px - pinConsumed - stickyPinFloorConsumed,
-      floorPx: state.pin.floorPx - stickyPinFloorConsumed,
-    },
-  });
-}
-
-export function shouldSyncPhysicalBottom(options: {
-  viewportGeometryChanged: boolean;
-  collapseProtectionActive: boolean;
-  wasAtPhysicalBottom: boolean;
-  ownsElementAnchor: boolean;
-}): boolean {
-  return (
-    options.viewportGeometryChanged &&
-    !options.collapseProtectionActive &&
-    options.wasAtPhysicalBottom &&
-    !options.ownsElementAnchor
-  );
-}
-
-export function shouldSuppressFollowingTailNegativeScrollBy(options: {
-  requestedTop: number | null;
-  isFollowingOutput: boolean;
-  isStreamingOutput: boolean;
-  wasAtPhysicalBottom: boolean;
-}): boolean {
-  return (
-    options.requestedTop !== null &&
-    options.requestedTop < -COMPENSATION_EPSILON_PX &&
-    options.isFollowingOutput &&
-    options.isStreamingOutput &&
-    options.wasAtPhysicalBottom
-  );
-}
-
-export function getCanceledUnsettledStickyPinGrowthPx(options: {
-  pendingGrowthPx: number;
-  shrinkPx: number;
-  hasActiveCollapseIntent: boolean;
-}): number {
-  if (options.hasActiveCollapseIntent) {
-    return 0;
-  }
-  return Math.min(
-    sanitizeReservationPx(options.pendingGrowthPx),
-    sanitizeReservationPx(options.shrinkPx),
-  );
-}
-
-export function shouldBypassShrinkCompensationInTailFollow(options: {
-  isFollowingOutput: boolean;
-  isStreamingOutput: boolean;
-  hasActiveCollapseIntent: boolean;
-}): boolean {
-  return (
-    options.isFollowingOutput &&
-    options.isStreamingOutput &&
-    !options.hasActiveCollapseIntent
-  );
-}
-
-export function shouldPreserveCollapseReservationAfterIntent(options: {
-  isFollowingOutput: boolean;
-  isStreamingOutput: boolean;
-}): boolean {
-  return options.isFollowingOutput && options.isStreamingOutput;
-}
-
-export function resolveAutoCollapseAnchorScrollTop(options: {
-  currentScrollTop: number;
-  previousStableScrollTop: number;
-  reason: string | null | undefined;
-  isFollowingOutput: boolean;
-  isStreamingOutput: boolean;
-}): number {
-  if (
-    options.reason !== 'auto' ||
-    !options.isFollowingOutput ||
-    !options.isStreamingOutput
-  ) {
-    return options.currentScrollTop;
-  }
-  return Math.max(options.currentScrollTop, options.previousStableScrollTop);
 }
 
 const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessageListProps>(({

--- a/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
@@ -1,0 +1,220 @@
+import type { FlowChatPinTurnToTopMode } from '../../events/flowchatNavigation';
+
+export const COMPENSATION_EPSILON_PX = 0.5;
+
+type BottomReservationKind = 'collapse' | 'pin';
+
+interface BottomReservationBase {
+  kind: BottomReservationKind;
+  px: number;
+  floorPx: number;
+}
+
+interface CollapseBottomReservation extends BottomReservationBase {
+  kind: 'collapse';
+}
+
+export interface PinBottomReservation extends BottomReservationBase {
+  kind: 'pin';
+  mode: FlowChatPinTurnToTopMode;
+  targetTurnId: string | null;
+}
+
+export interface BottomReservationState {
+  collapse: CollapseBottomReservation;
+  pin: PinBottomReservation;
+}
+
+export function transferCollapseReservationToPin(
+  currentState: BottomReservationState,
+  nextPinReservation: PinBottomReservation,
+): BottomReservationState {
+  return {
+    ...currentState,
+    collapse: {
+      ...currentState.collapse,
+      px: 0,
+      floorPx: 0,
+    },
+    pin: nextPinReservation,
+  };
+}
+
+export function createInitialBottomReservationState(): BottomReservationState {
+  return {
+    collapse: {
+      kind: 'collapse',
+      px: 0,
+      floorPx: 0,
+    },
+    pin: {
+      kind: 'pin',
+      px: 0,
+      floorPx: 0,
+      mode: 'transient',
+      targetTurnId: null,
+    },
+  };
+}
+
+function sanitizeReservationPx(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+export function sanitizeBottomReservationState(state: BottomReservationState): BottomReservationState {
+  const collapsePx = sanitizeReservationPx(state.collapse.px);
+  const collapseFloorPx = Math.min(collapsePx, sanitizeReservationPx(state.collapse.floorPx));
+  const pinPx = sanitizeReservationPx(state.pin.px);
+  const pinFloorPx = Math.min(pinPx, sanitizeReservationPx(state.pin.floorPx));
+
+  return {
+    collapse: {
+      kind: 'collapse',
+      px: collapsePx,
+      floorPx: collapseFloorPx,
+    },
+    pin: {
+      kind: 'pin',
+      px: pinPx,
+      floorPx: pinFloorPx,
+      mode: state.pin.mode ?? 'transient',
+      targetTurnId: state.pin.targetTurnId ?? null,
+    },
+  };
+}
+
+export function areBottomReservationStatesEqual(
+  left: BottomReservationState,
+  right: BottomReservationState,
+): boolean {
+  return (
+    Math.abs(left.collapse.px - right.collapse.px) <= COMPENSATION_EPSILON_PX &&
+    Math.abs(left.collapse.floorPx - right.collapse.floorPx) <= COMPENSATION_EPSILON_PX &&
+    Math.abs(left.pin.px - right.pin.px) <= COMPENSATION_EPSILON_PX &&
+    Math.abs(left.pin.floorPx - right.pin.floorPx) <= COMPENSATION_EPSILON_PX &&
+    left.pin.mode === right.pin.mode &&
+    left.pin.targetTurnId === right.pin.targetTurnId
+  );
+}
+
+export function getReservationTotalPx(reservation: BottomReservationBase): number {
+  return Math.max(0, reservation.px);
+}
+
+function getReservationConsumablePx(reservation: BottomReservationBase): number {
+  return Math.max(0, reservation.px - reservation.floorPx);
+}
+
+export function consumeBottomReservationForContentGrowth(
+  state: BottomReservationState,
+  amountPx: number,
+  consumeStickyPinFloor: boolean,
+  preserveCollapseReservation = false,
+): BottomReservationState {
+  let remaining = Math.max(0, amountPx);
+
+  const collapseConsumablePx = preserveCollapseReservation
+    ? 0
+    : getReservationConsumablePx(state.collapse);
+  const collapseConsumed = Math.min(collapseConsumablePx, remaining);
+  remaining -= collapseConsumed;
+
+  const pinConsumablePx = getReservationConsumablePx(state.pin);
+  const pinConsumed = Math.min(pinConsumablePx, remaining);
+  remaining -= pinConsumed;
+
+  const stickyPinFloorConsumed = consumeStickyPinFloor && state.pin.mode === 'sticky-latest'
+    ? Math.min(state.pin.floorPx, remaining)
+    : 0;
+
+  return sanitizeBottomReservationState({
+    collapse: {
+      ...state.collapse,
+      px: state.collapse.px - collapseConsumed,
+    },
+    pin: {
+      ...state.pin,
+      px: state.pin.px - pinConsumed - stickyPinFloorConsumed,
+      floorPx: state.pin.floorPx - stickyPinFloorConsumed,
+    },
+  });
+}
+
+export function shouldSyncPhysicalBottom(options: {
+  viewportGeometryChanged: boolean;
+  collapseProtectionActive: boolean;
+  wasAtPhysicalBottom: boolean;
+  ownsElementAnchor: boolean;
+}): boolean {
+  return (
+    options.viewportGeometryChanged &&
+    !options.collapseProtectionActive &&
+    options.wasAtPhysicalBottom &&
+    !options.ownsElementAnchor
+  );
+}
+
+export function shouldSuppressFollowingTailNegativeScrollBy(options: {
+  requestedTop: number | null;
+  isFollowingOutput: boolean;
+  isStreamingOutput: boolean;
+  wasAtPhysicalBottom: boolean;
+}): boolean {
+  return (
+    options.requestedTop !== null &&
+    options.requestedTop < -COMPENSATION_EPSILON_PX &&
+    options.isFollowingOutput &&
+    options.isStreamingOutput &&
+    options.wasAtPhysicalBottom
+  );
+}
+
+export function getCanceledUnsettledStickyPinGrowthPx(options: {
+  pendingGrowthPx: number;
+  shrinkPx: number;
+  hasActiveCollapseIntent: boolean;
+}): number {
+  if (options.hasActiveCollapseIntent) {
+    return 0;
+  }
+  return Math.min(
+    sanitizeReservationPx(options.pendingGrowthPx),
+    sanitizeReservationPx(options.shrinkPx),
+  );
+}
+
+export function shouldBypassShrinkCompensationInTailFollow(options: {
+  isFollowingOutput: boolean;
+  isStreamingOutput: boolean;
+  hasActiveCollapseIntent: boolean;
+}): boolean {
+  return (
+    options.isFollowingOutput &&
+    options.isStreamingOutput &&
+    !options.hasActiveCollapseIntent
+  );
+}
+
+export function shouldPreserveCollapseReservationAfterIntent(options: {
+  isFollowingOutput: boolean;
+  isStreamingOutput: boolean;
+}): boolean {
+  return options.isFollowingOutput && options.isStreamingOutput;
+}
+
+export function resolveAutoCollapseAnchorScrollTop(options: {
+  currentScrollTop: number;
+  previousStableScrollTop: number;
+  reason: string | null | undefined;
+  isFollowingOutput: boolean;
+  isStreamingOutput: boolean;
+}): number {
+  if (
+    options.reason !== 'auto' ||
+    !options.isFollowingOutput ||
+    !options.isStreamingOutput
+  ) {
+    return options.currentScrollTop;
+  }
+  return Math.max(options.currentScrollTop, options.previousStableScrollTop);
+}


### PR DESCRIPTION
## Summary

- Extract Flow Chat viewport reservation types and pure stability calculations from `VirtualMessageList.tsx`.
- Keep the React component module free of non-component runtime exports.
- Update focused tests to import the extracted helpers from their dedicated module.

Fixes #<issue-number>

## Type and Areas

Type:

Refactor

Areas:

Web UI, Flow Chat, virtualized message list

## Motivation / Impact

`VirtualMessageList.tsx` exported several non-component helper functions so they could be tested directly. This triggered eight `react-refresh/only-export-components` warnings and made the component module incompatible with React Fast Refresh expectations.

The helpers now live in a dedicated pure logic module. This is a behavior-preserving refactor with no direct user-facing change.

## Verification

- `pnpm run lint:web` — passed with 0 warnings and 0 errors
- `pnpm run type-check:web` — passed
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx src/flow_chat/components/modern/FlowChatViewportCoordinator.test.ts src/flow_chat/tool-cards/useToolCardHeightContract.test.tsx src/flow_chat/tool-cards/TodoWriteDisplay.test.tsx` — 4 files and 38 tests passed
- `git diff --check` — passed

## Reviewer Notes

This change only relocates existing reservation and scroll-stability calculations. `VirtualMessageList` and its tests consume the same functions through the new `flowChatScrollStability.ts` module.

No user-facing strings, locale resources, or public contracts were changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.