### PR TITLE
refactor(build): enforce Rust dependency and test boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,9 +202,11 @@ await api.invoke('your_command', { request: { ... } });
 ### Product architecture guardrails
 
 For any `bitfun-core` decomposition, feature-boundary, dependency-boundary, or
-Rust build-speed refactor, read
+Rust build-speed refactor, read both
 [`docs/architecture/product-architecture.md`](docs/architecture/product-architecture.md)
-before editing. Keep this file as an entry point; put module-specific ownership
+and
+[`docs/architecture/rust-build-dependency-boundaries.md`](docs/architecture/rust-build-dependency-boundaries.md)
+before editing. Keep these files as entry points; put module-specific ownership
 details in the nearest module `AGENTS.md`.
 
 Repository-level decomposition rules:
@@ -291,6 +293,7 @@ change directly affects build, packaging, or CI cannot protect the path.
 | Web UI i18n runtime, namespace loading, or direct `i18nService.t(...)` usage | `pnpm run i18n:contract:test && pnpm run type-check:web && pnpm --dir src/web-ui run test:run src/infrastructure/i18n/core/I18nService.test.ts` |
 | Mobile web UI, state, pairing, disconnect, or reconnect behavior | `pnpm --dir src/mobile-web run type-check`; include manual pairing / reconnect notes when behavior changes |
 | Product definition, schema, resolver, or Desktop/CLI product build adapter | `pnpm run product:test`, plus `pnpm run product:check` for the default definition |
+| Cargo manifests, features, test targets, or crate dependency boundaries | `pnpm run check:core-boundaries:test && pnpm run check:core-boundaries`; add the smallest affected `cargo check -p <owner> --no-default-features --features <feature>` or focused target test when the compiled path changes |
 | Shared Rust logic in `core`, `transport`, adapters, or services | `cargo check --workspace`, plus the nearest focused `cargo test` when behavior changed |
 | Desktop integration, Tauri APIs, browser/computer-use, or desktop-only behavior | `cargo check -p bitfun-desktop`, plus focused desktop tests when behavior changed |
 | Behavior covered by desktop smoke/functional flows | Prefer the nearest focused E2E/smoke check; rely on CI for broad build/test coverage unless build behavior changed |

--- a/docs/architecture/product-architecture.md
+++ b/docs/architecture/product-architecture.md
@@ -21,6 +21,9 @@ Headless CLI 与各产品入口的统一心智见
 状态共享、隔离、容量与 Plugin Host 关系见
 [`agent-runtime-deployment-design.md`](agent-runtime-deployment-design.md)。详细设计与本文件冲突时，以本文件为准。
 
+Cargo feature、第三方依赖 owner、测试目标和本地/CI 验证分工见
+[`rust-build-dependency-boundaries.md`](rust-build-dependency-boundaries.md)。该文档补充本架构的构建视图，不改变本文定义的运行时 owner 和分层依赖方向。
+
 本文件只约束稳定边界，不记录单次 PR 进度，也不把未来可能支持的生态能力提前声明为公开接口。
 
 ## 1. 架构目标

--- a/docs/architecture/rust-build-dependency-boundaries.md
+++ b/docs/architecture/rust-build-dependency-boundaries.md
@@ -1,0 +1,162 @@
+# Rust 构建与依赖边界
+
+本文定义 BitFun Rust workspace 的 Cargo feature、第三方依赖、测试目标和验证职责边界。它是
+[`product-architecture.md`](product-architecture.md) 的构建视图补充；运行时 owner、端口和产品分层仍以产品架构及最近的模块 `AGENTS.md` 为准。
+
+本文只记录长期规则，不记录当前 package 数量、重复版本数量或单次构建耗时。阶段性审计和迁移顺序保留在本地工作记录或对应 issue/PR，避免把过程文档和会变化的基线提交为可不断调高的门槛。
+
+## 1. 适用范围
+
+以下改动必须同时遵守本文：
+
+- workspace 或 crate `Cargo.toml` 的 dependency、feature、target 和 profile 变更；
+- `bitfun-core`、Assembly 或产品入口的 capability 装配；
+- 为降低构建/测试时间而做的 crate 拆分、owner 迁移或第三方库替换；
+- build script、proc-macro、TLS/crypto、系统库和其他重型原生依赖的引入或扩展；
+- integration test、example、binary 的 feature/target gate；
+- 本地验证命令和 CI 验证职责的调整。
+
+单纯减少依赖数量不是架构目标。依赖必须由实际能力和 owner 决定；构建收益不能作为向上依赖、重复实现或错误共享生命周期的理由。
+
+## 2. 四类决策必须分离
+
+| 概念 | 决策时机 | Owner | 表达内容 |
+|---|---|---|---|
+| Cargo feature | 编译期 | capability owner crate | 哪些代码和依赖进入编译图 |
+| Delivery Profile | 产品装配/构建期 | app 与 Assembly | 一个产品入口选择的 capability 集合 |
+| Runtime Config | 运行期 | domain/service owner | 已编译能力范围内的用户或组织配置 |
+| Capability Availability | 运行期事实 | owner port/provider | 能力是否已编译、注册且当前可用 |
+
+Delivery Profile 是架构概念，不是新的通用 manifest、schema 或运行时对象。当前产品入口可直接通过对 owner crate 的显式 feature 选择表达它；只有存在真实的多个构建消费者且静态声明不足时，才引入更高层装配对象。
+
+Runtime Config 不能让未编译能力凭空可用，也不能代替 target/feature gate。Capability Availability 必须反映真实 provider 状态，不能只根据配置值或静态 catalog 推断。
+
+## 3. Cargo feature 与依赖声明规则
+
+### 3.1 Feature 保持加法语义
+
+- 打开一个 feature 可以增加 API、实现或依赖，不应移除已有 API 或改变已启用能力的含义；
+- 不使用互斥 feature 表达产品枚举。互斥实现优先由 target、独立产品入口或 owner provider 选择；
+- `default` 只承载明确的兼容默认值，不是新产品入口的 capability 选择方式；
+- 可选依赖由声明它的 crate feature 激活，消费者不得越层拼装 owner 的内部依赖；
+- 一个 feature 应对应稳定能力边界，而不是临时 PR、UI 页面或单个调用点。
+
+Cargo 会统一同一 package 在依赖图中的 feature；workspace dependency 与成员声明的 feature 也会相加。因此共同声明必须保持最小，产品入口无法撤销下层已经开启的重 feature。具体解析语义见 Cargo 的
+[`Features`](https://doc.rust-lang.org/cargo/reference/features.html) 和
+[`workspace.dependencies`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) 文档。
+
+### 3.2 产品入口显式选择 Core 能力
+
+`src/apps/*`、`src/crates/interfaces/*` 和 installer app 直接依赖 `bitfun-core` 时必须同时：
+
+1. 设置 `default-features = false`；
+2. 声明非空 `features` 列表。
+
+入口应选择真实需要的 owner feature；`product-full` 只能描述确实需要完整产品装配的兼容入口，不能作为尚未完成 feature/owner 分解时的占位解法。缩小某个产品的 capability 集合时必须从实际 construction/command path 反推，并保留行为等价或明确 unsupported-state 测试。
+
+### 3.3 Workspace dependency 只提供共同底座
+
+- workspace 声明负责版本和真正跨产品共享的最小 feature；
+- runtime、HTTP、TLS、crypto、codec 等产品特定 feature 留给实际 app/service/adapter owner；
+- `full` feature 只有在所有真实消费者都需要且更窄集合不能稳定维护时才允许；
+- target-specific dependency 放在最接近平台实现的 owner，不因单一平台需求污染跨平台 crate；
+- 修改共享 dependency feature 视为构建影响变更，必须检查真实产品组合的 feature graph。
+
+## 4. 依赖 owner 与准入检查
+
+第三方库应位于调用外部系统或实现具体能力的最低合理 owner：
+
+- 协议/外部数据形状翻译属于 adapter；
+- OS、进程、文件系统、网络、Git、MCP 等具体实现属于 service；
+- 可移植的 agent/tool/harness 原语属于 execution；
+- DTO、事件和端口属于 contracts，保持行为轻量且不得依赖上层；
+- Assembly 选择和连接 capability，不实现具体 adapter、OS 或 service 细节；
+- app 只拥有入口、平台生命周期和产品呈现，不复制可复用服务逻辑。
+
+新增依赖或显著扩大已有依赖 feature 时，PR 描述至少给出：
+
+| 字段 | 评审问题 |
+|---|---|
+| Owner | 哪个 crate/模块拥有该外部能力？ |
+| Product consumers | 哪些产品形态实际需要？ |
+| Activation | 始终启用、target 还是 Cargo feature，为什么？ |
+| Build cost | 是否包含 proc-macro、`build.rs`、C/C++/系统库、TLS/crypto？ |
+| Version convergence | 是否新增重复版本，直接依赖升级能否安全收敛间接版本？ |
+| Existing alternatives | 标准库或现有三方库为什么不能合理承载？ |
+| Boundary fit | 为什么该依赖属于当前层和 owner？ |
+| Smallest verification | 哪个最小 check/test 能证明能力和边界？ |
+
+该记录保留在 PR 中，不新增全仓机器可读依赖台账。只有低误报、可长期稳定执行的结构事实进入 boundary checker。
+
+### 4.1 重复版本与间接依赖
+
+- 先用 `cargo tree -d` 确认重复的是可收敛版本、平台分支还是生态尚未统一的 major；
+- 优先调整直接依赖的兼容版本，让 Cargo 自然收敛间接版本；
+- 不用 `[patch]`、强制 lockfile pin 或降低版本来掩盖真实不兼容；
+- proc-macro、TLS/crypto、HTTP types、Windows/system bindings 的重复版本需额外关注，但仍以 API/ABI 和 owner 兼容为前提；
+- 版本收敛必须运行 owner 的行为测试；仅看到依赖树节点减少不足以证明安全。
+
+### 4.2 替换不活跃或重叠库
+
+替换前同时评估维护活跃度、安全公告、MSRV、目标平台、许可证、API 迁移成本、feature 粒度、原生构建成本和现有 adapter 行为。缺少近期 release 本身不是替换理由；稳定且边界清晰的库可以低频发布。
+
+只有同一 owner 内职责重叠、统一后不会扩大依赖闭包且能保持行为时，才合并到一个库。API 看似相似的 HTTP client、协议 adapter、认证、runtime 或 crypto 实现不能跨 owner 强行统一。
+
+## 5. 拆分、合并与 owner 迁移准则
+
+拆 crate 或迁移 runtime owner 至少要满足一项：
+
+1. 稳定能力可脱离产品装配独立编译和测试；
+2. 现 owner 混合协调策略与具体 adapter/service 实现，形成向上依赖或明显大闭包；
+3. 多个产品需要同一稳定 port/fact，但不应共享 UI、协议、认证、生命周期或平台实现；
+4. 重型依赖只服务少数能力，拆分后不使用它的产品和测试能退出该构建图；
+5. 能用行为等价测试覆盖旧路径，并给兼容入口定义删除条件。
+
+仅为减少文件行数、追求“一 crate 一 feature”、只有单一消费者且没有闭包收益，或必须先建立通用注册框架才能成立时，不拆 crate。可以先在原 crate 内按 owner 拆模块；只有物理 crate 边界带来真实依赖或独立验证收益时再升级。
+
+DTO/contract 抽取不等于 runtime owner 迁移。迁移 owner 必须先审查 port/provider、旧路径兼容、状态与错误语义、远程 workspace 行为和行为等价测试。
+
+## 6. Test target 与 feature 组合
+
+- feature-gated `[[test]]`、`[[bin]]`、`[[example]]` 使用 Cargo `required-features`，避免目标在能力不可用时仍进入构建图；
+- integration test 的 crate-level feature cfg 与 Cargo `required-features` 必须精确陈述同一组正向 AND 条件，不能额外加入扩大最小测试闭包的 umbrella feature；`not(feature)` 留在 Rust cfg 中，feature OR 条件应拆成独立 target，因为 Cargo target gate 无法等价表达；
+- integration test 只依赖被测 owner 的公开契约，不通过 `product-full` 获取测试便利；窄 feature 尚不能独立编译时，应将其记录为待拆分的 owner/feature 边界并保持现有 target 声明，不得新增或扩大 `product-full` 来制造已经收敛的假象；
+- 纯解析、策略和状态转换优先使用无外部系统的 owner-local fixture；
+- 需要真实 adapter/service 的测试单独作为 feature integration target；
+- 测试常用、真实的 feature 组合，不穷举指数级组合；
+- `--all-features` 用于兼容审计，不代替目标产品的最小组合测试。
+
+Cargo target gate 语义见
+[`required-features`](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-required-features-field)。
+
+## 7. 本地最小验证与 CI 分工
+
+本地验证由改动 owner 和影响面决定：
+
+| 改动 | 默认最小本地验证 |
+|---|---|
+| Cargo manifest、feature、crate dependency 边界 | `pnpm run check:core-boundaries:test` 和 `pnpm run check:core-boundaries` |
+| 单 crate Rust 实现 | `cargo check -p <owner>`；行为变化再加最近的 `cargo test -p <owner> <filter>` |
+| 单 capability feature | `cargo check -p <owner> --no-default-features --features <feature>` |
+| 单 integration target | `cargo test -p <owner> --test <target>` |
+| workspace dependency、低层公开 contract、build script | 按真实影响升级到 workspace check 和相关产品构建 |
+
+CI 负责 workspace 级检查、真实产品 feature 组合、跨平台、完整测试和最终产品构建。本地未执行的宽泛验证必须标记为未执行或 CI 覆盖，不能表述为本地通过。CI 失败时再按失败路径复现对应重命令，不要求每次本地改动预跑全部构建。
+
+## 8. 评审证据
+
+依赖治理 PR 按改动选择证据，不机械执行全部命令：
+
+```text
+cargo tree -d
+cargo tree -e features -p <product-or-owner>
+cargo tree -e normal,build -p <product-or-owner>
+cargo check -p <owner> --no-default-features --features <feature>
+cargo test -p <owner> --test <target>
+cargo check -p <product> --timings
+```
+
+前后对比优先列出真实产品 dependency closure、关键重依赖是否退出、冷/增量耗时环境与命令、最小 feature/test 是否可独立运行。测量结果是决策证据，不是永久硬阈值；如果收益不足以证明 owner 迁移或新抽象合理，应保留现有结构。
+
+当前硬边界由 `scripts/check-core-boundaries.mjs` 统一执行。不要为同一 Cargo 架构事实增加第二个 checker；新增规则先证明当前树满足、fixture 能捕获回归，并保持错误消息可直接定位到 owner manifest。
+检查器必须保持工作树只读；读取独立 manifest 的声明事实时不得生成新的 lockfile、target artifact 或格式化改动。

--- a/scripts/check-core-boundaries.test.mjs
+++ b/scripts/check-core-boundaries.test.mjs
@@ -8,6 +8,8 @@ import {
   collectCargoMetadataGraph,
   collectCargoMetadataPackages,
   findCargoLayerViolations,
+  findFeatureGatedTestTargetViolations,
+  findProductEntrypointCoreFeatureViolations,
 } from './core-boundaries/cargo-dependency-boundaries.mjs';
 import { crateLayoutRules } from './core-boundaries/rules/crate-layout.mjs';
 
@@ -44,8 +46,211 @@ function pathDependency(repoCratePath, options = {}) {
     kind: options.kind ?? null,
     optional: options.optional ?? false,
     target: options.target ?? null,
+    uses_default_features: options.usesDefaultFeatures ?? true,
+    features: options.features ?? [],
   };
 }
+
+function integrationTarget(name, sourcePath, requiredFeatures = []) {
+  return {
+    kind: ['test'],
+    name,
+    src_path: sourcePath,
+    'required-features': requiredFeatures,
+  };
+}
+
+test('feature-gated integration targets require every positive crate feature', () => {
+  const sourcePath = join(TEST_ROOT, 'tests', 'remote.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [integrationTarget('remote', sourcePath, ['remote-ssh'])],
+  };
+  const sources = new Map([[
+    sourcePath,
+    '#![cfg(all(feature = "remote-ssh", feature = "workspace-search", not(feature = "remote-ssh-concrete")))]\n',
+  ]]);
+
+  const violations = findFeatureGatedTestTargetViolations([pkg], {
+    readSource: (path) => sources.get(path),
+  });
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /workspace-search/);
+  assert.doesNotMatch(violations[0].message, /remote-ssh-concrete.*missing/);
+});
+
+test('matching integration target requirements cover all positive crate features', () => {
+  const sourcePath = join(TEST_ROOT, 'tests', 'remote.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [integrationTarget(
+      'remote',
+      sourcePath,
+      ['remote-ssh', 'workspace-search'],
+    )],
+  };
+
+  assert.deepEqual(
+    findFeatureGatedTestTargetViolations([pkg], {
+      readSource: () => '#![cfg(all(feature = "remote-ssh", feature = "workspace-search", not(feature = "remote-ssh-concrete")))]\n',
+    }),
+    [],
+  );
+});
+
+test('feature-gated integration targets reject extra umbrella requirements', () => {
+  const sourcePath = join(TEST_ROOT, 'tests', 'focused.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [integrationTarget('focused', sourcePath, ['focused', 'product-full'])],
+  };
+
+  const violations = findFeatureGatedTestTargetViolations([pkg], {
+    readSource: () => '#![cfg(feature = "focused")]\n',
+  });
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /unexpected required-features: product-full/);
+});
+
+test('target guard ignores module cfg and non-integration targets', () => {
+  const moduleSourcePath = join(TEST_ROOT, 'tests', 'module.rs');
+  const binarySourcePath = join(TEST_ROOT, 'src', 'main.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [
+      integrationTarget('module', moduleSourcePath),
+      {
+        ...integrationTarget('binary', binarySourcePath),
+        kind: ['bin'],
+      },
+    ],
+  };
+  const sources = new Map([
+    [moduleSourcePath, '#[cfg(feature = "serde")]\nmod serde_tests {}\n'],
+    [binarySourcePath, '#![cfg(feature = "cli")]\nfn main() {}\n'],
+  ]);
+
+  assert.deepEqual(
+    findFeatureGatedTestTargetViolations([pkg], {
+      readSource: (path) => sources.get(path),
+    }),
+    [],
+  );
+});
+
+test('target guard ignores crate cfg examples in comments and strings', () => {
+  const sourcePath = join(TEST_ROOT, 'tests', 'documented.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [integrationTarget('documented', sourcePath)],
+  };
+
+  assert.deepEqual(
+    findFeatureGatedTestTargetViolations([pkg], {
+      readSource: () => [
+        '// Example: #![cfg(feature = "commented")]',
+        'const EXAMPLE: &str = r#"',
+        '#![cfg(feature = "string-literal")]',
+        '"#;',
+      ].join('\n'),
+    }),
+    [],
+  );
+});
+
+test('target guard rejects feature OR gates that Cargo cannot express', () => {
+  const sourcePath = join(TEST_ROOT, 'tests', 'provider.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [integrationTarget('provider', sourcePath, ['provider-a'])],
+  };
+
+  const violations = findFeatureGatedTestTargetViolations([pkg], {
+    readSource: () => '#![cfg(any(feature = "provider-a", feature = "provider-b"))]\n',
+  });
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /cannot express.*split the target/);
+});
+
+test('multiple crate feature gates combine as required feature AND conditions', () => {
+  const sourcePath = join(TEST_ROOT, 'tests', 'combined.rs');
+  const pkg = {
+    ...packageAt('example', 'src/crates/services/example/Cargo.toml'),
+    targets: [integrationTarget('combined', sourcePath, ['first'])],
+  };
+
+  const violations = findFeatureGatedTestTargetViolations([pkg], {
+    readSource: () => '#![cfg(feature = "first")]\n#![cfg(feature = "second")]\n',
+  });
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /second/);
+});
+
+test('product entrypoints must disable bitfun-core default features', () => {
+  const core = packageAt('bitfun-core', 'src/crates/assembly/core/Cargo.toml');
+  const app = packageAt('entry', 'src/apps/example/Cargo.toml', [
+    pathDependency('src/crates/assembly/core', {
+      name: 'bitfun-core',
+      features: ['plugin-source'],
+    }),
+  ]);
+
+  const violations = findProductEntrypointCoreFeatureViolations(
+    [app, core],
+    { root: TEST_ROOT, crateLayoutRules },
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /default-features = false/);
+});
+
+test('product entrypoints must select explicit bitfun-core features', () => {
+  const core = packageAt('bitfun-core', 'src/crates/assembly/core/Cargo.toml');
+  const interfacePackage = packageAt(
+    'interface',
+    'src/crates/interfaces/acp/Cargo.toml',
+    [pathDependency('src/crates/assembly/core', {
+      name: 'bitfun-core',
+      usesDefaultFeatures: false,
+    })],
+  );
+
+  const violations = findProductEntrypointCoreFeatureViolations(
+    [interfacePackage, core],
+    { root: TEST_ROOT, crateLayoutRules },
+  );
+
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /at least one explicit feature/);
+});
+
+test('explicit product entrypoint bitfun-core feature selections pass', () => {
+  const core = packageAt('bitfun-core', 'src/crates/assembly/core/Cargo.toml');
+  const consumers = [
+    packageAt('app', 'src/apps/example/Cargo.toml'),
+    packageAt('interface', 'src/crates/interfaces/acp/Cargo.toml'),
+    packageAt('installer', 'BitFun-Installer/src-tauri/Cargo.toml'),
+  ].map((pkg) => ({
+    ...pkg,
+    dependencies: [pathDependency('src/crates/assembly/core', {
+      name: 'bitfun-core',
+      usesDefaultFeatures: false,
+      features: ['plugin-source'],
+    })],
+  }));
+
+  assert.deepEqual(
+    findProductEntrypointCoreFeatureViolations(
+      [...consumers, core, packageAt('no-core', 'src/apps/no-core/Cargo.toml')],
+      { root: TEST_ROOT, crateLayoutRules },
+    ),
+    [],
+  );
+});
 
 test('cargo layer checker rejects reverse edges across dependency kinds', () => {
   const packages = [
@@ -198,8 +403,8 @@ test('cargo metadata collection scans standalone manifests not covered by the wo
   const packages = collectCargoMetadataPackages({
     root: TEST_ROOT,
     manifestPaths: [workspaceManifest, memberManifest, installerManifest],
-    loadMetadata(manifestPath) {
-      calls.push(manifestPath);
+    loadMetadata(manifestPath, options) {
+      calls.push([manifestPath, options]);
       if (manifestPath === workspaceManifest) {
         const entry = packageAt('entry', 'src/apps/example/Cargo.toml');
         return { packages: [entry], workspace_members: [entry.id] };
@@ -211,7 +416,10 @@ test('cargo metadata collection scans standalone manifests not covered by the wo
     },
   });
 
-  assert.deepEqual(calls, [workspaceManifest, installerManifest]);
+  assert.deepEqual(calls, [
+    [workspaceManifest, { noDeps: false }],
+    [installerManifest, { noDeps: true }],
+  ]);
   assert.deepEqual(packages.map((pkg) => pkg.name), ['entry', 'installer']);
 });
 
@@ -230,8 +438,8 @@ test('cargo metadata collection rescans standalone packages discovered by the wo
   const graph = collectCargoMetadataGraph({
     root: TEST_ROOT,
     manifestPaths: [workspaceManifest, serviceManifest],
-    loadMetadata(manifestPath) {
-      calls.push(manifestPath);
+    loadMetadata(manifestPath, options) {
+      calls.push([manifestPath, options]);
       if (manifestPath === workspaceManifest) {
         return {
           packages: [assembly, service, entry],
@@ -271,7 +479,10 @@ test('cargo metadata collection rescans standalone packages discovered by the wo
     graph.resolvedDependencies,
   );
 
-  assert.deepEqual(calls, [workspaceManifest, serviceManifest]);
+  assert.deepEqual(calls, [
+    [workspaceManifest, { noDeps: false }],
+    [serviceManifest, { noDeps: true }],
+  ]);
   assert.equal(violations.length, 1);
   assert.match(violations[0].message, /service.*services.*->.*example.*apps.*normal optional dependency/);
 });
@@ -343,6 +554,53 @@ test('core boundary check is split into focused modules', async () => {
     sourceRuleEntry.split(/\r?\n/).length <= 40,
     'source rule entrypoint should delegate to focused source-rule modules',
   );
+});
+
+test('core checker runs the unified cargo dependency boundary check', async () => {
+  const checker = await readFile(
+    new URL('./core-boundaries/checker.mjs', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(checker, /checkCargoDependencyBoundariesSafely/);
+  assert.doesNotMatch(checker, /checkCargoDependencyLayersSafely/);
+});
+
+test('product entrypoint feature policy does not pin product-full per manifest', async () => {
+  const [checker, featureRules] = await Promise.all([
+    readFile(new URL('./core-boundaries/checker.mjs', import.meta.url), 'utf8'),
+    readFile(
+      new URL('./core-boundaries/rules/feature-rules.mjs', import.meta.url),
+      'utf8',
+    ),
+  ]);
+
+  assert.doesNotMatch(checker, /checkProductCoreFeatureAssembly/);
+  assert.doesNotMatch(featureRules, /productCoreFeatureAssemblyRules/);
+});
+
+test('Rust build dependency boundary policy stays discoverable', async () => {
+  const policyUrl = new URL(
+    '../docs/architecture/rust-build-dependency-boundaries.md',
+    import.meta.url,
+  );
+  await assert.doesNotReject(
+    () => access(policyUrl),
+    'the Rust build dependency boundary policy must exist',
+  );
+  const [agents, productArchitecture, policy] = await Promise.all([
+    readFile(new URL('../AGENTS.md', import.meta.url), 'utf8'),
+    readFile(new URL('../docs/architecture/product-architecture.md', import.meta.url), 'utf8'),
+    readFile(policyUrl, 'utf8'),
+  ]);
+
+  assert.match(agents, /docs\/architecture\/rust-build-dependency-boundaries\.md/);
+  assert.match(productArchitecture, /rust-build-dependency-boundaries\.md/);
+  assert.match(policy, /Cargo feature/);
+  assert.match(policy, /Delivery Profile/);
+  assert.match(policy, /Runtime Config/);
+  assert.match(policy, /Capability Availability/);
+  assert.match(policy, /pnpm run check:core-boundaries:test/);
 });
 
 test('transport contract stays limited to current delivery needs', async () => {

--- a/scripts/core-boundaries/cargo-dependency-boundaries.mjs
+++ b/scripts/core-boundaries/cargo-dependency-boundaries.mjs
@@ -1,4 +1,4 @@
-import { readdirSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
@@ -155,6 +155,246 @@ export function findCargoLayerViolations(
   return violations;
 }
 
+export function findProductEntrypointCoreFeatureViolations(
+  packages,
+  { root, crateLayoutRules },
+) {
+  const packageByManifest = new Map(
+    packages.map((pkg) => [normalizedPath(pkg.manifest_path), pkg]),
+  );
+  const violations = [];
+
+  for (const sourcePackage of packages) {
+    const sourceLayer = layerForManifest(sourcePackage.manifest_path, {
+      root,
+      crateLayoutRules,
+    });
+    if (sourceLayer !== 'apps' && sourceLayer !== 'interfaces') {
+      continue;
+    }
+
+    for (const dependency of sourcePackage.dependencies ?? []) {
+      if (!dependency.path || repositoryPath(root, dependency.path) === null) {
+        continue;
+      }
+      const targetPackage = packageByManifest.get(
+        normalizedPath(join(dependency.path, 'Cargo.toml')),
+      );
+      if (targetPackage?.name !== 'bitfun-core') {
+        continue;
+      }
+      if (dependency.uses_default_features !== false) {
+        violations.push({
+          path: sourcePackage.manifest_path,
+          line: 1,
+          message: `product entrypoint ${sourcePackage.name} must set default-features = false for its bitfun-core ${dependencyDescription(dependency)}`,
+        });
+      }
+      if (!Array.isArray(dependency.features) || dependency.features.length === 0) {
+        violations.push({
+          path: sourcePackage.manifest_path,
+          line: 1,
+          message: `product entrypoint ${sourcePackage.name} must select at least one explicit feature for its bitfun-core ${dependencyDescription(dependency)}`,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+function matchingClosingDelimiter(
+  source,
+  openingIndex,
+  openingCharacter,
+  closingCharacter,
+) {
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (let index = openingIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === openingCharacter) {
+      depth += 1;
+    } else if (character === closingCharacter) {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function matchingClosingParenthesis(source, openingIndex) {
+  return matchingClosingDelimiter(source, openingIndex, '(', ')');
+}
+
+function crateCfgBodies(source) {
+  const bodies = [];
+  let index = source.charCodeAt(0) === 0xFEFF ? 1 : 0;
+
+  while (index < source.length) {
+    if (/\s/.test(source[index])) {
+      index += 1;
+      continue;
+    }
+    if (source.startsWith('//', index)) {
+      const lineEnd = source.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? source.length : lineEnd + 1;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      let depth = 1;
+      index += 2;
+      while (index < source.length && depth > 0) {
+        if (source.startsWith('/*', index)) {
+          depth += 1;
+          index += 2;
+        } else if (source.startsWith('*/', index)) {
+          depth -= 1;
+          index += 2;
+        } else {
+          index += 1;
+        }
+      }
+      continue;
+    }
+    if (!source.startsWith('#![', index)) {
+      break;
+    }
+
+    const closingBracket = matchingClosingDelimiter(source, index + 2, '[', ']');
+    if (closingBracket === -1) {
+      break;
+    }
+    const attribute = source.slice(index, closingBracket + 1);
+    const cfgStart = /^#!\s*\[\s*cfg\s*\(/.exec(attribute);
+    if (cfgStart !== null) {
+      const openingIndex = cfgStart[0].length - 1;
+      const closingIndex = matchingClosingParenthesis(attribute, openingIndex);
+      if (closingIndex !== -1) {
+        bodies.push(attribute.slice(openingIndex + 1, closingIndex));
+      }
+    }
+    index = closingBracket + 1;
+  }
+
+  return bodies;
+}
+
+function removeCfgBranches(expression, branchName) {
+  const branchStart = new RegExp(`\\b${branchName}\\s*\\(`, 'g');
+  let result = expression;
+  for (let match = branchStart.exec(result); match !== null; match = branchStart.exec(result)) {
+    const openingIndex = branchStart.lastIndex - 1;
+    const closingIndex = matchingClosingParenthesis(result, openingIndex);
+    if (closingIndex === -1) {
+      break;
+    }
+    result = `${result.slice(0, match.index)}${' '.repeat(closingIndex + 1 - match.index)}${result.slice(closingIndex + 1)}`;
+    branchStart.lastIndex = match.index;
+  }
+  return result;
+}
+
+function containsFeatureAny(expression) {
+  const anyStart = /\bany\s*\(/g;
+  for (let match = anyStart.exec(expression); match !== null; match = anyStart.exec(expression)) {
+    const openingIndex = anyStart.lastIndex - 1;
+    const closingIndex = matchingClosingParenthesis(expression, openingIndex);
+    if (closingIndex === -1) {
+      return false;
+    }
+    const body = expression.slice(openingIndex + 1, closingIndex);
+    if (/\bfeature\s*=\s*"[^"]+"/.test(body)) {
+      return true;
+    }
+    anyStart.lastIndex = closingIndex + 1;
+  }
+  return false;
+}
+
+function crateFeatureCfgFacts(source) {
+  const positiveFeatures = new Set();
+  let unsupportedAny = false;
+
+  for (const body of crateCfgBodies(source)) {
+    const positiveExpression = removeCfgBranches(body, 'not');
+    unsupportedAny ||= containsFeatureAny(positiveExpression);
+    for (const match of positiveExpression.matchAll(/\bfeature\s*=\s*"([^"]+)"/g)) {
+      positiveFeatures.add(match[1]);
+    }
+  }
+
+  return { positiveFeatures, unsupportedAny };
+}
+
+export function findFeatureGatedTestTargetViolations(
+  packages,
+  { readSource = (path) => readFileSync(path, 'utf8') } = {},
+) {
+  const violations = [];
+
+  for (const pkg of packages) {
+    for (const target of pkg.targets ?? []) {
+      if (!(target.kind ?? []).includes('test')) {
+        continue;
+      }
+      const cfgFacts = crateFeatureCfgFacts(readSource(target.src_path));
+      if (cfgFacts.unsupportedAny) {
+        violations.push({
+          path: target.src_path,
+          line: 1,
+          message: `integration test target ${pkg.name}:${target.name} uses feature any(...), which Cargo required-features cannot express; split the target`,
+        });
+        continue;
+      }
+      const declared = new Set(target['required-features'] ?? []);
+      const missing = [...cfgFacts.positiveFeatures]
+        .filter((feature) => !declared.has(feature));
+      const unexpected = cfgFacts.positiveFeatures.size === 0
+        ? []
+        : [...declared].filter((feature) => !cfgFacts.positiveFeatures.has(feature));
+      if (missing.length > 0 && unexpected.length > 0) {
+        violations.push({
+          path: target.src_path,
+          line: 1,
+          message: `feature-gated integration test target ${pkg.name}:${target.name} must align required-features with crate-level cfg; missing: ${missing.join(', ')}; unexpected: ${unexpected.join(', ')}`,
+        });
+      } else if (missing.length > 0) {
+        violations.push({
+          path: target.src_path,
+          line: 1,
+          message: `feature-gated integration test target ${pkg.name}:${target.name} must declare required-features for: ${missing.join(', ')}`,
+        });
+      } else if (unexpected.length > 0) {
+        violations.push({
+          path: target.src_path,
+          line: 1,
+          message: `feature-gated integration test target ${pkg.name}:${target.name} has unexpected required-features: ${unexpected.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
 export function discoverCargoManifestPaths(root) {
   const manifests = [];
 
@@ -185,10 +425,15 @@ export function discoverCargoManifestPaths(root) {
   });
 }
 
-function loadCargoMetadata(manifestPath, root) {
+function loadCargoMetadata(manifestPath, root, { noDeps = false } = {}) {
+  const args = ['metadata', '--format-version', '1', '--all-features'];
+  if (noDeps) {
+    args.push('--no-deps');
+  }
+  args.push('--manifest-path', manifestPath);
   const result = spawnSync(
     'cargo',
-    ['metadata', '--format-version', '1', '--all-features', '--manifest-path', manifestPath],
+    args,
     {
       cwd: root,
       encoding: 'utf8',
@@ -252,7 +497,7 @@ function resolvedDependencyRecords(metadata, root) {
 export function collectCargoMetadataGraph({
   root,
   manifestPaths = discoverCargoManifestPaths(root),
-  loadMetadata = (manifestPath) => loadCargoMetadata(manifestPath, root),
+  loadMetadata = (manifestPath, options) => loadCargoMetadata(manifestPath, root, options),
 }) {
   const packagesByManifest = new Map();
   const dependenciesByKey = new Map();
@@ -274,7 +519,9 @@ export function collectCargoMetadataGraph({
       continue;
     }
 
-    const metadata = loadMetadata(manifestPath);
+    const metadata = loadMetadata(manifestPath, {
+      noDeps: manifestKey !== workspaceManifest,
+    });
     const workspaceMemberIds = new Set(metadata.workspace_members ?? []);
     for (const pkg of metadata.packages ?? []) {
       if (repositoryPath(root, pkg.manifest_path) === null) {
@@ -326,6 +573,34 @@ export function checkCargoDependencyLayersSafely({ root, crateLayoutRules }) {
       path: join(root, 'Cargo.toml'),
       line: 1,
       message: `cargo dependency layer check failed to run: ${error.message}`,
+    }];
+  }
+}
+
+export function checkCargoDependencyBoundaries({ root, crateLayoutRules }) {
+  const { packages, resolvedDependencies } = collectCargoMetadataGraph({ root });
+  return [
+    ...findCargoLayerViolations(
+      packages,
+      { root, crateLayoutRules },
+      resolvedDependencies,
+    ),
+    ...findProductEntrypointCoreFeatureViolations(
+      packages,
+      { root, crateLayoutRules },
+    ),
+    ...findFeatureGatedTestTargetViolations(packages),
+  ];
+}
+
+export function checkCargoDependencyBoundariesSafely({ root, crateLayoutRules }) {
+  try {
+    return checkCargoDependencyBoundaries({ root, crateLayoutRules });
+  } catch (error) {
+    return [{
+      path: join(root, 'Cargo.toml'),
+      line: 1,
+      message: `cargo dependency boundary check failed to run: ${error.message}`,
     }];
   }
 }

--- a/scripts/core-boundaries/checker.mjs
+++ b/scripts/core-boundaries/checker.mjs
@@ -18,8 +18,6 @@ import {
   coreProductFullFeatureAssemblyRule,
   optionalDependencyFeatureOwnerRules,
   ownerCrateFeatureAssemblyRules,
-  productCoreFeatureAssemblyRules,
-  productCoreFeatureAssemblyScanRoots,
 } from './rules/feature-rules.mjs';
 import {
   facadeOnlyFiles,
@@ -35,7 +33,7 @@ import {
   featureReferencesFeature,
   unexpectedDependencyOwnerFeatures,
 } from './manifest-feature-helpers.mjs';
-import { checkCargoDependencyLayersSafely } from './cargo-dependency-boundaries.mjs';
+import { checkCargoDependencyBoundariesSafely } from './cargo-dependency-boundaries.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..', '..');
@@ -197,48 +195,6 @@ function parseManifestDependencies(lines, options = {}) {
 
 function manifestDependencyText(dep) {
   return dep?.text?.join('\n') ?? '';
-}
-
-function manifestDependencyDisablesDefaultFeatures(dep) {
-  return /\bdefault-features\s*=\s*false\b/.test(manifestDependencyText(dep));
-}
-
-function parseManifestDependencyFeatureNames(dep) {
-  const features = new Set();
-  const text = manifestDependencyText(dep);
-  for (const match of text.matchAll(/\bfeatures\s*=\s*\[([\s\S]*?)\]/g)) {
-    for (const featureMatch of match[1].matchAll(/"([^"]+)"/g)) {
-      features.add(featureMatch[1]);
-    }
-  }
-  return features;
-}
-
-function collectProductCoreDependencyManifestPaths(manifestEntries) {
-  return manifestEntries
-    .filter((entry) => {
-      const deps = parseManifestDependencies(entry.text.split(/\r?\n/));
-      return deps.some((dep) => dep.name === 'bitfun-core');
-    })
-    .map((entry) => entry.manifestPath)
-    .sort();
-}
-
-function collectProductCoreDependencyManifests(scanRoots = productCoreFeatureAssemblyScanRoots) {
-  const manifestEntries = [];
-  for (const repoDir of scanRoots) {
-    const dir = join(ROOT, ...repoDir.split('/'));
-    walkFiles(dir, (path) => {
-      if (!path.endsWith('Cargo.toml')) {
-        return;
-      }
-      manifestEntries.push({
-        manifestPath: toRepoPath(path),
-        text: readText(path),
-      });
-    });
-  }
-  return collectProductCoreDependencyManifestPaths(manifestEntries);
 }
 
 function parseManifestFeatures(lines) {
@@ -597,53 +553,6 @@ function checkOptionalDependencyFeatureOwners(crateDir, rule) {
       line: dep.line,
       message: `${rule.reason}; optional runtime dependency must declare owner feature coverage: ${depName}`,
     });
-  }
-}
-
-function checkProductCoreFeatureAssembly(rule) {
-  const manifestPath = repoPathToFsPath(rule.manifestPath);
-  const deps = parseManifestDependencies(readText(manifestPath).split(/\r?\n/));
-  const dep = deps.find((candidate) => candidate.name === rule.dependencyName);
-  if (!dep) {
-    failures.push({
-      path: manifestPath,
-      line: 1,
-      message: `${rule.reason}; missing dependency: ${rule.dependencyName}`,
-    });
-    return;
-  }
-
-  if (!manifestDependencyDisablesDefaultFeatures(dep)) {
-    failures.push({
-      path: manifestPath,
-      line: dep.line,
-      message: `${rule.reason}; ${rule.dependencyName} must set default-features = false`,
-    });
-  }
-
-  const enabledFeatures = parseManifestDependencyFeatureNames(dep);
-  for (const featureName of rule.requiredFeatures) {
-    if (!enabledFeatures.has(featureName)) {
-      failures.push({
-        path: manifestPath,
-        line: dep.line,
-        message: `${rule.reason}; ${rule.dependencyName} must enable feature ${featureName}`,
-      });
-    }
-  }
-}
-
-function checkProductCoreFeatureAssemblyCoverage() {
-  const rulePaths = new Set(productCoreFeatureAssemblyRules.map((rule) => rule.manifestPath));
-  for (const manifestPath of collectProductCoreDependencyManifests()) {
-    if (!rulePaths.has(manifestPath)) {
-      failures.push({
-        path: join(ROOT, ...manifestPath.split('/')),
-        line: 1,
-        message:
-          'product entry crate depends on bitfun-core but is not covered by product-full assembly rules',
-      });
-    }
   }
 }
 
@@ -1095,11 +1004,7 @@ export function runCoreBoundaryCheck() {
       parseManifestDependencies,
       manifestDependencyMatches,
       matchingForbiddenDependency,
-      manifestDependencyDisablesDefaultFeatures,
-      parseManifestDependencyFeatureNames,
-      productCoreFeatureAssemblyRules,
       coreProductFullFeatureAssemblyRule,
-      collectProductCoreDependencyManifestPaths,
       ownerCrateFeatureAssemblyRules,
       parseManifestFeatures,
       optionalDependencyFeatureOwnerRules,
@@ -1126,7 +1031,7 @@ export function runCoreBoundaryCheck() {
   }
 
   checkCrateLayoutRules();
-  failures.push(...checkCargoDependencyLayersSafely({ root: ROOT, crateLayoutRules }));
+  failures.push(...checkCargoDependencyBoundariesSafely({ root: ROOT, crateLayoutRules }));
 
   for (const rule of forbiddenManifestDependencyRules) {
     checkForbiddenManifestDependencyRule(rule);
@@ -1157,10 +1062,6 @@ export function runCoreBoundaryCheck() {
     checkOptionalDependencyFeatureOwners(crateDir, rule);
   }
 
-  for (const rule of productCoreFeatureAssemblyRules) {
-    checkProductCoreFeatureAssembly(rule);
-  }
-  checkProductCoreFeatureAssemblyCoverage();
   checkCoreDefaultProductFullFeature();
   checkCoreProductFullFeatureAssembly(coreProductFullFeatureAssemblyRule);
   for (const rule of ownerCrateFeatureAssemblyRules) {

--- a/scripts/core-boundaries/rules/feature-rules.mjs
+++ b/scripts/core-boundaries/rules/feature-rules.mjs
@@ -138,44 +138,6 @@ export const optionalDependencyFeatureOwnerRules = [
   },
 ];
 
-export const productCoreFeatureAssemblyRules = [
-  {
-    manifestPath: 'src/apps/desktop/Cargo.toml',
-    dependencyName: 'bitfun-core',
-    requiredFeatures: ['product-full'],
-    reason: 'desktop must explicitly assemble the full bitfun-core product runtime',
-  },
-  {
-    manifestPath: 'src/apps/cli/Cargo.toml',
-    dependencyName: 'bitfun-core',
-    requiredFeatures: ['product-full'],
-    reason: 'CLI must explicitly assemble the full bitfun-core product runtime',
-  },
-  {
-    manifestPath: 'src/apps/sdk-host/Cargo.toml',
-    dependencyName: 'bitfun-core',
-    requiredFeatures: ['product-full'],
-    reason: 'SDK Host must explicitly assemble the full bitfun-core product runtime',
-  },
-  {
-    manifestPath: 'src/apps/server/Cargo.toml',
-    dependencyName: 'bitfun-core',
-    requiredFeatures: ['product-full'],
-    reason: 'Server must explicitly assemble the full bitfun-core product runtime',
-  },
-  {
-    manifestPath: 'src/crates/interfaces/acp/Cargo.toml',
-    dependencyName: 'bitfun-core',
-    requiredFeatures: ['product-full'],
-    reason: 'ACP must explicitly assemble the full bitfun-core product runtime',
-  },
-];
-
-export const productCoreFeatureAssemblyScanRoots = [
-  'src/apps',
-  'src/crates/interfaces/acp',
-];
-
 export const coreProductFullFeatureAssemblyRule = {
   manifestPath: 'src/crates/assembly/core/Cargo.toml',
   featureName: 'product-full',

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -6656,8 +6656,8 @@ export const requiredContentRules = [
         message: 'missing remote chat history assembly shape/order test',
       },
       {
-        regex: /\bremote_chat_history_assembly_skips_in_progress_assistant_history\b/,
-        message: 'missing remote chat history in-progress guard test',
+        regex: /\bremote_chat_history_assembly_preserves_in_progress_assistant_history\b/,
+        message: 'missing remote chat history in-progress preservation test',
       },
       {
         regex: /\bremote_connect_file_transfer_policy_preserves_limits_and_chunk_ranges\b/,

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -7,11 +7,7 @@ export function runManifestParserSelfTest({
   parseManifestDependencies,
   manifestDependencyMatches,
   matchingForbiddenDependency,
-  manifestDependencyDisablesDefaultFeatures,
-  parseManifestDependencyFeatureNames,
-  productCoreFeatureAssemblyRules,
   coreProductFullFeatureAssemblyRule,
-  collectProductCoreDependencyManifestPaths,
   ownerCrateFeatureAssemblyRules,
   parseManifestFeatures,
   optionalDependencyFeatureOwnerRules,
@@ -105,29 +101,6 @@ export function runManifestParserSelfTest({
   ) {
     throw new Error('dependency profile parser must detect single-quoted package aliases');
   }
-  const parsedCoreDep = parsedByName.get('bitfun-core');
-  if (!manifestDependencyDisablesDefaultFeatures(parsedCoreDep)) {
-    throw new Error('dependency profile parser must detect default-features = false');
-  }
-  if (!parseManifestDependencyFeatureNames(parsedCoreDep).has('product-full')) {
-    throw new Error('dependency profile parser must detect inline dependency features');
-  }
-  const parsedCoreTableDeps = parseManifestDependencies([
-    '[dependencies."bitfun-core"]',
-    'path = "../core"',
-    'default-features = false',
-    'features = [',
-    '  "product-full",',
-    '  "ssh-remote",',
-    ']',
-  ]);
-  const parsedCoreTableDep = parsedCoreTableDeps.find((dep) => dep.name === 'bitfun-core');
-  if (!manifestDependencyDisablesDefaultFeatures(parsedCoreTableDep)) {
-    throw new Error('dependency profile parser must detect table default-features = false');
-  }
-  if (!parseManifestDependencyFeatureNames(parsedCoreTableDep).has('ssh-remote')) {
-    throw new Error('dependency profile parser must detect table dependency features');
-  }
   if (parsedByName.has('image')) {
     throw new Error('dependency profile parser must ignore feature entries named like dependencies');
   }
@@ -170,24 +143,6 @@ export function runManifestParserSelfTest({
     throw new Error('forbidden dependency checks must reject Cargo package aliases');
   }
 
-  const productCoreRulePaths = new Set(
-    productCoreFeatureAssemblyRules.map((rule) => rule.manifestPath),
-  );
-  for (const manifestPath of [
-    'src/apps/desktop/Cargo.toml',
-    'src/apps/cli/Cargo.toml',
-    'src/apps/server/Cargo.toml',
-    'src/crates/interfaces/acp/Cargo.toml',
-  ]) {
-    if (!productCoreRulePaths.has(manifestPath)) {
-      throw new Error(`product core feature assembly rule must cover ${manifestPath}`);
-    }
-  }
-  for (const rule of productCoreFeatureAssemblyRules) {
-    if (!rule.requiredFeatures.includes('product-full')) {
-      throw new Error(`${rule.manifestPath} must require bitfun-core product-full`);
-    }
-  }
   for (const featureName of [
     'ssh-remote',
     'product-capabilities',
@@ -198,30 +153,6 @@ export function runManifestParserSelfTest({
     if (!coreProductFullFeatureAssemblyRule.requiredFeatureRefs.includes(featureName)) {
       throw new Error(`core product-full assembly rule must require ${featureName}`);
     }
-  }
-  const discoveredProductCoreManifests = collectProductCoreDependencyManifestPaths([
-    {
-      manifestPath: 'src/apps/desktop/Cargo.toml',
-      text:
-        '[dependencies]\nbitfun-core = { path = "../../crates/assembly/core", default-features = false, features = ["product-full"] }',
-    },
-    {
-      manifestPath: 'src/apps/server/Cargo.toml',
-      text:
-        '[dependencies]\nbitfun-core = { path = "../../crates/assembly/core", default-features = false, features = ["product-full"] }',
-    },
-    {
-      manifestPath: 'src/crates/interfaces/acp/Cargo.toml',
-      text: '[dependencies."bitfun-core"]\npath = "../../assembly/core"\ndefault-features = false\nfeatures = ["product-full"]',
-    },
-  ]);
-  if (
-    discoveredProductCoreManifests.join(',') !==
-    'src/apps/desktop/Cargo.toml,src/apps/server/Cargo.toml,src/crates/interfaces/acp/Cargo.toml'
-  ) {
-    throw new Error(
-      'product core dependency scanner must discover only manifests that depend on bitfun-core',
-    );
   }
   const ownerFeatureRulePaths = new Set(
     ownerCrateFeatureAssemblyRules.map((rule) => rule.manifestPath),
@@ -3313,7 +3244,7 @@ export function runManifestParserSelfTest({
         'remote_connect_cancel_and_restore_policy_preserve_runtime_decisions',
         'remote_connect_dialog_submit_outcome_builder_preserves_scheduler_shape',
         'remote_chat_history_assembly_preserves_message_shape_and_item_order',
-        'remote_chat_history_assembly_skips_in_progress_assistant_history',
+        'remote_chat_history_assembly_preserves_in_progress_assistant_history',
         'remote_connect_file_transfer_policy_preserves_limits_and_chunk_ranges',
         'remote_connect_file_transfer_policy_preserves_name_fallback',
         'remote_connect_tracker_keeps_finished_turn_snapshot_until_persistence_finalizes',

--- a/src/crates/contracts/product-domains/Cargo.toml
+++ b/src/crates/contracts/product-domains/Cargo.toml
@@ -34,6 +34,14 @@ name = "workspace_reference_contracts"
 path = "tests/workspace_reference_contracts.rs"
 required-features = ["external-sources"]
 
+[[test]]
+name = "function_agent_contracts"
+required-features = ["function-agents"]
+
+[[test]]
+name = "miniapp_contracts"
+required-features = ["miniapp"]
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/crates/execution/tool-call-jsonrepair/Cargo.toml
+++ b/src/crates/execution/tool-call-jsonrepair/Cargo.toml
@@ -19,5 +19,9 @@ serde_json = { workspace = true, optional = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 
+[[test]]
+name = "serde_tests"
+required-features = ["serde"]
+
 [lints]
 workspace = true

--- a/src/crates/services/services-core/Cargo.toml
+++ b/src/crates/services/services-core/Cargo.toml
@@ -78,6 +78,18 @@ name = "runtime_ownership_contracts"
 required-features = ["runtime-ownership"]
 
 [[test]]
+name = "local_runtime_ports"
+required-features = ["workspace-runtime"]
+
+[[test]]
+name = "permission_store_contracts"
+required-features = ["permission"]
+
+[[test]]
+name = "workspace_instruction_contracts"
+required-features = ["workspace-runtime"]
+
+[[test]]
 name = "session_write_lock_contracts"
 
 [lints]

--- a/src/crates/services/services-integrations/Cargo.toml
+++ b/src/crates/services/services-integrations/Cargo.toml
@@ -319,5 +319,45 @@ required-features = ["debug-log"]
 name = "script_tool_runtime"
 required-features = ["script-tool-runtime"]
 
+[[test]]
+name = "announcement_contracts"
+required-features = ["announcement"]
+
+[[test]]
+name = "file_watch_contracts"
+required-features = ["file-watch"]
+
+[[test]]
+name = "function_agent_contracts"
+required-features = ["function-agents"]
+
+[[test]]
+name = "git_contracts"
+required-features = ["git"]
+
+[[test]]
+name = "mcp_contracts"
+required-features = ["mcp"]
+
+[[test]]
+name = "remote_connect_contracts"
+required-features = ["remote-connect"]
+
+[[test]]
+name = "remote_ssh_contracts"
+required-features = ["remote-ssh"]
+
+[[test]]
+name = "remote_ssh_disabled_contracts"
+required-features = ["remote-ssh"]
+
+[[test]]
+name = "remote_workspace_search_disabled_contracts"
+required-features = ["remote-ssh", "workspace-search"]
+
+[[test]]
+name = "workspace_search_contracts"
+required-features = ["workspace-search"]
+
 [lints]
 workspace = true

--- a/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
+++ b/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
@@ -459,13 +459,16 @@ fn remote_chat_history_assembly_preserves_message_shape_and_item_order() {
 }
 
 #[test]
-fn remote_chat_history_assembly_skips_in_progress_assistant_history() {
+fn remote_chat_history_assembly_preserves_in_progress_assistant_history() {
     let turn = remote_history_contract_turn(true);
 
     let messages = build_remote_chat_messages(vec![turn]);
 
-    assert_eq!(messages.len(), 1);
+    assert_eq!(messages.len(), 2);
     assert_eq!(messages[0].role, "user");
+    assert_eq!(messages[1].role, "assistant");
+    assert_eq!(messages[1].content, "visible text");
+    assert_eq!(messages[1].tools.as_ref().unwrap()[0].status, "running");
 }
 
 #[test]

--- a/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
+++ b/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
@@ -1,29 +1,28 @@
-#[cfg(feature = "workspace-search")]
-mod workspace_search {
-    use bitfun_services_integrations::workspace_search::{
-        workspace_search_daemon_binary_name, workspace_search_daemon_binary_names,
-        workspace_search_daemon_missing_hint, WorkspaceSearchService,
-    };
+#![cfg(feature = "workspace-search")]
 
-    #[test]
-    fn daemon_binary_contract_lists_current_platform_candidate() {
-        let primary = workspace_search_daemon_binary_name();
+use bitfun_services_integrations::workspace_search::{
+    workspace_search_daemon_binary_name, workspace_search_daemon_binary_names,
+    workspace_search_daemon_missing_hint, WorkspaceSearchService,
+};
 
-        assert!(!primary.is_empty());
-        assert!(workspace_search_daemon_binary_names().contains(&primary));
-    }
+#[test]
+fn daemon_binary_contract_lists_current_platform_candidate() {
+    let primary = workspace_search_daemon_binary_name();
 
-    #[test]
-    fn daemon_missing_hint_preserves_env_override_guidance() {
-        let hint = workspace_search_daemon_missing_hint();
+    assert!(!primary.is_empty());
+    assert!(workspace_search_daemon_binary_names().contains(&primary));
+}
 
-        assert!(hint.contains("FLASHGREP_DAEMON_BIN"));
-        assert!(hint.contains("flashgrep/"));
-        assert!(hint.contains(workspace_search_daemon_binary_name()));
-    }
+#[test]
+fn daemon_missing_hint_preserves_env_override_guidance() {
+    let hint = workspace_search_daemon_missing_hint();
 
-    #[test]
-    fn service_constructs_without_core_runtime_dependencies() {
-        let _service = WorkspaceSearchService::new();
-    }
+    assert!(hint.contains("FLASHGREP_DAEMON_BIN"));
+    assert!(hint.contains("flashgrep/"));
+    assert!(hint.contains(workspace_search_daemon_binary_name()));
+}
+
+#[test]
+fn service_constructs_without_core_runtime_dependencies() {
+    let _service = WorkspaceSearchService::new();
 }


### PR DESCRIPTION
## 背景

Rust workspace 中一批 feature-gated integration test 只在源码使用 crate-level `cfg`，Cargo 仍会把对应 test target 加入无关 feature 组合的构建计划。同时，原有 Core 边界规则按固定 manifest 强制 `product-full`，不利于后续产品入口收窄真实 capability 集合。

本 PR 只处理可证明的依赖与测试 target 边界，不宣称已经缩小 Desktop、CLI、Server、SDK Host 或 ACP 的完整产品闭包。上述入口在上游 `main` 已显式依赖 `bitfun-core/product-full`，本 PR 未修改这些 manifest。

## 变更

- 新增正式的 Rust 构建与依赖边界文档，明确 dependency owner、feature、test target、本地验证与 CI 分工；过程 spec/plan 不进入 PR。
- 将产品入口 Core 规则从固定 manifest + `product-full` 清单改为 Cargo metadata 通用规则：直接依赖 `bitfun-core` 时必须关闭默认 feature，并显式选择非空 capability 集合，但不强制 umbrella feature。
- 复用现有 Core boundary checker 和同一次 Cargo metadata graph，不新增 TOML parser、checker、crate 或第三方依赖。
- 为 16 个 owner-local integration target 增加精确 `required-features`：product-domains 2 个、tool-call-jsonrepair 1 个、services-core 3 个、services-integrations 10 个。
- target guard 只检查真实 crate-level 正向 feature 条件：要求与 `required-features` 精确匹配，保留 negative cfg，拒绝 Cargo 无法表达的 feature OR，并避免评论、字符串和 module cfg 误报。
- 将 `workspace_search_contracts` 的整目标条件改为 crate-level cfg，使 Cargo target gate 与源码语义一致。
- 修正一条长期未在最小 `remote-connect` 组合执行的过时测试：与 Core owner 契约保持一致，进行中的 assistant 历史继续保留已持久化 text 和 running tool；生产代码不变。

## 明确不包含

- 不修改 `.github/workflows/ci.yml`，不新增 workflow、job、step 或 feature matrix。
- 不新增或扩大任何 `product-full` 直接依赖或 test `required-features`。
- 不修改 `bitfun-core` manifest、生产代码或 Core integration target。
- 不把当前不可独立编译的 Core `service-integrations` 伪装成已收敛；Core owner/feature 分解留给后续独立重构。
- 不提交 `docs/superpowers` 下的实施 spec/plan。
- 不以不同缓存状态的耗时数字宣称产品编译性能收益。本 PR 的直接收益是：feature 未启用时，16 个无关 integration target 不再进入 Cargo 构建计划。

## 结构结果

| 项目 | 结果 |
|---|---:|
| 新增精确 owner-local target gate | 16 |
| 新增 `product-full` 依赖或 target gate | 0 |
| Core / CI workflow 最终差异 | 0 个文件 |
| 新第三方依赖 / crate / CI job | 0 |
| `docs/superpowers` 最终差异 | 0 个文件 |

## 验证

- 16/16 target 均以各自精确 `--no-default-features --features <最小集合> --test <target>` 独立编译并实际运行，共 218 个测试通过。
- `pnpm run check:core-boundaries:test`：29 passed。
- `pnpm run check:core-boundaries`：通过。
- `cargo test --locked -p bitfun-core --lib core_service_agent_runtime_owner_preserves_in_progress_remote_assistant_history`：1 passed。
- `pnpm run check:repo-hygiene`：通过。
- `pnpm run check:github-config`：通过。
- `git diff --check`：通过。

本地 `cargo check --locked --workspace` 已尝试，但 Desktop Tauri build script 因 worktree 未生成 `src/mobile-web/dist` 而提前终止；没有为此生成或提交构建产物。完整产品与跨平台结果以本 PR 现有 CI checks 为准。

## 后续边界

后续 PR 应从真实产品 construction path 出发，分别处理 Core owner/feature 分解、产品入口 `product-full` 收窄、依赖版本收敛及重型依赖 closure；不得通过新的 umbrella feature、固定 manifest allowlist 或额外 CI 矩阵替代架构拆分。
