### PR TITLE
chore: bump version to 0.2.15

### DIFF
--- a/BitFun-Installer/package-lock.json
+++ b/BitFun-Installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-installer",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": true,
   "type": "module",
   "description": "BitFun Custom Installer - Modern branded installation experience",

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-installer"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Custom Installer - Modern branded installation experience"

--- a/BitFun-Installer/src/pages/LanguageSelect.tsx
+++ b/BitFun-Installer/src/pages/LanguageSelect.tsx
@@ -72,7 +72,7 @@ export function LanguageSelect({ onSelect }: LanguageSelectProps) {
             opacity: 0.6,
             letterSpacing: '0.5px',
           }}>
-            Version 0.2.14
+            Version 0.2.15
           </div>
         </div>
       </div>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-acp"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-runtime"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-agent-stream",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-runtime-ipc"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-events",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-stream"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-tools"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-core-types",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-ai-adapters"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-claude-code-adapter"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "arboard",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-codex-adapter"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-static-hook-support",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core-types"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-desktop"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-events"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-external-sources"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bitfun-product-domains",
  "futures",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-harness"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "thiserror 2.0.19",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-server"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-service"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-opencode-adapter"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-plugin-runtime-client",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-page-function-runtime"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "rquickjs",
  "serde",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-plugin-runtime-client"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-runtime-ports",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-capabilities"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-domains"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs 6.0.0",
  "hex",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-server"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-service"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-ports"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-services"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host-app"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-server"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-integrations"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-static-hook-support"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-call-jsonrepair"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -1544,11 +1544,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-packs"
-version = "0.2.14"
+version = "0.2.15"
 
 [[package]]
 name = "bitfun-transport"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-webdriver"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -10203,7 +10203,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10644,7 +10644,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tool-runtime"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "bitfun-agent-tools",
  "bitfun-events",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ resolver = "2"
 
 # Shared package metadata — single source of truth for version
 [workspace.package]
-version = "0.2.14" # x-release-please-version
+version = "0.2.15" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "BitFun",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "BitFun",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "hasInstallScript": true,
       "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BitFun",
   "private": true,
-  "version": "0.2.14",
+  "version": "0.2.15",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-server"
-version = "0.2.14" # x-release-please-version
+version = "0.2.15" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun standalone Remote Connect relay server"

--- a/src/crates/services/page-function-runtime/Cargo.toml
+++ b/src/crates/services/page-function-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-page-function-runtime"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Embedded JS Page Function runtime for BitFun Pages (rquickjs)"

--- a/src/crates/services/relay-service/Cargo.toml
+++ b/src/crates/services/relay-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-service"
-version = "0.2.14"
+version = "0.2.15"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Reusable relay runtime for BitFun Remote Connect"

--- a/src/crates/services/services-integrations/tests/announcement_contracts.rs
+++ b/src/crates/services/services-integrations/tests/announcement_contracts.rs
@@ -165,14 +165,14 @@ async fn announcement_state_store_round_trips_state_and_defaults_missing_file() 
 fn announcement_remote_fetch_request_preserves_legacy_query_shape() {
     let request = AnnouncementRemoteFetchRequest {
         endpoint_url: "https://announcements.example.com/cards".to_string(),
-        app_version: "0.2.14".to_string(),
+        app_version: "0.2.15".to_string(),
         locale: "zh-CN".to_string(),
         platform: "desktop".to_string(),
     };
 
     assert_eq!(
         request.request_url(),
-        "https://announcements.example.com/cards?app_version=0.2.14&locale=zh-CN&platform=desktop"
+        "https://announcements.example.com/cards?app_version=0.2.15&locale=zh-CN&platform=desktop"
     );
 }
 

--- a/src/miniapp-market-web/package.json
+++ b/src/miniapp-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-miniapp-market-web",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/miniapp-market-web/src/App.tsx
+++ b/src/miniapp-market-web/src/App.tsx
@@ -1036,7 +1036,7 @@ function SubmitPage({
           <legend>{t('releaseSection')}</legend>
           <div className="form-grid">
             <Field label={t('minBitfunVersionLabel')}>
-              <input name="minBitfunVersion" required defaultValue="0.2.14" />
+              <input name="minBitfunVersion" required defaultValue="0.2.15" />
             </Field>
             <Field label={t('publicRepositoryOptional')}>
               <input name="repositoryUrl" type="url" placeholder="https://github.com/…" />

--- a/src/mobile-web/package-lock.json
+++ b/src/mobile-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-mobile-web",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfun/web-ui",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "private": true,
   "description": "BitFun Web UI - 支持 Desktop 和 Server 两种部署方式",
   "type": "module",

--- a/src/web-ui/src/component-library/preview/PreviewApp.tsx
+++ b/src/web-ui/src/component-library/preview/PreviewApp.tsx
@@ -48,7 +48,7 @@ export const PreviewApp: React.FC = () => {
       <header className="preview-header">
         <div className="preview-logo">
           <h1>{t('componentLibrary.previewApp.title')}</h1>
-          <span className="preview-version">v0.2.14</span>
+          <span className="preview-version">v0.2.15</span>
         </div>
         <div className="preview-header-actions">
           <label className="preview-theme-selector">

--- a/src/web-ui/src/shared/utils/version.ts
+++ b/src/web-ui/src/shared/utils/version.ts
@@ -6,7 +6,7 @@ import { i18nService } from '@/infrastructure/i18n';
  
 const DEFAULT_VERSION_INFO: VersionInfo = {
   name: 'BitFun',
-  version: '0.2.14',
+  version: '0.2.15',
   buildDate: new Date().toISOString(),
   buildTimestamp: Date.now(),
   isDev: import.meta.env.DEV,


### PR DESCRIPTION
## Summary

- bump the BitFun product version from 0.2.14 to 0.2.15
- synchronize Rust, npm, installer, Web UI, mobile web, relay, and MiniApp Market version metadata
- update user-visible fallback/default version values and Cargo.lock workspace package entries
- fix the release-signing fallback so Linux downloads the pinned official minisign 0.12 CLI instead of trying to install the library-only `minisign` crate
- use Homebrew for the macOS fallback and add an Ubuntu regression check that forces the download path

## Verification

- `cargo metadata --no-deps --locked --format-version 1`
- `pnpm run type-check:web`
- `pnpm --dir src/mobile-web run type-check`
- `pnpm --dir BitFun-Installer run type-check`
- `cargo test -p bitfun-services-integrations --features announcement --test announcement_contracts` (7 passed)
- `pnpm run check:github-config`
- `bash -n scripts/sign-release-assets.sh`
- version metadata consistency check
- `git diff --check`

## Not run

- `pnpm --dir src/miniapp-market-web run type-check` could not run because that package has no local `node_modules`; TypeScript reported missing `react`, `vitest`, and related type declarations.
- the Linux minisign binary cannot execute on the local macOS host; the new `Shell Deploy Scripts` CI step downloads, verifies, and executes it on Ubuntu.