### PR TITLE
fix(web): unify workspace row icon; highlight active session instead

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -1041,11 +1041,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         >
           <span className="bitfun-nav-panel__workspace-item-icon" aria-hidden="true">
             <span className="bitfun-nav-panel__workspace-item-icon-default">
-              {isActive ? (
-                <span className="bitfun-nav-panel__workspace-item-active-icon">
-                  <DotMatrixArrowRightIcon size={14} />
-                </span>
-              ) : workspaceIsRemote ? (
+              {workspaceIsRemote ? (
                 <Server size={14} />
               ) : (
                 <FolderOpen size={14} />

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -319,13 +319,6 @@
     padding-right: 52px;
   }
 
-  &__workspace-item-active-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: inherit;
-  }
-
   &__assistant-item-active-icon {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary

The active workspace row used an arrow icon while sibling rows used a folder, which made sibling workspaces read as nested rather than parallel.

- Render the folder icon for every workspace row
- Rely on the existing active-session highlight for the current-workspace signal
- Remove the now-unused active-icon style block

Fixes #1849