### PR TITLE
chore: remove Flow Chat diagnostics setting entry

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/BasicsConfig.tsx
@@ -338,7 +338,6 @@ function BasicsLoggingSection() {
   const { t } = useTranslation('settings/basics');
   const [configLevel, setConfigLevel] = useState<BackendLogLevel>('info');
   const [includeSensitiveDiagnostics, setIncludeSensitiveDiagnostics] = useState(true);
-  const [flowChatDiagnostics, setFlowChatDiagnostics] = useState(false);
   const [runtimeInfo, setRuntimeInfo] = useState<RuntimeLoggingInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -367,16 +366,14 @@ function BasicsLoggingSection() {
     try {
       setLoading(true);
 
-      const [savedLevel, savedIncludeSensitiveDiagnostics, savedFlowChatDiagnostics, info] = await Promise.all([
+      const [savedLevel, savedIncludeSensitiveDiagnostics, info] = await Promise.all([
         configManager.getConfig<BackendLogLevel>('app.logging.level'),
         configManager.getConfig<boolean>('app.logging.include_sensitive_diagnostics'),
-        configManager.getConfig<boolean>('app.logging.flow_chat_diagnostics'),
         configAPI.getRuntimeLoggingInfo(),
       ]);
 
       setConfigLevel(savedLevel || info.effectiveLevel || 'info');
       setIncludeSensitiveDiagnostics(savedIncludeSensitiveDiagnostics ?? true);
-      setFlowChatDiagnostics(savedFlowChatDiagnostics ?? false);
       setRuntimeInfo(info);
     } catch (error) {
       log.error('Failed to load logging config', error);
@@ -434,27 +431,6 @@ function BasicsLoggingSection() {
       }
     },
     [includeSensitiveDiagnostics, showMessage, t]
-  );
-
-  const handleFlowChatDiagnosticsChange = useCallback(
-    async (checked: boolean) => {
-      const previousValue = flowChatDiagnostics;
-      setFlowChatDiagnostics(checked);
-      setSaving(true);
-
-      try {
-        await configManager.setConfig('app.logging.flow_chat_diagnostics', checked);
-        configManager.clearCache();
-        showMessage('success', t('logging.messages.flowChatDiagnosticsUpdated'));
-      } catch (error) {
-        setFlowChatDiagnostics(previousValue);
-        log.error('Failed to update Flow Chat diagnostics preference', { checked, error });
-        showMessage('error', t('logging.messages.saveFailed'));
-      } finally {
-        setSaving(false);
-      }
-    },
-    [flowChatDiagnostics, showMessage, t]
   );
 
   const handleOpenFolder = useCallback(async () => {
@@ -541,19 +517,6 @@ function BasicsLoggingSection() {
               checked={includeSensitiveDiagnostics}
               onChange={(e) => {
                 void handleSensitiveDiagnosticsChange(e.target.checked);
-              }}
-              disabled={saving}
-            />
-          </ConfigPageRow>
-          <ConfigPageRow
-            label={t('logging.flowChatDiagnostics.label')}
-            description={t('logging.flowChatDiagnostics.description')}
-            align="center"
-          >
-            <Switch
-              checked={flowChatDiagnostics}
-              onChange={(e) => {
-                void handleFlowChatDiagnosticsChange(e.target.checked);
               }}
               disabled={saving}
             />

--- a/src/web-ui/src/locales/en-US/settings/basics.json
+++ b/src/web-ui/src/locales/en-US/settings/basics.json
@@ -128,10 +128,6 @@
       "label": "Include sensitive diagnostic data",
       "description": "When enabled, local logs may include prompts, model request and response payloads, tool arguments, file paths, and webview event payloads for troubleshooting. BitFun does not upload these log files automatically."
     },
-    "flowChatDiagnostics": {
-      "label": "Flow Chat viewport diagnostics",
-      "description": "Record detailed local scroll, anchor, and layout events to flowchat.log. Enable only while reproducing a Flow Chat stability issue."
-    },
     "path": {
       "description": "Directory where log files for this run are written."
     },
@@ -172,7 +168,6 @@
       "saveFailed": "Failed to save logging level",
       "levelUpdated": "Logging level updated",
       "sensitiveDiagnosticsUpdated": "Sensitive diagnostic logging preference updated",
-      "flowChatDiagnosticsUpdated": "Flow Chat diagnostics preference updated",
       "refreshed": "Runtime status refreshed",
       "openedFolder": "Log folder opened",
       "openFailed": "Failed to open log folder",

--- a/src/web-ui/src/locales/zh-CN/settings/basics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/basics.json
@@ -128,10 +128,6 @@
       "label": "包含敏感调试信息",
       "description": "开启后，本地日志可能包含用户 Prompt、模型请求和响应 payload、工具参数、文件路径以及 Webview 事件 payload，用于问题排查。BitFun 不会自动上传这些日志文件。"
     },
-    "flowChatDiagnostics": {
-      "label": "Flow Chat 视口诊断",
-      "description": "将详细滚动、锚点和布局事件记录到 flowchat.log。仅在复现 Flow Chat 稳定性问题时开启。"
-    },
     "path": {
       "description": "本次启动写入日志文件所在的目录。"
     },
@@ -172,7 +168,6 @@
       "saveFailed": "保存日志级别失败",
       "levelUpdated": "日志级别已更新",
       "sensitiveDiagnosticsUpdated": "敏感调试信息日志偏好已更新",
-      "flowChatDiagnosticsUpdated": "Flow Chat 诊断偏好已更新",
       "refreshed": "运行时状态已刷新",
       "openedFolder": "日志文件夹已打开",
       "openFailed": "打开日志文件夹失败",

--- a/src/web-ui/src/locales/zh-TW/settings/basics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/basics.json
@@ -114,10 +114,6 @@
       "label": "包含敏感除錯資訊",
       "description": "開啟後，本機日誌可能包含使用者 Prompt、模型請求與回應 payload、工具參數、檔案路徑以及 Webview 事件 payload，用於問題排查。BitFun 不會自動上傳這些日誌檔案。"
     },
-    "flowChatDiagnostics": {
-      "label": "Flow Chat 視口診斷",
-      "description": "將詳細捲動、錨點和版面事件記錄到 flowchat.log。僅在重現 Flow Chat 穩定性問題時開啟。"
-    },
     "path": {
       "description": "本次啟動寫入日誌檔案所在的目錄。"
     },
@@ -158,7 +154,6 @@
       "saveFailed": "儲存日誌級別失敗",
       "levelUpdated": "日誌級別已更新",
       "sensitiveDiagnosticsUpdated": "敏感除錯資訊日誌偏好已更新",
-      "flowChatDiagnosticsUpdated": "Flow Chat 診斷偏好已更新",
       "refreshed": "運行時狀態已重新整理",
       "openedFolder": "日誌資料夾已開啟",
       "openFailed": "開啟日誌資料夾失敗",


### PR DESCRIPTION
- Remove the Flow Chat viewport diagnostics toggle from basic logging settings
- Remove unused logging preference state and localized copy
- Preserve internal diagnostics configuration support
