### PR TITLE
refactor(mcp): converge OAuth integration ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,6 @@ dependencies = [
  "notify",
  "regex",
  "reqwest",
- "rmcp",
  "rusqlite",
  "serde",
  "serde_json",

--- a/scripts/core-boundaries/rules/crate-rules.mjs
+++ b/scripts/core-boundaries/rules/crate-rules.mjs
@@ -70,6 +70,17 @@ export const noCoreDependencyCrates = [
 
 export const forbiddenManifestDependencyRules = [
   {
+    dependencyNames: ['rmcp'],
+    scanRoots: ['src/apps', 'src/crates', 'BitFun-Installer/src-tauri'],
+    workspaceManifestPath: 'Cargo.toml',
+    forbidWorkspaceAliases: false,
+    allowManifestPaths: [
+      'src/crates/services/services-integrations/Cargo.toml',
+    ],
+    reason: 'the RMCP SDK is a concrete MCP integration service dependency',
+    message: 'rmcp must stay in services-integrations and be consumed through its MCP owner facade',
+  },
+  {
     dependencyNames: ['bitfun-agent-runtime-ipc'],
     scanRoots: ['src/apps', 'src/crates', 'BitFun-Installer/src-tauri'],
     workspaceManifestPath: 'Cargo.toml',

--- a/scripts/core-boundaries/rules/feature-rules.mjs
+++ b/scripts/core-boundaries/rules/feature-rules.mjs
@@ -86,7 +86,6 @@ export const optionalDependencyFeatureOwnerRules = [
       { depName: 'indexmap', ownerFeatures: ['product-full'] },
       { depName: 'md5', ownerFeatures: ['product-full'] },
       { depName: 'reqwest', ownerFeatures: ['ai-adapter-runtime', 'product-full'] },
-      { depName: 'rmcp', ownerFeatures: ['product-full'] },
       { depName: 'rusqlite', ownerFeatures: ['product-full'] },
       { depName: 'serde_yaml', ownerFeatures: ['workspace-runtime'] },
       { depName: 'similar', ownerFeatures: ['product-full'] },

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -763,6 +763,7 @@ export function runManifestParserSelfTest({
     'qrcode',
     'rand',
     'readability-js',
+    'rmcp',
     'russh',
     'rustls',
     'rustls-native-certs',
@@ -779,7 +780,7 @@ export function runManifestParserSelfTest({
       throw new Error(`core optional dependency owner rule must cover forbidden dependency ${dep}`);
     }
   }
-  for (const dep of ['rmcp', 'image', 'tool-runtime']) {
+  for (const dep of ['image', 'tool-runtime']) {
     if (!coreOptionalOwnerDeps.has(dep)) {
       throw new Error(`core optional dependency owner rule must cover ${dep}`);
     }
@@ -1529,6 +1530,14 @@ export function runManifestParserSelfTest({
     'src/crates/services/services-integrations/Cargo.toml',
   )) {
     throw new Error('speech engine manifest guard must allow only its integration service owner');
+  }
+  const rmcpManifestRule = forbiddenManifestDependencyRules.find((rule) =>
+    rule.dependencyNames?.includes('rmcp'),
+  );
+  if (!rmcpManifestRule?.allowManifestPaths?.includes(
+    'src/crates/services/services-integrations/Cargo.toml',
+  )) {
+    throw new Error('RMCP manifest guard must allow only its integration service owner');
   }
   const coreSpeechOwnerRule = forbiddenContentUnderRules.find(
     (rule) => rule.path === 'src/crates/assembly/core/src/service',

--- a/src/apps/desktop/src/api/mcp_api.rs
+++ b/src/apps/desktop/src/api/mcp_api.rs
@@ -2,9 +2,7 @@
 
 use crate::api::app_state::AppState;
 use crate::startup_trace::DesktopStartupTrace;
-use bitfun_core::service::mcp::auth::{
-    has_stored_oauth_credentials, MCPRemoteOAuthSessionSnapshot,
-};
+use bitfun_core::service::mcp::auth::MCPRemoteOAuthSessionSnapshot;
 use bitfun_core::service::mcp::config::MCPConfigService;
 use bitfun_core::service::mcp::protocol::{
     MCPPrompt, MCPResource, PromptsGetResult, ResourcesReadResult,
@@ -203,6 +201,7 @@ pub async fn get_mcp_servers(state: State<'_, AppState>) -> Result<Vec<MCPServer
 
     let mut infos = Vec::new();
     let runtime_manager = RuntimeManager::new().ok();
+    let mcp_server_manager = mcp_service.server_manager();
 
     for config in configs {
         let transport = config.resolved_transport();
@@ -214,7 +213,8 @@ pub async fn get_mcp_servers(state: State<'_, AppState>) -> Result<Vec<MCPServer
         let oauth_enabled =
             matches!(config.server_type, MCPServerType::Remote) && config.remote_oauth_enabled();
         let oauth_auth_configured = if oauth_enabled {
-            has_stored_oauth_credentials(&config.id)
+            mcp_server_manager
+                .has_remote_oauth_credentials(&config.id)
                 .await
                 .unwrap_or(false)
         } else {

--- a/src/crates/assembly/core/Cargo.toml
+++ b/src/crates/assembly/core/Cargo.toml
@@ -57,10 +57,6 @@ include_dir = { workspace = true, optional = true }
 similar = { workspace = true, optional = true }
 urlencoding = { workspace = true }
 
-# MCP Streamable HTTP client (official rust-sdk)
-rmcp = { workspace = true, features = [
-    "transport-streamable-http-client-reqwest",
-], optional = true }
 # Shared AI protocol adapters
 bitfun-ai-adapters = { path = "../../adapters/ai-adapters", optional = true }
 
@@ -156,7 +152,6 @@ product-full = [
     "dep:md5",
     "dep:reqwest",
     "dep:rusqlite",
-    "dep:rmcp",
     "dep:similar",
     "dep:tokio-tungstenite",
     "dep:tower-http",

--- a/src/crates/assembly/core/src/service/mcp/auth.rs
+++ b/src/crates/assembly/core/src/service/mcp/auth.rs
@@ -4,12 +4,14 @@
 //! module keeps the legacy core entrypoints and injects the product data directory.
 
 use async_trait::async_trait;
-use rmcp::transport::auth::{AuthorizationManager, CredentialStore, StoredCredentials};
 use std::path::PathBuf;
 
 use crate::infrastructure::try_get_path_manager_arc;
 use crate::service::mcp::server::MCPServerConfig;
 use crate::util::errors::{BitFunError, BitFunResult};
+use bitfun_services_integrations::mcp::auth::rmcp_compat::{
+    AuthError, AuthorizationManager, CredentialStore, StoredCredentials,
+};
 
 pub use bitfun_services_integrations::mcp::auth::{
     MCPRemoteOAuthSessionSnapshot, MCPRemoteOAuthStatus, PreparedMCPRemoteOAuthAuthorization,
@@ -79,31 +81,28 @@ impl MCPRemoteOAuthCredentialStore {
 #[allow(deprecated)]
 #[async_trait]
 impl CredentialStore for MCPRemoteOAuthCredentialStore {
-    async fn load(&self) -> Result<Option<StoredCredentials>, rmcp::transport::auth::AuthError> {
+    async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
         MCPRemoteOAuthCredentialVault::new()
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))?
+            .map_err(|error| AuthError::InternalError(error.to_string()))?
             .load(&self.server_id)
             .await
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))
+            .map_err(|error| AuthError::InternalError(error.to_string()))
     }
 
-    async fn save(
-        &self,
-        credentials: StoredCredentials,
-    ) -> Result<(), rmcp::transport::auth::AuthError> {
+    async fn save(&self, credentials: StoredCredentials) -> Result<(), AuthError> {
         MCPRemoteOAuthCredentialVault::new()
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))?
+            .map_err(|error| AuthError::InternalError(error.to_string()))?
             .store(&self.server_id, &credentials)
             .await
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))
+            .map_err(|error| AuthError::InternalError(error.to_string()))
     }
 
-    async fn clear(&self) -> Result<(), rmcp::transport::auth::AuthError> {
+    async fn clear(&self) -> Result<(), AuthError> {
         MCPRemoteOAuthCredentialVault::new()
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))?
+            .map_err(|error| AuthError::InternalError(error.to_string()))?
             .clear(&self.server_id)
             .await
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))
+            .map_err(|error| AuthError::InternalError(error.to_string()))
     }
 }
 

--- a/src/crates/assembly/core/src/service/mcp/mod.rs
+++ b/src/crates/assembly/core/src/service/mcp/mod.rs
@@ -54,7 +54,15 @@ impl MCPService {
         config_service: Arc<crate::service::config::ConfigService>,
     ) -> crate::util::errors::BitFunResult<Self> {
         let mcp_config_service = Arc::new(MCPConfigService::new(config_service)?);
-        let server_manager = Arc::new(MCPServerManager::new(mcp_config_service.clone()));
+        // Keep service startup compatible when strict path initialization is
+        // unavailable; OAuth operations retain the existing lazy error path.
+        let oauth_data_dir = crate::infrastructure::try_get_path_manager_arc()
+            .ok()
+            .map(|manager| manager.user_data_dir());
+        let server_manager = Arc::new(MCPServerManager::assemble(
+            mcp_config_service.clone(),
+            oauth_data_dir,
+        ));
         let context_provider = Arc::new(MCPContextProvider::new(server_manager.clone()));
 
         Ok(Self {

--- a/src/crates/assembly/core/src/service/mcp/server/manager/auth.rs
+++ b/src/crates/assembly/core/src/service/mcp/server/manager/auth.rs
@@ -1,515 +1,32 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::{
-    extract::{Query, State},
-    http::HeaderMap,
-    response::{Html, IntoResponse},
-    routing::get,
-    Router,
-};
 use reqwest::Url;
 use tokio::sync::{oneshot, Mutex};
 use tokio::time::{timeout, Duration};
 
 use crate::service::config::app_language::get_app_language_code;
-use crate::service::i18n::LocaleId;
 use crate::service::mcp::auth::{
-    clear_stored_oauth_credentials, map_auth_error, prepare_remote_oauth_authorization,
-    MCPRemoteOAuthSessionSnapshot, MCPRemoteOAuthStatus,
+    map_auth_error, MCPRemoteOAuthSessionSnapshot, MCPRemoteOAuthStatus,
 };
 use crate::service::mcp::server::MCPServerType;
 use crate::util::errors::{BitFunError, BitFunResult};
+use bitfun_services_integrations::mcp::auth::{
+    clear_stored_oauth_credentials, has_stored_oauth_credentials,
+    prepare_remote_oauth_authorization,
+};
 
+use super::auth_callback::build_oauth_callback_router;
 use super::{ActiveRemoteOAuthSession, MCPServerManager};
 
 const OAUTH_CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 
-#[derive(Debug)]
-struct OAuthCallbackPayload {
-    code: Option<String>,
-    state: Option<String>,
-    error: Option<String>,
-    error_description: Option<String>,
-}
-
-#[derive(Clone, Copy)]
-enum OAuthCallbackLocale {
-    ZhCN,
-    ZhTW,
-    EnUS,
-}
-
-struct OAuthCallbackPageCopy {
-    html_lang: &'static str,
-    page_title: &'static str,
-    brand_label: &'static str,
-    badge_success: &'static str,
-    badge_warning: &'static str,
-    badge_error: &'static str,
-    success_title: &'static str,
-    success_message: &'static str,
-    success_detail_title: &'static str,
-    success_detail_body: &'static str,
-    warning_title: &'static str,
-    warning_message: &'static str,
-    warning_detail_title: &'static str,
-    error_title: &'static str,
-    error_message: &'static str,
-    error_detail_title: &'static str,
-    close_hint: &'static str,
-}
-
-impl OAuthCallbackLocale {
-    fn from_language_code(value: &str) -> Option<Self> {
-        match LocaleId::from_str(value)? {
-            LocaleId::ZhCN => Some(Self::ZhCN),
-            LocaleId::ZhTW => Some(Self::ZhTW),
-            LocaleId::EnUS => Some(Self::EnUS),
-        }
-    }
-
-    fn from_accept_language(value: &str) -> Self {
-        value
-            .split(',')
-            .filter_map(|part| part.split(';').next())
-            .find_map(|part| Self::from_language_code(part.trim()))
-            .unwrap_or(Self::ZhCN)
-    }
-
-    fn copy(self) -> OAuthCallbackPageCopy {
-        match self {
-            Self::ZhCN => OAuthCallbackPageCopy {
-                html_lang: "zh-CN",
-                page_title: "BitFun OAuth 回调",
-                brand_label: "BitFun Desktop",
-                badge_success: "已收到授权",
-                badge_warning: "回调参数不完整",
-                badge_error: "授权失败",
-                success_title: "BitFun 已收到 OAuth 回调",
-                success_message: "可以返回 BitFun。应用正在交换授权码并重新连接 MCP 服务器。",
-                success_detail_title: "接下来会发生什么",
-                success_detail_body:
-                    "这个页面可以直接关闭。如果 BitFun 没有自动完成重连，请回到 MCP 设置页后重试 OAuth。",
-                warning_title: "BitFun 收到的 OAuth 回调缺少必要参数",
-                warning_message:
-                    "OAuth 提供方已跳转回来，但缺少必须的参数。请返回 BitFun 重新发起登录流程。",
-                warning_detail_title: "缺少的参数",
-                error_title: "BitFun 未能完成 OAuth 授权",
-                error_message:
-                    "请返回 BitFun，并根据下面的提供方返回信息检查问题后重新发起 OAuth。",
-                error_detail_title: "提供方返回",
-                close_hint: "处理完成后，这个页面可以直接关闭。",
-            },
-            Self::ZhTW => OAuthCallbackPageCopy {
-                html_lang: "zh-TW",
-                page_title: "BitFun OAuth 回調",
-                brand_label: "BitFun Desktop",
-                badge_success: "已收到授權",
-                badge_warning: "回調參數不完整",
-                badge_error: "授權失敗",
-                success_title: "BitFun 已收到 OAuth 回調",
-                success_message: "可以返回 BitFun。應用正在交換授權碼並重新連接 MCP 服務器。",
-                success_detail_title: "接下來會發生什麼",
-                success_detail_body:
-                    "這個頁面可以直接關閉。如果 BitFun 沒有自動完成重連，請回到 MCP 設置頁後重試 OAuth。",
-                warning_title: "BitFun 收到的 OAuth 回調缺少必要參數",
-                warning_message:
-                    "OAuth 提供方已跳轉回來，但缺少必須的參數。請返回 BitFun 重新發起登錄流程。",
-                warning_detail_title: "缺少的參數",
-                error_title: "BitFun 未能完成 OAuth 授權",
-                error_message:
-                    "請返回 BitFun，並根據下面的提供方返回信息檢查問題後重新發起 OAuth。",
-                error_detail_title: "提供方返回",
-                close_hint: "處理完成後，這個頁面可以直接關閉。",
-            },
-            Self::EnUS => OAuthCallbackPageCopy {
-                html_lang: "en-US",
-                page_title: "BitFun OAuth Callback",
-                brand_label: "BitFun Desktop",
-                badge_success: "Authorization received",
-                badge_warning: "Callback incomplete",
-                badge_error: "Authorization failed",
-                success_title: "BitFun received the OAuth callback",
-                success_message:
-                    "You can return to BitFun now. The app is exchanging the authorization code and reconnecting the MCP server.",
-                success_detail_title: "What happens next",
-                success_detail_body:
-                    "This page can be closed now. If BitFun does not finish reconnecting automatically, return to MCP settings and retry OAuth.",
-                warning_title: "BitFun received an OAuth callback with missing parameters",
-                warning_message:
-                    "The provider redirected back, but required OAuth parameters were missing. Return to BitFun and start the sign-in flow again.",
-                warning_detail_title: "Missing parameters",
-                error_title: "BitFun could not finish the OAuth authorization",
-                error_message:
-                    "Return to BitFun and review the provider response below before retrying OAuth.",
-                error_detail_title: "Provider response",
-                close_hint: "This page can be closed after you review the status.",
-            },
-        }
-    }
-}
-
-fn escape_html(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
-
-fn resolve_oauth_callback_locale(
-    preferred_language: Option<&str>,
-    accept_language: Option<&str>,
-) -> OAuthCallbackLocale {
-    preferred_language
-        .and_then(OAuthCallbackLocale::from_language_code)
-        .or_else(|| accept_language.map(OAuthCallbackLocale::from_accept_language))
-        .unwrap_or(OAuthCallbackLocale::ZhCN)
-}
-
-fn render_oauth_callback_page(
-    payload: &OAuthCallbackPayload,
-    locale: OAuthCallbackLocale,
-) -> String {
-    let copy = locale.copy();
-    let (badge, badge_class, title, message, detail_title, detail_body, icon_label) =
-        if let Some(error) = payload.error.as_deref() {
-            let description = payload
-                .error_description
-                .as_deref()
-                .unwrap_or(match locale {
-                    OAuthCallbackLocale::ZhCN => "OAuth 提供方拒绝了这次授权请求。",
-                    OAuthCallbackLocale::ZhTW => "OAuth 提供方拒絕了這次授權請求。",
-                    OAuthCallbackLocale::EnUS => "The provider rejected the authorization request.",
-                });
-            (
-                copy.badge_error,
-                "is-error",
-                copy.error_title,
-                copy.error_message,
-                copy.error_detail_title,
-                format!("{}: {}", escape_html(error), escape_html(description)),
-                "!",
-            )
-        } else if payload.code.is_some() && payload.state.is_some() {
-            (
-                copy.badge_success,
-                "is-success",
-                copy.success_title,
-                copy.success_message,
-                copy.success_detail_title,
-                copy.success_detail_body.to_string(),
-                match locale {
-                    OAuthCallbackLocale::ZhCN => "完成",
-                    OAuthCallbackLocale::ZhTW => "完成",
-                    OAuthCallbackLocale::EnUS => "Done",
-                },
-            )
-        } else {
-            let mut missing = Vec::new();
-            if payload.code.is_none() {
-                missing.push("code");
-            }
-            if payload.state.is_none() {
-                missing.push("state");
-            }
-            (
-                copy.badge_warning,
-                "is-warning",
-                copy.warning_title,
-                copy.warning_message,
-                copy.warning_detail_title,
-                escape_html(&missing.join(", ")),
-                "?",
-            )
-        };
-
-    format!(
-        r#"<!DOCTYPE html>
-<html lang="{html_lang}">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{page_title}</title>
-    <style>
-      :root {{
-        color-scheme: light;
-        --bg-0: #f3efe5;
-        --bg-1: #dbe7ff;
-        --bg-2: #f8c98b;
-        --panel: rgba(255, 252, 246, 0.88);
-        --panel-border: rgba(53, 66, 97, 0.14);
-        --text-strong: #172033;
-        --text-muted: #5c6474;
-        --shadow: 0 24px 80px rgba(23, 32, 51, 0.16);
-        --success: #176b52;
-        --success-soft: rgba(23, 107, 82, 0.12);
-        --warning: #9a5a00;
-        --warning-soft: rgba(154, 90, 0, 0.14);
-        --error: #a63232;
-        --error-soft: rgba(166, 50, 50, 0.12);
-      }}
-
-      * {{
-        box-sizing: border-box;
-      }}
-
-      body {{
-        margin: 0;
-        min-height: 100vh;
-        font-family: "Segoe UI Variable Display", "Aptos", "Trebuchet MS", sans-serif;
-        color: var(--text-strong);
-        background:
-          radial-gradient(circle at top left, rgba(255, 255, 255, 0.72), transparent 34%),
-          radial-gradient(circle at bottom right, rgba(255, 230, 202, 0.9), transparent 30%),
-          linear-gradient(135deg, var(--bg-0) 0%, var(--bg-1) 52%, var(--bg-2) 100%);
-        overflow: hidden;
-      }}
-
-      .orb {{
-        position: fixed;
-        border-radius: 999px;
-        filter: blur(12px);
-        opacity: 0.56;
-        pointer-events: none;
-      }}
-
-      .orb-a {{
-        width: 320px;
-        height: 320px;
-        top: -96px;
-        right: -48px;
-        background: rgba(126, 159, 255, 0.34);
-      }}
-
-      .orb-b {{
-        width: 260px;
-        height: 260px;
-        bottom: -84px;
-        left: -40px;
-        background: rgba(255, 193, 118, 0.38);
-      }}
-
-      .shell {{
-        position: relative;
-        min-height: 100vh;
-        display: grid;
-        place-items: center;
-        padding: 28px;
-      }}
-
-      .panel {{
-        width: min(100%, 720px);
-        padding: 32px;
-        border: 1px solid var(--panel-border);
-        border-radius: 28px;
-        background: var(--panel);
-        backdrop-filter: blur(18px);
-        box-shadow: var(--shadow);
-      }}
-
-      .brand {{
-        display: flex;
-        align-items: center;
-        gap: 16px;
-        margin-bottom: 24px;
-      }}
-
-      .brand-mark {{
-        width: 52px;
-        height: 52px;
-        border-radius: 16px;
-        display: grid;
-        place-items: center;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        color: #fffaf0;
-        background: linear-gradient(135deg, #172033 0%, #335c95 100%);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
-      }}
-
-      .eyebrow {{
-        display: block;
-        margin-bottom: 4px;
-        font-size: 12px;
-        font-weight: 700;
-        letter-spacing: 0.16em;
-        text-transform: uppercase;
-        color: var(--text-muted);
-      }}
-
-      h1 {{
-        margin: 0;
-        font-size: clamp(28px, 5vw, 44px);
-        line-height: 1.04;
-        letter-spacing: -0.04em;
-      }}
-
-      .badge {{
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        padding: 8px 14px;
-        border-radius: 999px;
-        font-size: 13px;
-        font-weight: 700;
-      }}
-
-      .badge.is-success {{
-        color: var(--success);
-        background: var(--success-soft);
-      }}
-
-      .badge.is-warning {{
-        color: var(--warning);
-        background: var(--warning-soft);
-      }}
-
-      .badge.is-error {{
-        color: var(--error);
-        background: var(--error-soft);
-      }}
-
-      .content {{
-        display: grid;
-        gap: 20px;
-      }}
-
-      .content > * {{
-        min-width: 0;
-      }}
-
-      .lead {{
-        margin: 0;
-        max-width: 58ch;
-        font-size: 17px;
-        line-height: 1.7;
-        color: var(--text-muted);
-      }}
-
-      .status-card {{
-        display: grid;
-        grid-template-columns: auto 1fr;
-        gap: 18px;
-        padding: 20px;
-        border-radius: 22px;
-        background: rgba(255, 255, 255, 0.58);
-        border: 1px solid rgba(53, 66, 97, 0.08);
-      }}
-
-      .status-icon {{
-        width: 52px;
-        height: 52px;
-        border-radius: 18px;
-        display: grid;
-        place-items: center;
-        font-weight: 800;
-        font-size: 16px;
-        color: var(--text-strong);
-        background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(227, 235, 255, 0.92));
-        border: 1px solid rgba(53, 66, 97, 0.08);
-      }}
-
-      .status-title {{
-        margin: 0 0 8px;
-        font-size: 15px;
-        font-weight: 700;
-        letter-spacing: 0.01em;
-      }}
-
-      .status-body {{
-        margin: 0;
-        font-family: "Cascadia Code", "Consolas", monospace;
-        font-size: 13px;
-        line-height: 1.7;
-        color: var(--text-muted);
-        word-break: break-word;
-      }}
-
-      .close-note {{
-        padding: 16px 18px;
-        border-radius: 18px;
-        background: rgba(23, 32, 51, 0.06);
-        border: 1px solid rgba(53, 66, 97, 0.08);
-      }}
-
-      .footnote {{
-        margin: 0;
-        font-size: 13px;
-        line-height: 1.7;
-        color: var(--text-muted);
-      }}
-
-      @media (max-width: 640px) {{
-        .panel {{
-          padding: 24px;
-          border-radius: 24px;
-        }}
-
-        .brand,
-        .status-card {{
-          grid-template-columns: 1fr;
-        }}
-
-        .status-card {{
-          gap: 14px;
-        }}
-      }}
-    </style>
-  </head>
-  <body>
-    <div class="orb orb-a"></div>
-    <div class="orb orb-b"></div>
-    <main class="shell">
-      <section class="panel">
-        <div class="brand">
-          <div class="brand-mark">BF</div>
-          <div>
-            <span class="eyebrow">{brand_label}</span>
-            <h1>{title}</h1>
-          </div>
-        </div>
-        <div class="content">
-          <div class="badge {badge_class}">{badge}</div>
-          <p class="lead">{message}</p>
-          <div class="status-card">
-            <div class="status-icon">{icon_label}</div>
-            <div>
-              <p class="status-title">{detail_title}</p>
-              <p class="status-body">{detail_body}</p>
-            </div>
-          </div>
-          <div class="close-note">
-            <p class="footnote">{close_hint}</p>
-          </div>
-        </div>
-      </section>
-    </main>
-  </body>
-</html>"#,
-        html_lang = copy.html_lang,
-        page_title = copy.page_title,
-        brand_label = copy.brand_label,
-        title = title,
-        badge = badge,
-        badge_class = badge_class,
-        message = message,
-        detail_title = detail_title,
-        detail_body = detail_body,
-        icon_label = icon_label,
-        close_hint = copy.close_hint,
-    )
-}
-
-#[derive(Clone)]
-struct OAuthCallbackAppState {
-    callback_tx: Arc<Mutex<Option<oneshot::Sender<OAuthCallbackPayload>>>>,
-    preferred_language: String,
-}
-
 impl MCPServerManager {
+    fn oauth_data_dir(&self) -> BitFunResult<std::path::PathBuf> {
+        self.oauth_data_dir.clone().map(Ok).unwrap_or_else(|| {
+            Ok(crate::infrastructure::try_get_path_manager_arc()?.user_data_dir())
+        })
+    }
+
     pub(super) async fn set_oauth_snapshot(
         session: &Arc<ActiveRemoteOAuthSession>,
         snapshot: MCPRemoteOAuthSessionSnapshot,
@@ -582,7 +99,9 @@ impl MCPServerManager {
             Self::shutdown_oauth_session(&existing).await;
         }
 
-        let prepared = prepare_remote_oauth_authorization(&config).await?;
+        let prepared = prepare_remote_oauth_authorization(self.oauth_data_dir()?, &config)
+            .await
+            .map_err(map_auth_error)?;
         let callback_path = Url::parse(&prepared.redirect_uri)
             .map_err(|error| {
                 BitFunError::MCPError(format!(
@@ -612,13 +131,8 @@ impl MCPServerManager {
             Self::shutdown_oauth_session(&previous).await;
         }
 
-        let callback_state = OAuthCallbackAppState {
-            callback_tx: Arc::new(Mutex::new(Some(callback_tx))),
-            preferred_language: get_app_language_code().await,
-        };
-        let router = Router::new()
-            .route(&callback_path, get(handle_oauth_callback))
-            .with_state(callback_state);
+        let router =
+            build_oauth_callback_router(&callback_path, callback_tx, get_app_language_code().await);
         let callback_server_session = session.clone();
         let callback_server_id = server_id.to_string();
         tokio::spawn(async move {
@@ -786,6 +300,12 @@ impl MCPServerManager {
         Some(snapshot)
     }
 
+    pub async fn has_remote_oauth_credentials(&self, server_id: &str) -> BitFunResult<bool> {
+        has_stored_oauth_credentials(self.oauth_data_dir()?, server_id)
+            .await
+            .map_err(map_auth_error)
+    }
+
     pub async fn cancel_remote_oauth_authorization(&self, server_id: &str) -> BitFunResult<()> {
         let session = self.oauth_sessions.write().await.remove(server_id);
         if let Some(session) = session {
@@ -801,31 +321,8 @@ impl MCPServerManager {
 
     pub async fn clear_remote_oauth_credentials(&self, server_id: &str) -> BitFunResult<()> {
         self.cancel_remote_oauth_authorization(server_id).await?;
-        clear_stored_oauth_credentials(server_id).await
+        clear_stored_oauth_credentials(self.oauth_data_dir()?, server_id)
+            .await
+            .map_err(map_auth_error)
     }
-}
-
-async fn handle_oauth_callback(
-    State(state): State<OAuthCallbackAppState>,
-    headers: HeaderMap,
-    Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
-    let payload = OAuthCallbackPayload {
-        code: params.get("code").cloned(),
-        state: params.get("state").cloned(),
-        error: params.get("error").cloned(),
-        error_description: params.get("error_description").cloned(),
-    };
-    let accept_language = headers
-        .get(axum::http::header::ACCEPT_LANGUAGE)
-        .and_then(|value| value.to_str().ok());
-    let locale =
-        resolve_oauth_callback_locale(Some(state.preferred_language.as_str()), accept_language);
-    let page = render_oauth_callback_page(&payload, locale);
-
-    if let Some(callback_tx) = state.callback_tx.lock().await.take() {
-        let _ = callback_tx.send(payload);
-    }
-
-    Html(page)
 }

--- a/src/crates/assembly/core/src/service/mcp/server/manager/auth_callback.rs
+++ b/src/crates/assembly/core/src/service/mcp/server/manager/auth_callback.rs
@@ -1,0 +1,561 @@
+//! Product-owned HTTP callback adapter and localized MCP OAuth result page.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::HeaderMap,
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
+use tokio::sync::{oneshot, Mutex};
+
+use crate::service::i18n::LocaleId;
+
+#[derive(Debug)]
+pub(super) struct OAuthCallbackPayload {
+    pub(super) code: Option<String>,
+    pub(super) state: Option<String>,
+    pub(super) error: Option<String>,
+    pub(super) error_description: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum OAuthCallbackLocale {
+    ZhCN,
+    ZhTW,
+    EnUS,
+}
+
+struct OAuthCallbackPageCopy {
+    html_lang: &'static str,
+    page_title: &'static str,
+    brand_label: &'static str,
+    badge_success: &'static str,
+    badge_warning: &'static str,
+    badge_error: &'static str,
+    success_title: &'static str,
+    success_message: &'static str,
+    success_detail_title: &'static str,
+    success_detail_body: &'static str,
+    warning_title: &'static str,
+    warning_message: &'static str,
+    warning_detail_title: &'static str,
+    error_title: &'static str,
+    error_message: &'static str,
+    error_detail_title: &'static str,
+    close_hint: &'static str,
+}
+
+impl OAuthCallbackLocale {
+    fn from_language_code(value: &str) -> Option<Self> {
+        match LocaleId::from_str(value)? {
+            LocaleId::ZhCN => Some(Self::ZhCN),
+            LocaleId::ZhTW => Some(Self::ZhTW),
+            LocaleId::EnUS => Some(Self::EnUS),
+        }
+    }
+
+    fn from_accept_language(value: &str) -> Self {
+        value
+            .split(',')
+            .filter_map(|part| part.split(';').next())
+            .find_map(|part| Self::from_language_code(part.trim()))
+            .unwrap_or(Self::ZhCN)
+    }
+
+    fn copy(self) -> OAuthCallbackPageCopy {
+        match self {
+            Self::ZhCN => OAuthCallbackPageCopy {
+                html_lang: "zh-CN",
+                page_title: "BitFun OAuth 回调",
+                brand_label: "BitFun Desktop",
+                badge_success: "已收到授权",
+                badge_warning: "回调参数不完整",
+                badge_error: "授权失败",
+                success_title: "BitFun 已收到 OAuth 回调",
+                success_message: "可以返回 BitFun。应用正在交换授权码并重新连接 MCP 服务器。",
+                success_detail_title: "接下来会发生什么",
+                success_detail_body:
+                    "这个页面可以直接关闭。如果 BitFun 没有自动完成重连，请回到 MCP 设置页后重试 OAuth。",
+                warning_title: "BitFun 收到的 OAuth 回调缺少必要参数",
+                warning_message:
+                    "OAuth 提供方已跳转回来，但缺少必须的参数。请返回 BitFun 重新发起登录流程。",
+                warning_detail_title: "缺少的参数",
+                error_title: "BitFun 未能完成 OAuth 授权",
+                error_message:
+                    "请返回 BitFun，并根据下面的提供方返回信息检查问题后重新发起 OAuth。",
+                error_detail_title: "提供方返回",
+                close_hint: "处理完成后，这个页面可以直接关闭。",
+            },
+            Self::ZhTW => OAuthCallbackPageCopy {
+                html_lang: "zh-TW",
+                page_title: "BitFun OAuth 回調",
+                brand_label: "BitFun Desktop",
+                badge_success: "已收到授權",
+                badge_warning: "回調參數不完整",
+                badge_error: "授權失敗",
+                success_title: "BitFun 已收到 OAuth 回調",
+                success_message: "可以返回 BitFun。應用正在交換授權碼並重新連接 MCP 服務器。",
+                success_detail_title: "接下來會發生什麼",
+                success_detail_body:
+                    "這個頁面可以直接關閉。如果 BitFun 沒有自動完成重連，請回到 MCP 設置頁後重試 OAuth。",
+                warning_title: "BitFun 收到的 OAuth 回調缺少必要參數",
+                warning_message:
+                    "OAuth 提供方已跳轉回來，但缺少必須的參數。請返回 BitFun 重新發起登錄流程。",
+                warning_detail_title: "缺少的參數",
+                error_title: "BitFun 未能完成 OAuth 授權",
+                error_message:
+                    "請返回 BitFun，並根據下面的提供方返回信息檢查問題後重新發起 OAuth。",
+                error_detail_title: "提供方返回",
+                close_hint: "處理完成後，這個頁面可以直接關閉。",
+            },
+            Self::EnUS => OAuthCallbackPageCopy {
+                html_lang: "en-US",
+                page_title: "BitFun OAuth Callback",
+                brand_label: "BitFun Desktop",
+                badge_success: "Authorization received",
+                badge_warning: "Callback incomplete",
+                badge_error: "Authorization failed",
+                success_title: "BitFun received the OAuth callback",
+                success_message:
+                    "You can return to BitFun now. The app is exchanging the authorization code and reconnecting the MCP server.",
+                success_detail_title: "What happens next",
+                success_detail_body:
+                    "This page can be closed now. If BitFun does not finish reconnecting automatically, return to MCP settings and retry OAuth.",
+                warning_title: "BitFun received an OAuth callback with missing parameters",
+                warning_message:
+                    "The provider redirected back, but required OAuth parameters were missing. Return to BitFun and start the sign-in flow again.",
+                warning_detail_title: "Missing parameters",
+                error_title: "BitFun could not finish the OAuth authorization",
+                error_message:
+                    "Return to BitFun and review the provider response below before retrying OAuth.",
+                error_detail_title: "Provider response",
+                close_hint: "This page can be closed after you review the status.",
+            },
+        }
+    }
+}
+
+fn escape_html(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn resolve_oauth_callback_locale(
+    preferred_language: Option<&str>,
+    accept_language: Option<&str>,
+) -> OAuthCallbackLocale {
+    preferred_language
+        .and_then(OAuthCallbackLocale::from_language_code)
+        .or_else(|| accept_language.map(OAuthCallbackLocale::from_accept_language))
+        .unwrap_or(OAuthCallbackLocale::ZhCN)
+}
+
+fn render_oauth_callback_page(
+    payload: &OAuthCallbackPayload,
+    locale: OAuthCallbackLocale,
+) -> String {
+    let copy = locale.copy();
+    let (badge, badge_class, title, message, detail_title, detail_body, icon_label) =
+        if let Some(error) = payload.error.as_deref() {
+            let description = payload
+                .error_description
+                .as_deref()
+                .unwrap_or(match locale {
+                    OAuthCallbackLocale::ZhCN => "OAuth 提供方拒绝了这次授权请求。",
+                    OAuthCallbackLocale::ZhTW => "OAuth 提供方拒絕了這次授權請求。",
+                    OAuthCallbackLocale::EnUS => "The provider rejected the authorization request.",
+                });
+            (
+                copy.badge_error,
+                "is-error",
+                copy.error_title,
+                copy.error_message,
+                copy.error_detail_title,
+                format!("{}: {}", escape_html(error), escape_html(description)),
+                "!",
+            )
+        } else if payload.code.is_some() && payload.state.is_some() {
+            (
+                copy.badge_success,
+                "is-success",
+                copy.success_title,
+                copy.success_message,
+                copy.success_detail_title,
+                copy.success_detail_body.to_string(),
+                match locale {
+                    OAuthCallbackLocale::ZhCN => "完成",
+                    OAuthCallbackLocale::ZhTW => "完成",
+                    OAuthCallbackLocale::EnUS => "Done",
+                },
+            )
+        } else {
+            let mut missing = Vec::new();
+            if payload.code.is_none() {
+                missing.push("code");
+            }
+            if payload.state.is_none() {
+                missing.push("state");
+            }
+            (
+                copy.badge_warning,
+                "is-warning",
+                copy.warning_title,
+                copy.warning_message,
+                copy.warning_detail_title,
+                escape_html(&missing.join(", ")),
+                "?",
+            )
+        };
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="{html_lang}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{page_title}</title>
+    <style>
+      :root {{
+        color-scheme: light;
+        --bg-0: #f3efe5;
+        --bg-1: #dbe7ff;
+        --bg-2: #f8c98b;
+        --panel: rgba(255, 252, 246, 0.88);
+        --panel-border: rgba(53, 66, 97, 0.14);
+        --text-strong: #172033;
+        --text-muted: #5c6474;
+        --shadow: 0 24px 80px rgba(23, 32, 51, 0.16);
+        --success: #176b52;
+        --success-soft: rgba(23, 107, 82, 0.12);
+        --warning: #9a5a00;
+        --warning-soft: rgba(154, 90, 0, 0.14);
+        --error: #a63232;
+        --error-soft: rgba(166, 50, 50, 0.12);
+      }}
+
+      * {{
+        box-sizing: border-box;
+      }}
+
+      body {{
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Segoe UI Variable Display", "Aptos", "Trebuchet MS", sans-serif;
+        color: var(--text-strong);
+        background:
+          radial-gradient(circle at top left, rgba(255, 255, 255, 0.72), transparent 34%),
+          radial-gradient(circle at bottom right, rgba(255, 230, 202, 0.9), transparent 30%),
+          linear-gradient(135deg, var(--bg-0) 0%, var(--bg-1) 52%, var(--bg-2) 100%);
+        overflow: hidden;
+      }}
+
+      .orb {{
+        position: fixed;
+        border-radius: 999px;
+        filter: blur(12px);
+        opacity: 0.56;
+        pointer-events: none;
+      }}
+
+      .orb-a {{
+        width: 320px;
+        height: 320px;
+        top: -96px;
+        right: -48px;
+        background: rgba(126, 159, 255, 0.34);
+      }}
+
+      .orb-b {{
+        width: 260px;
+        height: 260px;
+        bottom: -84px;
+        left: -40px;
+        background: rgba(255, 193, 118, 0.38);
+      }}
+
+      .shell {{
+        position: relative;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 28px;
+      }}
+
+      .panel {{
+        width: min(100%, 720px);
+        padding: 32px;
+        border: 1px solid var(--panel-border);
+        border-radius: 28px;
+        background: var(--panel);
+        backdrop-filter: blur(18px);
+        box-shadow: var(--shadow);
+      }}
+
+      .brand {{
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 24px;
+      }}
+
+      .brand-mark {{
+        width: 52px;
+        height: 52px;
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        color: #fffaf0;
+        background: linear-gradient(135deg, #172033 0%, #335c95 100%);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+      }}
+
+      .eyebrow {{
+        display: block;
+        margin-bottom: 4px;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--text-muted);
+      }}
+
+      h1 {{
+        margin: 0;
+        font-size: clamp(28px, 5vw, 44px);
+        line-height: 1.04;
+        letter-spacing: -0.04em;
+      }}
+
+      .badge {{
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 14px;
+        border-radius: 999px;
+        font-size: 13px;
+        font-weight: 700;
+      }}
+
+      .badge.is-success {{
+        color: var(--success);
+        background: var(--success-soft);
+      }}
+
+      .badge.is-warning {{
+        color: var(--warning);
+        background: var(--warning-soft);
+      }}
+
+      .badge.is-error {{
+        color: var(--error);
+        background: var(--error-soft);
+      }}
+
+      .content {{
+        display: grid;
+        gap: 20px;
+      }}
+
+      .content > * {{
+        min-width: 0;
+      }}
+
+      .lead {{
+        margin: 0;
+        max-width: 58ch;
+        font-size: 17px;
+        line-height: 1.7;
+        color: var(--text-muted);
+      }}
+
+      .status-card {{
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 18px;
+        padding: 20px;
+        border-radius: 22px;
+        background: rgba(255, 255, 255, 0.58);
+        border: 1px solid rgba(53, 66, 97, 0.08);
+      }}
+
+      .status-icon {{
+        width: 52px;
+        height: 52px;
+        border-radius: 18px;
+        display: grid;
+        place-items: center;
+        font-weight: 800;
+        font-size: 16px;
+        color: var(--text-strong);
+        background: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(227, 235, 255, 0.92));
+        border: 1px solid rgba(53, 66, 97, 0.08);
+      }}
+
+      .status-title {{
+        margin: 0 0 8px;
+        font-size: 15px;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+      }}
+
+      .status-body {{
+        margin: 0;
+        font-family: "Cascadia Code", "Consolas", monospace;
+        font-size: 13px;
+        line-height: 1.7;
+        color: var(--text-muted);
+        word-break: break-word;
+      }}
+
+      .close-note {{
+        padding: 16px 18px;
+        border-radius: 18px;
+        background: rgba(23, 32, 51, 0.06);
+        border: 1px solid rgba(53, 66, 97, 0.08);
+      }}
+
+      .footnote {{
+        margin: 0;
+        font-size: 13px;
+        line-height: 1.7;
+        color: var(--text-muted);
+      }}
+
+      @media (max-width: 640px) {{
+        .panel {{
+          padding: 24px;
+          border-radius: 24px;
+        }}
+
+        .brand,
+        .status-card {{
+          grid-template-columns: 1fr;
+        }}
+
+        .status-card {{
+          gap: 14px;
+        }}
+      }}
+    </style>
+  </head>
+  <body>
+    <div class="orb orb-a"></div>
+    <div class="orb orb-b"></div>
+    <main class="shell">
+      <section class="panel">
+        <div class="brand">
+          <div class="brand-mark">BF</div>
+          <div>
+            <span class="eyebrow">{brand_label}</span>
+            <h1>{title}</h1>
+          </div>
+        </div>
+        <div class="content">
+          <div class="badge {badge_class}">{badge}</div>
+          <p class="lead">{message}</p>
+          <div class="status-card">
+            <div class="status-icon">{icon_label}</div>
+            <div>
+              <p class="status-title">{detail_title}</p>
+              <p class="status-body">{detail_body}</p>
+            </div>
+          </div>
+          <div class="close-note">
+            <p class="footnote">{close_hint}</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>"#,
+        html_lang = copy.html_lang,
+        page_title = copy.page_title,
+        brand_label = copy.brand_label,
+        title = title,
+        badge = badge,
+        badge_class = badge_class,
+        message = message,
+        detail_title = detail_title,
+        detail_body = detail_body,
+        icon_label = icon_label,
+        close_hint = copy.close_hint,
+    )
+}
+
+#[derive(Clone)]
+struct OAuthCallbackAppState {
+    callback_tx: Arc<Mutex<Option<oneshot::Sender<OAuthCallbackPayload>>>>,
+    preferred_language: String,
+}
+
+pub(super) fn build_oauth_callback_router(
+    callback_path: &str,
+    callback_tx: oneshot::Sender<OAuthCallbackPayload>,
+    preferred_language: String,
+) -> Router {
+    let state = OAuthCallbackAppState {
+        callback_tx: Arc::new(Mutex::new(Some(callback_tx))),
+        preferred_language,
+    };
+    Router::new()
+        .route(callback_path, get(handle_oauth_callback))
+        .with_state(state)
+}
+
+async fn handle_oauth_callback(
+    State(state): State<OAuthCallbackAppState>,
+    headers: HeaderMap,
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let payload = OAuthCallbackPayload {
+        code: params.get("code").cloned(),
+        state: params.get("state").cloned(),
+        error: params.get("error").cloned(),
+        error_description: params.get("error_description").cloned(),
+    };
+    let accept_language = headers
+        .get(axum::http::header::ACCEPT_LANGUAGE)
+        .and_then(|value| value.to_str().ok());
+    let locale =
+        resolve_oauth_callback_locale(Some(state.preferred_language.as_str()), accept_language);
+    let page = render_oauth_callback_page(&payload, locale);
+
+    if let Some(callback_tx) = state.callback_tx.lock().await.take() {
+        let _ = callback_tx.send(payload);
+    }
+
+    Html(page)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_oauth_callback_page, resolve_oauth_callback_locale, OAuthCallbackPayload};
+
+    #[test]
+    fn callback_page_prefers_the_product_locale_and_escapes_provider_errors() {
+        let locale = resolve_oauth_callback_locale(Some("en-US"), Some("zh-CN,zh;q=0.9"));
+        let page = render_oauth_callback_page(
+            &OAuthCallbackPayload {
+                code: None,
+                state: None,
+                error: Some("denied<script>".to_string()),
+                error_description: Some("bad & unsafe".to_string()),
+            },
+            locale,
+        );
+
+        assert!(page.contains("BitFun could not finish the OAuth authorization"));
+        assert!(page.contains("denied&lt;script&gt;: bad &amp; unsafe"));
+        assert!(!page.contains("denied<script>"));
+    }
+}

--- a/src/crates/assembly/core/src/service/mcp/server/manager/mod.rs
+++ b/src/crates/assembly/core/src/service/mcp/server/manager/mod.rs
@@ -4,6 +4,7 @@
 //! catalog, interaction, and tool-registration logic can evolve independently.
 
 mod auth;
+mod auth_callback;
 mod catalog;
 mod external_lifecycle;
 mod interaction;
@@ -27,7 +28,7 @@ use bitfun_services_integrations::mcp::server::MCPServerRuntimeState;
 use log::{debug, error, info, warn};
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -55,6 +56,7 @@ struct ActiveRemoteOAuthSession {
 pub struct MCPServerManager {
     config_service: Arc<MCPConfigService>,
     runtime: Arc<MCPServerRuntimeState>,
+    oauth_data_dir: Option<PathBuf>,
     reconnect_monitor_started: Arc<AtomicBool>,
     connection_event_tasks: Arc<tokio::sync::RwLock<HashMap<String, JoinHandle<()>>>>,
     pending_interactions: Arc<tokio::sync::RwLock<HashMap<String, PendingMCPInteraction>>>,
@@ -70,9 +72,17 @@ pub struct MCPServerManager {
 impl MCPServerManager {
     /// Creates a new server manager.
     pub fn new(config_service: Arc<MCPConfigService>) -> Self {
+        Self::assemble(config_service, None)
+    }
+
+    pub(crate) fn assemble(
+        config_service: Arc<MCPConfigService>,
+        oauth_data_dir: Option<PathBuf>,
+    ) -> Self {
         Self {
             config_service,
             runtime: Arc::new(MCPServerRuntimeState::new()),
+            oauth_data_dir,
             reconnect_monitor_started: Arc::new(AtomicBool::new(false)),
             connection_event_tasks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             pending_interactions: Arc::new(tokio::sync::RwLock::new(HashMap::new())),

--- a/src/crates/assembly/core/src/service/mcp/server/manager/tests.rs
+++ b/src/crates/assembly/core/src/service/mcp/server/manager/tests.rs
@@ -1,4 +1,8 @@
+use std::sync::Arc;
 use std::time::Duration;
+
+use bitfun_services_integrations::mcp::auth::rmcp_compat::StoredCredentials;
+use bitfun_services_integrations::mcp::auth::MCPRemoteOAuthCredentialVault;
 
 #[test]
 fn ephemeral_retirement_waits_for_in_flight_connection_users_but_is_bounded() {
@@ -34,4 +38,59 @@ fn superseded_external_start_token_cannot_clean_up_current_instance() {
         &first
     ));
     assert!(!super::external_start_token_is_current(None, &first));
+}
+
+#[tokio::test]
+async fn oauth_credentials_follow_the_manager_injected_data_dir() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let path_manager = Arc::new(
+        crate::infrastructure::PathManager::with_user_root_for_tests(root.path().join("config")),
+    );
+    let config_service = Arc::new(
+        crate::service::config::ConfigService::with_settings(
+            crate::service::config::ConfigManagerSettings {
+                path_manager: Some(path_manager),
+                auto_save: false,
+                backup_count: 0,
+            },
+        )
+        .await
+        .expect("config service"),
+    );
+    let mcp_config_service = Arc::new(
+        crate::service::mcp::config::MCPConfigService::new(config_service)
+            .expect("MCP config service"),
+    );
+    let oauth_data_dir = root.path().join("oauth");
+    let manager =
+        super::MCPServerManager::assemble(mcp_config_service, Some(oauth_data_dir.clone()));
+    let vault = MCPRemoteOAuthCredentialVault::new(oauth_data_dir);
+    let credentials: StoredCredentials = serde_json::from_value(serde_json::json!({
+        "client_id": "client-123",
+        "token_response": {
+            "access_token": "access-token",
+            "token_type": "bearer"
+        }
+    }))
+    .expect("stored credentials");
+
+    vault
+        .store("server-a", &credentials)
+        .await
+        .expect("store credentials");
+
+    assert!(manager
+        .has_remote_oauth_credentials("server-a")
+        .await
+        .expect("query credentials"));
+
+    manager
+        .clear_remote_oauth_credentials("server-a")
+        .await
+        .expect("clear credentials");
+    assert!(vault
+        .load("server-a")
+        .await
+        .expect("load credentials after clear")
+        .is_none());
 }

--- a/src/crates/services/services-integrations/AGENTS.md
+++ b/src/crates/services/services-integrations/AGENTS.md
@@ -15,7 +15,10 @@ slices that are outside pure product logic but still platform-neutral.
   integration feature-group list.
 - MCP config/process/transport lifecycle, server runtime state
   (registry/connection pool/catalog/reconnect/runtime-only config), lifecycle
-  policy, and protocol result-content rendering live here; MCP wire types may be
+  policy, OAuth credential storage/authorization bootstrap, the concrete RMCP
+  dependency, and protocol result-content rendering live here. Core may keep
+  compatibility exports plus product callback/session/reconnect orchestration,
+  but must not reintroduce a direct RMCP dependency. MCP wire types may be
   projected into execution-owned tool bridge descriptors. Product tool registry
   assembly, manifest filtering, `GetToolSpec` execution, and bridge
   presentation/validation behavior remain outside this crate unless a reviewed

--- a/src/crates/services/services-integrations/src/mcp/auth.rs
+++ b/src/crates/services/services-integrations/src/mcp/auth.rs
@@ -11,7 +11,16 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
 use rand::RngCore;
-use rmcp::transport::auth::{AuthorizationManager, CredentialStore, OAuthState, StoredCredentials};
+use rmcp::transport::auth::OAuthState;
+
+#[doc(hidden)]
+pub mod rmcp_compat {
+    pub use rmcp::transport::auth::{
+        AuthError, AuthorizationManager, CredentialStore, StoredCredentials,
+    };
+}
+
+use rmcp_compat::{AuthError, AuthorizationManager, CredentialStore, StoredCredentials};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -265,28 +274,25 @@ impl MCPRemoteOAuthCredentialStore {
 
 #[async_trait]
 impl CredentialStore for MCPRemoteOAuthCredentialStore {
-    async fn load(&self) -> Result<Option<StoredCredentials>, rmcp::transport::auth::AuthError> {
+    async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
         MCPRemoteOAuthCredentialVault::new(self.data_dir.clone())
             .load(&self.server_id)
             .await
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))
+            .map_err(|error| AuthError::InternalError(error.to_string()))
     }
 
-    async fn save(
-        &self,
-        credentials: StoredCredentials,
-    ) -> Result<(), rmcp::transport::auth::AuthError> {
+    async fn save(&self, credentials: StoredCredentials) -> Result<(), AuthError> {
         MCPRemoteOAuthCredentialVault::new(self.data_dir.clone())
             .store(&self.server_id, &credentials)
             .await
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))
+            .map_err(|error| AuthError::InternalError(error.to_string()))
     }
 
-    async fn clear(&self) -> Result<(), rmcp::transport::auth::AuthError> {
+    async fn clear(&self) -> Result<(), AuthError> {
         MCPRemoteOAuthCredentialVault::new(self.data_dir.clone())
             .clear(&self.server_id)
             .await
-            .map_err(|error| rmcp::transport::auth::AuthError::InternalError(error.to_string()))
+            .map_err(|error| AuthError::InternalError(error.to_string()))
     }
 }
 

--- a/src/crates/services/services-integrations/tests/mcp_contracts.rs
+++ b/src/crates/services/services-integrations/tests/mcp_contracts.rs
@@ -1,8 +1,12 @@
 #![cfg(feature = "mcp")]
 
 use async_trait::async_trait;
+use bitfun_services_integrations::mcp::auth::rmcp_compat::{
+    AuthorizationManager, CredentialStore, StoredCredentials,
+};
 use bitfun_services_integrations::mcp::auth::{
-    MCPRemoteOAuthCredentialVault, MCPRemoteOAuthSessionSnapshot, MCPRemoteOAuthStatus,
+    MCPRemoteOAuthCredentialStore, MCPRemoteOAuthCredentialVault, MCPRemoteOAuthSessionSnapshot,
+    MCPRemoteOAuthStatus,
 };
 use bitfun_services_integrations::mcp::config::ConfigLocation;
 use bitfun_services_integrations::mcp::config::{
@@ -35,7 +39,6 @@ use bitfun_services_integrations::mcp::{
     PromptAdapter, ResourceAdapter, MCP_TOOL_DELIMITER, MCP_TOOL_PREFIX,
 };
 use rmcp::model::{AnnotateAble, Annotations, Content, Icon, Meta, RawResource, ResourceContents};
-use rmcp::transport::auth::StoredCredentials;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -1876,6 +1879,15 @@ fn mcp_oauth_session_snapshot_preserves_camel_case_status_contract() {
             "redirectUri": "http://127.0.0.1:49152/oauth/callback"
         })
     );
+}
+
+#[test]
+fn mcp_oauth_owner_exports_the_auth_primitives_needed_by_compatibility_facades() {
+    fn assert_credential_store<T: CredentialStore>() {}
+
+    assert_credential_store::<MCPRemoteOAuthCredentialStore>();
+    let _: Option<AuthorizationManager> = None;
+    let _: Option<StoredCredentials> = None;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- move MCP OAuth credential storage and authorization bootstrap behind the Services integration owner
- keep Core's public compatibility facade plus product callback/session/reconnect orchestration
- route Desktop OAuth credential status through the assembled MCP manager instead of the Core global facade
- split the product-owned callback page/HTTP adapter into a private manager module without changing its behavior

## Architecture boundary

| Concern | Owner after this PR |
| --- | --- |
| RMCP SDK, credential vault/store, authorization bootstrap | Services integrations |
| Product callback page, OAuth session/cancel/reconnect orchestration | Core product assembly |
| Desktop command projection | Desktop via assembled Core manager |

Core's direct `rmcp` manifest edge changes from 1 to 0, and `product-full` no longer selects `dep:rmcp` directly. Services integrations remains the single direct RMCP owner. RMCP is still transitively present in full MCP products; this PR establishes ownership and does not claim to remove the full cold-build graph.

## Compatibility and scope

- preserves the existing Core OAuth facade for callers
- preserves callback locale selection, HTML escaping, first-callback delivery, timeout, cancellation, token exchange, and reconnect flow
- adds an existing-boundary guard preventing new direct RMCP manifest edges outside Services integrations
- adds one owner-local manager regression test in the existing Core test target
- does not add or change GitHub Actions jobs, workflows, test targets, or product delivery features

## Dependency impact

| Metric | Before | After |
| --- | ---: | ---: |
| Core direct `rmcp` dependency | 1 | 0 |
| Core `product-full` direct `dep:rmcp` selection | 1 | 0 |
| Services integrations direct `rmcp` owner | 1 | 1 |

## Validation

- `pnpm run check:core-boundaries:test` (36/36)
- `pnpm run check:core-boundaries`
- `cargo test -p bitfun-services-integrations --no-default-features --features mcp --test mcp_contracts` (42/42)
- `cargo check -p bitfun-core --no-default-features`
- `cargo test -p bitfun-core service::mcp::server::manager::auth_callback::tests::callback_page_prefers_the_product_locale_and_escapes_provider_errors -- --exact`
- `cargo test -p bitfun-core service::mcp::server::manager::tests::oauth_credentials_follow_the_manager_injected_data_dir -- --exact`
- `cargo check -p bitfun-desktop`