### PR TITLE
fix(flow-chat): stabilize sticky pins across session re-entry

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -191,6 +191,31 @@ shrink it while Virtuoso item measurements are still moving. Stream end
 performs one final atomic collapse-to-pin transfer using the settled required
 range.
 
+When a sticky target is temporarily virtualized, its provisional range must be
+computed from `scrollHeight - currentPinPx`. Reusing physical `scrollHeight`
+directly feeds the synthetic footer back into the next retry and grows the range
+on every frame. Provisional pins remain at `floorPx: 0`; if the request expires
+without capturing an element anchor, that range is removed atomically.
+
+The pin-owned portion of the footer is capped at one viewport. A rendered
+target can never require more than `clientHeight` of extra range to align its
+top inside the viewport, and one viewport is also sufficient to materialize a
+virtualized target. This cap applies to provisional and established pin ranges.
+It does not apply to collapse compensation or the total footer: a large card or
+several cumulative collapses can legitimately require more than one viewport to
+preserve the current semantic anchor.
+
+Pending pin retries carry a synchronous generation plus the owning session and
+turn. Canceling or replacing a request increments the generation before React
+state is updated, so already-queued animation frames cannot restore a canceled
+reservation. User navigation drops a provisional sticky range instead of
+transferring it into protected collapse. Established pins keep the existing
+protected-range handoff.
+
+Mounting an already-streaming session is not a new-turn event. Session entry
+resumes tail follow directly, while sticky pinning remains reserved for a new
+turn that appears in the currently mounted session.
+
 ## 4. Collapse Intent
 
 Some collapses are predictable before layout actually shrinks.

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -9,14 +9,19 @@ import {
   type VirtualMessageListRef,
 } from './VirtualMessageList';
 import {
+  clampPinReservationPxToViewport,
   consumeBottomReservationForContentGrowth,
   getCanceledUnsettledStickyPinGrowthPx,
+  isTurnPinRequestIdentityCurrent,
   protectCurrentCollapseReservation,
   reconcileUnsignaledShrinkReservation,
+  releasePinReservationForUserNavigation,
   resolveAutoCollapseAnchorScrollTop,
+  resolveProvisionalStickyPinReservationPx,
   settleCollapseReservationForPreservedViewport,
   shouldBypassShrinkCompensationInTailFollow,
   shouldPreserveCollapseReservationAfterIntent,
+  shouldClearExpiredProvisionalStickyPin,
   shouldSyncPhysicalBottom,
   shouldSuppressFollowingTailNegativeScrollBy,
   transferCollapseReservationToPin,
@@ -36,6 +41,7 @@ const stateMocks = vi.hoisted(() => ({
 }));
 const virtuosoMocks = vi.hoisted(() => ({
   renderedRange: null as { start: number; end: number } | null,
+  scrollerScrollTo: vi.fn(),
   scrollToIndex: vi.fn(),
 }));
 const flowStoreMocks = vi.hoisted(() => ({
@@ -83,6 +89,19 @@ vi.mock('react-virtuoso', () => ({
     React.useLayoutEffect(() => {
       if (!scrollerRef.current) {
         return;
+      }
+
+      if (typeof scrollerRef.current.scrollTo !== 'function') {
+        Object.defineProperty(scrollerRef.current, 'scrollTo', {
+          configurable: true,
+          writable: true,
+          value: (options?: ScrollToOptions) => {
+            virtuosoMocks.scrollerScrollTo(options);
+            if (typeof options?.top === 'number') {
+              scrollerRef.current!.scrollTop = options.top;
+            }
+          },
+        });
       }
 
       props.scrollerRef?.(scrollerRef.current);
@@ -361,6 +380,7 @@ describe('VirtualMessageList session boundary', () => {
     stateMocks.visibleTurnInfo = null;
     stateMocks.setVisibleTurnInfo.mockReset();
     virtuosoMocks.renderedRange = null;
+    virtuosoMocks.scrollerScrollTo.mockReset();
     virtuosoMocks.scrollToIndex.mockReset();
     flowStoreMocks.hasPendingSessionHistoryCompletion.mockReset();
     flowStoreMocks.hasPendingSessionHistoryCompletion.mockReturnValue(false);
@@ -451,6 +471,124 @@ describe('VirtualMessageList session boundary', () => {
         targetTurnId: null,
       },
     });
+  });
+
+  it('invalidates pending turn pin work by generation, session, and target', () => {
+    const request = {
+      generation: 7,
+      sessionId: 'session-a',
+      turnId: 'turn-a',
+    };
+
+    expect(isTurnPinRequestIdentityCurrent(request, request)).toBe(true);
+    expect(isTurnPinRequestIdentityCurrent(request, {
+      ...request,
+      generation: 8,
+    })).toBe(false);
+    expect(isTurnPinRequestIdentityCurrent(request, {
+      ...request,
+      sessionId: 'session-b',
+    })).toBe(false);
+    expect(isTurnPinRequestIdentityCurrent(request, {
+      ...request,
+      turnId: 'turn-b',
+    })).toBe(false);
+  });
+
+  it('drops a provisional sticky pin on user intent without protecting its range', () => {
+    const currentState = {
+      collapse: { kind: 'collapse' as const, px: 12, floorPx: 4 },
+      pin: {
+        kind: 'pin' as const,
+        px: 3_780,
+        floorPx: 0,
+        mode: 'sticky-latest' as const,
+        targetTurnId: 'turn-a',
+      },
+    };
+
+    expect(releasePinReservationForUserNavigation(currentState, {
+      preserveCurrentRange: true,
+      ownsElementAnchor: false,
+    })).toEqual({
+      collapse: currentState.collapse,
+      pin: {
+        kind: 'pin',
+        px: 0,
+        floorPx: 0,
+        mode: 'transient',
+        targetTurnId: null,
+      },
+    });
+  });
+
+  it('protects an established sticky pin range when user intent exits it', () => {
+    const currentState = {
+      collapse: { kind: 'collapse' as const, px: 12, floorPx: 4 },
+      pin: {
+        kind: 'pin' as const,
+        px: 100,
+        floorPx: 100,
+        mode: 'sticky-latest' as const,
+        targetTurnId: 'turn-a',
+      },
+    };
+
+    expect(releasePinReservationForUserNavigation(currentState, {
+      preserveCurrentRange: true,
+      ownsElementAnchor: true,
+    })).toEqual(transferPinReservationToProtectedCollapse(currentState));
+  });
+
+  it('keeps unresolved sticky pin fallback reservation idempotent and viewport-bounded', () => {
+    expect(resolveProvisionalStickyPinReservationPx({
+      scrollHeight: 3_803,
+      clientHeight: 1_023,
+      currentPinPx: 0,
+    })).toBe(1_023);
+    expect(resolveProvisionalStickyPinReservationPx({
+      scrollHeight: 4_826,
+      clientHeight: 1_023,
+      currentPinPx: 1_023,
+    })).toBe(1_023);
+    expect(resolveProvisionalStickyPinReservationPx({
+      scrollHeight: 6_583,
+      clientHeight: 1_023,
+      currentPinPx: 5_560,
+    })).toBe(1_023);
+
+    expect(clampPinReservationPxToViewport(640, 1_023)).toBe(640);
+    expect(clampPinReservationPxToViewport(2_780, 1_023)).toBe(1_023);
+  });
+
+  it('clears only expired provisional sticky pins without an element anchor', () => {
+    const pinReservation = {
+      kind: 'pin' as const,
+      px: 2_780,
+      floorPx: 0,
+      mode: 'sticky-latest' as const,
+      targetTurnId: 'turn-a',
+    };
+    const baseOptions = {
+      requestTurnId: 'turn-a',
+      requestPinMode: 'sticky-latest' as const,
+      pinReservation,
+      ownsElementAnchor: false,
+    };
+
+    expect(shouldClearExpiredProvisionalStickyPin(baseOptions)).toBe(true);
+    expect(shouldClearExpiredProvisionalStickyPin({
+      ...baseOptions,
+      ownsElementAnchor: true,
+    })).toBe(false);
+    expect(shouldClearExpiredProvisionalStickyPin({
+      ...baseOptions,
+      pinReservation: { ...pinReservation, floorPx: 200 },
+    })).toBe(false);
+    expect(shouldClearExpiredProvisionalStickyPin({
+      ...baseOptions,
+      requestTurnId: 'turn-b',
+    })).toBe(false);
   });
 
   it('protects a settled element range from later unsignaled shrink reconciliation', () => {
@@ -688,6 +826,34 @@ describe('VirtualMessageList session boundary', () => {
     expect(container.querySelector('[data-testid="scroll-to-latest"]')?.getAttribute('data-visible')).toBe('false');
   });
 
+  it('resumes tail follow when a mounted streaming session receives its initial items', () => {
+    const session = createSession('session-a', 'turn-a');
+    session.dialogTurns[0].status = 'processing';
+    session.dialogTurns[0].modelRounds = [{
+      id: 'round-turn-a',
+      status: 'streaming',
+      isStreaming: true,
+      items: [],
+      startTime: 1,
+    } as typeof session.dialogTurns[number]['modelRounds'][number]];
+    stateMocks.activeSession = session;
+    stateMocks.virtualItems = [];
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+    virtuosoMocks.scrollerScrollTo.mockClear();
+
+    stateMocks.virtualItems = [createItem('turn-a'), createModelItem('turn-a')];
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    expect(virtuosoMocks.scrollerScrollTo).toHaveBeenCalledWith(expect.objectContaining({
+      behavior: 'auto',
+    }));
+  });
+
   it('keeps static initial history position when background updates arrive after an upward scroll', () => {
     let nowMs = 1_000;
     const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
@@ -827,6 +993,91 @@ describe('VirtualMessageList session boundary', () => {
     expect(scroller.scrollTop).toBe(4_443);
     expect(target.getBoundingClientRect().top).toBe(57);
     expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a canceled pending sticky pin RAF restore provisional footer space', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const turnIds = Array.from(
+      { length: 24 },
+      (_, index) => `turn-${String(index + 1).padStart(2, '0')}`,
+    );
+    const latestTurnId = turnIds[turnIds.length - 1];
+    const session = createSessionWithTurns('session-a', turnIds);
+    const latestTurn = session.dialogTurns[session.dialogTurns.length - 1];
+    latestTurn.status = 'processing';
+    latestTurn.modelRounds = [{
+      id: `round-${latestTurnId}`,
+      status: 'streaming',
+      isStreaming: true,
+      items: [],
+      startTime: 1,
+    } as typeof latestTurn.modelRounds[number]];
+    stateMocks.activeSession = session;
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+    virtuosoMocks.renderedRange = { start: 0, end: 4 };
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    const footer = container.querySelector<HTMLElement>('.message-list-footer');
+    expect(scroller).not.toBeNull();
+    expect(footer).not.toBeNull();
+    if (!scroller || !footer) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 5_000,
+      clientHeight: 1_000,
+      scrollTop: 0,
+    });
+    const baselineFooterHeight = Number.parseFloat(footer.style.height);
+
+    let status: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
+    act(() => {
+      status = listRef.current?.pinTurnToTopWithStatus(latestTurnId, {
+        behavior: 'auto',
+        pinMode: 'sticky-latest',
+      }) ?? 'rejected';
+    });
+    expect(status).toBe('pending');
+    expect(Number.parseFloat(footer.style.height)).toBeGreaterThan(baselineFooterHeight);
+    expect(Number.parseFloat(footer.style.height) - baselineFooterHeight)
+      .toBeLessThanOrEqual(scroller.clientHeight);
+
+    const target = container.querySelector<HTMLElement>(
+      `[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`,
+    );
+    expect(target).not.toBeNull();
+    if (!target) {
+      return;
+    }
+    vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 0,
+      bottom: 1_000,
+      height: 1_000,
+    }));
+    vi.spyOn(target, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 4_500,
+      bottom: 4_540,
+      height: 40,
+    }));
+
+    act(() => {
+      scroller.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+    expect(Number.parseFloat(footer.style.height)).toBe(baselineFooterHeight);
+
+    flushAnimationFrame();
+    expect(Number.parseFloat(footer.style.height)).toBe(baselineFooterHeight);
   });
 
   it('centers the exact text range when navigating to a search match', () => {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -67,22 +67,26 @@ import {
 } from './flowChatSearchDom';
 import {
   areBottomReservationStatesEqual,
+  clampPinReservationPxToViewport,
   COMPENSATION_EPSILON_PX,
   consumeBottomReservationForContentGrowth,
   createInitialBottomReservationState,
   getCanceledUnsettledStickyPinGrowthPx,
   getReservationTotalPx,
+  isTurnPinRequestIdentityCurrent,
   protectCurrentCollapseReservation,
   reconcileUnsignaledShrinkReservation,
+  releasePinReservationForUserNavigation,
   resolveAutoCollapseAnchorScrollTop,
+  resolveProvisionalStickyPinReservationPx,
   sanitizeBottomReservationState,
   settleCollapseReservationForPreservedViewport,
   shouldBypassShrinkCompensationInTailFollow,
   shouldPreserveCollapseReservationAfterIntent,
+  shouldClearExpiredProvisionalStickyPin,
   shouldSuppressFollowingTailNegativeScrollBy,
   shouldSyncPhysicalBottom,
   transferCollapseReservationToPin,
-  transferPinReservationToProtectedCollapse,
   type BottomReservationState,
   type PinBottomReservation,
 } from './flowChatScrollStability';
@@ -248,6 +252,8 @@ interface ScrollerGeometrySnapshot {
 }
 
 interface PendingTurnPinState {
+  generation: number;
+  sessionId: string;
   turnId: string;
   behavior: ScrollBehavior;
   pinMode: FlowChatPinTurnToTopMode;
@@ -448,6 +454,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const visibleTurnMeasureFrameRef = useRef<number | null>(null);
   const pinReservationReconcileFrameRef = useRef<number | null>(null);
   const turnPinStabilizationFrameRef = useRef<number | null>(null);
+  const turnPinRequestGenerationRef = useRef(0);
   const latestEndAnchorStabilizationFrameRef = useRef<number | null>(null);
   const searchNavigationRequestIdRef = useRef(0);
   const staticInitialHistoryBottomGuardFrameRef = useRef<number | null>(null);
@@ -807,6 +814,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }, []);
 
   const clearTurnPinRequest = useCallback(() => {
+    turnPinRequestGenerationRef.current += 1;
     transientTurnPinStabilizationRef.current = null;
 
     if (turnPinStabilizationFrameRef.current !== null) {
@@ -1449,6 +1457,21 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
   const latestTurnId = userMessageItems[userMessageItems.length - 1]?.item.turnId ?? null;
   const latestUserMessageIndex = userMessageItems[userMessageItems.length - 1]?.index ?? 0;
+  const isTurnPinRequestCurrent = useCallback((request: PendingTurnPinState) => {
+    const currentSessionId = activeSessionIdRef.current;
+    const currentTargetTurnId = request.pinMode === 'sticky-latest'
+      ? latestTurnId
+      : request.turnId;
+    if (!currentSessionId || !currentTargetTurnId) {
+      return false;
+    }
+
+    return isTurnPinRequestIdentityCurrent(request, {
+      generation: turnPinRequestGenerationRef.current,
+      sessionId: currentSessionId,
+      turnId: currentTargetTurnId,
+    });
+  }, [latestTurnId]);
   const hasPendingHistoryCompletion = activeSession?.sessionId
     ? flowChatStore.hasPendingSessionHistoryCompletion(activeSession.sessionId)
     : false;
@@ -1754,9 +1777,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     turnId: string,
     pinMode: FlowChatPinTurnToTopMode,
     requiredTailSpacePx: number,
+    maxPinReservationPx: number,
     currentPinReservation: PinBottomReservation = bottomReservationStateRef.current.pin,
   ): PinBottomReservation => {
-    const resolvedRequiredTailSpacePx = sanitizeReservationPx(requiredTailSpacePx);
+    const resolvedRequiredTailSpacePx = clampPinReservationPxToViewport(
+      requiredTailSpacePx,
+      maxPinReservationPx,
+    );
     const nextFloorPx = pinMode === 'sticky-latest'
       ? resolvedRequiredTailSpacePx
       : 0;
@@ -1770,7 +1797,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         currentPinReservation.floorPx > COMPENSATION_EPSILON_PX
       )
     );
-    const preservedPx = shouldPreserveCurrentPx ? currentPinReservation.px : 0;
+    const preservedPx = shouldPreserveCurrentPx
+      ? clampPinReservationPxToViewport(currentPinReservation.px, maxPinReservationPx)
+      : 0;
     const shouldRetainTarget = (
       pinMode === 'sticky-latest' ||
       resolvedRequiredTailSpacePx > COMPENSATION_EPSILON_PX ||
@@ -1802,7 +1831,31 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     const maxScrollTop = Math.max(0, rawMaxScrollTop);
     // When content is shorter than the viewport, the clamped max scroll range is 0
     // even though we still need to reserve the underflow gap before the target can pin.
-    const missingTailSpace = Math.max(0, desiredScrollTop - rawMaxScrollTop);
+    const rawMissingTailSpace = Math.max(0, desiredScrollTop - rawMaxScrollTop);
+    const missingTailSpace = clampPinReservationPxToViewport(
+      rawMissingTailSpace,
+      scroller.clientHeight,
+    );
+    if (
+      flowChatDiagnostics.isEnabled() &&
+      rawMissingTailSpace - missingTailSpace > COMPENSATION_EPSILON_PX
+    ) {
+      flowChatDiagnostics.trace({
+        hypothesis: 'F',
+        location: 'VirtualMessageList.resolveTurnPinMetrics',
+        message: 'Pin reservation exceeded the viewport and was clamped',
+        data: () => ({
+          turnId,
+          rawMissingTailSpace,
+          missingTailSpace,
+          clientHeight: scroller.clientHeight,
+          desiredScrollTop,
+          rawMaxScrollTop,
+          effectiveScrollHeight,
+          ignoredTailSpacePx,
+        }),
+      });
+    }
 
     return {
       targetElement,
@@ -1840,20 +1893,43 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return false;
     }
 
-    const requiredFloorPx = sanitizeReservationPx(resolvedMetrics.missingTailSpace);
+    const requiredFloorPx = clampPinReservationPxToViewport(
+      resolvedMetrics.missingTailSpace,
+      scroller.clientHeight,
+    );
+    const boundedCurrentPx = clampPinReservationPxToViewport(
+      pinReservation.px,
+      scroller.clientHeight,
+    );
+    const boundedCurrentFloorPx = clampPinReservationPxToViewport(
+      pinReservation.floorPx,
+      scroller.clientHeight,
+    );
+    const currentReservationExceedsViewport = (
+      pinReservation.px - boundedCurrentPx > COMPENSATION_EPSILON_PX ||
+      pinReservation.floorPx - boundedCurrentFloorPx > COMPENSATION_EPSILON_PX
+    );
     // A live target rect is transient while Virtuoso is reconciling item
     // measurements. It is safe to increase the range from that snapshot, but
     // reducing the floor can remove scroll range for a frame and strand the
     // semantic anchor at the physical bottom. Real content growth drains the
-    // floor through measureHeightChange instead.
-    if (requiredFloorPx <= pinReservation.floorPx + COMPENSATION_EPSILON_PX) {
+    // floor through measureHeightChange instead; the viewport cap is the only
+    // synchronous reduction allowed here.
+    if (
+      requiredFloorPx <= pinReservation.floorPx + COMPENSATION_EPSILON_PX &&
+      !currentReservationExceedsViewport
+    ) {
       return false;
     }
 
+    const nextFloorPx = Math.max(requiredFloorPx, boundedCurrentFloorPx);
     const nextPinReservation: PinBottomReservation = {
       ...pinReservation,
-      px: Math.max(requiredFloorPx, pinReservation.px),
-      floorPx: requiredFloorPx,
+      px: clampPinReservationPxToViewport(
+        Math.max(nextFloorPx, boundedCurrentPx),
+        scroller.clientHeight,
+      ),
+      floorPx: nextFloorPx,
     };
 
     if (
@@ -1899,6 +1975,45 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
     run(Math.max(1, frames));
   }, [reconcileStickyPinReservation]);
+
+  const clearExpiredProvisionalStickyPin = useCallback((request: PendingTurnPinState) => {
+    const currentState = bottomReservationStateRef.current;
+    if (!shouldClearExpiredProvisionalStickyPin({
+      requestTurnId: request.turnId,
+      requestPinMode: request.pinMode,
+      pinReservation: currentState.pin,
+      ownsElementAnchor: viewportCoordinatorRef.current.ownsElementAnchor(),
+    })) {
+      return false;
+    }
+
+    const nextState: BottomReservationState = {
+      ...currentState,
+      pin: {
+        kind: 'pin',
+        px: 0,
+        floorPx: 0,
+        mode: 'transient',
+        targetTurnId: null,
+      },
+    };
+    viewportCoordinatorRef.current.release('unresolved-turn-pin-expired');
+    updateBottomReservationState(nextState);
+    applyFooterCompensationNow(nextState);
+
+    const scroller = scrollerElementRef.current;
+    if (scroller) {
+      previousScrollTopRef.current = scroller.scrollTop;
+      previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller, nextState);
+      recordScrollerGeometry(scroller);
+    }
+    return true;
+  }, [
+    applyFooterCompensationNow,
+    recordScrollerGeometry,
+    snapshotMeasuredContentHeight,
+    updateBottomReservationState,
+  ]);
 
   const scrollStaticTurnToTop = useCallback((turnId: string, behavior: ScrollBehavior) => {
     const scroller = scrollerElementRef.current;
@@ -1950,6 +2065,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   ]);
 
   const tryResolvePendingTurnPin = useCallback((request: PendingTurnPinState) => {
+    if (!isTurnPinRequestCurrent(request)) {
+      return false;
+    }
+
     const scroller = scrollerElementRef.current;
     const virtuoso = virtuosoRef.current;
 
@@ -1991,9 +2110,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       // deferred pin to expire. Materialize it first, then let the existing live
       // geometry pass perform the exact alignment and stabilization.
       const fallbackBehavior: ScrollBehavior = 'auto';
-      const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
       const provisionalPinPx = request.pinMode === 'sticky-latest'
-        ? Math.max(maxScrollTop, currentPinReservation.px)
+        ? resolveProvisionalStickyPinReservationPx({
+          scrollHeight: scroller.scrollHeight,
+          clientHeight: scroller.clientHeight,
+          currentPinPx: currentPinReservation.px,
+        })
         : 0;
 
       if (request.pinMode === 'sticky-latest' && provisionalPinPx > COMPENSATION_EPSILON_PX) {
@@ -2038,6 +2160,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         request.turnId,
         request.pinMode,
         resolvedMetrics.missingTailSpace,
+        scroller.clientHeight,
       ),
     };
     updateBottomReservationState(nextReservationState);
@@ -2138,6 +2261,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     buildPinReservation,
     applyFooterCompensationNow,
     getRenderedUserMessageElement,
+    isTurnPinRequestCurrent,
     recordScrollerGeometry,
     resolveTurnPinMetrics,
     schedulePinReservationReconcile,
@@ -2221,11 +2345,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return null;
     }
 
-    const nextPinReservation = stickyPinTarget && resolvedPinMetrics
+    const nextPinReservation = stickyPinTarget && resolvedPinMetrics && scroller
       ? buildPinReservation(
         stickyPinTarget,
         'sticky-latest',
         resolvedPinMetrics.missingTailSpace,
+        scroller.clientHeight,
         currentState.pin,
       )
       : currentState.pin;
@@ -3637,8 +3762,20 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   useEffect(() => {
     if (!pendingTurnPin) return;
 
+    if (!isTurnPinRequestCurrent(pendingTurnPin)) {
+      setPendingTurnPin(prev => (
+        prev?.generation === pendingTurnPin.generation ? null : prev
+      ));
+      return;
+    }
+
     if (performance.now() > pendingTurnPin.expiresAtMs) {
       clearTurnPinRequest();
+      if (clearExpiredProvisionalStickyPin(pendingTurnPin)) {
+        followOutputControllerRef.current.scheduleFollowToLatest(
+          'unresolved-turn-pin-expired',
+        );
+      }
       return;
     }
 
@@ -3662,7 +3799,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       }
 
       setPendingTurnPin(prev => {
-        if (!prev || prev.turnId !== pendingTurnPin.turnId) {
+        if (
+          !prev ||
+          prev.generation !== pendingTurnPin.generation ||
+          !isTurnPinRequestCurrent(pendingTurnPin)
+        ) {
           return prev;
         }
 
@@ -3679,7 +3820,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     };
   }, [
     activateTransientTurnPinStabilization,
+    clearExpiredProvisionalStickyPin,
     clearTurnPinRequest,
+    isTurnPinRequestCurrent,
     pendingTurnPin,
     scheduleTransientTurnPinStabilization,
     scheduleVisibleTurnMeasure,
@@ -3760,18 +3903,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return;
     }
 
-    const nextReservationState: BottomReservationState = options?.preserveCurrentRange
-      ? transferPinReservationToProtectedCollapse(currentState)
-      : {
-        ...currentState,
-        pin: {
-          kind: 'pin',
-          px: 0,
-          floorPx: 0,
-          mode: 'transient',
-          targetTurnId: null,
-        },
-      };
+    const nextReservationState = releasePinReservationForUserNavigation(currentState, {
+      preserveCurrentRange: options?.preserveCurrentRange === true,
+      ownsElementAnchor: viewportCoordinatorRef.current.ownsElementAnchor(),
+    });
     if (flowChatDiagnostics.isEnabled()) {
       flowChatDiagnostics.trace({
         hypothesis: 'A',
@@ -4072,13 +4207,21 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return 'settled';
     }
 
+    const requestSessionId = activeSessionIdRef.current;
+    if (!requestSessionId) {
+      return 'rejected';
+    }
+
     const request: PendingTurnPinState = {
+      generation: turnPinRequestGenerationRef.current + 1,
+      sessionId: requestSessionId,
       turnId,
       behavior: requestedBehavior,
       pinMode: requestedPinMode,
       expiresAtMs: performance.now() + 1500,
       attempts: 0,
     };
+    turnPinRequestGenerationRef.current = request.generation;
 
     startupTrace.markPhase('flowchat_turn_pin_request', {
       turnId,
@@ -4124,6 +4267,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     enterFollowOutput,
     exitFollowOutput,
     armFollowOutputForNewTurn,
+    resumeFollowOutputForMountedStream,
     activateArmedFollowOutput,
     cancelPendingAutoFollowArm,
     scheduleFollowToLatest,
@@ -4180,21 +4324,25 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return;
     }
 
-    hasPrimedMountedStreamingTurnFollowRef.current = true;
-    if (!latestTurnId || !isStreamingOutput) {
+    if (!isStreamingOutput) {
+      hasPrimedMountedStreamingTurnFollowRef.current = true;
+      return;
+    }
+    if (!latestTurnId) {
       return;
     }
 
+    previousLatestTurnIdForFollowRef.current = latestTurnId;
     latestTurnAutoFollowStateRef.current = {
-      turnId: latestTurnId,
+      turnId: null,
       sawPositiveFloor: false,
     };
-    armFollowOutputForNewTurn();
+    hasPrimedMountedStreamingTurnFollowRef.current = resumeFollowOutputForMountedStream();
   }, [
     activeSession?.sessionId,
-    armFollowOutputForNewTurn,
     isStreamingOutput,
     latestTurnId,
+    resumeFollowOutputForMountedStream,
     virtualItems.length,
   ]);
 
@@ -4227,16 +4375,17 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         });
       }
 
-      // When switching to a streaming session, arm follow output so the
-      // viewport tracks new content as it arrives.  Without this, the
+      // When switching to a streaming session, resume tail follow so the
+      // viewport tracks new content as it arrives. Without this, the
       // Virtuoso stays at initialTopMostItemIndex (the user message),
       // and if that position is not yet rendered or measured the
       // viewport may show blank space.
       if (isStreamingOutput) {
-        // Reset the one-shot streaming prime flag so arm-follow can
-        // fire again for the new session's latest turn.
-        hasPrimedMountedStreamingTurnFollowRef.current = false;
-        armFollowOutputForNewTurn();
+        latestTurnAutoFollowStateRef.current = {
+          turnId: null,
+          sawPositiveFloor: false,
+        };
+        hasPrimedMountedStreamingTurnFollowRef.current = resumeFollowOutputForMountedStream();
       }
 
       return;
@@ -4266,6 +4415,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     cancelPendingAutoFollowArm,
     isStreamingOutput,
     latestTurnId,
+    resumeFollowOutputForMountedStream,
     toVirtuosoIndex,
     virtualItems.length,
   ]);

--- a/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
@@ -25,6 +25,23 @@ export interface BottomReservationState {
   pin: PinBottomReservation;
 }
 
+export interface TurnPinRequestIdentity {
+  generation: number;
+  sessionId: string;
+  turnId: string;
+}
+
+export function isTurnPinRequestIdentityCurrent(
+  request: TurnPinRequestIdentity,
+  current: TurnPinRequestIdentity,
+): boolean {
+  return (
+    request.generation === current.generation &&
+    request.sessionId === current.sessionId &&
+    request.turnId === current.turnId
+  );
+}
+
 export function transferCollapseReservationToPin(
   currentState: BottomReservationState,
   nextPinReservation: PinBottomReservation,
@@ -51,6 +68,34 @@ export function transferPinReservationToProtectedCollapse(
       px: currentState.collapse.px + transferredPx,
       floorPx: currentState.collapse.floorPx + transferredPx,
     },
+    pin: {
+      kind: 'pin',
+      px: 0,
+      floorPx: 0,
+      mode: 'transient',
+      targetTurnId: null,
+    },
+  });
+}
+
+export function releasePinReservationForUserNavigation(
+  currentState: BottomReservationState,
+  options: {
+    preserveCurrentRange: boolean;
+    ownsElementAnchor: boolean;
+  },
+): BottomReservationState {
+  const isProvisionalStickyPin = (
+    currentState.pin.mode === 'sticky-latest' &&
+    currentState.pin.floorPx <= COMPENSATION_EPSILON_PX &&
+    !options.ownsElementAnchor
+  );
+  if (options.preserveCurrentRange && !isProvisionalStickyPin) {
+    return transferPinReservationToProtectedCollapse(currentState);
+  }
+
+  return sanitizeBottomReservationState({
+    ...currentState,
     pin: {
       kind: 'pin',
       px: 0,
@@ -127,6 +172,51 @@ export function reconcileUnsignaledShrinkReservation(
       ),
     },
   });
+}
+
+export function clampPinReservationPxToViewport(
+  reservationPx: number,
+  clientHeight: number,
+): number {
+  return Math.min(
+    sanitizeReservationPx(reservationPx),
+    sanitizeReservationPx(clientHeight),
+  );
+}
+
+export function resolveProvisionalStickyPinReservationPx(options: {
+  scrollHeight: number;
+  clientHeight: number;
+  currentPinPx: number;
+}): number {
+  const currentPinPx = sanitizeReservationPx(options.currentPinPx);
+  const effectiveScrollHeight = Math.max(
+    0,
+    sanitizeReservationPx(options.scrollHeight) - currentPinPx,
+  );
+  const effectiveMaxScrollTop = Math.max(
+    0,
+    effectiveScrollHeight - sanitizeReservationPx(options.clientHeight),
+  );
+  return clampPinReservationPxToViewport(
+    Math.max(currentPinPx, effectiveMaxScrollTop),
+    options.clientHeight,
+  );
+}
+
+export function shouldClearExpiredProvisionalStickyPin(options: {
+  requestTurnId: string;
+  requestPinMode: FlowChatPinTurnToTopMode;
+  pinReservation: PinBottomReservation;
+  ownsElementAnchor: boolean;
+}): boolean {
+  return (
+    options.requestPinMode === 'sticky-latest' &&
+    options.pinReservation.mode === 'sticky-latest' &&
+    options.pinReservation.targetTurnId === options.requestTurnId &&
+    options.pinReservation.floorPx <= COMPENSATION_EPSILON_PX &&
+    !options.ownsElementAnchor
+  );
 }
 
 export function createInitialBottomReservationState(): BottomReservationState {

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
@@ -24,10 +24,12 @@ function Harness({
   scroller,
   onController,
   performAutoFollowScroll,
+  performLatestTurnStickyPin = vi.fn(),
 }: {
   scroller: HTMLElement;
   onController: (controller: FollowOutputController) => void;
   performAutoFollowScroll: () => void;
+  performLatestTurnStickyPin?: () => void;
 }) {
   const scrollerRef = React.useRef<HTMLElement | null>(scroller);
   scrollerRef.current = scroller;
@@ -40,7 +42,7 @@ function Harness({
     scrollerRef,
     performUserFollowScroll: vi.fn(),
     performAutoFollowScroll,
-    performLatestTurnStickyPin: vi.fn(),
+    performLatestTurnStickyPin,
   });
 
   onController(controller);
@@ -190,5 +192,41 @@ describe('useFlowChatFollowOutput', () => {
 
     expect(activated).toBe(false);
     expect(controller?.isFollowingOutput).toBe(false);
+  });
+
+  it('resumes a mounted streaming session at the tail without replaying sticky pin', () => {
+    const scroller = document.createElement('div');
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1500,
+      clientHeight: 500,
+      scrollTop: 0,
+    });
+    const performAutoFollowScroll = vi.fn(() => {
+      scroller.scrollTop = 1000;
+    });
+    const performLatestTurnStickyPin = vi.fn();
+
+    act(() => {
+      root.render(
+        <Harness
+          scroller={scroller}
+          onController={nextController => {
+            controller = nextController;
+          }}
+          performAutoFollowScroll={performAutoFollowScroll}
+          performLatestTurnStickyPin={performLatestTurnStickyPin}
+        />,
+      );
+    });
+
+    let resumed = false;
+    act(() => {
+      resumed = controller?.resumeFollowOutputForMountedStream() ?? false;
+    });
+
+    expect(resumed).toBe(true);
+    expect(controller?.isFollowingOutput).toBe(true);
+    expect(performAutoFollowScroll).toHaveBeenCalledTimes(1);
+    expect(performLatestTurnStickyPin).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -55,6 +55,7 @@ interface UseFlowChatFollowOutputResult {
   enterFollowOutput: (reason: FollowOutputEnterReason) => void;
   exitFollowOutput: (reason: FollowOutputExitReason) => void;
   armFollowOutputForNewTurn: () => void;
+  resumeFollowOutputForMountedStream: () => boolean;
   activateArmedFollowOutput: () => boolean;
   cancelPendingAutoFollowArm: () => void;
   scheduleFollowToLatest: (reason: string) => void;
@@ -256,6 +257,15 @@ export function useFlowChatFollowOutput({
     runProgrammaticScroll,
     setFollowingOutput,
   ]);
+
+  const resumeFollowOutputForMountedStream = useCallback(() => {
+    if (!latestTurnId || !isStreaming || virtualItemCount === 0) {
+      return false;
+    }
+
+    enterFollowOutput('auto-follow');
+    return true;
+  }, [enterFollowOutput, isStreaming, latestTurnId, virtualItemCount]);
 
   const activateArmedFollowOutput = useCallback(() => {
     const armedTurnId = armedAutoFollowTurnIdRef.current;
@@ -481,6 +491,7 @@ export function useFlowChatFollowOutput({
     enterFollowOutput,
     exitFollowOutput,
     armFollowOutputForNewTurn,
+    resumeFollowOutputForMountedStream,
     activateArmedFollowOutput,
     cancelPendingAutoFollowArm,
     scheduleFollowToLatest,


### PR DESCRIPTION
## Summary

- Scope pending sticky pin retries to their generation, session, and target turn so canceled RAF callbacks cannot restore stale footer reservations.
- Drop unresolved provisional pin space on user navigation or expiry while preserving established pinned ranges.
- Resume tail follow directly when reopening an already-streaming session instead of replaying new-turn sticky pin behavior.
- Cap pin-owned footer compensation at one viewport without limiting collapse compensation or total footer space.
- Add regression coverage for stale RAF callbacks, delayed virtual items, session re-entry, and viewport-bounded reservations.

No linked issue.

## Type and Areas

Type:

Regression fix

Areas:

Web UI, FlowChat scrolling and virtualization

## Motivation / Impact

Switching away from and back to a streaming conversation could create excessive tail space. If the user scrolled before automatic recovery, stale pending pin callbacks could restore or transfer that provisional space, leaving the viewport blank until the turn ended.

The updated request lifecycle prevents stale retries from mutating the active viewport, distinguishes mounted streaming sessions from genuinely new turns, and limits pin-generated footer space to the maximum geometrically useful range.

## Verification

- `pnpm run type-check:web`
  - Passed.
- `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx --pool=forks --maxWorkers=1`
  - Passed: 1 file, 32 tests.
- `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx src/flow_chat/components/modern/FlowChatViewportCoordinator.test.ts src/flow_chat/components/modern/VirtualMessageList.layout.test.ts --pool=forks --maxWorkers=1`
  - Passed: 3 files, 33 tests.
- Focused ESLint checks for the modified production files.
  - Passed.
- `git diff --cached --check`
  - Passed.

## Reviewer Notes

- Pending sticky pin remains responsible for materializing a virtualized target, but all retries now carry synchronous generation, session, and turn identity.
- Pin-owned reservation is capped at `clientHeight`.
- Collapse reservation and total footer compensation remain uncapped because large or cumulative tool-card collapses may legitimately require more than one viewport.
- Viewport clamp events are logged only when FlowChat diagnostics are enabled.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.