### PR TITLE
fix(release): install minisign CLI fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,22 @@ jobs:
           done < <(git ls-files -z '*.sh' '*.bash')
           exit "$rc"
 
+      - name: Verify minisign download fallback
+        run: |
+          set -euo pipefail
+          test_root="$(mktemp -d)"
+          trap 'rm -rf "$test_root"' EXIT
+          mkdir -p "$test_root/stubs"
+          printf '#!/usr/bin/env bash\nexit 1\n' >"$test_root/stubs/sudo"
+          chmod +x "$test_root/stubs/sudo"
+
+          PATH="$test_root/stubs:/usr/bin:/bin" \
+            RUNNER_TEMP="$test_root" \
+            BITFUN_SIGNING_KEY="YQ==" \
+            bash scripts/sign-release-assets.sh "$test_root/missing-asset"
+
+          "$test_root/bitfun-minisign-0.12/bin/minisign" -v
+
   # ── CLI: independent tests ─────────────────────────────────────────
   cli-test:
     name: CLI Tests (${{ matrix.os }})

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -322,9 +322,6 @@ jobs:
             --repo "GCWing/BitFun" \
             --out linux-release-assets/linux-binaries.json
 
-      - name: Setup Rust toolchain (minisign fallback)
-        uses: dtolnay/rust-toolchain@stable
-
       # The Tauri bundler signs the five updater artifacts during `tauri build`,
       # but the installers people download by hand from the release page — dmg,
       # deb, rpm, the Windows installer and the direct AppImages — shipped with

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -319,9 +319,6 @@ jobs:
             --repo "GCWing/BitFun" \
             --out linux-release-assets/linux-binaries.json
 
-      - name: Setup Rust toolchain (minisign fallback)
-        uses: dtolnay/rust-toolchain@stable
-
       # The Tauri bundler signs the five updater artifacts during `tauri build`,
       # but the installers people download by hand from the release page — dmg,
       # deb, rpm, the Windows installer and the direct AppImages — shipped with

--- a/scripts/sign-release-assets.sh
+++ b/scripts/sign-release-assets.sh
@@ -34,17 +34,53 @@ fi
 
 if ! command -v minisign >/dev/null 2>&1; then
   echo "[sign] Installing minisign..."
-  # Ubuntu's package is not available in the default repositories on every
-  # runner image (notably ubuntu-24.04-arm). Prefer it when present, then use
-  # the portable Rust distribution as a fallback.
-  if ! sudo apt-get install -y --no-install-recommends minisign >/dev/null 2>&1; then
-    if ! command -v cargo >/dev/null 2>&1; then
-      echo "[sign] ERROR: minisign is unavailable and cargo is not installed." >&2
+  case "$(uname -s)" in
+    Linux)
+      # Ubuntu's package is not available on every runner image, notably ARM.
+      if ! command -v sudo >/dev/null 2>&1 ||
+        ! sudo apt-get install -y --no-install-recommends minisign >/dev/null 2>&1; then
+        MINISIGN_VERSION="0.12"
+        MINISIGN_ARCHIVE_SHA256="9a599b48ba6eb7b1e80f12f36b94ceca7c00b7a5173c95c3efc88d9822957e73"
+        case "$(uname -m)" in
+          x86_64 | amd64)
+            MINISIGN_ARCH="x86_64"
+            ;;
+          aarch64 | arm64)
+            MINISIGN_ARCH="aarch64"
+            ;;
+          *)
+            echo "[sign] ERROR: unsupported Linux architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
+        MINISIGN_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/bitfun-minisign-${MINISIGN_VERSION}"
+        MINISIGN_ARCHIVE="$MINISIGN_ROOT/minisign-linux.tar.gz"
+        mkdir -p "$MINISIGN_ROOT/bin"
+        curl --fail --location --retry 3 \
+          "https://github.com/jedisct1/minisign/releases/download/${MINISIGN_VERSION}/minisign-${MINISIGN_VERSION}-linux.tar.gz" \
+          --output "$MINISIGN_ARCHIVE"
+        printf '%s  %s\n' "$MINISIGN_ARCHIVE_SHA256" "$MINISIGN_ARCHIVE" | sha256sum --check --status
+        tar -xzf "$MINISIGN_ARCHIVE" -C "$MINISIGN_ROOT/bin" \
+          --strip-components=2 "minisign-linux/${MINISIGN_ARCH}/minisign"
+        export PATH="$MINISIGN_ROOT/bin:$PATH"
+      fi
+      ;;
+    Darwin)
+      if ! command -v brew >/dev/null 2>&1 || ! brew install minisign >/dev/null; then
+        echo "[sign] ERROR: minisign is unavailable and Homebrew could not install it." >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "[sign] ERROR: automatic minisign installation is unsupported on $(uname -s)." >&2
       exit 1
-    fi
-    MINISIGN_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/bitfun-minisign"
-    cargo install --registry crates-io --locked --root "$MINISIGN_ROOT" minisign >/dev/null
-    export PATH="$MINISIGN_ROOT/bin:$PATH"
+      ;;
+  esac
+
+  if ! command -v minisign >/dev/null 2>&1; then
+    echo "[sign] ERROR: minisign installation completed without a usable binary." >&2
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## Summary

- replace the broken `cargo install minisign` fallback introduced in #1759; the `minisign` crate is library-only and has no binary target
- on Linux, download the pinned official Minisign 0.12 archive, verify its SHA-256, and select the x86_64 or aarch64 executable
- on macOS, use Homebrew when minisign is absent
- remove Rust setup steps that existed only for the invalid Cargo fallback
- add an Ubuntu CI regression that forces package installation failure, exercises the download fallback, and executes the installed binary

## Verification

- `pnpm run check:github-config`
- `bash -n scripts/sign-release-assets.sh`
- `git diff --check`
- inspected both official Linux binaries as statically linked x86-64/aarch64 executables

## Local limitation

Docker is installed but its daemon is not running locally, so the Linux executable test is delegated to the new `Shell Deploy Scripts` Ubuntu CI step.