### PR TITLE
fix(cli): stabilize dispatch retention after lock contention

### DIFF
--- a/src/apps/cli/src/dispatch/store.rs
+++ b/src/apps/cli/src/dispatch/store.rs
@@ -1292,6 +1292,14 @@ impl JobLock {
     }
 }
 
+impl Drop for JobLock {
+    fn drop(&mut self) {
+        if let Err(error) = fs2::FileExt::unlock(&self._file) {
+            tracing::warn!("Failed to release dispatch job lock: {error}");
+        }
+    }
+}
+
 struct FileLock;
 
 impl FileLock {
@@ -2537,12 +2545,28 @@ mod tests {
             0
         );
         assert!(job_dir.exists());
-        assert_eq!(
-            store
+
+        let released_lock = JobLock::try_exclusive(&job_dir.join(".lock"))
+            .expect("reopen released job lock")
+            .expect("job lock must be released after contention");
+        drop(released_lock);
+
+        let retry_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let removed = loop {
+            let removed = store
                 .collect_expired_terminal_jobs(now)
-                .expect("retry expired job"),
-            1
-        );
+                .expect("retry expired job");
+            if removed == 1 {
+                break removed;
+            }
+            assert_eq!(removed, 0, "only the contended job may be removed");
+            assert!(
+                std::time::Instant::now() < retry_deadline,
+                "expired job must be removed after transient Windows file contention clears"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+        assert_eq!(removed, 1);
         assert!(!job_dir.exists());
     }
 


### PR DESCRIPTION
## Summary

- explicitly release `JobLock` through `fs2::FileExt::unlock` before the backing file handle is closed
- verify a contended job lock can be reacquired after the holder is dropped
- retry retention cleanup within a bounded deadline when Windows briefly keeps job files busy

## Root cause

The GitCode Windows pipeline exposed a timing-dependent failure in `retention_skips_contended_job_without_blocking_and_retries_later`: the first collection correctly skipped the locked job, but the single immediate retry returned `0` instead of `1`.

Retention already treats Windows `PermissionDenied` rename failures as retryable and defers cleanup to a later collection. The test assumed that "later" meant the very next call, while `JobLock` also relied on implicit handle-close semantics instead of explicitly releasing its `fs2` lock. Under transient Windows file contention, those assumptions made the test flaky.

This keeps retention non-blocking and preserves its existing eventual-cleanup behavior. It does not change storage schemas, lock paths, public APIs, or job lifecycle semantics.

## Verification

- `cargo check --locked -p bitfun-cli`
- `cargo test --locked -p bitfun-cli` (503 unit tests and all CLI integration suites passed)
- focused contended-retention and Windows sharing-violation tests
- contended-retention regression repeated 200/200 times
- the corresponding GitCode `bitfun_ci` run passed `ohos_arrch64`, `macos_arm64`, and `cargo-test`

The original failure is timing-dependent and may pass locally on the unmodified code; the remote Windows failure is the observed regression evidence.
