### PR TITLE
fix(web-ui): stabilize FlowChat history paging

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
@@ -92,6 +92,30 @@
     overflow-wrap: anywhere;
     pointer-events: none;
   }
+
+  &__history-paging-sentinel {
+    width: 100%;
+    height: 28px;
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    line-height: 18px;
+    pointer-events: none;
+    overflow-anchor: none;
+    visibility: hidden;
+
+    &[data-history-paging-sentinel='loading'] {
+      visibility: visible;
+    }
+  }
+
+  &__history-paging-spinner {
+    animation: history-paging-spin 0.9s linear infinite;
+  }
   
   .message-list-footer {
     /* Inline height from VirtualMessageList (measured drop-zone + bottom inset + tail clearance). */
@@ -149,4 +173,9 @@
     }
   }
 
+}
+
+@keyframes history-paging-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -197,6 +197,9 @@ vi.mock('../../store/chatInputStateStore', () => ({
 
 vi.mock('../../store/FlowChatStore', () => ({
   flowChatStore: {
+    getState: () => ({
+      sessions: new Map(stateMocks.activeSession ? [[stateMocks.activeSession.sessionId, stateMocks.activeSession]] : []),
+    }),
     hasPendingSessionHistoryCompletion: flowStoreMocks.hasPendingSessionHistoryCompletion,
     hasDeferredSessionHistoryProjection: flowStoreMocks.hasDeferredSessionHistoryProjection,
     requestSessionFullHistoryProjection: flowStoreMocks.requestSessionFullHistoryProjection,
@@ -2151,6 +2154,129 @@ describe('VirtualMessageList session boundary', () => {
 
     expect(flowStoreMocks.requestSessionFullHistoryProjection).not.toHaveBeenCalled();
     expect(flowStoreMocks.revealPreviousSessionHistoryWindow).toHaveBeenCalledWith('session-a', 'wheel-up');
+  });
+
+  it('expands partial static history before prepending older turns', () => {
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(true);
+    flowStoreMocks.revealPreviousSessionHistoryWindow.mockReturnValue(true);
+    stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-3', 'turn-4', 'turn-5'], {
+      isHistorical: true,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 6,
+    });
+    stateMocks.virtualItems = ['turn-3', 'turn-4', 'turn-5'].flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const staticScroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(staticScroller).not.toBeNull();
+    expect(container.querySelector('[data-initial-history-render-windowed]')).not.toBeNull();
+
+    act(() => {
+      staticScroller?.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120,
+        bubbles: true,
+      }));
+    });
+
+    expect(container.querySelector('[data-initial-history-render-windowed]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="virtuoso"]')).toBeNull();
+    expect(container.querySelector('[data-history-initial-render-spacer="true"]')).toBeNull();
+    expect(container.querySelector('[data-turn-id="turn-3"]')).not.toBeNull();
+    expect(container.querySelector('[data-history-paging-sentinel="loading"]')).not.toBeNull();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).not.toHaveBeenCalled();
+
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).toHaveBeenCalledWith('session-a', 'wheel-up');
+
+    stateMocks.activeSession = createSessionWithTurns(
+      'session-a',
+      ['turn-0', 'turn-1', 'turn-2', 'turn-3', 'turn-4', 'turn-5'],
+      {
+        isHistorical: true,
+        historyState: 'ready',
+        contextRestoreState: 'pending',
+        isPartial: false,
+        loadedTurnCount: 6,
+        totalTurnCount: 6,
+      },
+    );
+    stateMocks.virtualItems = ['turn-0', 'turn-1', 'turn-2', 'turn-3', 'turn-4', 'turn-5'].flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    expect(container.querySelector('[data-history-initial-render-spacer="true"]')).toBeNull();
+    expect(container.querySelector('[data-turn-id="turn-3"]')).not.toBeNull();
+    expect(container.querySelector('[data-history-paging-sentinel]')).toBeNull();
+  });
+
+  it('waits until the static history boundary is near before starting pagination', () => {
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(true);
+    stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-3', 'turn-4', 'turn-5'], {
+      isHistorical: true,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 6,
+    });
+    stateMocks.virtualItems = ['turn-3', 'turn-4', 'turn-5'].flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    const spacer = container.querySelector<HTMLElement>('[data-history-initial-render-spacer="true"]');
+    expect(scroller).not.toBeNull();
+    expect(spacer).not.toBeNull();
+    if (!scroller || !spacer) {
+      return;
+    }
+
+    const spacerHeight = Number.parseFloat(spacer.style.height);
+    setScrollerGeometry(scroller, {
+      scrollHeight: spacerHeight + 3_000,
+      clientHeight: 1_000,
+      scrollTop: spacerHeight + 500,
+    });
+
+    act(() => {
+      scroller.dispatchEvent(new WheelEvent('wheel', { deltaY: -120, bubbles: true }));
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    flushAnimationFrame();
+    flushAnimationFrame();
+
+    expect(container.querySelector('[data-initial-history-render-windowed]')).not.toBeNull();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).not.toHaveBeenCalled();
+
+    scroller.scrollTop = spacerHeight + 100;
+    act(() => {
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-initial-history-render-windowed]')).not.toBeNull();
+    expect(container.querySelector('[data-history-initial-render-spacer="true"]')).toBeNull();
+    expect(container.querySelector('[data-history-paging-sentinel="loading"]')).not.toBeNull();
   });
 
   it('does not reveal previous history for upward scroll away from the history boundary', () => {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -19,6 +19,7 @@ import {
   type ContextProp,
 } from 'react-virtuoso';
 import { useTranslation } from 'react-i18next';
+import { Loader2 } from 'lucide-react';
 import { useActiveSessionState } from '../../hooks/useActiveSessionState';
 import { VirtualItemRenderer } from './VirtualItemRenderer';
 import { ScrollToLatestBar } from '../ScrollToLatestBar';
@@ -114,6 +115,7 @@ const LATEST_END_ANCHOR_STATIC_FAST_PATH_TOLERANCE_PX = 96;
 const VIRTUOSO_FIRST_ITEM_INDEX_BASE = 1_000_000;
 const PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET = 16;
 const PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX = 1200;
+const PARTIAL_HISTORY_STATIC_BOUNDARY_THRESHOLD_PX = 120;
 const HISTORY_PROJECTION_HANDOFF_MAX_DURATION_MS = 5000;
 const SESSION_OPEN_HANDOFF_ITEM_BUDGET = 24;
 const PREVIOUS_HISTORY_BOUNDARY_STATUS_DURATION_MS = 2500;
@@ -136,6 +138,20 @@ const FlowChatVirtuosoHeader = ({ context }: ContextProp<FlowChatVirtuosoContext
     <div className="message-list-header" />
     {context.previousHistoryBoundaryStatusNode}
   </>
+);
+
+const FlowChatHistoryPagingSentinel = ({ visible, label }: { visible: boolean; label: string }) => (
+  <div
+    className="virtual-message-list__history-paging-sentinel"
+    data-history-paging-sentinel={visible ? 'loading' : 'idle'}
+    data-history-boundary-status={visible ? 'preparing' : undefined}
+    aria-hidden={!visible}
+    role={visible ? 'status' : undefined}
+    aria-live={visible ? 'polite' : undefined}
+  >
+    <Loader2 size={14} aria-hidden className="virtual-message-list__history-paging-spinner" />
+    <span>{label}</span>
+  </div>
 );
 
 const FlowChatVirtuosoFooter = ({ context }: ContextProp<FlowChatVirtuosoContext>) => (
@@ -415,6 +431,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const [pendingTurnPin, setPendingTurnPin] = useState<PendingTurnPinState | null>(null);
   const [historyProjectionHandoff, setHistoryProjectionHandoff] = useState<HistoryProjectionHandoffSnapshot | null>(null);
   const [expandedInitialHistoryRenderKey, setExpandedInitialHistoryRenderKey] = useState<string | null>(null);
+  const [historyPagingActive, setHistoryPagingActive] = useState(false);
+  const [historyPagingLoading, setHistoryPagingLoading] = useState(false);
+  const [historyPagingAnchorTurnId, setHistoryPagingAnchorTurnId] = useState<string | null>(null);
   const [staticAnchorWindowTurnId, setStaticAnchorWindowTurnId] = useState<string | null>(null);
   const [previousHistoryBoundaryStatus, setPreviousHistoryBoundaryStatus] = useState<{
     sessionId: string;
@@ -451,6 +470,20 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     omittedEstimatedHeightPx: number;
     wasAtBottom: boolean;
   } | null>(null);
+  const pendingHistoryPrependAnchorRef = useRef<{
+    turnId: string;
+    offsetFromScrollerTop: number;
+    beforeItemCount: number;
+    handoffRestored: boolean;
+    prependRestored: boolean;
+  } | null>(null);
+  const historyPagingActiveRef = useRef(false);
+  const historyPagingRevealScheduledRef = useRef(false);
+  const pendingHistoryPagingRevealRef = useRef<{
+    sessionId: string;
+    reason: string;
+  } | null>(null);
+  const historyPagingRetryTimerRef = useRef<number | null>(null);
   const pendingStaticTurnPinRef = useRef<PendingStaticTurnPinState | null>(null);
   const pendingStaticLatestScrollBehaviorRef = useRef<('auto' | 'smooth') | null>(null);
   const initialHistoryRenderWindowCheckFrameRef = useRef<number | null>(null);
@@ -3091,6 +3124,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       window.clearTimeout(previousHistoryBoundaryStatusTimerRef.current);
       previousHistoryBoundaryStatusTimerRef.current = null;
     }
+    if (historyPagingRetryTimerRef.current !== null) {
+      window.clearTimeout(historyPagingRetryTimerRef.current);
+      historyPagingRetryTimerRef.current = null;
+    }
   }, []);
 
   useEffect(() => {
@@ -3102,6 +3139,32 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     });
   }, [activeSessionId]);
 
+  const captureHistoryPrependAnchor = useCallback(() => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) {
+      return null;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const nodes = Array.from(scroller.querySelectorAll<HTMLElement>(
+      '.virtual-item-wrapper[data-item-type="user-message"][data-turn-id]',
+    ));
+    const visibleNode = nodes.find(node => {
+      const rect = node.getBoundingClientRect();
+      return rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
+    });
+    const node = visibleNode ?? nodes[0];
+    const turnId = node?.dataset.turnId;
+    if (!node || !turnId) {
+      return null;
+    }
+
+    return {
+      turnId,
+      offsetFromScrollerTop: node.getBoundingClientRect().top - scrollerRect.top,
+    };
+  }, []);
+
   const revealPreviousHistoryWindowForUserIntent = useCallback((reason: string) => {
     const sessionId = activeSession?.sessionId;
     if (
@@ -3111,6 +3174,46 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     ) {
       return;
     }
+
+    if (!historyPagingActiveRef.current) {
+      const anchor = captureHistoryPrependAnchor();
+      historyPagingActiveRef.current = true;
+      setHistoryPagingActive(true);
+      setHistoryPagingLoading(true);
+      if (anchor) {
+        setHistoryPagingAnchorTurnId(anchor.turnId);
+        pendingHistoryPrependAnchorRef.current = {
+          ...anchor,
+          beforeItemCount: virtualItems.length,
+          handoffRestored: false,
+          prependRestored: false,
+        };
+      }
+      showPreviousHistoryBoundaryStatus(sessionId, reason, 'preparing');
+      if (useStaticInitialHistoryListRef.current) {
+        pendingHistoryPagingRevealRef.current = { sessionId, reason };
+        return;
+      }
+    }
+
+    if (historyPagingRevealScheduledRef.current || pendingHistoryPagingRevealRef.current) {
+      return;
+    }
+
+    const pendingAnchor = pendingHistoryPrependAnchorRef.current;
+    if (!pendingAnchor || pendingAnchor.prependRestored) {
+      const anchor = captureHistoryPrependAnchor();
+      if (anchor) {
+        setHistoryPagingAnchorTurnId(anchor.turnId);
+        pendingHistoryPrependAnchorRef.current = {
+          ...anchor,
+          beforeItemCount: virtualItems.length,
+          handoffRestored: true,
+          prependRestored: false,
+        };
+      }
+    }
+    setHistoryPagingLoading(true);
 
     if (!flowChatStore.hasDeferredSessionHistoryProjection(sessionId)) {
       if (flowChatStore.hasPendingSessionHistoryCompletion(sessionId)) {
@@ -3124,7 +3227,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           reason,
           released,
         });
+        if (historyPagingRetryTimerRef.current === null) {
+          historyPagingRetryTimerRef.current = window.setTimeout(() => {
+            historyPagingRetryTimerRef.current = null;
+            if (activeSessionIdRef.current === sessionId && historyPagingActiveRef.current) {
+              revealPreviousHistoryWindowForUserIntent('history-ready-after-scroll');
+            }
+          }, 50);
+        }
       } else {
+        setHistoryPagingLoading(false);
         showPreviousHistoryBoundaryStatus(sessionId, reason, 'not-ready');
         startupTrace.markPhase('flowchat_previous_history_window_not_ready', {
           sessionId,
@@ -3135,9 +3247,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
 
     const revealed = flowChatStore.revealPreviousSessionHistoryWindow(sessionId, reason);
+    if (historyPagingRetryTimerRef.current !== null) {
+      window.clearTimeout(historyPagingRetryTimerRef.current);
+      historyPagingRetryTimerRef.current = null;
+    }
     if (revealed) {
       clearPreviousHistoryBoundaryStatus();
     } else {
+      setHistoryPagingLoading(false);
       showPreviousHistoryBoundaryStatus(sessionId, reason, 'not-ready');
     }
     startupTrace.markPhase('flowchat_previous_history_window_requested', {
@@ -3149,8 +3266,48 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     activeSession?.historyState,
     activeSession?.isPartial,
     activeSession?.sessionId,
+    captureHistoryPrependAnchor,
     clearPreviousHistoryBoundaryStatus,
     showPreviousHistoryBoundaryStatus,
+    virtualItems.length,
+  ]);
+
+  useEffect(() => {
+    const pendingReveal = pendingHistoryPagingRevealRef.current;
+    const pendingAnchor = pendingHistoryPrependAnchorRef.current;
+    if (
+      !pendingReveal ||
+      !historyPagingActive ||
+      !scrollerElement?.isConnected ||
+      (pendingAnchor && !pendingAnchor.handoffRestored) ||
+      historyPagingRevealScheduledRef.current
+    ) {
+      return;
+    }
+
+    historyPagingRevealScheduledRef.current = true;
+    const frameId = requestAnimationFrame(() => {
+      historyPagingRevealScheduledRef.current = false;
+      const currentPendingReveal = pendingHistoryPagingRevealRef.current;
+      if (
+        !currentPendingReveal ||
+        currentPendingReveal.sessionId !== pendingReveal.sessionId ||
+        activeSessionIdRef.current !== pendingReveal.sessionId
+      ) {
+        return;
+      }
+      pendingHistoryPagingRevealRef.current = null;
+      revealPreviousHistoryWindowForUserIntent(currentPendingReveal.reason);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      historyPagingRevealScheduledRef.current = false;
+    };
+  }, [
+    historyPagingActive,
+    revealPreviousHistoryWindowForUserIntent,
+    scrollerElement,
   ]);
 
   const shouldRevealPreviousHistoryWindowForUserIntent = useCallback((options?: { force?: boolean }) => {
@@ -3230,6 +3387,17 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     previousScrollerGeometryRef.current = null;
     pendingStaticAnchorTurnIdRef.current = null;
     pendingStaticTurnPinRef.current = null;
+    historyPagingActiveRef.current = false;
+    historyPagingRevealScheduledRef.current = false;
+    pendingHistoryPagingRevealRef.current = null;
+    if (historyPagingRetryTimerRef.current !== null) {
+      window.clearTimeout(historyPagingRetryTimerRef.current);
+      historyPagingRetryTimerRef.current = null;
+    }
+    pendingHistoryPrependAnchorRef.current = null;
+    setHistoryPagingActive(false);
+    setHistoryPagingLoading(false);
+    setHistoryPagingAnchorTurnId(null);
     const currentSessionId = activeSession?.sessionId ?? null;
     const activeHandoff = historyProjectionHandoffRef.current;
     if (!activeHandoff || activeHandoff.sessionId !== currentSessionId) {
@@ -4495,6 +4663,18 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return lastDialogTurn.modelRounds.some(round => round.isStreaming);
   }, [activeSession, isProcessing]);
   const initialTopMostItemIndex = React.useMemo(() => {
+    if (historyPagingActive && historyPagingAnchorTurnId) {
+      const anchorIndex = virtualItems.findIndex(item => (
+        item.turnId === historyPagingAnchorTurnId && item.type === 'user-message'
+      ));
+      if (anchorIndex >= 0) {
+        return {
+          index: toVirtuosoIndex(anchorIndex),
+          align: 'start' as const,
+        };
+      }
+    }
+
     if (isStreamingOutput) {
       return toVirtuosoIndex(latestUserMessageIndex);
     }
@@ -4505,9 +4685,58 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     };
   }, [
     isStreamingOutput,
+    historyPagingActive,
+    historyPagingAnchorTurnId,
     latestUserMessageIndex,
     toVirtuosoIndex,
-    virtualItems.length,
+    virtualItems,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!historyPagingActive || !historyPagingAnchorTurnId) {
+      return;
+    }
+
+    const pendingAnchor = pendingHistoryPrependAnchorRef.current;
+    if (!pendingAnchor || pendingAnchor.turnId !== historyPagingAnchorTurnId) {
+      return;
+    }
+    const isPrependCommit = virtualItems.length > pendingAnchor.beforeItemCount;
+    if (isPrependCommit ? pendingAnchor.prependRestored : pendingAnchor.handoffRestored) {
+      return;
+    }
+
+    const scroller = scrollerElementRef.current;
+    const anchorElement = getRenderedUserMessageElement(historyPagingAnchorTurnId);
+    if (!scroller || !anchorElement) {
+      return;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const actualOffset = anchorElement.getBoundingClientRect().top - scrollerRect.top;
+    const correction = actualOffset - pendingAnchor.offsetFromScrollerTop;
+    if (Math.abs(correction) > COMPENSATION_EPSILON_PX) {
+      scroller.scrollTop = Math.max(0, scroller.scrollTop + correction);
+    }
+    if (isPrependCommit) {
+      pendingAnchor.prependRestored = true;
+      setHistoryPagingLoading(false);
+      clearPreviousHistoryBoundaryStatus();
+    } else {
+      pendingAnchor.handoffRestored = true;
+    }
+    previousScrollTopRef.current = scroller.scrollTop;
+    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    recordScrollerGeometry(scroller);
+  }, [
+    clearPreviousHistoryBoundaryStatus,
+    getRenderedUserMessageElement,
+    historyPagingActive,
+    historyPagingAnchorTurnId,
+    recordScrollerGeometry,
+    scrollerElement,
+    snapshotMeasuredContentHeight,
+    virtualItems,
   ]);
 
   useEffect(() => {
@@ -5916,6 +6145,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     initialHistoryRenderWindow.startIndex,
   ].join(':');
   const isInitialHistoryRenderWindowExpanded =
+    historyPagingActive ||
     !initialHistoryRenderWindow.isWindowed ||
     expandedInitialHistoryRenderKey === initialHistoryRenderKey;
   const renderedInitialHistoryItems = isInitialHistoryRenderWindowExpanded
@@ -6010,24 +6240,40 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const expandInitialHistoryRenderWindowIfNeeded = useCallback((reason: string) => {
     if (
       !useStaticInitialHistoryList ||
-      !initialHistoryRenderWindow.isWindowed ||
-      isInitialHistoryRenderWindowExpanded ||
-      omittedInitialHistoryEstimatedHeightPx <= 0
+      isInitialHistoryRenderWindowExpanded && activeSession?.isPartial !== true
     ) {
       return;
     }
 
     const scroller = scrollerElementRef.current;
-    if (!scroller || scroller.scrollTop > omittedInitialHistoryEstimatedHeightPx) {
+    if (!scroller) {
+      return;
+    }
+
+    if (activeSession?.isPartial === true) {
+      const pagingThresholdPx = omittedInitialHistoryEstimatedHeightPx + PARTIAL_HISTORY_STATIC_BOUNDARY_THRESHOLD_PX;
+      if (scroller.scrollTop <= pagingThresholdPx) {
+        revealPreviousHistoryWindowForUserIntent(reason);
+      }
+      return;
+    }
+
+    if (!initialHistoryRenderWindow.isWindowed || omittedInitialHistoryEstimatedHeightPx <= 0) {
+      return;
+    }
+
+    if (scroller.scrollTop > omittedInitialHistoryEstimatedHeightPx) {
       return;
     }
 
     expandInitialHistoryRenderWindow(reason);
   }, [
     expandInitialHistoryRenderWindow,
+    activeSession?.isPartial,
     initialHistoryRenderWindow.isWindowed,
     isInitialHistoryRenderWindowExpanded,
     omittedInitialHistoryEstimatedHeightPx,
+    revealPreviousHistoryWindowForUserIntent,
     useStaticInitialHistoryList,
   ]);
   const scheduleInitialHistoryRenderWindowCheck = useCallback((reason: string) => {
@@ -6077,9 +6323,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     getEffectiveBottomScrollTop,
     staticAnchorWindowTurnId,
   ]);
-  const handleInitialHistoryStaticWheelCapture = useCallback(() => {
-    scheduleInitialHistoryRenderWindowCheck('wheel-near-omitted-history');
-  }, [scheduleInitialHistoryRenderWindowCheck]);
+  const handleInitialHistoryStaticWheelCapture = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    if (event.deltaY >= 0) {
+      return;
+    }
+    expandInitialHistoryRenderWindowIfNeeded('wheel-up');
+    scheduleInitialHistoryRenderWindowCheck('wheel-up');
+  }, [expandInitialHistoryRenderWindowIfNeeded, scheduleInitialHistoryRenderWindowCheck]);
   const handleInitialHistoryStaticKeyDownCapture = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (
       event.key === 'Home' ||
@@ -6376,7 +6626,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     useStaticInitialHistoryList,
   ]);
   const previousHistoryBoundaryStatusNode = React.useMemo(
-    () => previousHistoryBoundaryStatus?.sessionId === activeSessionId ? (
+    () => previousHistoryBoundaryStatus?.sessionId === activeSessionId && (
+      previousHistoryBoundaryStatus.state === 'not-ready' || !historyPagingActive
+    ) ? (
       <div
         className="virtual-message-list__history-boundary-status"
         data-history-boundary-status={previousHistoryBoundaryStatus.state}
@@ -6388,18 +6640,31 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           : t('historyState.olderHistoryNotReady')}
       </div>
     ) : null,
-    [activeSessionId, previousHistoryBoundaryStatus, t],
+    [activeSessionId, historyPagingActive, previousHistoryBoundaryStatus, t],
+  );
+  const historyPagingSentinelNode = React.useMemo(
+    () => historyPagingActive && activeSession?.isPartial === true ? (
+      <FlowChatHistoryPagingSentinel
+        visible={historyPagingLoading}
+        label={t('historyState.preparingOlderHistory')}
+      />
+    ) : null,
+    [activeSession?.isPartial, historyPagingActive, historyPagingLoading, t],
   );
   const virtuosoContext = React.useMemo<FlowChatVirtuosoContext>(() => ({
     // Reservation pixels are applied imperatively to the stable Footer node.
     // Keeping them out of context prevents a measurement-sensitive Virtuoso
     // render for every compensation update.
     footerRef: handleFooterElementRef,
-    previousHistoryBoundaryStatusNode,
+    previousHistoryBoundaryStatusNode: <>
+      {historyPagingSentinelNode}
+      {previousHistoryBoundaryStatusNode}
+    </>,
     runtimeStatusSessionId: activeSessionId,
   }), [
     activeSessionId,
     handleFooterElementRef,
+    historyPagingSentinelNode,
     previousHistoryBoundaryStatusNode,
   ]);
   const computeVirtuosoItemKey = useCallback((_: number, item: VirtualItem) => (
@@ -6441,6 +6706,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           onKeyDownCapture={handleInitialHistoryStaticKeyDownCapture}
         >
           <div className="message-list-header" />
+          {historyPagingSentinelNode}
           {previousHistoryBoundaryStatusNode}
           {omittedInitialHistoryEstimatedHeightPx > 0 ? (
             <div


### PR DESCRIPTION
## Summary

Fixes #1537

FlowChat history paging no longer replaces the active scroller during upward navigation. The existing static history viewport stays mounted, expands before prepend, and restores the visible user-message anchor across both expansion and older-history insertion.

The loading sentinel is shown only while older history remains available. It is removed when `isPartial` becomes `false`, so the first turn aligns directly with the chat header.

## Type and Areas

Type:

Regression fix / UI/UX / test

Areas:

Web UI / FlowChat / virtual message list

## Motivation / Impact

Previously, scrolling toward the oldest loaded turn could insert a large estimated spacer, briefly blank the viewport, and restore the user to the wrong position. An intermediate attempt to switch from the static list to Virtuoso during the scroll transaction could also return the viewport to the latest turn.

This change keeps the scroller stable, preserves a semantic message anchor, loads older turns near the actual boundary, and removes the loading placeholder once the first turn is reached.

## Verification

- `pnpm exec vitest run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx src/flow_chat/components/modern/VirtualMessageList.layout.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism` from `src/web-ui`
  - 63 tests passed
- `pnpm run type-check:web`
  - Passed
- `pnpm exec eslint src/flow_chat/components/modern/VirtualMessageList.tsx --no-warn-ignored` from `src/web-ui`
  - Passed
- `git diff --check`
  - Passed
- Manual reproduction confirmed the main history paging behavior; the final first-turn sentinel removal is covered by the focused regression test.

## Reviewer Notes

- The static scroller remains active during the paging transaction; no renderer switch occurs while the user is scrolling.
- The semantic anchor is a rendered `user-message` element and is restored in a layout effect before the next paint.
- The loading sentinel reserves a fixed height while partial history remains, preventing layout movement when its visibility changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.