### PR TITLE
fix(flowchat): fix arbitrary turn navigation across renderer handoff

### DIFF
--- a/flowchat-turn-navigation-fix-plan.md
+++ b/flowchat-turn-navigation-fix-plan.md
@@ -1,0 +1,149 @@
+# FlowChat Turn Navigation Fix Plan
+
+## Confirmed Root Cause
+
+The failure is not caused by an explicit streaming-time navigation block.
+
+Before a new turn starts, a restored historical session may use the static
+initial-history list. Arbitrary turn navigation can then materialize a target
+by changing `staticAnchorWindowTurnId` and rendering a bounded window around
+the target.
+
+Starting a new turn completes backend context restoration. The session changes
+from `contextRestoreState: 'pending'` to `ready`, which disables
+`useStaticInitialHistoryList` and replaces the static scroller with Virtuoso.
+
+After this transition, a far arbitrary turn uses Virtuoso's
+`scrollToIndex` fallback. In the reproduced failure:
+
+- Header navigation returned `accepted: true`.
+- Both during streaming and after streaming, pin status stayed `pending`.
+- `isFollowingOutput` was `false` in both cases.
+- The target turn remained unrendered.
+- The viewport stayed at the physical bottom.
+
+The visible drop to the bottom is a secondary effect. The navigation path
+clears the new-turn sticky pin/footer reservation before the target has been
+materialized. When materialization fails, the browser clamps the scroll
+position to the physical bottom and there is no successful target alignment to
+replace it.
+
+There is also a separate scroller handoff bug: `ScrollAnchor` listens through a
+stable ref object and does not rebind when `.current` changes from the static
+scroller to the Virtuoso scroller.
+
+## Recommended Design
+
+### 1. Use one turn-navigation transaction
+
+Header navigation, right-side anchor navigation, and search navigation should
+share one transaction with:
+
+- `targetTurnId`
+- `targetVirtualIndex`
+- `sessionId`
+- `phase: materializing | aligning | settled | canceled`
+- a generation for cancellation and stale-request rejection
+
+The callers should request a transaction; the viewport implementation should
+own the lifecycle.
+
+### 2. Carry the pending target across the static-to-Virtuoso handoff
+
+When Virtuoso mounts while a turn navigation is pending, use the pending target
+as `initialTopMostItemIndex` with `align: 'start'` instead of defaulting to the
+latest turn. After the target DOM exists, perform the exact pinned-top
+alignment using the shared `57px` header offset.
+
+This avoids depending on a post-mount reverse jump from the latest tail to a
+far, unmeasured target.
+
+### 3. Preserve the physical range until target alignment succeeds
+
+The navigation sequence should be:
+
+1. Capture the target and start the navigation transaction.
+2. Exit follow mode.
+3. Preserve the current physical range and existing footer reservation while
+   the target is being materialized.
+4. Materialize the target.
+5. Align the target user message to the pinned top offset.
+6. Confirm stable geometry for a few frames.
+7. Only then release or transfer the pin reservation.
+
+If the request is canceled, restore the appropriate physical range and clear
+the transaction without silently moving to the bottom.
+
+### 4. Make `rangeChanged` part of materialization completion
+
+Do not rely only on blind per-frame retries. On `rangeChanged` or virtual-item
+updates:
+
+- check whether the target DOM node exists;
+- retry materialization only while it is absent;
+- enter `aligning` when it appears;
+- settle after stable top alignment.
+
+Keep a bounded timeout as a final guard, but make expiry a controlled cancel
+and recovery path rather than a silent fall to the physical bottom.
+
+### 5. Rebind `ScrollAnchor` to the actual scroller element
+
+Pass the current scroller element as state instead of relying only on a stable
+ref object:
+
+```tsx
+<ScrollAnchor scrollerElement={scrollerElement} />
+```
+
+The listener effect should depend on `scrollerElement`, so static-to-Virtuoso
+replacement removes the old listener and attaches to the new node.
+
+## Implementation Order
+
+1. Add the shared navigation transaction and preserve-range semantics.
+2. Feed the pending target into Virtuoso's initial positioning during the
+   renderer handoff.
+3. Resolve the target through `rangeChanged` and exact DOM alignment.
+4. Fix `ScrollAnchor` scroller rebinding.
+5. Remove temporary debug instrumentation after the user confirms the issue
+   is fixed.
+
+## Regression Coverage
+
+Add focused tests for:
+
+- arbitrary navigation in the static history window;
+- navigation after a new turn switches static rendering to Virtuoso;
+- navigation during streaming;
+- navigation after streaming ends;
+- an unrendered far target becoming rendered and then aligning at the top;
+- preservation of the sticky pin/footer range until alignment succeeds;
+- cancellation via jump-to-latest, user scroll, session switch, or a newer
+  navigation request;
+- `ScrollAnchor` rebinding after the scroller DOM node changes.
+
+## Implementation Status
+
+Implemented in the modern FlowChat viewport:
+
+- pending navigation generations are invalidated without removing the active
+  footer range; stale sticky reconciliation is suspended until the new target
+  settles
+- Virtuoso receives pending static/Virtuoso targets through
+  `initialTopMostItemIndex`, and `rangeChanged` participates in materialization
+- timeout and replacement paths release semantic ownership without silently
+  falling to the physical bottom
+- `ScrollAnchor` rebinds to the concrete scroller element
+- regression coverage covers range preservation, static-to-Virtuoso handoff,
+  and scroller rebinding
+
+Automated verification passed:
+
+- `pnpm run type-check:web`
+- `pnpm --dir src/web-ui run lint`
+- 51 focused FlowChat tests passed
+
+Interactive reproduction remains the final acceptance step. Temporary
+interactive-debug instrumentation is intentionally retained until that
+reproduction is confirmed fixed.

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -260,6 +260,25 @@ reservation. User navigation drops a provisional sticky range instead of
 transferring it into protected collapse. Established pins keep the existing
 protected-range handoff.
 
+Arbitrary-turn navigation is a materialize-then-align transaction. Starting a
+new request exits tail follow, but it does not remove the previous established
+pin reservation before the target DOM exists. That reservation remains only as
+physical scroll range; the active request prevents the old sticky target from
+reconciling it. Once the requested user message is rendered, the shared pin
+resolver replaces the old reservation, aligns the message to the 57px viewport
+offset, and starts bounded transient stabilization. An expired request releases
+semantic ownership while preserving the current physical range, so failure
+cannot silently clamp the pane to the bottom.
+
+`rangeChanged` is a target-materialization signal, not a source of turn
+identity. It retries the active generation against real DOM geometry. RAF
+retries remain as a bounded fallback for browsers that coalesce range updates.
+When the static initial-history renderer hands off to Virtuoso with a pending
+target, that target becomes Virtuoso's `initialTopMostItemIndex`; the normal pin
+resolver then performs exact alignment after mount. The right-side
+`ScrollAnchor` must bind to the actual scroller element, because the stable ref
+object does not change identity when its `.current` node is replaced.
+
 Mounting an already-streaming session is not a new-turn event. Session entry
 resumes tail follow directly, while sticky pinning remains reserved for a new
 turn that appears in the currently mounted session.
@@ -344,6 +363,53 @@ If a shrink happens without a collapse intent:
 
 This path is safer than doing nothing, but it is more likely to show visible movement than the pre-compensation path.
 
+## C. Static Initial-History Turn Navigation
+
+The initial-history path renders a bounded static window plus estimated leading
+and trailing spacers before handing the complete projection to Virtuoso. Header
+turn selection and the right-side scroll anchor may target a turn outside that
+window. The list first materializes a new window around the target and then
+issues the requested scroll.
+
+A smooth scroll does not update `scrollTop` synchronously. The window swap can
+therefore emit a scroll event at the old, browser-clamped physical bottom before
+the target motion begins. That geometry is not evidence that the user returned
+to the latest turn. While a static anchor window is active:
+
+- physical `atBottom` does not make the viewport semantically latest
+- programmatic turn navigation never releases the anchor window
+- programmatic turn navigation must not start older-history pagination when it
+  crosses the leading spacer; only an explicit upward user gesture may do so
+- explicit jump-to-latest navigation releases it directly
+- wheel, touch, keyboard, or scrollbar motion must establish a recent downward
+  user intent before arrival at the physical bottom may release it
+- session reset clears the anchor window and any pending bottom-return intent
+
+Keep the user-intent window bounded. It exists only to classify the scroll event
+that follows an input gesture; it must not become a persistent scroll lock or a
+second viewport writer.
+
+## D. Arbitrary Turn Navigation Through Virtuoso
+
+Header turn selection and the right-side scroll anchor use the same top-aligned
+pin transaction:
+
+1. record generation, session, target turn, behavior, and pin mode
+2. exit tail follow without removing established physical range
+3. if the target is absent, issue an immediate `scrollToIndex(..., align:
+   'start')`
+4. retry from `rangeChanged` and bounded RAF work until the target user message
+   exists
+5. replace the prior pin reservation with the target's measured reservation
+6. align the target to the shared 57px header offset and stabilize delayed
+   Virtuoso measurements
+7. cancel stale work on a newer request, user intent, session switch, jump to
+   latest, or timeout
+
+Do not clear the previous pin/footer range in step 2. The target may be outside
+the current Virtuoso range, and removing the footer first lets the browser clamp
+the old position to the physical bottom before materialization succeeds.
+
 ## Why Transition Tracking Exists
 
 User-initiated expand/collapse still uses animated layout properties such as:
@@ -379,7 +445,7 @@ current `scrollTop`, without retaining provisional pixels above that range.
 These owner-specific transactions prevent both clear-and-reacquire frames and
 cumulative provisional whitespace. Any deferred follow is then replayed.
 
-## C. Follow-Output Mode (continuous tail)
+## E. Follow-Output Mode (continuous tail)
 
 When the viewport is in follow-output mode and the latest turn is still
 streaming, the user's intent is "keep the tail visible". After the viewport

--- a/src/web-ui/src/flow_chat/components/modern/ScrollAnchor.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ScrollAnchor.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScrollAnchor } from './ScrollAnchor';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../store/modernFlowChatStore', () => ({
+  useVirtualItems: () => [{
+    type: 'user-message',
+    turnId: 'turn-a',
+    data: {
+      id: 'user-turn-a',
+      content: 'turn-a',
+      timestamp: 1,
+    },
+  }],
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    formatDate: () => 'now',
+  },
+}));
+
+describe('ScrollAnchor', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('rebinds scroll listeners when the concrete scroller element changes', () => {
+    vi.useFakeTimers();
+    const firstScroller = document.createElement('div');
+    const secondScroller = document.createElement('div');
+    const onAnchorNavigate = vi.fn();
+
+    act(() => {
+      root.render(
+        <ScrollAnchor
+          onAnchorNavigate={onAnchorNavigate}
+          scrollerElement={firstScroller}
+        />,
+      );
+    });
+
+    act(() => {
+      firstScroller.dispatchEvent(new Event('scroll'));
+    });
+    expect(container.querySelector('.scroll-anchor')?.className).toContain('scrolling');
+
+    act(() => {
+      vi.advanceTimersByTime(801);
+    });
+    expect(container.querySelector('.scroll-anchor')?.className).not.toContain('scrolling');
+
+    act(() => {
+      root.render(
+        <ScrollAnchor
+          onAnchorNavigate={onAnchorNavigate}
+          scrollerElement={secondScroller}
+        />,
+      );
+    });
+
+    act(() => {
+      firstScroller.dispatchEvent(new Event('scroll'));
+    });
+    expect(container.querySelector('.scroll-anchor')?.className).not.toContain('scrolling');
+
+    act(() => {
+      secondScroller.dispatchEvent(new Event('scroll'));
+    });
+    expect(container.querySelector('.scroll-anchor')?.className).toContain('scrolling');
+
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/ScrollAnchor.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ScrollAnchor.tsx
@@ -11,6 +11,7 @@ import './ScrollAnchor.scss';
 interface ScrollAnchorProps {
   onAnchorNavigate: (turnId: string) => void;
   scrollerRef?: React.RefObject<HTMLElement | null>;
+  scrollerElement?: HTMLElement | null;
 }
 
 interface AnchorPoint {
@@ -27,6 +28,7 @@ interface AnchorPoint {
 export const ScrollAnchor: React.FC<ScrollAnchorProps> = ({
   onAnchorNavigate,
   scrollerRef,
+  scrollerElement,
 }) => {
   const virtualItems = useVirtualItems();
   const [hoveredAnchor, setHoveredAnchor] = useState<AnchorPoint | null>(null);
@@ -37,7 +39,10 @@ export const ScrollAnchor: React.FC<ScrollAnchorProps> = ({
   const [isHovering, setIsHovering] = useState(false);
 
   useEffect(() => {
-    const scroller = scrollerRef?.current;
+    // The ref object is stable while the static-history renderer hands off to
+    // Virtuoso. Depend on the actual element as well so the listener follows
+    // that DOM replacement instead of staying attached to a disconnected node.
+    const scroller = scrollerElement ?? scrollerRef?.current;
     if (!scroller) return;
 
     const handleScroll = () => {
@@ -60,10 +65,10 @@ export const ScrollAnchor: React.FC<ScrollAnchorProps> = ({
         clearTimeout(scrollTimeoutRef.current);
       }
     };
-  }, [scrollerRef]);
+  }, [scrollerElement, scrollerRef]);
 
   useEffect(() => {
-    const scroller = scrollerRef?.current;
+    const scroller = scrollerElement ?? scrollerRef?.current;
     if (!scroller) return;
 
     if (isHovering) {
@@ -75,7 +80,7 @@ export const ScrollAnchor: React.FC<ScrollAnchorProps> = ({
     return () => {
       scroller.classList.remove('anchor-hovering');
     };
-  }, [scrollerRef, isHovering]);
+  }, [isHovering, scrollerElement, scrollerRef]);
 
   const anchorPoints = useMemo<AnchorPoint[]>(() => {
     if (virtualItems.length === 0) return [];

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -48,6 +48,8 @@ const virtuosoMocks = vi.hoisted(() => ({
   renderedRange: null as { start: number; end: number } | null,
   scrollerScrollTo: vi.fn(),
   scrollToIndex: vi.fn(),
+  initialTopMostItemIndex: null as unknown,
+  rangeChanged: null as (() => void) | null,
 }));
 const flowStoreMocks = vi.hoisted(() => ({
   hasPendingSessionHistoryCompletion: vi.fn(() => false),
@@ -64,6 +66,9 @@ const inputStateMocks = vi.hoisted(() => ({
 const flowDiagnosticsMocks = vi.hoisted(() => ({
   enabled: false,
   trace: vi.fn(),
+}));
+const scrollAnchorMocks = vi.hoisted(() => ({
+  targetTurnId: null as string | null,
 }));
 
 vi.mock('@/infrastructure/diagnostics/flowChatDiagnostics', () => ({
@@ -93,11 +98,13 @@ vi.mock('react-virtuoso', () => ({
   Virtuoso: React.forwardRef((props: any, ref) => {
     const scrollerRef = React.useRef<HTMLDivElement | null>(null);
     const [, rerender] = React.useReducer((value: number) => value + 1, 0);
+    virtuosoMocks.initialTopMostItemIndex = props.initialTopMostItemIndex;
+    virtuosoMocks.rangeChanged = props.rangeChanged ?? null;
     React.useImperativeHandle(ref, () => ({
       scrollTo: vi.fn(),
       scrollToIndex: vi.fn((options: { index: number }) => {
         virtuosoMocks.scrollToIndex(options);
-        const localIndex = Math.max(0, options.index - (props.firstItemIndex ?? 0));
+        const localIndex = Math.max(0, options.index);
         virtuosoMocks.renderedRange = {
           start: localIndex,
           end: Math.min(props.data?.length ?? 0, localIndex + 4),
@@ -249,7 +256,17 @@ vi.mock('../StickyTaskIndicator', () => ({
 }));
 
 vi.mock('./ScrollAnchor', () => ({
-  ScrollAnchor: () => null,
+  ScrollAnchor: ({ onAnchorNavigate }: { onAnchorNavigate: (turnId: string) => void }) => (
+    <button
+      type="button"
+      data-testid="scroll-anchor-navigate"
+      onClick={() => {
+        if (scrollAnchorMocks.targetTurnId) {
+          onAnchorNavigate(scrollAnchorMocks.targetTurnId);
+        }
+      }}
+    />
+  ),
 }));
 
 function createSession(sessionId: string, turnId: string, overrides: Partial<Session> = {}): Session {
@@ -396,6 +413,8 @@ describe('VirtualMessageList session boundary', () => {
     virtuosoMocks.renderedRange = null;
     virtuosoMocks.scrollerScrollTo.mockReset();
     virtuosoMocks.scrollToIndex.mockReset();
+    virtuosoMocks.initialTopMostItemIndex = null;
+    virtuosoMocks.rangeChanged = null;
     flowStoreMocks.hasPendingSessionHistoryCompletion.mockReset();
     flowStoreMocks.hasPendingSessionHistoryCompletion.mockReturnValue(false);
     flowStoreMocks.hasDeferredSessionHistoryProjection.mockReset();
@@ -410,6 +429,7 @@ describe('VirtualMessageList session boundary', () => {
     inputStateMocks.inputHeight = 0;
     flowDiagnosticsMocks.enabled = false;
     flowDiagnosticsMocks.trace.mockReset();
+    scrollAnchorMocks.targetTurnId = null;
   });
 
   afterEach(() => {
@@ -1464,6 +1484,7 @@ describe('VirtualMessageList session boundary', () => {
 
     expect(status).toBe('pending');
     expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledWith(expect.objectContaining({
+      index: 2,
       align: 'start',
       behavior: 'auto',
     }));
@@ -1504,6 +1525,151 @@ describe('VirtualMessageList session boundary', () => {
     expect(scroller.scrollTop).toBe(4_443);
     expect(target.getBoundingClientRect().top).toBe(57);
     expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the existing sticky range while a distant turn is materialized', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const turnIds = Array.from({ length: 24 }, (_, index) => `turn-${String(index + 1).padStart(2, '0')}`);
+    const latestTurnId = turnIds[turnIds.length - 1];
+    const targetTurnId = turnIds[1];
+    const session = createSessionWithTurns('session-a', turnIds);
+    const latestTurn = session.dialogTurns[session.dialogTurns.length - 1];
+    latestTurn.status = 'processing';
+    latestTurn.modelRounds = [{
+      id: `round-${latestTurnId}`,
+      status: 'streaming',
+      isStreaming: true,
+      items: [],
+      startTime: 1,
+    } as typeof latestTurn.modelRounds[number]];
+    stateMocks.activeSession = session;
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+    virtuosoMocks.renderedRange = { start: 40, end: 48 };
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    const footer = container.querySelector<HTMLElement>('.message-list-footer');
+    const latestTarget = container.querySelector<HTMLElement>(
+      `[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`,
+    );
+    expect(scroller).not.toBeNull();
+    expect(footer).not.toBeNull();
+    expect(latestTarget).not.toBeNull();
+    if (!scroller || !footer || !latestTarget) {
+      return;
+    }
+
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 1_000 },
+      scrollHeight: {
+        configurable: true,
+        get: () => 1_200 + (Number.parseFloat(footer.style.height) || 0),
+      },
+      scrollTop: { configurable: true, writable: true, value: 200 },
+    });
+    vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 0,
+      bottom: 1_000,
+      height: 1_000,
+    }));
+    const latestTargetDocumentTop = 700;
+    vi.spyOn(latestTarget, 'getBoundingClientRect').mockImplementation(() => {
+      const top = latestTargetDocumentTop - scroller.scrollTop;
+      return createRect({ top, bottom: top + 40, height: 40 });
+    });
+
+    let latestPinStatus: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
+    act(() => {
+      latestPinStatus = listRef.current?.pinTurnToTopWithStatus(latestTurnId, {
+        behavior: 'auto',
+        pinMode: 'sticky-latest',
+      }) ?? 'rejected';
+    });
+    expect(latestPinStatus).toBe('settled');
+    const stickyFooterHeight = Number.parseFloat(footer.style.height);
+    expect(stickyFooterHeight).toBeGreaterThan(0);
+
+    virtuosoMocks.scrollToIndex.mockClear();
+    let targetPinStatus: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
+    act(() => {
+      targetPinStatus = listRef.current?.pinTurnToTopWithStatus(targetTurnId, {
+        behavior: 'auto',
+        pinMode: 'transient',
+      }) ?? 'rejected';
+    });
+
+    expect(targetPinStatus).toBe('pending');
+    expect(Number.parseFloat(footer.style.height)).toBe(stickyFooterHeight);
+    expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledWith(expect.objectContaining({
+      align: 'start',
+      behavior: 'auto',
+    }));
+
+    const target = container.querySelector<HTMLElement>(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    );
+    expect(target).not.toBeNull();
+    if (!target) {
+      return;
+    }
+    const targetDocumentTop = 800;
+    vi.spyOn(target, 'getBoundingClientRect').mockImplementation(() => {
+      const top = targetDocumentTop - scroller.scrollTop;
+      return createRect({ top, bottom: top + 40, height: 40 });
+    });
+
+    act(() => {
+      virtuosoMocks.rangeChanged?.();
+    });
+
+    expect(target.getBoundingClientRect().top).toBe(57);
+    expect(Number.parseFloat(footer.style.height)).toBeGreaterThan(0);
+  });
+
+  it('uses a pending static target as Virtuoso initial position during renderer handoff', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const turnIds = Array.from({ length: 8 }, (_, index) => `turn-${index}`);
+    const targetTurnId = 'turn-1';
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+      contextRestoreState: 'pending',
+      isPartial: true,
+      historyState: 'ready',
+    });
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+    expect(container.querySelector('[data-initial-history-render-windowed]')).not.toBeNull();
+
+    let status: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
+    act(() => {
+      status = listRef.current?.pinTurnToTopWithStatus(targetTurnId, {
+        behavior: 'smooth',
+        pinMode: 'transient',
+      }) ?? 'rejected';
+      stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+        contextRestoreState: 'ready',
+        isPartial: false,
+        historyState: 'ready',
+      });
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    expect(status).toBe('pending');
+    expect(virtuosoMocks.initialTopMostItemIndex).toEqual({
+      index: 2,
+      align: 'start',
+    });
   });
 
   it('does not let a canceled pending sticky pin RAF restore provisional footer space', () => {
@@ -1962,6 +2128,238 @@ describe('VirtualMessageList session boundary', () => {
     expect(onUserScrollIntent).toHaveBeenCalledTimes(1);
     expect(container.querySelector(`[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`)).not.toBeNull();
     expect(scroller.scrollTop).toBe(11_000);
+  });
+
+  it('does not clear a static history pin when smooth navigation reports the old bottom first', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const turnIds = Array.from({ length: 8 }, (_, index) => `turn-${index}`);
+    const targetTurnId = 'turn-0';
+    const latestTurnId = 'turn-7';
+
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+    if (!scroller) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 6_275,
+      clientHeight: 1_027,
+      scrollTop: 5_248,
+    });
+    const scrollTo = vi.fn((options?: ScrollToOptions) => {
+      if (options?.behavior !== 'smooth' && typeof options?.top === 'number') {
+        scroller.scrollTop = options.top;
+      }
+    });
+    Object.defineProperty(scroller, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).toBeNull();
+    expect(container.querySelector(
+      `[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+
+    let pinStatus: ReturnType<VirtualMessageListRef['pinTurnToTopWithStatus']> = 'rejected';
+    act(() => {
+      pinStatus = listRef.current?.pinTurnToTopWithStatus(targetTurnId, {
+        behavior: 'smooth',
+      }) ?? 'rejected';
+    });
+
+    expect(pinStatus).toBe('pending');
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+
+    // The browser clamps the old bottom position when the target window is
+    // materialized, before the smooth scroll animation has moved the pane.
+    setScrollerGeometry(scroller, {
+      scrollHeight: 2_693,
+      clientHeight: 1_027,
+      scrollTop: 1_666,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+    expect(container.querySelector('[data-history-initial-render-tail-spacer="true"]')).not.toBeNull();
+
+    // A real downward user gesture is still allowed to return to the latest
+    // window once the pane reaches its physical bottom.
+    act(() => {
+      scroller.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, bubbles: true }));
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+
+    expect(container.querySelector(
+      `[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+  });
+
+  it('does not page older history when scroll-anchor navigation reaches the top boundary', () => {
+    const turnIds = Array.from({ length: 8 }, (_, index) => `turn-${index}`);
+    const targetTurnId = 'turn-0';
+
+    flowStoreMocks.hasDeferredSessionHistoryProjection.mockReturnValue(true);
+    flowStoreMocks.revealPreviousSessionHistoryWindow.mockReturnValue(true);
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+    scrollAnchorMocks.targetTurnId = targetTurnId;
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    const anchorButton = container.querySelector<HTMLElement>('[data-testid="scroll-anchor-navigate"]');
+    expect(scroller).not.toBeNull();
+    expect(anchorButton).not.toBeNull();
+    if (!scroller || !anchorButton) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 6_275,
+      clientHeight: 1_027,
+      scrollTop: 5_248,
+    });
+    const scrollTo = vi.fn();
+    Object.defineProperty(scroller, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).toBeNull();
+
+    act(() => {
+      anchorButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 2_693,
+      clientHeight: 1_027,
+      scrollTop: 100,
+    });
+    act(() => {
+      scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+    expect(container.querySelector('[data-history-initial-render-tail-spacer="true"]')).not.toBeNull();
+    expect(flowStoreMocks.revealPreviousSessionHistoryWindow).not.toHaveBeenCalled();
+  });
+
+  it('pins static scroll-anchor navigation to the user message top offset', () => {
+    const turnIds = Array.from({ length: 8 }, (_, index) => `turn-${index}`);
+    const targetTurnId = 'turn-7';
+
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+    scrollAnchorMocks.targetTurnId = targetTurnId;
+
+    act(() => {
+      root.render(<VirtualMessageList />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    const anchorButton = container.querySelector<HTMLElement>('[data-testid="scroll-anchor-navigate"]');
+    const target = container.querySelector<HTMLElement>(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    );
+    expect(scroller).not.toBeNull();
+    expect(anchorButton).not.toBeNull();
+    expect(target).not.toBeNull();
+    if (!scroller || !anchorButton || !target) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 6_275,
+      clientHeight: 1_027,
+      scrollTop: 3_000,
+    });
+    vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 40,
+      bottom: 1_067,
+      height: 1_027,
+    }));
+    const targetDocumentTop = 3_140;
+    vi.spyOn(target, 'getBoundingClientRect').mockImplementation(() => {
+      const top = targetDocumentTop - scroller.scrollTop;
+      return createRect({
+        top,
+        bottom: top + 40,
+        height: 40,
+      });
+    });
+    const scrollTo = vi.fn((options?: ScrollToOptions) => {
+      if (typeof options?.top === 'number') {
+        scroller.scrollTop = options.top;
+      }
+    });
+    Object.defineProperty(scroller, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+
+    act(() => {
+      anchorButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 3_043,
+      behavior: 'smooth',
+    });
+    expect(target.getBoundingClientRect().top - scroller.getBoundingClientRect().top).toBe(57);
   });
 
   it('keeps static initial history position when footer height changes after an upward scroll', () => {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -106,6 +106,7 @@ import './VirtualMessageList.scss';
 const PINNED_TURN_VIEWPORT_OFFSET_PX = 57; // Keep in sync with `.message-list-header`.
 const TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX = 6;
 const USER_UPWARD_SCROLL_INTENT_WINDOW_MS = 800;
+const STATIC_HISTORY_BOTTOM_RETURN_INTENT_WINDOW_MS = 800;
 const LATEST_END_ANCHOR_STABILIZATION_MAX_ATTEMPTS = 120;
 const LATEST_END_ANCHOR_STABILIZATION_MIN_ATTEMPTS = 12;
 const LATEST_END_ANCHOR_STABLE_VISIBLE_FRAMES = 8;
@@ -117,6 +118,7 @@ const PARTIAL_HISTORY_INITIAL_TAIL_TURN_BUDGET = 16;
 const PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX = 1200;
 const PARTIAL_HISTORY_STATIC_BOUNDARY_THRESHOLD_PX = 120;
 const HISTORY_PROJECTION_HANDOFF_MAX_DURATION_MS = 5000;
+const TURN_PIN_REQUEST_TTL_MS = 5000;
 const SESSION_OPEN_HANDOFF_ITEM_BUDGET = 24;
 const PREVIOUS_HISTORY_BOUNDARY_STATUS_DURATION_MS = 2500;
 const SEARCH_NAVIGATION_MAX_ATTEMPTS = 24;
@@ -126,6 +128,15 @@ const STICKY_PIN_GROWTH_SETTLE_MS = 300;
 const RETAINED_COLLAPSE_QUIET_SETTLE_MS = 120;
 const RETAINED_COLLAPSE_QUIET_SETTLE_FRAMES = 2;
 const RETAINED_COLLAPSE_RELEASE_QUIET_MS = COLLAPSE_INTENT_TTL_MS;
+
+function getPinnedTurnScrollTop(scroller: HTMLElement, targetElement: HTMLElement): number {
+  const targetRect = targetElement.getBoundingClientRect();
+  const scrollerRect = scroller.getBoundingClientRect();
+  return Math.max(
+    0,
+    scroller.scrollTop + targetRect.top - scrollerRect.top - PINNED_TURN_VIEWPORT_OFFSET_PX,
+  );
+}
 
 type FlowChatVirtuosoContext = {
   footerRef: React.RefCallback<HTMLDivElement>;
@@ -284,6 +295,7 @@ interface PendingTurnPinState {
 interface PendingStaticTurnPinState {
   turnId: string;
   behavior: ScrollBehavior;
+  pinMode: FlowChatPinTurnToTopMode;
 }
 
 function sanitizeReservationPx(value: number): number {
@@ -421,7 +433,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     virtuosoIndexState.virtualItems = virtualItems;
   }
   const virtuosoFirstItemIndex = virtuosoIndexState.firstItemIndex;
-  const toVirtuosoIndex = useCallback((localIndex: number) => virtuosoFirstItemIndex + localIndex, [virtuosoFirstItemIndex]);
 
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
@@ -486,12 +497,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const historyPagingRetryTimerRef = useRef<number | null>(null);
   const pendingStaticTurnPinRef = useRef<PendingStaticTurnPinState | null>(null);
   const pendingStaticLatestScrollBehaviorRef = useRef<('auto' | 'smooth') | null>(null);
+  const staticHistoryBottomReturnIntentUntilMsRef = useRef(0);
   const initialHistoryRenderWindowCheckFrameRef = useRef<number | null>(null);
   const measureFrameRef = useRef<number | null>(null);
   const visibleTurnMeasureFrameRef = useRef<number | null>(null);
   const pinReservationReconcileFrameRef = useRef<number | null>(null);
   const turnPinStabilizationFrameRef = useRef<number | null>(null);
   const turnPinRequestGenerationRef = useRef(0);
+  const activeTurnPinRequestRef = useRef<PendingTurnPinState | null>(null);
   const latestEndAnchorStabilizationFrameRef = useRef<number | null>(null);
   const searchNavigationRequestIdRef = useRef(0);
   const staticInitialHistoryBottomGuardFrameRef = useRef<number | null>(null);
@@ -529,6 +542,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   });
   const stickyPinGrowthSettleTimerRef = useRef<number | null>(null);
   const settlePendingStickyPinGrowthRef = useRef<(reason: string) => void>(() => {});
+  const cancelUnresolvedTurnPinRef = useRef<() => void>(() => {});
   const maybeHandoffPinnedTurnToTailRef = useRef<(reason: string) => boolean>(() => false);
   const preparePinnedTurnFollowHandoffRef = useRef<() => void>(() => {});
   const finalizeCollapseIntentRef = useRef<(
@@ -674,6 +688,27 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     staticInitialHistoryUserLeftBottomRef.current =
       distanceFromBottom > LATEST_END_ANCHOR_STABLE_EPSILON_PX;
   }, [getEffectiveBottomScrollTop]);
+
+  const clearStaticHistoryBottomReturnIntent = useCallback(() => {
+    staticHistoryBottomReturnIntentUntilMsRef.current = 0;
+  }, []);
+
+  const markStaticHistoryBottomReturnIntent = useCallback(() => {
+    staticHistoryBottomReturnIntentUntilMsRef.current =
+      performance.now() + STATIC_HISTORY_BOTTOM_RETURN_INTENT_WINDOW_MS;
+  }, []);
+
+  const hasRecentStaticHistoryBottomReturnIntent = useCallback(() => {
+    const intentUntilMs = staticHistoryBottomReturnIntentUntilMsRef.current;
+    return intentUntilMs > 0 && performance.now() <= intentUntilMs;
+  }, []);
+
+  const releaseStaticHistoryAnchorWindow = useCallback(() => {
+    pendingStaticTurnPinRef.current = null;
+    pendingStaticAnchorTurnIdRef.current = null;
+    clearStaticHistoryBottomReturnIntent();
+    setStaticAnchorWindowTurnId(null);
+  }, [clearStaticHistoryBottomReturnIntent]);
 
   const recordScrollerGeometryIfLayoutStable = useCallback((scroller: HTMLElement) => {
     const previousGeometry = previousScrollerGeometryRef.current;
@@ -887,6 +922,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
   const clearTurnPinRequest = useCallback(() => {
     turnPinRequestGenerationRef.current += 1;
+    activeTurnPinRequestRef.current = null;
     transientTurnPinStabilizationRef.current = null;
 
     if (turnPinStabilizationFrameRef.current !== null) {
@@ -1881,9 +1917,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const useInitialHistoryRenderBudget = hasPendingHistoryCompletion || hasPartialHistoryInitialViewport;
   const useStaticInitialHistoryList = useInitialHistoryRenderBudget;
   useStaticInitialHistoryListRef.current = useStaticInitialHistoryList;
-  useEffect(() => {
-    setStaticAnchorWindowTurnId(null);
-  }, [activeSession?.sessionId]);
   const hasPrimedMountedStreamingTurnFollowRef = useRef(false);
   const previousLatestTurnIdForFollowRef = useRef<string | null>(latestTurnId);
   const previousSessionIdForFollowRef = useRef<string | undefined>(activeSession?.sessionId);
@@ -2266,6 +2299,20 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return false;
     }
 
+    // A new arbitrary-turn navigation may be materializing a distant target
+    // while the previous sticky-latest footer still provides physical range.
+    // Do not let the old sticky target rewrite that reservation until the new
+    // request has either aligned or been cancelled.
+    const activeTurnPinTargetId = activeTurnPinRequestRef.current?.turnId ??
+      pendingStaticTurnPinRef.current?.turnId ??
+      null;
+    if (
+      activeTurnPinTargetId &&
+      activeTurnPinTargetId !== pinReservation.targetTurnId
+    ) {
+      return false;
+    }
+
     const collapseIntent = pendingCollapseIntentRef.current;
     const hasActiveCollapseProtection = (
       collapseIntent.active
@@ -2414,12 +2461,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return false;
     }
 
-    const targetRect = targetElement.getBoundingClientRect();
-    const scrollerRect = scroller.getBoundingClientRect();
-    const targetScrollTop = Math.max(
-      0,
-      scroller.scrollTop + targetRect.top - scrollerRect.top - PINNED_TURN_VIEWPORT_OFFSET_PX,
-    );
+    const targetScrollTop = getPinnedTurnScrollTop(scroller, targetElement);
     cancelStaticInitialHistoryBottomGuard();
     scroller.scrollTo({
       top: targetScrollTop,
@@ -2529,7 +2571,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       }
 
       virtuoso.scrollToIndex({
-        index: toVirtuosoIndex(targetItem.index),
+        index: targetItem.index,
         align: 'start',
         behavior: fallbackBehavior,
       });
@@ -2659,7 +2701,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     schedulePinReservationReconcile,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
-    toVirtuosoIndex,
     updateBottomReservationState,
     userMessageItems,
   ]);
@@ -2671,6 +2712,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
 
     if (request.pinMode !== 'transient' || performance.now() > request.expiresAtMs) {
+      if (activeTurnPinRequestRef.current?.generation === request.generation) {
+        activeTurnPinRequestRef.current = null;
+      }
       transientTurnPinStabilizationRef.current = null;
       return;
     }
@@ -3385,8 +3429,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     pendingCollapseIntentRef.current = createInactiveCollapseIntentState();
     retainedCollapseAnchorRef.current = null;
     previousScrollerGeometryRef.current = null;
-    pendingStaticAnchorTurnIdRef.current = null;
-    pendingStaticTurnPinRef.current = null;
+    releaseStaticHistoryAnchorWindow();
+    pendingStaticLatestScrollBehaviorRef.current = null;
     historyPagingActiveRef.current = false;
     historyPagingRevealScheduledRef.current = false;
     pendingHistoryPagingRevealRef.current = null;
@@ -3413,6 +3457,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     clearPendingStickyPinGrowth,
     clearHistoryProjectionHandoff,
     clearTurnPinRequest,
+    releaseStaticHistoryAnchorWindow,
     resetBottomReservations,
   ]);
 
@@ -3565,6 +3610,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       const intentCheckPreviousScrollTop = previousScrollTopRef.current;
       const intentCheckScrollDelta = intentCheckScrollTop - intentCheckPreviousScrollTop;
       const hasRecentUserUpwardIntent = now <= userInitiatedUpwardScrollUntilMsRef.current;
+      if (scrollbarPointerInteractionActiveRef.current) {
+        if (intentCheckScrollDelta > COMPENSATION_EPSILON_PX) {
+          markStaticHistoryBottomReturnIntent();
+        } else if (intentCheckScrollDelta < -COMPENSATION_EPSILON_PX) {
+          clearStaticHistoryBottomReturnIntent();
+        }
+      }
       if (
         flowChatDiagnostics.isEnabled() &&
         Math.abs(intentCheckScrollDelta) > COMPENSATION_EPSILON_PX
@@ -3777,6 +3829,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         cancelLatestEndAnchorStabilization();
       }
 
+      if (event.deltaY > 0) {
+        markStaticHistoryBottomReturnIntent();
+      } else if (event.deltaY < 0) {
+        clearStaticHistoryBottomReturnIntent();
+      }
+
       if (event.deltaY < 0) {
         staticInitialHistoryUserLeftBottomRef.current = true;
         userInitiatedUpwardScrollUntilMsRef.current =
@@ -3809,6 +3867,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         notifyUserScrollIntent();
         clearTurnPinRequest();
         cancelLatestEndAnchorStabilization();
+
+        if (currentY - startY < -TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX) {
+          markStaticHistoryBottomReturnIntent();
+        } else {
+          clearStaticHistoryBottomReturnIntent();
+        }
       }
 
       if (currentY - startY > TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX) {
@@ -3818,6 +3882,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
         schedulePreviousHistoryWindowForUserIntent('touch-scroll-up');
         followOutputControllerRef.current.handleUserScrollIntent();
+      }
+      if (Math.abs(currentY - startY) > TOUCH_SCROLL_INTENT_EXIT_THRESHOLD_PX) {
+        touchScrollIntentStartYRef.current = currentY;
       }
     };
 
@@ -3843,9 +3910,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       cancelLatestEndAnchorStabilization();
 
       if (!isUpwardScrollIntentKey(event)) {
+        markStaticHistoryBottomReturnIntent();
         return;
       }
 
+      clearStaticHistoryBottomReturnIntent();
       staticInitialHistoryUserLeftBottomRef.current = true;
       userInitiatedUpwardScrollUntilMsRef.current =
         performance.now() + USER_UPWARD_SCROLL_INTENT_WINDOW_MS;
@@ -4146,6 +4215,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     getTotalBottomCompensationPx,
     latestTurnId,
     notifyUserScrollIntent,
+    clearStaticHistoryBottomReturnIntent,
+    markStaticHistoryBottomReturnIntent,
     pendingTurnPin?.pinMode,
     pendingTurnPin?.turnId,
     preserveCollapseAnchorScrollTop,
@@ -4342,7 +4413,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     } else if (virtuoso) {
       request.visibleFrames = 0;
       virtuoso.scrollToIndex({
-        index: toVirtuosoIndex(targetIndex),
+        index: targetIndex,
         align: 'end',
         behavior: 'auto',
       });
@@ -4395,14 +4466,55 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     recordScrollerGeometry,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
-    toVirtuosoIndex,
     virtualItems,
   ]);
   resolveLatestEndAnchorStabilizationRef.current = resolveLatestEndAnchorStabilization;
 
+  const resolvePendingTurnPinFromRangeChange = useCallback(() => {
+    if (
+      !pendingTurnPin ||
+      !isTurnPinRequestCurrent(pendingTurnPin) ||
+      performance.now() > pendingTurnPin.expiresAtMs
+    ) {
+      return;
+    }
+
+    const nextRequest: PendingTurnPinState = {
+      ...pendingTurnPin,
+      attempts: pendingTurnPin.attempts + 1,
+      behavior: 'auto',
+    };
+    if (!tryResolvePendingTurnPin(nextRequest)) {
+      setPendingTurnPin(current => (
+        current?.generation === nextRequest.generation ? nextRequest : current
+      ));
+      return;
+    }
+
+    if (nextRequest.pinMode === 'transient') {
+      activateTransientTurnPinStabilization(nextRequest);
+      scheduleTransientTurnPinStabilization(2);
+      setPendingTurnPin(current => (
+        current?.generation === nextRequest.generation ? null : current
+      ));
+    } else {
+      clearTurnPinRequest();
+    }
+    scheduleVisibleTurnMeasure(2);
+  }, [
+    activateTransientTurnPinStabilization,
+    clearTurnPinRequest,
+    isTurnPinRequestCurrent,
+    pendingTurnPin,
+    scheduleTransientTurnPinStabilization,
+    scheduleVisibleTurnMeasure,
+    tryResolvePendingTurnPin,
+  ]);
+
   // `rangeChanged` is affected by overscan/increaseViewportBy, so treat it as a
   // "rendered DOM changed" signal and derive the pinned turn from real DOM visibility.
   const handleRangeChanged = useCallback(() => {
+    resolvePendingTurnPinFromRangeChange();
     resolveLatestEndAnchorStabilization('range-changed');
     scheduleVisibleTurnMeasure(2);
     schedulePinReservationReconcile(2);
@@ -4414,6 +4526,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     // so the handoff stays until 3 frames of stability pass.
     scheduleHistoryProjectionHandoffRelease(3);
   }, [
+    resolvePendingTurnPinFromRangeChange,
     resolveLatestEndAnchorStabilization,
     scheduleFollowToLatestWithViewportState,
     scheduleHistoryProjectionHandoffRelease,
@@ -4453,11 +4566,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
 
     if (performance.now() > pendingTurnPin.expiresAtMs) {
-      clearTurnPinRequest();
       if (clearExpiredProvisionalStickyPin(pendingTurnPin)) {
+        clearTurnPinRequest();
         followOutputControllerRef.current.scheduleFollowToLatest(
           'unresolved-turn-pin-expired',
         );
+      } else {
+        cancelUnresolvedTurnPinRef.current();
       }
       return;
     }
@@ -4621,6 +4736,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     updateBottomReservationState,
   ]);
 
+  cancelUnresolvedTurnPinRef.current = () => {
+    clearPinReservationForUserNavigation('unresolved-turn-pin-expired', {
+      preserveCurrentRange: true,
+    });
+    viewportCoordinatorRef.current.release('unresolved-turn-pin-expired');
+  };
+
   exitPinnedViewportForUserIntentRef.current = reason => {
     if (flowChatDiagnostics.isEnabled()) {
       flowChatDiagnostics.trace({
@@ -4663,24 +4785,39 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return lastDialogTurn.modelRounds.some(round => round.isStreaming);
   }, [activeSession, isProcessing]);
   const initialTopMostItemIndex = React.useMemo(() => {
+    const pendingTurnId = pendingTurnPin?.turnId ??
+      pendingStaticTurnPinRef.current?.turnId ??
+      staticAnchorWindowTurnId;
+    if (pendingTurnId) {
+      const pendingTargetIndex = virtualItems.findIndex(item => (
+        item.turnId === pendingTurnId && item.type === 'user-message'
+      ));
+      if (pendingTargetIndex >= 0) {
+        return {
+          index: pendingTargetIndex,
+          align: 'start' as const,
+        };
+      }
+    }
+
     if (historyPagingActive && historyPagingAnchorTurnId) {
       const anchorIndex = virtualItems.findIndex(item => (
         item.turnId === historyPagingAnchorTurnId && item.type === 'user-message'
       ));
       if (anchorIndex >= 0) {
         return {
-          index: toVirtuosoIndex(anchorIndex),
+          index: anchorIndex,
           align: 'start' as const,
         };
       }
     }
 
     if (isStreamingOutput) {
-      return toVirtuosoIndex(latestUserMessageIndex);
+      return latestUserMessageIndex;
     }
 
     return {
-      index: toVirtuosoIndex(Math.max(0, virtualItems.length - 1)),
+      index: Math.max(0, virtualItems.length - 1),
       align: 'end' as const,
     };
   }, [
@@ -4688,7 +4825,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     historyPagingActive,
     historyPagingAnchorTurnId,
     latestUserMessageIndex,
-    toVirtuosoIndex,
+    pendingTurnPin?.turnId,
+    staticAnchorWindowTurnId,
     virtualItems,
   ]);
 
@@ -4909,10 +5047,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (!scroller) return;
 
     if (useStaticInitialHistoryListRef.current && staticAnchorWindowTurnId) {
-      pendingStaticTurnPinRef.current = null;
-      pendingStaticAnchorTurnIdRef.current = null;
       pendingStaticLatestScrollBehaviorRef.current = behavior;
-      setStaticAnchorWindowTurnId(null);
+      releaseStaticHistoryAnchorWindow();
       return;
     }
 
@@ -4963,6 +5099,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     clearPinReservationForUserNavigation,
     getTotalBottomCompensationPx,
     recordStaticInitialHistoryBottomState,
+    releaseStaticHistoryAnchorWindow,
     staticAnchorWindowTurnId,
   ]);
   useLayoutEffect(() => {
@@ -4991,11 +5128,17 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return 'rejected';
     }
 
+    // Replacing a pending navigation must invalidate its RAF/state generation,
+    // but it must not remove the footer range that keeps the current viewport
+    // physically reachable while the new target is being materialized.
+    clearTurnPinRequest();
+
     if (!virtuosoRef.current) {
       if (!useStaticInitialHistoryList) {
         return 'rejected';
       }
 
+      clearStaticHistoryBottomReturnIntent();
       retainedCollapseAnchorRef.current = null;
       if (requestedPinMode === 'sticky-latest' && turnId === latestTurnId) {
         preparePinnedTurnFollowHandoffRef.current();
@@ -5005,6 +5148,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       pendingStaticTurnPinRef.current = {
         turnId,
         behavior: requestedBehavior,
+        pinMode: requestedPinMode,
       };
 
       startupTrace.markPhase('flowchat_static_turn_pin_request', {
@@ -5049,10 +5193,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       turnId,
       behavior: requestedBehavior,
       pinMode: requestedPinMode,
-      expiresAtMs: performance.now() + 1500,
+      expiresAtMs: performance.now() + TURN_PIN_REQUEST_TTL_MS,
       attempts: 0,
     };
     turnPinRequestGenerationRef.current = request.generation;
+    activeTurnPinRequestRef.current = request;
 
     startupTrace.markPhase('flowchat_turn_pin_request', {
       turnId,
@@ -5078,6 +5223,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     activeSession?.dialogTurns,
     activateTransientTurnPinStabilization,
     clearTurnPinRequest,
+    clearStaticHistoryBottomReturnIntent,
     latestTurnId,
     scheduleTransientTurnPinStabilization,
     scheduleVisibleTurnMeasure,
@@ -5085,6 +5231,35 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     tryResolvePendingTurnPin,
     useStaticInitialHistoryList,
     userMessageItems,
+  ]);
+
+  useLayoutEffect(() => {
+    if (useStaticInitialHistoryList || !virtuosoRef.current || pendingTurnPin) {
+      return;
+    }
+
+    const pendingStaticTurnPin = pendingStaticTurnPinRef.current;
+    if (!pendingStaticTurnPin) {
+      return;
+    }
+
+    // The static renderer can be replaced by Virtuoso while a target window
+    // is still being materialized. Keep the target as Virtuoso's initial
+    // position (computed above), then continue through the normal pin
+    // transaction once the new scroller exists.
+    pendingStaticTurnPinRef.current = null;
+    releaseStaticHistoryAnchorWindow();
+    requestTurnPinToTop(pendingStaticTurnPin.turnId, {
+      behavior: pendingStaticTurnPin.behavior,
+      pinMode: pendingStaticTurnPin.pinMode,
+    });
+  }, [
+    pendingTurnPin,
+    releaseStaticHistoryAnchorWindow,
+    requestTurnPinToTop,
+    scrollerElement,
+    useStaticInitialHistoryList,
+    virtualItems.length,
   ]);
 
   const performAutoFollowSync = useCallback(() => {
@@ -5193,7 +5368,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         // switch; scrolling by index lets Virtuoso resolve the correct position.
         const scrollToBottom = () => {
           virtuosoRef.current?.scrollToIndex({
-            index: toVirtuosoIndex(virtualItems.length - 1),
+            index: virtualItems.length - 1,
             align: 'end',
             behavior: 'auto',
           });
@@ -5237,7 +5412,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     isStreamingOutput,
     latestTurnId,
     resumeFollowOutputForMountedStream,
-    toVirtuosoIndex,
     virtualItems.length,
   ]);
 
@@ -5436,12 +5610,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       virtuosoRef.current.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
       virtuosoRef.current.scrollToIndex({
-        index: toVirtuosoIndex(targetItem.index),
+        index: targetItem.index,
         behavior: 'smooth',
         align: 'center',
       });
     }
-  }, [clearPinReservationForUserNavigation, exitFollowOutput, toVirtuosoIndex, userMessageItems]);
+  }, [clearPinReservationForUserNavigation, exitFollowOutput, userMessageItems]);
 
   const scrollToIndex = useCallback((index: number) => {
     if (!virtuosoRef.current) return;
@@ -5454,9 +5628,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (index === 0) {
       virtuosoRef.current.scrollTo({ top: 0, behavior: 'auto' });
     } else {
-      virtuosoRef.current.scrollToIndex({ index: toVirtuosoIndex(index), align: 'center', behavior: 'auto' });
+      virtuosoRef.current.scrollToIndex({ index, align: 'center', behavior: 'auto' });
     }
-  }, [clearPinReservationForUserNavigation, exitFollowOutput, toVirtuosoIndex, virtualItems.length]);
+  }, [clearPinReservationForUserNavigation, exitFollowOutput, virtualItems.length]);
 
   const clearSearchMatch = useCallback(() => {
     searchNavigationRequestIdRef.current += 1;
@@ -5486,6 +5660,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     retainedCollapseAnchorRef.current = null;
     exitFollowOutput('scroll-to-index');
     clearPinReservationForUserNavigation();
+    clearStaticHistoryBottomReturnIntent();
 
     const virtuoso = virtuosoRef.current;
     if (virtuoso) {
@@ -5493,7 +5668,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         virtuoso.scrollTo({ top: 0, behavior: 'auto' });
       } else {
         virtuoso.scrollToIndex({
-          index: toVirtuosoIndex(target.virtualItemIndex),
+          index: target.virtualItemIndex,
           align: 'center',
           behavior: 'auto',
         });
@@ -5664,12 +5839,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     requestAnimationFrame(resolveExactTextPosition);
   }, [
     clearPinReservationForUserNavigation,
+    clearStaticHistoryBottomReturnIntent,
     clearSearchMatch,
     exitFollowOutput,
     getRenderedVirtualItemElement,
     recordScrollerGeometry,
     scheduleVisibleTurnMeasure,
-    toVirtuosoIndex,
     virtualItems,
   ]);
 
@@ -5685,13 +5860,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     );
     if (shouldExitFollowOutput) {
       exitFollowOutput('pin-turn-to-top');
-      // Drop stale sticky tail padding before transient jumps so the previous
-      // latest-turn reservation cannot leak into the new viewport.
-      clearPinReservationForUserNavigation();
     }
 
     return requestTurnPinToTop(turnId, options);
-  }, [clearPinReservationForUserNavigation, exitFollowOutput, latestTurnId, requestTurnPinToTop]);
+  }, [
+    exitFollowOutput,
+    latestTurnId,
+    requestTurnPinToTop,
+  ]);
 
   const pinTurnToTop = useCallback((turnId: string, options?: { behavior?: ScrollBehavior; pinMode?: FlowChatPinTurnToTopMode }) => {
     return pinTurnToTopWithStatus(turnId, options) !== 'rejected';
@@ -5880,7 +6056,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       virtualItemCount: virtualItems.length,
     });
     virtuosoRef.current.scrollToIndex({
-      index: toVirtuosoIndex(targetIndex),
+      index: targetIndex,
       align: 'end',
       behavior: 'auto',
     });
@@ -5902,7 +6078,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     resolveLatestEndAnchorStabilization,
     scheduleVisibleTurnMeasure,
     snapshotMeasuredContentHeight,
-    toVirtuosoIndex,
     useStaticInitialHistoryList,
     virtualItems,
   ]);
@@ -6165,11 +6340,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     const targetElement = getRenderedUserMessageElement(turnId);
     if (!scroller || !targetElement) return null;
 
-    const targetRect = targetElement.getBoundingClientRect();
-    const scrollerRect = scroller.getBoundingClientRect();
-    const targetTop = scroller.scrollTop + targetRect.top - scrollerRect.top;
-    const centerOffset = Math.max(0, (scroller.clientHeight - targetRect.height) / 2);
-    return Math.max(0, targetTop - centerOffset);
+    return getPinnedTurnScrollTop(scroller, targetElement);
   }, [getRenderedUserMessageElement]);
   const expandInitialHistoryRenderWindow = useCallback((reason: string) => {
     if (
@@ -6311,17 +6482,30 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       getEffectiveBottomScrollTop(scroller) - scroller.scrollTop,
     );
     const atBottom = distanceFromBottom <= 50;
-    setIsAtBottom(atBottom);
-    if (atBottom && staticAnchorWindowTurnId) {
-      pendingStaticTurnPinRef.current = null;
-      pendingStaticAnchorTurnIdRef.current = null;
-      setStaticAnchorWindowTurnId(null);
+    const hasRecentBottomReturnIntent = hasRecentStaticHistoryBottomReturnIntent();
+    const hasRecentPreviousHistoryIntent =
+      performance.now() <= userInitiatedUpwardScrollUntilMsRef.current ||
+      scrollbarPointerInteractionActiveRef.current;
+    const shouldReleaseStaticAnchorWindow = atBottom &&
+      staticAnchorWindowTurnId !== null &&
+      hasRecentBottomReturnIntent;
+    // A programmatic static-history pin can temporarily report the old
+    // physical bottom while its smooth scroll is still in flight. Keep the
+    // semantic state away from latest until the user explicitly heads back to
+    // the bottom.
+    setIsAtBottom(shouldReleaseStaticAnchorWindow || (atBottom && !staticAnchorWindowTurnId));
+    if (shouldReleaseStaticAnchorWindow) {
+      releaseStaticHistoryAnchorWindow();
     }
-    expandInitialHistoryRenderWindowIfNeeded('scroll-near-omitted-history');
+    if (hasRecentPreviousHistoryIntent) {
+      expandInitialHistoryRenderWindowIfNeeded('scroll-near-omitted-history');
+    }
   }, [
     expandInitialHistoryRenderWindowIfNeeded,
     getEffectiveBottomScrollTop,
+    hasRecentStaticHistoryBottomReturnIntent,
     staticAnchorWindowTurnId,
+    releaseStaticHistoryAnchorWindow,
   ]);
   const handleInitialHistoryStaticWheelCapture = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
     if (event.deltaY >= 0) {
@@ -6829,6 +7013,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           retainedCollapseAnchorRef.current = null;
           exitFollowOutput('scroll-to-turn');
           clearPinReservationForUserNavigation();
+          clearStaticHistoryBottomReturnIntent();
 
           pendingStaticAnchorTurnIdRef.current = turnId;
           const anchorScrollTop = getStaticAnchorScrollTop(turnId);
@@ -6846,6 +7031,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           pendingStaticAnchorTurnIdRef.current = null;
         }}
         scrollerRef={scrollerElementRef}
+        scrollerElement={scrollerElement}
       />
 
       <ScrollToTurnHeaderButton


### PR DESCRIPTION
## Summary

Fix arbitrary FlowChat turn navigation during and after streaming, including navigation across the static-history to Virtuoso renderer handoff.

## Type and Areas

Type:

- bug fix
- regression fix
- UI/UX
- docs
- test

Areas:

- Web UI
- FlowChat

## Motivation / Impact

Previously, arbitrary turn navigation could remain pending, jump back to the bottom, or stop working after a new turn switched rendering modes.

This change:

- Preserves the existing footer and pin range while distant targets materialize.
- Uses local Virtuoso data indices for navigation APIs.
- Resolves pending navigation through `rangeChanged` and bounded retries.
- Carries pending targets through the static-history to Virtuoso handoff.
- Aligns the target user message to the shared top offset.
- Adds cancellation and timeout recovery without silently falling to the bottom.
- Rebinds `ScrollAnchor` to the concrete scroller element.
- Adds regression tests and scroll stability documentation.

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run lint`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx src/flow_chat/components/modern/ScrollAnchor.test.tsx`
- `git diff --check`
- Focused tests: 51 passed
- Manual reproduction confirmed that arbitrary turn navigation works during and after streaming.

## Reviewer Notes

- Virtuoso navigation now uses local data indices; `firstItemIndex` remains only a rendering coordinate.
- Navigation follows a materialize-then-align transaction.
- The existing physical range is preserved until the new target is rendered and aligned.
- `rangeChanged` participates in target materialization, with bounded RAF retries as fallback.
- The root `flowchat-turn-navigation-fix-plan.md` file is an explicitly requested durable diagnostic and design artifact.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.