### PR TITLE
fix(web-ui): tolerate missing model identity in model-round events

### DIFF
--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -532,6 +532,103 @@ describe('handleDialogTurnFailed', () => {
   });
 });
 
+async function startStreamingMachine(): Promise<void> {
+  await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+    taskId: 'session-1',
+    dialogTurnId: 'turn-1',
+  });
+}
+
+describe('handleModelRoundStart', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  afterEach(() => {
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  it('creates a model round even when model identity fields are absent (external ACP agents)', async () => {
+    createSessionWithTurn({
+      id: 'turn-1',
+      sessionId: 'session-1',
+      userMessage: {
+        id: 'user-1',
+        content: 'Initial request',
+        timestamp: 900,
+      },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 900,
+    });
+    await startStreamingMachine();
+    const context = createFlowChatContext();
+
+    expect(() =>
+      __test_only__.handleModelRoundStart(context, {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        roundId: 'round-1',
+        roundIndex: 0,
+      } as any),
+    ).not.toThrow();
+
+    const turn = FlowChatStore.getInstance()
+      .getState()
+      .sessions.get('session-1')
+      ?.dialogTurns.find(item => item.id === 'turn-1');
+
+    expect(turn?.modelRounds).toHaveLength(1);
+    expect(turn?.modelRounds[0]).toMatchObject({
+      id: 'round-1',
+      index: 0,
+      isStreaming: true,
+    });
+    expect(turn?.modelRounds[0]?.modelConfigId).toBeUndefined();
+    expect(turn?.modelRounds[0]?.effectiveModelName).toBeUndefined();
+  });
+
+  it('trims and stores model identity fields when present', async () => {
+    createSessionWithTurn({
+      id: 'turn-1',
+      sessionId: 'session-1',
+      userMessage: {
+        id: 'user-1',
+        content: 'Initial request',
+        timestamp: 900,
+      },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 900,
+    });
+    await startStreamingMachine();
+    const context = createFlowChatContext();
+
+    __test_only__.handleModelRoundStart(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      roundId: 'round-1',
+      roundIndex: 0,
+      modelConfigId: '  config-1  ',
+      effectiveModelName: '  gpt-4o  ',
+    } as any);
+
+    const turn = FlowChatStore.getInstance()
+      .getState()
+      .sessions.get('session-1')
+      ?.dialogTurns.find(item => item.id === 'turn-1');
+
+    expect(turn?.modelRounds).toHaveLength(1);
+    expect(turn?.modelRounds[0]).toMatchObject({
+      modelConfigId: 'config-1',
+      effectiveModelName: 'gpt-4o',
+    });
+  });
+});
+
 function resetFlowChatStore(): void {
   FlowChatStore.getInstance().setState(() => ({
     sessions: new Map(),

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -160,6 +160,7 @@ export const __test_only__ = {
   handleDialogTurnStarted,
   handleDialogTurnFailed,
   handleSubagentSessionLinked,
+  handleModelRoundStart,
 };
 
 function shouldMarkUnreadCompletion(sessionId: string): boolean {
@@ -1906,9 +1907,6 @@ function handleModelRoundStart(context: FlowChatContext, event: ModelRoundStarte
     event.renderHints?.disableExploreGrouping === true ||
     event.metadata?.disableExploreGrouping === true ||
     event.disableExploreGrouping === true;
-  const modelConfigId = event.modelConfigId.trim();
-  const effectiveModelName = event.effectiveModelName.trim();
-
   const modelRound: ModelRound = {
     id: roundId,
     index: roundIndex || 0,
@@ -1918,8 +1916,9 @@ function handleModelRoundStart(context: FlowChatContext, event: ModelRoundStarte
     isComplete: false,
     status: 'streaming',
     startTime: Date.now(),
-    modelConfigId,
-    effectiveModelName,
+    // Model identity is optional: external ACP agents carry none.
+    ...(event.modelConfigId ? { modelConfigId: event.modelConfigId.trim() } : {}),
+    ...(event.effectiveModelName ? { effectiveModelName: event.effectiveModelName.trim() } : {}),
     ...(disableExploreGrouping
       ? { renderHints: { disableExploreGrouping: true } }
       : {}),
@@ -1931,12 +1930,12 @@ function handleModelRoundStart(context: FlowChatContext, event: ModelRoundStarte
   const linkedParentInfo =
     findSubagentParentInfoByRound(sessionId, turnId) ||
     getLinkedSubagentParentInfo(sessionId);
-  if (linkedParentInfo && effectiveModelName) {
+  if (linkedParentInfo && modelRound.effectiveModelName) {
     updateSubagentParentTaskModel(
       context,
       linkedParentInfo,
-      modelConfigId,
-      effectiveModelName,
+      modelRound.modelConfigId,
+      modelRound.effectiveModelName,
     );
   }
   

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -478,9 +478,9 @@ export interface ModelRoundCompletedEvent extends AgenticEvent {
   durationMs?: number;
   providerId?: string;
   /** Resolved AI model configuration ID. */
-  modelConfigId: string;
+  modelConfigId?: string;
   /** Provider model name sent on the request. */
-  effectiveModelName: string;
+  effectiveModelName?: string;
   firstChunkMs?: number;
   firstVisibleOutputMs?: number;
   streamDurationMs?: number;
@@ -501,9 +501,9 @@ export interface ModelRoundStartedEvent extends AgenticEvent {
   roundGroupId?: string;
   roundIndex: number;
   /** Resolved AI model configuration ID. */
-  modelConfigId: string;
+  modelConfigId?: string;
   /** Provider model name sent on the request. */
-  effectiveModelName: string;
+  effectiveModelName?: string;
 }
 
 export interface AcpContextUsageUpdatedEvent extends AgenticEvent {


### PR DESCRIPTION
## Problem

When BitFun runs as an ACP client chatting with an external ACP agent (Codex, Claude Code, etc.), the FlowChat transcript stays empty: the agent keeps running, permission prompts may appear, files may be modified, but assistant text / tool results never show up.

## Root cause

Since commit 4d7358556 ("feat(agentic): support configurable subagent models"), `handleModelRoundStart` in `EventHandlerModule.ts` treats `modelConfigId` and `effectiveModelName` as required and calls `.trim()` on them unconditionally. The native `AgenticEvent::ModelRoundStarted` projection always carries both fields, but the ACP client emitter (`acp_client_api.rs`) builds the `agentic://model-round-started` payload by hand and does not include them.

Failure chain:
1. ACP model round starts -> event lacks the two fields -> `.trim()` on `undefined` throws a TypeError.
2. No `ModelRound` is created for that round.
3. Subsequent `agentic://text-chunk` / tool events look up the round via `addModelRoundItem` and are dropped ("Model round not found").
4. Transcript stays empty while the upstream agent keeps working.

## Fix

- Make `modelConfigId` / `effectiveModelName` optional on `ModelRoundStartedEvent` and `ModelRoundCompletedEvent` (AgentAPI.ts).
- Omit them from the created `ModelRound` when absent instead of fabricating placeholder values (external ACP agents have no BitFun model identity).
- `updateSubagentParentTaskModel` reads from the created round and only runs when a model name is present.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts` - 25/25 passed
- `pnpm run type-check:web` - passed
