### PR TITLE
feat(instructions): activate path-scoped rules after reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "dirs 6.0.0",
  "dunce",
  "hex",
+ "log",
  "regex",
  "serde_json",
  "serde_yaml",

--- a/docs/architecture/extensions/external-ai-work-sources-design.md
+++ b/docs/architecture/extensions/external-ai-work-sources-design.md
@@ -348,6 +348,7 @@ Plugin Host Runtime、LSP，以及通用动态模型路由器。现有 capabilit
 
 | 能力 | OpenCode | Claude Code | Codex | 当前边界 |
 |---|---|---|---|---|
+| Rules / Instructions | 用户级 `AGENTS.md`/Claude fallback 与本地 `instructions` 文件、glob；项目级本地文件、glob | 用户与项目 `CLAUDE.md`、项目导入及 `.claude/rules/**/*.md`；带 `paths` 的规则延迟生效 | 用户与项目 `AGENTS.md` | 无条件来源按既有 user → workspace 顺序进入启动上下文；Claude path-scoped rule 仅在 `Read` 成功返回且工作区相对路径命中后追加到当前会话历史。条件内容在压缩时丢弃，之后需再次命中读取才恢复；不增加 watcher、UI、Plugin Host Runtime 或第二套 Rules owner。Remote 只发现远端工作区来源，不回退控制端用户目录。 |
 | Prompt Command | JSON/JSONC、Markdown 的 prompt、本地文本文件与经审阅 shell 上下文子集 | legacy `commands/**/*.md` 的同一子集；Skills 仍由 Skill 归属模块处理 | 没有稳定、独立于 Skills 的声明式 Command 来源，因此不伪造 provider | `$ARGUMENTS`/位置参数及模板内 workspace 相对 UTF-8 `@file` 可展开；`!shell` 在展示精确计划并重新校验后仅把 stdout 加入 Prompt，参数相关计划不可记住。Claude `allowed-tools` 只校验宿主格式，不授予预批准；动态/绝对/越界文件、指定 Agent/模型等整体受限；Remote 不回退本机执行。 |
 | Subagent | 用户/项目声明的安全子集 | 用户/项目 `agents/**/*.md` 的安全子集 | 用户/项目 `[agents]`、角色文件与安全配置层子集 | prompt、描述、`Default`/真实继承/不透明模型引用、OpenCode 不透明 variant、Claude/Codex reasoning effort 和可表达工具请求进入既有归属模块；无 profile 的模型引用可唯一精确匹配，variant/effort profile 必须由用户绑定到现有配置后才可激活。来源请求、profile、实际模型和解析方式在 Web/TUI 可见。权限、私有 MCP/Hook、reasoning summary/verbosity、采样、并发等没有对应实现的字段仍会阻止或降级。 |
 | MCP | 用户/显式目录/项目配置的安全子集 | user/project/local 原生层的安全子集 | 用户与项目 `config.toml` 原生层的安全子集 | 支持可表达的 stdio 与 HTTPS Streamable HTTP；发现不启动 Server，首次激活继续经 BitFun MCP 审批。OAuth、remote executor、per-tool policy 等不完整语义明确降级。 |
@@ -357,6 +358,7 @@ Plugin Host Runtime、LSP，以及通用动态模型路由器。现有 capabilit
 
 生态原生语义由各 adapter 以契约测试固定，不抽象成全局优先级：
 
+- Claude path-scoped Instructions 只解析 `.claude/rules/**/*.md` front matter 中非空的 `paths` 字符串列表；无效 YAML、绝对路径、URL、父目录逃逸与无效 glob 均 fail closed。用户与项目规则沿用既有 Instructions 发现、去重和渲染预算，执行引擎只识别成功的 `Read`/deferred `Read` 工具结果，不根据 Grep、Edit 或失败结果推测规则生效。规则首次命中后作为带来源身份的内部提醒持久化，同一活动上下文不重复注入。
 - Claude legacy Command 扫描用户与项目 `.claude/commands/**/*.md`，保留 `frontend/component` 到
   `/frontend:component` 的原生命名空间；同层重名无效，遵循 Claude Code 当前“personal 覆盖 project”的 Skill/legacy Command
   规则，同名 Skill 仅通过有界名称索引遮蔽 Command。

--- a/scripts/check-core-boundaries.test.mjs
+++ b/scripts/check-core-boundaries.test.mjs
@@ -967,6 +967,7 @@ test('services-core capability profiles keep heavy owners out of the empty profi
   ]);
   assert.deepEqual(profiles.get('workspace-instructions'), [
     'dep:globset',
+    'dep:serde_yaml',
     'tokio/fs',
     'tokio/io-util',
   ]);

--- a/scripts/core-boundaries/rules/feature-rules.mjs
+++ b/scripts/core-boundaries/rules/feature-rules.mjs
@@ -35,7 +35,7 @@ export const optionalDependencyFeatureOwnerRules = [
       { depName: 'libc', ownerFeatures: ['local-storage', 'process-runtime'] },
       { depName: 'notify', ownerFeatures: ['lsp'] },
       { depName: 'rusqlite', ownerFeatures: ['permission'] },
-      { depName: 'serde_yaml', ownerFeatures: ['markdown'] },
+      { depName: 'serde_yaml', ownerFeatures: ['markdown', 'workspace-instructions'] },
       {
         depName: 'sha2',
         ownerFeatures: [
@@ -274,9 +274,9 @@ export const coreClosedFeatureProfileRules = [
   {
     manifestPath: 'src/crates/services/services-core/Cargo.toml',
     featureName: 'workspace-instructions',
-    requiredFeatureRefs: ['dep:globset', 'tokio/fs', 'tokio/io-util'],
+    requiredFeatureRefs: ['dep:globset', 'dep:serde_yaml', 'tokio/fs', 'tokio/io-util'],
     exact: true,
-    reason: 'services-core workspace-instructions must own declarative instruction glob expansion only',
+    reason: 'services-core workspace-instructions must own declarative instruction discovery, scope parsing, and glob expansion only',
   },
   {
     manifestPath: 'src/crates/services/services-core/Cargo.toml',

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -218,7 +218,7 @@ export function runManifestParserSelfTest({
     [
       servicesCoreManifest,
       'workspace-instructions',
-      ['dep:globset', 'tokio/fs', 'tokio/io-util'],
+      ['dep:globset', 'dep:serde_yaml', 'tokio/fs', 'tokio/io-util'],
     ],
     [
       servicesCoreManifest,
@@ -849,7 +849,7 @@ export function runManifestParserSelfTest({
     ['libc', ['local-storage', 'process-runtime']],
     ['notify', ['lsp']],
     ['rusqlite', ['permission']],
-    ['serde_yaml', ['markdown']],
+    ['serde_yaml', ['markdown', 'workspace-instructions']],
     [
       'sha2',
       [

--- a/src/crates/adapters/claude-code-adapter/Cargo.toml
+++ b/src/crates/adapters/claude-code-adapter/Cargo.toml
@@ -16,6 +16,7 @@ bitfun-static-hook-support = { path = "../static-hook-support" }
 dirs = { workspace = true }
 dunce = { workspace = true }
 hex = { workspace = true }
+log = { workspace = true }
 regex = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/src/crates/adapters/claude-code-adapter/src/instruction_source.rs
+++ b/src/crates/adapters/claude-code-adapter/src/instruction_source.rs
@@ -1,9 +1,10 @@
 use bitfun_services_core::bounded_fs::{
     collect_bounded_regular_files, BoundedDirectoryWalkError, BoundedDirectoryWalkLimits,
 };
+use bitfun_services_core::instruction_scope::{parse_instruction_path_scope, InstructionPathScope};
 use bitfun_services_core::local_instructions::{
     read_local_instruction_file, LocalInstructionFile, LocalInstructionFiles,
-    MAX_LOCAL_INSTRUCTION_FILES,
+    MAX_LOCAL_INSTRUCTION_FILES, MAX_LOCAL_INSTRUCTION_TOTAL_BYTES,
 };
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
@@ -92,19 +93,93 @@ pub fn load_claude_code_user_instructions(
         let Some(file) = read_source(options, config_dir, &rule)? else {
             continue;
         };
-        if claude_rule_has_paths_frontmatter(&file.content) {
-            continue;
+        match parse_instruction_path_scope(&file.content) {
+            Ok(InstructionPathScope::Unscoped) => append_source_tree(
+                &mut files,
+                &mut read_attempts,
+                options,
+                config_dir,
+                rule,
+                Some(file),
+            )?,
+            Ok(InstructionPathScope::Scoped { paths, body }) => {
+                let mut file = file;
+                file.content = expand_scoped_rule_imports(
+                    &mut read_attempts,
+                    options,
+                    config_dir,
+                    &rule,
+                    body,
+                )?;
+                file.path_patterns = paths;
+                files.push(file);
+            }
+            Err(error) => {
+                log::warn!("Ignoring invalid Claude Code rule front matter: {error}");
+            }
         }
-        append_source_tree(
-            &mut files,
-            &mut read_attempts,
-            options,
-            config_dir,
-            rule,
-            Some(file),
-        )?;
     }
     Ok(files.into_files())
+}
+
+fn expand_scoped_rule_imports(
+    read_attempts: &mut usize,
+    options: &ClaudeCodeInstructionSourceOptions,
+    config_dir: &Path,
+    rule_path: &Path,
+    body: String,
+) -> Result<String, String> {
+    let mut expanded = body;
+    let mut seen = HashSet::from([normalize_path_lexically(rule_path)]);
+    let mut pending = claude_import_paths(
+        config_dir,
+        options.home_dir.as_deref(),
+        rule_path,
+        &expanded,
+    )
+    .into_iter()
+    .rev()
+    .map(|path| (path, 1usize))
+    .collect::<Vec<_>>();
+
+    while let Some((path, depth)) = pending.pop() {
+        if *read_attempts >= MAX_LOCAL_INSTRUCTION_FILES {
+            break;
+        }
+        *read_attempts += 1;
+        let Some(file) = read_source(options, config_dir, &path)? else {
+            continue;
+        };
+        if !seen.insert(file.canonical_path.clone()) {
+            continue;
+        }
+        let imports = if depth < MAX_CLAUDE_IMPORT_DEPTH {
+            claude_import_paths(
+                config_dir,
+                options.home_dir.as_deref(),
+                &path,
+                &file.content,
+            )
+        } else {
+            Vec::new()
+        };
+        if !file.content.trim().is_empty() {
+            if expanded
+                .len()
+                .saturating_add(file.content.len())
+                .saturating_add(3)
+                > MAX_LOCAL_INSTRUCTION_TOTAL_BYTES
+            {
+                log::warn!("Claude Code scoped rule import byte limit reached");
+                break;
+            }
+            expanded.push_str("\n\n");
+            expanded.push_str(file.content.trim());
+            expanded.push('\n');
+        }
+        pending.extend(imports.into_iter().rev().map(|import| (import, depth + 1)));
+    }
+    Ok(expanded)
 }
 
 fn append_source_tree(
@@ -228,26 +303,6 @@ fn normalize_path_lexically(path: &Path) -> PathBuf {
     normalized
 }
 
-fn claude_rule_has_paths_frontmatter(content: &str) -> bool {
-    let mut lines = content.lines();
-    if lines.next().map(str::trim) != Some("---") {
-        return false;
-    }
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            return false;
-        }
-        if trimmed
-            .split_once(':')
-            .is_some_and(|(key, _)| key.trim() == "paths")
-        {
-            return true;
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
@@ -256,7 +311,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     #[test]
-    fn user_memory_resolves_bounded_imports_and_unconditional_rules_only() {
+    fn user_memory_resolves_bounded_imports_and_preserves_scoped_rules() {
         let temp = tempfile::tempdir().expect("tempdir");
         let config_dir = temp.path().join("claude");
         std::fs::create_dir_all(config_dir.join("imports")).expect("imports directory");
@@ -303,10 +358,84 @@ mod tests {
                 "$CLAUDE_CONFIG_DIR/imports/base.md",
                 "$CLAUDE_CONFIG_DIR/imports/nested.md",
                 "$CLAUDE_CONFIG_DIR/rules/nested/a-first.md",
+                "$CLAUDE_CONFIG_DIR/rules/scoped.md",
                 "$CLAUDE_CONFIG_DIR/rules/z-last.md",
             ]
         );
-        assert!(!files.iter().any(|file| file.name.contains("scoped")));
+        assert_eq!(
+            files
+                .iter()
+                .find(|file| file.name.ends_with("/scoped.md"))
+                .expect("scoped rule")
+                .path_patterns,
+            vec!["src/**/*.rs"]
+        );
+    }
+
+    #[test]
+    fn user_instruction_sources_preserve_path_scoped_rules_without_frontmatter() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_dir = temp.path().join("claude");
+        std::fs::create_dir_all(config_dir.join("rules")).expect("rules directory");
+        std::fs::write(
+            config_dir.join("rules/scoped.md"),
+            "---\npaths:\n  - src/**/*.{rs,toml}\n  - tests/**/*.rs\n---\n\nScoped rule\n",
+        )
+        .expect("scoped rule");
+        let options = ClaudeCodeInstructionSourceOptions {
+            config_dir: Some(config_dir),
+            home_dir: None,
+            display_root: "$CLAUDE_CONFIG_DIR".to_string(),
+        };
+
+        let files = load_claude_code_user_instructions(&options).expect("sources");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, "$CLAUDE_CONFIG_DIR/rules/scoped.md");
+        assert_eq!(
+            files[0].path_patterns,
+            vec!["src/**/*.{rs,toml}", "tests/**/*.rs"]
+        );
+        assert_eq!(files[0].content, "Scoped rule\n");
+    }
+
+    #[test]
+    fn path_scoped_user_rule_imports_inherit_the_parent_scope() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_dir = temp.path().join("claude");
+        std::fs::create_dir_all(config_dir.join("shared")).expect("shared directory");
+        std::fs::create_dir_all(config_dir.join("rules")).expect("rules directory");
+        std::fs::write(
+            config_dir.join("rules/rust.md"),
+            "---\npaths:\n  - src/**/*.rs\n---\nRust rule\n@../shared/base.md\n",
+        )
+        .expect("scoped rule");
+        std::fs::write(
+            config_dir.join("shared/base.md"),
+            "Imported base\n@nested.md\n",
+        )
+        .expect("base import");
+        std::fs::write(config_dir.join("shared/nested.md"), "Nested import\n")
+            .expect("nested import");
+        let options = ClaudeCodeInstructionSourceOptions {
+            config_dir: Some(config_dir),
+            home_dir: None,
+            display_root: "$CLAUDE_CONFIG_DIR".to_string(),
+        };
+
+        let files = load_claude_code_user_instructions(&options).expect("sources");
+        let rule = files
+            .iter()
+            .find(|file| file.name.ends_with("/rust.md"))
+            .expect("scoped rule");
+
+        assert_eq!(rule.path_patterns, vec!["src/**/*.rs"]);
+        assert!(rule.content.contains("Rust rule"));
+        assert!(rule.content.contains("Imported base"));
+        assert!(rule.content.contains("Nested import"));
+        assert!(files.iter().all(|file| {
+            !file.name.ends_with("/base.md") && !file.name.ends_with("/nested.md")
+        }));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -12433,6 +12433,10 @@ mod tests {
     use tokio::sync::Notify;
     use tokio_util::sync::CancellationToken;
 
+    // These tests settle only after the real filesystem and SQLite persistence path completes.
+    // Keep the wait state-based, but allow for loaded hosted Windows runners.
+    const USER_SHELL_TURN_SETTLEMENT_TIMEOUT: Duration = Duration::from_secs(30);
+
     #[test]
     fn manual_compaction_cancellation_wins_before_commit() {
         let gate = ManualCompactionCommitGate::planning();
@@ -14184,7 +14188,7 @@ mod tests {
             .wait_for_turn_settlement(
                 &accepted.session_id,
                 &accepted.turn_id,
-                Duration::from_secs(5),
+                USER_SHELL_TURN_SETTLEMENT_TIMEOUT,
             )
             .await
             .expect("shell turn settles");
@@ -14279,7 +14283,7 @@ mod tests {
             .wait_for_turn_settlement(
                 &accepted.session_id,
                 &accepted.turn_id,
-                Duration::from_secs(5),
+                USER_SHELL_TURN_SETTLEMENT_TIMEOUT,
             )
             .await
             .expect("denied shell turn settles");
@@ -14337,7 +14341,7 @@ mod tests {
             .wait_for_turn_settlement(
                 &accepted.session_id,
                 &accepted.turn_id,
-                Duration::from_secs(5),
+                USER_SHELL_TURN_SETTLEMENT_TIMEOUT,
             )
             .await
             .expect("failed shell turn settles");
@@ -14433,7 +14437,7 @@ mod tests {
             .wait_for_turn_settlement(
                 &accepted.session_id,
                 &accepted.turn_id,
-                Duration::from_secs(5),
+                USER_SHELL_TURN_SETTLEMENT_TIMEOUT,
             )
             .await
             .expect("cancelled shell turn settles");

--- a/src/crates/assembly/core/src/agentic/core/message.rs
+++ b/src/crates/assembly/core/src/agentic/core/message.rs
@@ -70,6 +70,10 @@ pub struct MessageMetadata {
     pub compression_payload: Option<CompressionPayload>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_citation: Option<MemoryCitation>,
+    /// Stable source identities carried only by conditional instruction
+    /// reminders so activation can be reconstructed from persisted history.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub activated_instruction_sources: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -117,6 +121,8 @@ pub enum InternalReminderKind {
     /// Model-visible context contributed by a SessionStart or
     /// UserPromptSubmit hook.
     HookContext,
+    /// Instructions activated after a successful read of a matching file.
+    ConditionalInstructions,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -148,6 +154,7 @@ impl InternalReminderKind {
                 | Self::ThinkingOnlyRescue
                 | Self::FinalizeCacheAnchor
                 | Self::CompressionContinuation
+                | Self::ConditionalInstructions
                 // Mid-turn scaffolding: the Stop hook's feedback matters only
                 // while the reopened turn is still running. HookContext is
                 // deliberately absent — it carries real context a hook asked
@@ -554,6 +561,15 @@ impl Message {
 
     pub fn internal_reminder_kind(&self) -> Option<InternalReminderKind> {
         self.metadata.internal_reminder_kind
+    }
+
+    pub fn with_activated_instruction_sources(mut self, sources: Vec<String>) -> Self {
+        self.metadata.activated_instruction_sources = sources;
+        self
+    }
+
+    pub fn activated_instruction_sources(&self) -> &[String] {
+        &self.metadata.activated_instruction_sources
     }
 
     pub fn with_compression_payload(mut self, compression_payload: CompressionPayload) -> Self {

--- a/src/crates/assembly/core/src/agentic/execution/conditional_instructions.rs
+++ b/src/crates/assembly/core/src/agentic/execution/conditional_instructions.rs
@@ -1,0 +1,397 @@
+use crate::agentic::core::{InternalReminderKind, Message, MessageContent};
+use crate::agentic::workspace::WorkspaceServices;
+use crate::agentic::WorkspaceBinding;
+use crate::service::instruction_context::{
+    load_local_conditional_instruction_files, load_local_conditional_instruction_files_with_fs,
+    load_workspace_conditional_instruction_files_with_fs, render_instruction_documents,
+};
+use crate::util::errors::BitFunResult;
+use bitfun_services_core::workspace_instructions::{
+    WorkspaceInstructionFile, WorkspaceInstructionPathMatcher,
+};
+use log::warn;
+use std::collections::HashSet;
+
+const MAX_CONDITIONAL_INSTRUCTION_FILES: usize = 256;
+const MAX_CONDITIONAL_INSTRUCTION_BYTES: usize = 2 * 1024 * 1024;
+const CONDITIONAL_INSTRUCTION_HEADER: &str = "## Path-scoped instructions\n\nThe files just read made these instructions applicable. Follow them while working with matching files.\n";
+
+struct CompiledConditionalInstruction {
+    file: WorkspaceInstructionFile,
+    matcher: WorkspaceInstructionPathMatcher,
+}
+
+pub(crate) struct ConditionalInstructionCatalog {
+    entries: Vec<CompiledConditionalInstruction>,
+}
+
+pub(crate) async fn build_conditional_instruction_reminder(
+    workspace: &WorkspaceBinding,
+    workspace_services: Option<&WorkspaceServices>,
+    read_paths: &[String],
+    messages: &[Message],
+    turn_id: &str,
+    round_id: &str,
+) -> BitFunResult<Option<Message>> {
+    Ok(
+        ConditionalInstructionCatalog::load(workspace, workspace_services)
+            .await?
+            .build_reminder(read_paths, messages, turn_id, round_id),
+    )
+}
+
+impl ConditionalInstructionCatalog {
+    pub(crate) async fn load(
+        workspace: &WorkspaceBinding,
+        workspace_services: Option<&WorkspaceServices>,
+    ) -> BitFunResult<Self> {
+        let files = if workspace.is_remote() {
+            let Some(services) = workspace_services else {
+                warn!(
+                    "Remote conditional instruction discovery skipped because workspace services are unavailable"
+                );
+                return Ok(Self::from_files(Vec::new()));
+            };
+            load_workspace_conditional_instruction_files_with_fs(
+                services.fs.as_ref(),
+                &workspace.root_path_string(),
+            )
+            .await?
+        } else if let Some(services) = workspace_services {
+            load_local_conditional_instruction_files_with_fs(
+                workspace.root_path(),
+                services.fs.as_ref(),
+                &workspace.root_path_string(),
+            )
+            .await?
+        } else {
+            load_local_conditional_instruction_files(workspace.root_path()).await?
+        };
+        Ok(Self::from_files(files))
+    }
+
+    pub(crate) fn from_files(files: Vec<WorkspaceInstructionFile>) -> Self {
+        let mut entries = Vec::new();
+        let mut source_names = HashSet::new();
+        let mut total_bytes = 0usize;
+
+        for file in files {
+            if entries.len() >= MAX_CONDITIONAL_INSTRUCTION_FILES
+                || total_bytes.saturating_add(file.content.len())
+                    > MAX_CONDITIONAL_INSTRUCTION_BYTES
+            {
+                break;
+            }
+            if file.path_patterns.is_empty()
+                || file.content.trim().is_empty()
+                || !source_names.insert(file.name.clone())
+            {
+                continue;
+            }
+            let Some(matcher) =
+                WorkspaceInstructionPathMatcher::compile(&file.path_patterns, &file.name)
+            else {
+                continue;
+            };
+            total_bytes += file.content.len();
+            entries.push(CompiledConditionalInstruction { file, matcher });
+        }
+
+        Self { entries }
+    }
+
+    pub(crate) fn build_reminder(
+        &self,
+        read_paths: &[String],
+        messages: &[Message],
+        turn_id: &str,
+        round_id: &str,
+    ) -> Option<Message> {
+        let active_sources = messages
+            .iter()
+            .flat_map(Message::activated_instruction_sources)
+            .map(String::as_str)
+            .collect::<HashSet<_>>();
+        let matched_files = self
+            .entries
+            .iter()
+            .filter(|entry| !active_sources.contains(entry.file.name.as_str()))
+            .filter(|entry| read_paths.iter().any(|path| entry.matcher.is_match(path)))
+            .map(|entry| &entry.file)
+            .collect::<Vec<_>>();
+        let (content, activated_sources) =
+            render_instruction_documents(CONDITIONAL_INSTRUCTION_HEADER, matched_files);
+        let content = content?;
+
+        Some(
+            Message::internal_reminder(InternalReminderKind::ConditionalInstructions, content)
+                .with_turn_id(turn_id.to_string())
+                .with_round_id(round_id.to_string())
+                .with_activated_instruction_sources(activated_sources),
+        )
+    }
+}
+
+pub(crate) fn successful_workspace_read_paths(
+    messages: &[Message],
+    workspace: &WorkspaceBinding,
+) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    for message in messages {
+        let MessageContent::ToolResult {
+            tool_name,
+            effective_tool_name,
+            result,
+            is_error,
+            ..
+        } = &message.content
+        else {
+            continue;
+        };
+        let effective_name = effective_tool_name.as_deref().unwrap_or(tool_name);
+        if *is_error || effective_name != "Read" {
+            continue;
+        }
+        let Some(file_path) = result.get("file_path").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some(relative_path) = workspace_relative_path(workspace, file_path) else {
+            continue;
+        };
+        if seen.insert(relative_path.clone()) {
+            paths.push(relative_path);
+        }
+    }
+    paths
+}
+
+fn workspace_relative_path(workspace: &WorkspaceBinding, file_path: &str) -> Option<String> {
+    if file_path.starts_with("bitfun://") {
+        return None;
+    }
+    let file_path = file_path.trim().replace('\\', "/");
+    if !path_is_effectively_absolute(&file_path, workspace.is_remote()) {
+        return normalize_relative_read_path(&file_path);
+    }
+
+    let root = workspace.root_path_string().replace('\\', "/");
+    let root = root.trim_end_matches('/');
+    let prefix = format!("{root}/");
+    let relative = if cfg!(windows) && !workspace.is_remote() {
+        file_path
+            .get(..prefix.len())
+            .filter(|candidate| candidate.eq_ignore_ascii_case(&prefix))?;
+        &file_path[prefix.len()..]
+    } else {
+        file_path.strip_prefix(&prefix)?
+    };
+    normalize_relative_read_path(relative)
+}
+
+fn path_is_effectively_absolute(path: &str, remote: bool) -> bool {
+    if remote {
+        return path.starts_with('/');
+    }
+    std::path::Path::new(path).is_absolute() || has_windows_drive_prefix(path)
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+fn normalize_relative_read_path(path: &str) -> Option<String> {
+    let mut components = Vec::new();
+    for component in path.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                components.pop()?;
+            }
+            component => components.push(component),
+        }
+    }
+    (!components.is_empty()).then(|| components.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_conditional_instruction_reminder, successful_workspace_read_paths,
+        ConditionalInstructionCatalog,
+    };
+    use crate::agentic::core::{Message, MessageContent};
+    use crate::agentic::WorkspaceBinding;
+    use crate::instruction_sources::test_support::{lock_environment, EnvironmentGuard};
+    use bitfun_services_core::workspace_instructions::WorkspaceInstructionFile;
+    use serde_json::json;
+
+    fn conditional_file(name: &str, patterns: &[&str], content: &str) -> WorkspaceInstructionFile {
+        WorkspaceInstructionFile {
+            name: name.to_string(),
+            content: content.to_string(),
+            path_patterns: patterns
+                .iter()
+                .map(|pattern| (*pattern).to_string())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn catalog_matches_relative_globs_in_source_order_and_deduplicates_active_sources() {
+        let catalog = ConditionalInstructionCatalog::from_files(vec![
+            conditional_file(
+                "~/.claude/rules/typescript.md",
+                &["src/**/*.{ts,tsx}"],
+                "Use strict types.",
+            ),
+            conditional_file(
+                ".claude/rules/api.md",
+                &["src/api/**/*.ts", "tests/**/*.test.ts"],
+                "Validate API inputs.",
+            ),
+            conditional_file(
+                ".claude/rules/invalid.md",
+                &["../outside/**"],
+                "Must never load.",
+            ),
+        ]);
+
+        let first = catalog
+            .build_reminder(
+                &["src/api/users/route.ts".to_string()],
+                &[],
+                "turn-1",
+                "round-1",
+            )
+            .expect("matching reminder");
+
+        assert_eq!(
+            first.activated_instruction_sources(),
+            &["~/.claude/rules/typescript.md", ".claude/rules/api.md"]
+        );
+        let MessageContent::Text(text) = &first.content else {
+            panic!("conditional instructions must be an internal text reminder");
+        };
+        assert!(
+            text.find("Use strict types.").unwrap() < text.find("Validate API inputs.").unwrap()
+        );
+        assert!(!text.contains("Must never load."));
+        assert!(catalog
+            .build_reminder(
+                &["src/api/users/route.ts".to_string()],
+                &[first],
+                "turn-1",
+                "round-2",
+            )
+            .is_none());
+        assert!(
+            crate::agentic::core::InternalReminderKind::ConditionalInstructions
+                .should_drop_during_compaction()
+        );
+    }
+
+    #[test]
+    fn successful_read_paths_ignore_errors_other_tools_and_outside_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = WorkspaceBinding::new(None, temp.path().to_path_buf());
+        let inside = temp.path().join("src/lib.rs").to_string_lossy().to_string();
+        let outside = temp
+            .path()
+            .with_extension("outside.rs")
+            .to_string_lossy()
+            .to_string();
+        let messages = vec![
+            tool_result("Read", None, false, json!({"file_path": inside})),
+            tool_result("Grep", None, false, json!({"file_path": "src/other.rs"})),
+            tool_result("Read", None, true, json!({"file_path": "src/failed.rs"})),
+            tool_result(
+                "CallDeferredTool",
+                Some("Read"),
+                false,
+                json!({"file_path": outside}),
+            ),
+        ];
+
+        assert_eq!(
+            successful_workspace_read_paths(&messages, &workspace),
+            vec!["src/lib.rs"]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unmatched_read_does_not_freeze_rule_content_before_activation() {
+        let _environment = lock_environment();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp.path().join("workspace");
+        let xdg = temp.path().join("xdg");
+        let codex = temp.path().join("codex");
+        let claude = temp.path().join("claude");
+        std::fs::create_dir_all(workspace_root.join(".claude/rules")).expect("workspace rules");
+        std::fs::create_dir_all(xdg.join("opencode")).expect("OpenCode config");
+        std::fs::create_dir_all(&codex).expect("Codex config");
+        std::fs::create_dir_all(&claude).expect("Claude config");
+        let rule_path = workspace_root.join(".claude/rules/rust.md");
+        std::fs::write(&rule_path, "---\npaths:\n  - src/**/*.rs\n---\nOld rule\n")
+            .expect("old rule");
+        let _guard = EnvironmentGuard::set(&[
+            ("XDG_CONFIG_HOME", &xdg),
+            ("CODEX_HOME", &codex),
+            ("CLAUDE_CONFIG_DIR", &claude),
+        ]);
+        let workspace = WorkspaceBinding::new(None, workspace_root);
+
+        assert!(build_conditional_instruction_reminder(
+            &workspace,
+            None,
+            &["README.md".to_string()],
+            &[],
+            "turn-1",
+            "round-1",
+        )
+        .await
+        .expect("unmatched snapshot")
+        .is_none());
+
+        std::fs::write(&rule_path, "---\npaths:\n  - src/**/*.rs\n---\nNew rule\n")
+            .expect("updated rule");
+        let reminder = build_conditional_instruction_reminder(
+            &workspace,
+            None,
+            &["src/lib.rs".to_string()],
+            &[],
+            "turn-1",
+            "round-2",
+        )
+        .await
+        .expect("matching snapshot")
+        .expect("matching reminder");
+
+        assert!(reminder.content.to_string().contains("New rule"));
+        assert!(!reminder.content.to_string().contains("Old rule"));
+    }
+
+    fn tool_result(
+        tool_name: &str,
+        effective_tool_name: Option<&str>,
+        is_error: bool,
+        result: serde_json::Value,
+    ) -> Message {
+        Message {
+            id: format!("{tool_name}-result"),
+            role: crate::agentic::core::MessageRole::Tool,
+            content: MessageContent::ToolResult {
+                tool_id: format!("{tool_name}-id"),
+                tool_name: tool_name.to_string(),
+                effective_tool_name: effective_tool_name.map(str::to_string),
+                result,
+                result_for_assistant: None,
+                is_error,
+                image_attachments: None,
+            },
+            timestamp: std::time::SystemTime::now(),
+            metadata: Default::default(),
+        }
+    }
+}

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -18,6 +18,10 @@ use crate::agentic::core::{
     MessageRole, MessageSemanticKind, RequestReasoningTokenPolicy, Session,
 };
 use crate::agentic::events::{AgenticEvent, EventPriority, EventQueue};
+#[cfg(feature = "product-full")]
+use crate::agentic::execution::conditional_instructions::{
+    build_conditional_instruction_reminder, successful_workspace_read_paths,
+};
 use crate::agentic::execution::types::FinishReason;
 use crate::agentic::image_analysis::{
     build_multimodal_message_with_images, process_image_contexts_for_provider, ImageContextData,
@@ -145,6 +149,60 @@ fn manual_compaction_terminal_error(error: BitFunError) -> BitFunError {
     match error {
         error @ BitFunError::Cancelled(_) => error,
         error => BitFunError::Session(error.to_string()),
+    }
+}
+
+#[cfg(feature = "product-full")]
+async fn activate_conditional_instructions_after_round(
+    session_manager: &SessionManager,
+    context: &ExecutionContext,
+    round_result: &RoundResult,
+    messages: &mut Vec<Message>,
+) {
+    let Some(workspace) = context.workspace.as_ref() else {
+        return;
+    };
+    let read_paths = successful_workspace_read_paths(&round_result.tool_result_messages, workspace);
+    if read_paths.is_empty() {
+        return;
+    }
+
+    let reminder_round_id = round_result
+        .tool_result_messages
+        .first()
+        .and_then(|message| message.metadata.round_id.as_deref())
+        .unwrap_or("conditional-instructions");
+    let reminder = build_conditional_instruction_reminder(
+        workspace,
+        context.workspace_services.as_ref(),
+        &read_paths,
+        messages,
+        &context.dialog_turn_id,
+        reminder_round_id,
+    )
+    .await;
+    let Some(reminder) = (match reminder {
+        Ok(reminder) => reminder,
+        Err(error) => {
+            warn!(
+                "Failed to load conditional instructions; retrying after a later matching read: {}",
+                error
+            );
+            None
+        }
+    }) else {
+        return;
+    };
+
+    messages.push(reminder.clone());
+    if let Err(error) = session_manager
+        .add_message(&context.session_id, reminder)
+        .await
+    {
+        warn!(
+            "Failed to persist conditional instruction reminder: {}",
+            error
+        );
     }
 }
 
@@ -3798,6 +3856,15 @@ impl ExecutionEngine {
                 }
             }
 
+            #[cfg(feature = "product-full")]
+            activate_conditional_instructions_after_round(
+                self.session_manager.as_ref(),
+                &context,
+                &round_result,
+                &mut messages,
+            )
+            .await;
+
             debug!(
                 "Updated round messages in memory: round_index={}, assistant + {} tool results",
                 round_index,
@@ -4520,16 +4587,21 @@ impl ExecutionEngine {
 #[cfg(test)]
 mod tests {
     use super::{
-        manual_compaction_terminal_error, ContextHealthSnapshot, ExecutionEngine,
-        TurnPromptScaffold,
+        activate_conditional_instructions_after_round, manual_compaction_terminal_error,
+        ContextHealthSnapshot, ExecutionEngine, RoundResult, TurnPromptScaffold,
     };
     use crate::agentic::agents::{
         PrependedPromptReminders, PromptBuilderContext, UserContextPolicy,
     };
     use crate::agentic::core::{InternalReminderKind, Message, MessageRole, ToolCall, ToolResult};
-    use crate::agentic::session::{TokenAnchor, TokenAnchorInput};
+    use crate::agentic::persistence::PersistenceManager;
+    use crate::agentic::session::{
+        ContextCompressor, PromptCachePolicy, SessionContextStore, SessionManager,
+        SessionManagerConfig, TokenAnchor, TokenAnchorInput,
+    };
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::agentic::workspace::{local_workspace_services, WorkspaceBinding};
+    use crate::infrastructure::PathManager;
     use crate::instruction_sources::test_support::{lock_environment, EnvironmentGuard};
     use crate::service::config::types::AIConfig;
     use crate::service::config::types::AIModelConfig;
@@ -4542,6 +4614,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn manual_compaction_preserves_cancellation_as_a_terminal_cancellation() {
@@ -4834,6 +4907,220 @@ mod tests {
         assert!(context.contains("Local user source"));
         assert!(context.contains("Recovered workspace instructions."));
         assert!(!context.contains("Disk project source"));
+    }
+
+    #[tokio::test]
+    async fn conditional_rules_persist_once_and_reload_after_compaction() {
+        let _environment = lock_environment();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp.path().join("workspace");
+        let claude = temp.path().join("claude");
+        let xdg = temp.path().join("xdg");
+        let codex = temp.path().join("codex");
+        std::fs::create_dir_all(workspace_root.join(".claude/rules")).expect("workspace rules");
+        std::fs::create_dir_all(&claude).expect("Claude config");
+        std::fs::create_dir_all(xdg.join("opencode")).expect("OpenCode config");
+        std::fs::create_dir_all(&codex).expect("Codex config");
+        let rule_path = workspace_root.join(".claude/rules/rust.md");
+        std::fs::write(&rule_path, "---\npaths:\n  - src/**/*.rs\n---\nOld rule\n")
+            .expect("old rule");
+        let _guard = EnvironmentGuard::set(&[
+            ("XDG_CONFIG_HOME", &xdg),
+            ("CODEX_HOME", &codex),
+            ("CLAUDE_CONFIG_DIR", &claude),
+        ]);
+
+        let session_manager = SessionManager::new(
+            Arc::new(SessionContextStore::new()),
+            Arc::new(
+                PersistenceManager::new(Arc::new(PathManager::with_user_root_for_tests(
+                    temp.path().join("user-root"),
+                )))
+                .expect("persistence manager"),
+            ),
+            SessionManagerConfig {
+                max_active_sessions: 4,
+                session_idle_timeout: Duration::from_secs(3600),
+                auto_save_interval: Duration::from_secs(300),
+                enable_persistence: false,
+                prompt_cache_policy: PromptCachePolicy::default(),
+            },
+        );
+        let workspace = WorkspaceBinding::new(None, workspace_root.clone());
+        let context = crate::agentic::execution::types::ExecutionContext {
+            session_id: "session".to_string(),
+            dialog_turn_id: "turn".to_string(),
+            turn_index: 0,
+            agent_type: "agentic".to_string(),
+            workspace: Some(workspace),
+            context: HashMap::new(),
+            subagent_parent_info: None,
+            permission_delegation: None,
+            permission_runtime_ceiling: None,
+            delegation_policy: bitfun_runtime_ports::DelegationPolicy::top_level(),
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            workspace_services: Some(local_workspace_services(
+                workspace_root.to_string_lossy().to_string(),
+            )),
+            terminal_port: None,
+            remote_exec_port: None,
+            round_injection: None,
+            emit_lifecycle_events: false,
+            recover_partial_on_cancel: false,
+        };
+        let mut messages = vec![
+            Message::system("system".to_string()),
+            Message::user("older request".repeat(200)),
+        ];
+        for message in messages.iter().cloned() {
+            session_manager
+                .add_message(&context.session_id, message)
+                .await
+                .expect("seed context");
+        }
+
+        let first_round = conditional_read_round(&workspace_root, "round-1");
+        append_round_messages(
+            &session_manager,
+            &context.session_id,
+            &first_round,
+            &mut messages,
+        )
+        .await;
+        activate_conditional_instructions_after_round(
+            &session_manager,
+            &context,
+            &first_round,
+            &mut messages,
+        )
+        .await;
+        activate_conditional_instructions_after_round(
+            &session_manager,
+            &context,
+            &first_round,
+            &mut messages,
+        )
+        .await;
+
+        assert_eq!(conditional_reminders(&messages).len(), 1);
+        let persisted = session_manager
+            .get_context_messages(&context.session_id)
+            .await
+            .expect("persisted context");
+        assert_eq!(conditional_reminders(&persisted).len(), 1);
+        assert!(conditional_reminders(&persisted)[0]
+            .content
+            .to_string()
+            .contains("Old rule"));
+
+        let compressor = ContextCompressor::new(Default::default());
+        let plan = compressor
+            .plan_compression(&context.session_id, &persisted, 128_000, 100)
+            .expect("compression plan")
+            .expect("compressible context");
+        let compressed = compressor
+            .compress_plan_with_contract(
+                &context.session_id,
+                128_000,
+                plan,
+                None,
+                Some("summary".to_string()),
+            )
+            .expect("compression result")
+            .messages;
+        session_manager
+            .replace_context_messages(&context.session_id, compressed.clone())
+            .await;
+        assert!(conditional_reminders(&compressed).is_empty());
+        assert!(conditional_reminders(
+            &session_manager
+                .get_context_messages(&context.session_id)
+                .await
+                .expect("compacted context")
+        )
+        .is_empty());
+
+        std::fs::write(&rule_path, "---\npaths:\n  - src/**/*.rs\n---\nNew rule\n")
+            .expect("new rule");
+        messages = compressed;
+        let second_round = conditional_read_round(&workspace_root, "round-2");
+        append_round_messages(
+            &session_manager,
+            &context.session_id,
+            &second_round,
+            &mut messages,
+        )
+        .await;
+        activate_conditional_instructions_after_round(
+            &session_manager,
+            &context,
+            &second_round,
+            &mut messages,
+        )
+        .await;
+
+        let reloaded = conditional_reminders(&messages);
+        assert_eq!(reloaded.len(), 1);
+        assert!(reloaded[0].content.to_string().contains("New rule"));
+        assert!(!reloaded[0].content.to_string().contains("Old rule"));
+    }
+
+    fn conditional_read_round(workspace_root: &std::path::Path, round_id: &str) -> RoundResult {
+        let assistant = Message::assistant("Reading source".to_string())
+            .with_turn_id("turn".to_string())
+            .with_round_id(round_id.to_string());
+        let tool_result = Message::tool_result(ToolResult {
+            tool_id: format!("{round_id}-read"),
+            tool_name: bitfun_agent_tools::CALL_DEFERRED_TOOL_NAME.to_string(),
+            effective_tool_name: Some("Read".to_string()),
+            result: json!({ "file_path": workspace_root.join("src/lib.rs") }),
+            result_for_assistant: Some("source".to_string()),
+            is_error: false,
+            duration_ms: Some(1),
+            image_attachments: None,
+        })
+        .with_turn_id("turn".to_string())
+        .with_round_id(round_id.to_string());
+        RoundResult {
+            assistant_message: assistant,
+            tool_calls: Vec::new(),
+            tool_result_messages: vec![tool_result],
+            has_more_rounds: true,
+            finish_reason: crate::agentic::execution::types::FinishReason::Complete,
+            usage: None,
+            provider_metadata: None,
+            partial_recovery_reason: None,
+            had_assistant_text: false,
+            had_thinking_content: false,
+        }
+    }
+
+    async fn append_round_messages(
+        session_manager: &SessionManager,
+        session_id: &str,
+        round: &RoundResult,
+        messages: &mut Vec<Message>,
+    ) {
+        for message in std::iter::once(&round.assistant_message)
+            .chain(round.tool_result_messages.iter())
+            .cloned()
+        {
+            messages.push(message.clone());
+            session_manager
+                .add_message(session_id, message)
+                .await
+                .expect("persist round message");
+        }
+    }
+
+    fn conditional_reminders(messages: &[Message]) -> Vec<&Message> {
+        messages
+            .iter()
+            .filter(|message| {
+                message.internal_reminder_kind()
+                    == Some(InternalReminderKind::ConditionalInstructions)
+            })
+            .collect()
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/execution/mod.rs
+++ b/src/crates/assembly/core/src/agentic/execution/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! Responsible for AI interaction and model round control
 
+#[cfg(feature = "product-full")]
+pub(crate) mod conditional_instructions;
 pub mod edit_constraint_guard;
 pub mod execution_engine;
 pub(crate) mod model_exchange_trace;

--- a/src/crates/assembly/core/src/agentic/session/compression/compressor.rs
+++ b/src/crates/assembly/core/src/agentic/session/compression/compressor.rs
@@ -98,14 +98,17 @@ impl ContextCompressor {
         recent_target_tokens: usize,
     ) -> BitFunResult<Option<CompressionPlan>> {
         let runtime_messages = if runtime_messages.iter().any(|message| {
-            message.internal_reminder_kind() == Some(InternalReminderKind::CompressionContinuation)
+            message
+                .internal_reminder_kind()
+                .is_some_and(InternalReminderKind::should_drop_during_compaction)
         }) {
             Cow::Owned(
                 runtime_messages
                     .iter()
                     .filter(|message| {
-                        message.internal_reminder_kind()
-                            != Some(InternalReminderKind::CompressionContinuation)
+                        !message
+                            .internal_reminder_kind()
+                            .is_some_and(InternalReminderKind::should_drop_during_compaction)
                     })
                     .cloned()
                     .collect(),
@@ -748,6 +751,48 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn conditional_instruction_reminders_do_not_enter_any_compacted_context() {
+        let compressor = ContextCompressor::new(Default::default());
+        let summarized_reminder = Message::internal_reminder(
+            InternalReminderKind::ConditionalInstructions,
+            "older path rule",
+        );
+        let recent_reminder = Message::internal_reminder(
+            InternalReminderKind::ConditionalInstructions,
+            "recent path rule",
+        );
+        let messages = vec![
+            Message::system("system".to_string()),
+            Message::user("older request".repeat(200)),
+            summarized_reminder.clone(),
+            Message::assistant("older answer".repeat(200)),
+            Message::user("current request".to_string()),
+            recent_reminder.clone(),
+            Message::assistant("current answer".to_string()),
+        ];
+
+        let plan = compressor
+            .plan_compression("session", &messages, 128_000, 100)
+            .expect("planning succeeds")
+            .expect("plan exists");
+
+        for reminder in [summarized_reminder, recent_reminder] {
+            assert!(!plan
+                .summary_request_messages
+                .iter()
+                .any(|message| message.id == reminder.id));
+            assert!(!plan
+                .summary_messages
+                .iter()
+                .any(|message| message.id == reminder.id));
+            assert!(!plan
+                .recent_tail_messages
+                .iter()
+                .any(|message| message.id == reminder.id));
+        }
     }
 
     #[test]

--- a/src/crates/assembly/core/src/instruction_sources.rs
+++ b/src/crates/assembly/core/src/instruction_sources.rs
@@ -16,6 +16,14 @@ pub(crate) struct LocalUserInstructionFiles {
 pub(crate) async fn load_local_user_instruction_files(
     workspace_root: &Path,
 ) -> LocalUserInstructionFiles {
+    let mut sources = load_local_user_instruction_sources(workspace_root).await;
+    sources.files.retain(|file| file.path_patterns.is_empty());
+    sources
+}
+
+pub(crate) async fn load_local_user_instruction_sources(
+    workspace_root: &Path,
+) -> LocalUserInstructionFiles {
     let workspace_root = workspace_root.to_path_buf();
     let result = tokio::task::spawn_blocking(move || {
         let mut files = Vec::new();
@@ -65,6 +73,34 @@ pub(crate) async fn load_local_user_instruction_files(
     }
 }
 
+pub(crate) async fn load_local_user_conditional_instruction_sources() -> Vec<LocalInstructionFile> {
+    match tokio::task::spawn_blocking(|| {
+        load_claude_code_user_instructions(&ClaudeCodeInstructionSourceOptions::from_environment())
+            .map(|files| {
+                files
+                    .into_iter()
+                    .filter(|file| !file.path_patterns.is_empty())
+                    .collect()
+            })
+    })
+    .await
+    {
+        Ok(Ok(files)) => files,
+        Ok(Err(error)) => {
+            log::warn!(
+                "Failed to load Claude Code conditional instructions; retrying after a later matching read: {error}"
+            );
+            Vec::new()
+        }
+        Err(error) => {
+            log::warn!(
+                "Failed to join Claude Code conditional instruction discovery; retrying after a later matching read: {error}"
+            );
+            Vec::new()
+        }
+    }
+}
+
 fn deduplicate_user_instruction_files(files: &mut Vec<LocalInstructionFile>) {
     let mut bounded = LocalInstructionFiles::default();
     bounded.extend(std::mem::take(files));
@@ -84,6 +120,7 @@ mod tests {
                 canonical_path: PathBuf::from(format!("source-{index}.md")),
                 name: format!("source-{index}.md"),
                 content: format!("instruction {index}"),
+                path_patterns: Vec::new(),
             })
             .collect::<Vec<_>>();
         files.insert(
@@ -92,6 +129,7 @@ mod tests {
                 canonical_path: PathBuf::from("source-0.md"),
                 name: "duplicate.md".to_string(),
                 content: "duplicate must lose".to_string(),
+                path_patterns: Vec::new(),
             },
         );
 
@@ -109,6 +147,7 @@ mod tests {
                 canonical_path: PathBuf::from(format!("large-{index}.md")),
                 name: format!("large-{index}.md"),
                 content: "x".repeat(1024 * 1024),
+                path_patterns: Vec::new(),
             })
             .collect::<Vec<_>>();
 

--- a/src/crates/assembly/core/src/service/instruction_context.rs
+++ b/src/crates/assembly/core/src/service/instruction_context.rs
@@ -63,29 +63,93 @@ pub(crate) async fn build_local_workspace_instruction_files_context_with_fs_deta
 fn compose_local_instruction_sources(
     workspace_root: &Path,
     user_instruction_files: crate::instruction_sources::LocalUserInstructionFiles,
-    mut workspace_instruction_files: Vec<WorkspaceInstructionFile>,
+    workspace_instruction_files: Vec<WorkspaceInstructionFile>,
 ) -> InstructionContextBuild {
+    let cacheable = user_instruction_files.cacheable;
+    let instruction_files = merge_local_instruction_sources(
+        workspace_root,
+        user_instruction_files.files,
+        workspace_instruction_files,
+    );
+    InstructionContextBuild {
+        content: render_workspace_instruction_files_section(&instruction_files),
+        cacheable,
+    }
+}
+
+fn merge_local_instruction_sources(
+    workspace_root: &Path,
+    user_instruction_files: Vec<bitfun_services_core::local_instructions::LocalInstructionFile>,
+    mut workspace_instruction_files: Vec<WorkspaceInstructionFile>,
+) -> Vec<WorkspaceInstructionFile> {
     bitfun_services_core::workspace_instructions::retain_distinct_local_workspace_instruction_files(
         workspace_root,
         user_instruction_files
-            .files
             .iter()
             .map(|file| file.canonical_path.clone()),
         &mut workspace_instruction_files,
     );
     let mut instruction_files = user_instruction_files
-        .files
         .into_iter()
         .map(|file| WorkspaceInstructionFile {
             name: file.name,
             content: file.content,
+            path_patterns: file.path_patterns,
         })
         .collect::<Vec<_>>();
     instruction_files.extend(workspace_instruction_files);
-    InstructionContextBuild {
-        content: render_workspace_instruction_files_section(&instruction_files),
-        cacheable: user_instruction_files.cacheable,
-    }
+    instruction_files
+}
+
+pub(crate) async fn load_local_conditional_instruction_files(
+    workspace_root: &Path,
+) -> BitFunResult<Vec<WorkspaceInstructionFile>> {
+    let user_instruction_files =
+        crate::instruction_sources::load_local_user_conditional_instruction_sources().await;
+    let workspace_instruction_files =
+        bitfun_services_core::workspace_instructions::read_workspace_conditional_instruction_sources(
+            workspace_root,
+        )
+        .await
+        .map_err(BitFunError::service)?;
+    Ok(merge_local_instruction_sources(
+        workspace_root,
+        user_instruction_files,
+        workspace_instruction_files,
+    ))
+}
+
+pub(crate) async fn load_local_conditional_instruction_files_with_fs(
+    workspace_root: &Path,
+    fs: &dyn WorkspaceFileSystem,
+    workspace_root_path: &str,
+) -> BitFunResult<Vec<WorkspaceInstructionFile>> {
+    let user_instruction_files =
+        crate::instruction_sources::load_local_user_conditional_instruction_sources().await;
+    let workspace_instruction_files =
+        bitfun_services_core::workspace_instructions::read_workspace_conditional_instruction_sources_with_fs(
+            fs,
+            workspace_root_path,
+        )
+        .await
+        .map_err(BitFunError::service)?;
+    Ok(merge_local_instruction_sources(
+        workspace_root,
+        user_instruction_files,
+        workspace_instruction_files,
+    ))
+}
+
+pub(crate) async fn load_workspace_conditional_instruction_files_with_fs(
+    fs: &dyn WorkspaceFileSystem,
+    workspace_root: &str,
+) -> BitFunResult<Vec<WorkspaceInstructionFile>> {
+    Ok(bitfun_services_core::workspace_instructions::read_workspace_conditional_instruction_sources_with_fs(
+            fs,
+            workspace_root,
+        )
+        .await
+        .map_err(BitFunError::service)?)
 }
 
 pub(crate) async fn build_workspace_instruction_files_context_with_fs(
@@ -107,15 +171,21 @@ pub(crate) async fn build_workspace_instruction_files_context_with_fs(
 fn render_workspace_instruction_files_section(
     files: &[WorkspaceInstructionFile],
 ) -> Option<String> {
-    if files.is_empty() {
-        return None;
-    }
+    render_instruction_documents(
+        "## Codebase and user instructions\n\nBe sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.\n",
+        files.iter().filter(|file| file.path_patterns.is_empty()),
+    )
+    .0
+}
 
-    let mut rendered =
-        String::from("## Codebase and user instructions\n\nBe sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.\n");
+pub(crate) fn render_instruction_documents<'a>(
+    header: &str,
+    files: impl IntoIterator<Item = &'a WorkspaceInstructionFile>,
+) -> (Option<String>, Vec<String>) {
+    let mut rendered = String::from(header);
+    let mut rendered_names = Vec::new();
 
-    let mut rendered_file_count = 0usize;
-    for file in files.iter().take(MAX_RENDERED_INSTRUCTION_FILES) {
+    for file in files.into_iter().take(MAX_RENDERED_INSTRUCTION_FILES) {
         let escaped_name = escape_document_name(&file.name);
         let document = format!(
             "<document name=\"{}\">\n{}\n</document>\n\n",
@@ -126,10 +196,13 @@ fn render_workspace_instruction_files_section(
             break;
         }
         rendered.push_str(&document);
-        rendered_file_count += 1;
+        rendered_names.push(file.name.clone());
     }
 
-    (rendered_file_count > 0).then(|| rendered.trim_end().to_string())
+    (
+        (!rendered_names.is_empty()).then(|| rendered.trim_end().to_string()),
+        rendered_names,
+    )
 }
 
 fn escape_document_name(name: &str) -> String {
@@ -145,7 +218,8 @@ mod tests {
         build_workspace_instruction_files_context,
         build_workspace_instruction_files_context_detailed,
         build_workspace_instruction_files_context_with_fs,
-        render_workspace_instruction_files_section, WorkspaceInstructionFile,
+        load_local_conditional_instruction_files, render_workspace_instruction_files_section,
+        WorkspaceInstructionFile,
     };
     use crate::instruction_sources::test_support::{lock_environment, EnvironmentGuard};
     use bitfun_services_core::workspace::LocalWorkspaceFs;
@@ -190,6 +264,91 @@ mod tests {
                 .expect("workspace instructions"),
         ];
         assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[tokio::test]
+    async fn conditional_instructions_keep_user_then_workspace_precedence() {
+        let _environment = lock_environment();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let xdg = temp.path().join("xdg");
+        let codex = temp.path().join("codex");
+        let claude = temp.path().join("claude");
+        std::fs::create_dir_all(xdg.join("opencode")).expect("OpenCode config directory");
+        std::fs::create_dir_all(&codex).expect("Codex config directory");
+        std::fs::create_dir_all(claude.join("rules")).expect("Claude rules directory");
+        std::fs::create_dir_all(workspace.join(".claude/rules"))
+            .expect("workspace rules directory");
+        std::fs::write(
+            claude.join("rules/user.md"),
+            "---\npaths:\n  - src/**/*.rs\n---\nUser rule\n",
+        )
+        .expect("user rule");
+        std::fs::write(
+            workspace.join(".claude/rules/project.md"),
+            "---\npaths:\n  - src/**/*.rs\n---\nProject rule\n",
+        )
+        .expect("project rule");
+        let _guard = EnvironmentGuard::set(&[
+            ("XDG_CONFIG_HOME", &xdg),
+            ("CODEX_HOME", &codex),
+            ("CLAUDE_CONFIG_DIR", &claude),
+        ]);
+
+        let files = load_local_conditional_instruction_files(&workspace)
+            .await
+            .expect("conditional instructions");
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "$CLAUDE_CONFIG_DIR/rules/user.md",
+                ".claude/rules/project.md"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_user_rule_does_not_hide_project_conditional_instructions() {
+        let _environment = lock_environment();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let xdg = temp.path().join("xdg");
+        let codex = temp.path().join("codex");
+        let claude = temp.path().join("claude");
+        std::fs::create_dir_all(xdg.join("opencode")).expect("OpenCode config directory");
+        std::fs::create_dir_all(&codex).expect("Codex config directory");
+        std::fs::create_dir_all(claude.join("rules")).expect("Claude rules directory");
+        std::fs::create_dir_all(workspace.join(".claude/rules"))
+            .expect("workspace rules directory");
+        std::fs::write(
+            claude.join("rules/oversized.md"),
+            vec![
+                b'x';
+                bitfun_services_core::local_instructions::MAX_LOCAL_INSTRUCTION_FILE_BYTES + 1
+            ],
+        )
+        .expect("oversized user rule");
+        std::fs::write(
+            workspace.join(".claude/rules/project.md"),
+            "---\npaths:\n  - src/**/*.rs\n---\nProject rule\n",
+        )
+        .expect("project rule");
+        let _guard = EnvironmentGuard::set(&[
+            ("XDG_CONFIG_HOME", &xdg),
+            ("CODEX_HOME", &codex),
+            ("CLAUDE_CONFIG_DIR", &claude),
+        ]);
+
+        let files = load_local_conditional_instruction_files(&workspace)
+            .await
+            .expect("project conditional instructions");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, ".claude/rules/project.md");
     }
 
     #[tokio::test]
@@ -337,6 +496,7 @@ mod tests {
         let rendered = render_workspace_instruction_files_section(&[WorkspaceInstructionFile {
             name: "<configured-path>/team\"&.md".to_string(),
             content: "Team instructions".to_string(),
+            path_patterns: Vec::new(),
         }])
         .expect("rendered instructions");
 
@@ -350,6 +510,7 @@ mod tests {
             .map(|index| WorkspaceInstructionFile {
                 name: format!("source-{index}.md"),
                 content: format!("source-{index}\n{}", "x".repeat(700 * 1024)),
+                path_patterns: Vec::new(),
             })
             .collect::<Vec<_>>();
 
@@ -368,6 +529,7 @@ mod tests {
             .map(|index| WorkspaceInstructionFile {
                 name: format!("source-{index}.md"),
                 content: format!("instruction {index}"),
+                path_patterns: Vec::new(),
             })
             .collect::<Vec<_>>();
 

--- a/src/crates/services/services-core/Cargo.toml
+++ b/src/crates/services/services-core/Cargo.toml
@@ -74,7 +74,7 @@ process-runtime = [
     "windows/Win32_System_Diagnostics_ToolHelp",
     "windows/Win32_System_Threading",
 ]
-workspace-instructions = ["dep:globset", "tokio/fs", "tokio/io-util"]
+workspace-instructions = ["dep:globset", "dep:serde_yaml", "tokio/fs", "tokio/io-util"]
 lsp = [
     "dep:anyhow",
     "dep:bitfun-core-types",

--- a/src/crates/services/services-core/src/instruction_scope.rs
+++ b/src/crates/services/services-core/src/instruction_scope.rs
@@ -1,0 +1,117 @@
+use serde_yaml::Value;
+use std::sync::LazyLock;
+
+static FRONT_MATTER_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?s)^---\r?\n(.*?)\r?\n---").expect("front matter regex pattern is valid")
+});
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstructionPathScope {
+    Unscoped,
+    Scoped { paths: Vec<String>, body: String },
+}
+
+pub(crate) fn parse_front_matter(content: &str) -> Result<(Value, String), String> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let captures = FRONT_MATTER_REGEX
+        .captures(content)
+        .ok_or_else(|| "Failed to capture content".to_string())?;
+    let yaml = captures
+        .get(1)
+        .ok_or_else(|| "Failed to get captures".to_string())?
+        .as_str();
+    let metadata =
+        serde_yaml::from_str(yaml).map_err(|error| format!("Failed to parse YAML: {error}"))?;
+    let body_start = captures
+        .get(0)
+        .ok_or_else(|| "Failed to get captures".to_string())?
+        .end();
+    Ok((metadata, content[body_start..].trim_start().to_string()))
+}
+
+/// Parses a declarative `paths` scope without assigning provider-specific
+/// meaning to the Markdown body. Malformed front matter fails closed so a
+/// conditional document cannot accidentally become startup context.
+pub fn parse_instruction_path_scope(content: &str) -> Result<InstructionPathScope, String> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    if !content.starts_with("---\n") && !content.starts_with("---\r\n") {
+        return Ok(InstructionPathScope::Unscoped);
+    }
+
+    let (metadata, body) = parse_front_matter(content)?;
+    let Some(raw_paths) = metadata.get("paths") else {
+        return Ok(InstructionPathScope::Unscoped);
+    };
+    let Some(raw_paths) = raw_paths.as_sequence() else {
+        return Err("paths must be a sequence of non-empty strings".to_string());
+    };
+    let paths = raw_paths
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| "paths must be a sequence of non-empty strings".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if paths.is_empty() {
+        return Err("paths must be a sequence of non-empty strings".to_string());
+    }
+
+    Ok(InstructionPathScope::Scoped { paths, body })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_instruction_path_scope, InstructionPathScope};
+
+    #[test]
+    fn extracts_ordered_patterns_and_body() {
+        let content =
+            "---\npaths:\n  - src/**/*.{ts,tsx}\n  - tests/**/*.test.ts\n---\n\n# TypeScript rules\n";
+
+        assert_eq!(
+            parse_instruction_path_scope(content).expect("valid path scope"),
+            InstructionPathScope::Scoped {
+                paths: vec![
+                    "src/**/*.{ts,tsx}".to_string(),
+                    "tests/**/*.test.ts".to_string(),
+                ],
+                body: "# TypeScript rules\n".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn distinguishes_unscoped_and_invalid_metadata() {
+        assert_eq!(
+            parse_instruction_path_scope("Always applies\n").expect("plain markdown"),
+            InstructionPathScope::Unscoped
+        );
+        assert_eq!(
+            parse_instruction_path_scope("---\ntitle: General\n---\nGeneral rules\n")
+                .expect("front matter without paths"),
+            InstructionPathScope::Unscoped
+        );
+
+        let error = parse_instruction_path_scope("---\npaths: src/**/*.rs\n---\nInvalid\n")
+            .expect_err("paths must be a sequence");
+        assert!(error.contains("sequence of non-empty strings"));
+    }
+
+    #[test]
+    fn accepts_utf8_bom_and_crlf_before_scoped_front_matter() {
+        assert_eq!(
+            parse_instruction_path_scope(
+                "\u{feff}---\r\npaths:\r\n  - src/**/*.rs\r\n---\r\n\r\nWindows rule\r\n",
+            )
+            .expect("BOM-prefixed path scope"),
+            InstructionPathScope::Scoped {
+                paths: vec!["src/**/*.rs".to_string()],
+                body: "Windows rule\r\n".to_string(),
+            }
+        );
+    }
+}

--- a/src/crates/services/services-core/src/lib.rs
+++ b/src/crates/services/services-core/src/lib.rs
@@ -13,6 +13,8 @@ pub mod dispatch_workspace;
 mod file_lock;
 #[cfg(feature = "filesystem")]
 pub mod filesystem;
+#[cfg(any(feature = "markdown", feature = "workspace-instructions"))]
+pub mod instruction_scope;
 #[cfg(feature = "local-storage")]
 pub mod json_store;
 pub mod jsonc;

--- a/src/crates/services/services-core/src/local_instructions.rs
+++ b/src/crates/services/services-core/src/local_instructions.rs
@@ -13,6 +13,9 @@ pub struct LocalInstructionFile {
     pub canonical_path: PathBuf,
     pub name: String,
     pub content: String,
+    /// Empty means the document applies unconditionally. Non-empty patterns
+    /// are matched against workspace-relative paths by the product owner.
+    pub path_patterns: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -153,6 +156,7 @@ pub fn read_local_text_file(
         canonical_path,
         name: name.into(),
         content,
+        path_patterns: Vec::new(),
     }))
 }
 

--- a/src/crates/services/services-core/src/markdown.rs
+++ b/src/crates/services/services-core/src/markdown.rs
@@ -1,11 +1,7 @@
+use crate::instruction_scope::parse_front_matter;
 use serde_yaml::Value;
 use std::ops::Range;
 use std::sync::LazyLock;
-
-/// Compiled once; front-matter parsing runs on every `.md` scan.
-static FRONT_MATTER_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r"(?s)^---\r?\n(.*?)\r?\n---").expect("front matter regex pattern is valid")
-});
 
 static PROMPT_ARGUMENT_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r#"(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)"#)
@@ -280,25 +276,7 @@ impl FrontMatterMarkdown {
     }
 
     pub fn load_str(content: &str) -> Result<(Value, String), String> {
-        let caps = FRONT_MATTER_REGEX
-            .captures(content)
-            .ok_or_else(|| "Failed to capture content".to_string())?;
-
-        let yaml_content = caps
-            .get(1)
-            .ok_or_else(|| "Failed to get captures".to_string())?
-            .as_str();
-
-        let metadata: Value = serde_yaml::from_str(yaml_content)
-            .map_err(|e| format!("Failed to parse YAML: {}", e))?;
-
-        let after_front_matter = caps
-            .get(0)
-            .ok_or_else(|| "Failed to get captures".to_string())?
-            .end();
-        let markdown_body = content[after_front_matter..].trim_start();
-
-        Ok((metadata, markdown_body.to_string()))
+        parse_front_matter(content)
     }
 
     pub fn save(path: &str, metadata: &Value, body: &str) -> Result<(), String> {

--- a/src/crates/services/services-core/src/workspace_instructions.rs
+++ b/src/crates/services/services-core/src/workspace_instructions.rs
@@ -1,10 +1,11 @@
-use globset::GlobBuilder;
+use globset::{GlobBuilder, GlobMatcher};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tokio::io::AsyncReadExt;
 
+use crate::instruction_scope::{parse_instruction_path_scope, InstructionPathScope};
 use crate::jsonc::strip_jsonc;
 
 pub const WORKSPACE_INSTRUCTION_FILE_NAMES: [&str; 5] = [
@@ -37,6 +38,51 @@ const RECURSIVE_SCAN_IGNORED_DIRECTORIES: &[&str] =
 pub struct WorkspaceInstructionFile {
     pub name: String,
     pub content: String,
+    /// Empty means startup context; non-empty patterns defer the document
+    /// until a matching workspace file is read.
+    pub path_patterns: Vec<String>,
+}
+
+/// Compiled workspace-relative path scope owned alongside declarative
+/// instruction glob expansion. Consumers do not need a direct glob dependency.
+pub struct WorkspaceInstructionPathMatcher {
+    matchers: Vec<GlobMatcher>,
+}
+
+impl WorkspaceInstructionPathMatcher {
+    pub fn compile(patterns: &[String], source_name: &str) -> Option<Self> {
+        let matchers = patterns
+            .iter()
+            .filter_map(|pattern| {
+                let Some(pattern) = normalize_instruction_scope_glob(pattern) else {
+                    log::warn!(
+                        "Ignoring non-relative conditional instruction pattern in {source_name}: {pattern}"
+                    );
+                    return None;
+                };
+                match GlobBuilder::new(&pattern)
+                    .literal_separator(true)
+                    .backslash_escape(true)
+                    .build()
+                {
+                    Ok(glob) => Some(glob.compile_matcher()),
+                    Err(error) => {
+                        log::warn!(
+                            "Ignoring invalid conditional instruction pattern in {source_name}: {error}"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        (!matchers.is_empty()).then_some(Self { matchers })
+    }
+
+    pub fn is_match(&self, workspace_relative_path: &str) -> bool {
+        self.matchers
+            .iter()
+            .any(|matcher| matcher.is_match(workspace_relative_path))
+    }
 }
 
 /// Keeps the first physical local file across a preceding source set and the
@@ -297,6 +343,22 @@ impl<'a> WorkspaceInstructionResolver<'a> {
                 .await?;
         }
 
+        self.append_claude_rules(false).await?;
+
+        for config_path in OPENCODE_PROJECT_CONFIG_FILES {
+            self.append_opencode_config_instructions(config_path)
+                .await?;
+        }
+
+        Ok(self.files)
+    }
+
+    async fn resolve_conditional(mut self) -> Result<Vec<WorkspaceInstructionFile>, String> {
+        self.append_claude_rules(true).await?;
+        Ok(self.files)
+    }
+
+    async fn append_claude_rules(&mut self, conditional_only: bool) -> Result<(), String> {
         let rules = self.collect_files(CLAUDE_RULES_DIRECTORY).await?;
         for rule in rules
             .into_iter()
@@ -308,19 +370,32 @@ impl<'a> WorkspaceInstructionResolver<'a> {
             let Some(content) = self.read_instruction_text(&rule).await? else {
                 continue;
             };
-            if claude_rule_has_paths_frontmatter(&content) {
-                continue;
+            match parse_instruction_path_scope(&content) {
+                Ok(InstructionPathScope::Unscoped) if !conditional_only => {
+                    self.append_source_tree_with_content(rule, true, Some(content))
+                        .await?;
+                }
+                Ok(InstructionPathScope::Unscoped) => {
+                    self.seen.insert(rule);
+                }
+                Ok(InstructionPathScope::Scoped { paths, body }) => {
+                    self.seen.insert(rule.clone());
+                    let content = self.expand_scoped_rule_imports(&rule, body).await?;
+                    if !content.trim().is_empty() {
+                        self.files.push(WorkspaceInstructionFile {
+                            name: rule,
+                            content,
+                            path_patterns: paths,
+                        });
+                    }
+                }
+                Err(error) => {
+                    self.seen.insert(rule);
+                    log::warn!("Ignoring invalid Claude Code rule front matter: {error}");
+                }
             }
-            self.append_source_tree_with_content(rule, true, Some(content))
-                .await?;
         }
-
-        for config_path in OPENCODE_PROJECT_CONFIG_FILES {
-            self.append_opencode_config_instructions(config_path)
-                .await?;
-        }
-
-        Ok(self.files)
+        Ok(())
     }
 
     async fn first_existing(&self, candidates: &[&str]) -> Result<Option<String>, String> {
@@ -412,6 +487,7 @@ impl<'a> WorkspaceInstructionResolver<'a> {
                 self.files.push(WorkspaceInstructionFile {
                     name: path.clone(),
                     content,
+                    path_patterns: Vec::new(),
                 });
             }
 
@@ -423,6 +499,41 @@ impl<'a> WorkspaceInstructionResolver<'a> {
             );
         }
         Ok(())
+    }
+
+    async fn expand_scoped_rule_imports(
+        &mut self,
+        rule_path: &str,
+        body: String,
+    ) -> Result<String, String> {
+        let mut expanded = body;
+        let mut seen = HashSet::from([rule_path.to_string()]);
+        let mut pending = claude_import_paths(rule_path, &expanded)
+            .into_iter()
+            .rev()
+            .map(|path| (path, 1usize))
+            .collect::<Vec<_>>();
+
+        while let Some((path, depth)) = pending.pop() {
+            if !seen.insert(path.clone()) {
+                continue;
+            }
+            let Some(content) = self.read_instruction_text(&path).await? else {
+                continue;
+            };
+            let imports = if depth < MAX_CLAUDE_IMPORT_DEPTH {
+                claude_import_paths(&path, &content)
+            } else {
+                Vec::new()
+            };
+            if !content.trim().is_empty() {
+                expanded.push_str("\n\n");
+                expanded.push_str(content.trim());
+                expanded.push('\n');
+            }
+            pending.extend(imports.into_iter().rev().map(|import| (import, depth + 1)));
+        }
+        Ok(expanded)
     }
 
     async fn append_opencode_config_instructions(
@@ -544,8 +655,26 @@ impl<'a> WorkspaceInstructionResolver<'a> {
 pub async fn read_workspace_instruction_files(
     workspace_root: &Path,
 ) -> Result<Vec<WorkspaceInstructionFile>, String> {
+    Ok(read_workspace_instruction_sources(workspace_root)
+        .await?
+        .into_iter()
+        .filter(|file| file.path_patterns.is_empty())
+        .collect())
+}
+
+pub async fn read_workspace_instruction_sources(
+    workspace_root: &Path,
+) -> Result<Vec<WorkspaceInstructionFile>, String> {
     WorkspaceInstructionResolver::new(InstructionIo::Local(workspace_root))
         .resolve()
+        .await
+}
+
+pub async fn read_workspace_conditional_instruction_sources(
+    workspace_root: &Path,
+) -> Result<Vec<WorkspaceInstructionFile>, String> {
+    WorkspaceInstructionResolver::new(InstructionIo::Local(workspace_root))
+        .resolve_conditional()
         .await
 }
 
@@ -554,11 +683,38 @@ pub async fn read_workspace_instruction_files_with_fs(
     fs: &dyn bitfun_runtime_ports::WorkspaceFileSystem,
     workspace_root: &str,
 ) -> Result<Vec<WorkspaceInstructionFile>, String> {
+    Ok(
+        read_workspace_instruction_sources_with_fs(fs, workspace_root)
+            .await?
+            .into_iter()
+            .filter(|file| file.path_patterns.is_empty())
+            .collect(),
+    )
+}
+
+#[cfg(feature = "workspace-runtime")]
+pub async fn read_workspace_instruction_sources_with_fs(
+    fs: &dyn bitfun_runtime_ports::WorkspaceFileSystem,
+    workspace_root: &str,
+) -> Result<Vec<WorkspaceInstructionFile>, String> {
     WorkspaceInstructionResolver::new(InstructionIo::Port {
         fs,
         root: workspace_root,
     })
     .resolve()
+    .await
+}
+
+#[cfg(feature = "workspace-runtime")]
+pub async fn read_workspace_conditional_instruction_sources_with_fs(
+    fs: &dyn bitfun_runtime_ports::WorkspaceFileSystem,
+    workspace_root: &str,
+) -> Result<Vec<WorkspaceInstructionFile>, String> {
+    WorkspaceInstructionResolver::new(InstructionIo::Port {
+        fs,
+        root: workspace_root,
+    })
+    .resolve_conditional()
     .await
 }
 
@@ -761,6 +917,23 @@ fn normalize_glob_pattern(value: &str) -> Option<String> {
     Some(components.join("/"))
 }
 
+fn normalize_instruction_scope_glob(value: &str) -> Option<String> {
+    let value = value.trim();
+    let value = value.strip_prefix("./").unwrap_or(value);
+    if value.is_empty()
+        || value.starts_with("http://")
+        || value.starts_with("https://")
+        || value.starts_with('~')
+        || value.starts_with('/')
+        || value.starts_with("\\\\")
+        || has_windows_drive_component(value)
+        || value.split('/').any(|component| component == "..")
+    {
+        return None;
+    }
+    Some(value.to_string())
+}
+
 fn has_glob_meta(value: &str) -> bool {
     value.contains(['*', '?', '[', '{'])
 }
@@ -779,26 +952,6 @@ fn recursive_scan_ignores(relative_path: &str) -> bool {
             .iter()
             .any(|ignored| name.eq_ignore_ascii_case(ignored))
     })
-}
-
-fn claude_rule_has_paths_frontmatter(content: &str) -> bool {
-    let mut lines = content.lines();
-    if lines.next().map(str::trim) != Some("---") {
-        return false;
-    }
-    for line in lines {
-        let trimmed = line.trim();
-        if trimmed == "---" {
-            return false;
-        }
-        if trimmed
-            .split_once(':')
-            .is_some_and(|(key, _)| key.trim() == "paths")
-        {
-            return true;
-        }
-    }
-    false
 }
 
 fn claude_import_paths(source_path: &str, content: &str) -> Vec<String> {

--- a/src/crates/services/services-core/tests/declarative_workspace_instruction_contracts.rs
+++ b/src/crates/services/services-core/tests/declarative_workspace_instruction_contracts.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "workspace-instructions")]
 
-use bitfun_services_core::workspace_instructions::read_workspace_instruction_files;
+use bitfun_services_core::workspace_instructions::{
+    read_workspace_conditional_instruction_sources, read_workspace_instruction_files,
+    read_workspace_instruction_sources, WorkspaceInstructionPathMatcher,
+};
 use std::fs;
 
 fn instruction_names(
@@ -94,6 +97,127 @@ async fn claude_project_files_and_unconditional_rules_have_deterministic_order()
     assert_eq!(files[1].content, "root claude\n");
     assert!(!files.iter().any(|file| file.name == ".claude/CLAUDE.md"));
     assert!(!files.iter().any(|file| file.name.contains("path-scoped")));
+}
+
+#[tokio::test]
+async fn claude_project_sources_preserve_path_scoped_rules_for_late_activation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(temp.path().join(".claude/rules")).expect("rules dir");
+    fs::write(
+        temp.path().join(".claude/rules/rust.md"),
+        "---\npaths:\n  - src/**/*.rs\n  - tests/**/*.rs\n---\n\nUse the shared error type.\n",
+    )
+    .expect("path scoped rule");
+
+    let files = read_workspace_instruction_sources(temp.path())
+        .await
+        .expect("instruction sources");
+
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].name, ".claude/rules/rust.md");
+    assert_eq!(files[0].path_patterns, vec!["src/**/*.rs", "tests/**/*.rs"]);
+    assert_eq!(files[0].content, "Use the shared error type.\n");
+}
+
+#[tokio::test]
+async fn bom_prefixed_path_scoped_rule_is_never_loaded_at_startup() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(temp.path().join(".claude/rules")).expect("rules dir");
+    fs::write(
+        temp.path().join(".claude/rules/windows.md"),
+        "\u{feff}---\r\npaths:\r\n  - src/**/*.rs\r\n---\r\n\r\nWindows rule\r\n",
+    )
+    .expect("path scoped rule");
+
+    let startup = read_workspace_instruction_files(temp.path())
+        .await
+        .expect("startup instructions");
+    let conditional = read_workspace_conditional_instruction_sources(temp.path())
+        .await
+        .expect("conditional instructions");
+
+    assert!(startup.is_empty());
+    assert_eq!(
+        instruction_names(&conditional),
+        vec![".claude/rules/windows.md"]
+    );
+    assert_eq!(conditional[0].path_patterns, vec!["src/**/*.rs"]);
+    assert_eq!(conditional[0].content, "Windows rule\r\n");
+}
+
+#[tokio::test]
+async fn path_scoped_project_rule_imports_inherit_the_parent_scope() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(temp.path().join(".claude/shared")).expect("shared dir");
+    fs::create_dir_all(temp.path().join(".claude/rules")).expect("rules dir");
+    fs::write(
+        temp.path().join(".claude/rules/rust.md"),
+        "---\npaths:\n  - src/**/*.rs\n---\nRust rule\n@../shared/base.md\n",
+    )
+    .expect("path scoped rule");
+    fs::write(
+        temp.path().join(".claude/shared/base.md"),
+        "Imported base\n@nested.md\n",
+    )
+    .expect("base import");
+    fs::write(
+        temp.path().join(".claude/shared/nested.md"),
+        "Nested import\n",
+    )
+    .expect("nested import");
+
+    let files = read_workspace_instruction_sources(temp.path())
+        .await
+        .expect("instruction sources");
+    let rule = files
+        .iter()
+        .find(|file| file.name == ".claude/rules/rust.md")
+        .expect("scoped rule");
+
+    assert_eq!(rule.path_patterns, vec!["src/**/*.rs"]);
+    assert!(rule.content.contains("Rust rule"));
+    assert!(rule.content.contains("Imported base"));
+    assert!(rule.content.contains("Nested import"));
+}
+
+#[tokio::test]
+async fn conditional_discovery_skips_unconditional_and_opencode_sources() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(temp.path().join(".claude/rules")).expect("rules dir");
+    fs::write(temp.path().join("AGENTS.md"), "startup instructions\n").expect("agents");
+    fs::write(
+        temp.path().join("opencode.json"),
+        r#"{"instructions":["missing.md"]}"#,
+    )
+    .expect("OpenCode config");
+    fs::write(
+        temp.path().join(".claude/rules/general.md"),
+        "General rule\n",
+    )
+    .expect("general rule");
+    fs::write(
+        temp.path().join(".claude/rules/rust.md"),
+        "---\npaths:\n  - src/**/*.rs\n---\nRust rule\n",
+    )
+    .expect("scoped rule");
+
+    let files = read_workspace_conditional_instruction_sources(temp.path())
+        .await
+        .expect("conditional sources");
+
+    assert_eq!(instruction_names(&files), vec![".claude/rules/rust.md"]);
+}
+
+#[test]
+fn claude_path_scope_globs_preserve_literal_bracket_escapes() {
+    let matcher = WorkspaceInstructionPathMatcher::compile(
+        &[r"photos \[2024/**".to_string()],
+        ".claude/rules/photos.md",
+    )
+    .expect("escaped pattern must compile");
+
+    assert!(matcher.is_match("photos [2024/a.png"));
+    assert!(!matcher.is_match("photos a/a.png"));
 }
 
 #[tokio::test]

--- a/src/crates/services/services-core/tests/workspace_instruction_contracts.rs
+++ b/src/crates/services/services-core/tests/workspace_instruction_contracts.rs
@@ -3,6 +3,7 @@
 use bitfun_services_core::workspace::LocalWorkspaceFs;
 use bitfun_services_core::workspace_instructions::{
     read_workspace_instruction_files, read_workspace_instruction_files_with_fs,
+    read_workspace_instruction_sources, read_workspace_instruction_sources_with_fs,
 };
 use std::fs;
 
@@ -56,6 +57,30 @@ async fn port_backed_and_local_instruction_resolution_have_identical_order_and_c
         .expect("port instructions");
 
     assert_eq!(port, local);
+}
+
+#[tokio::test]
+async fn port_backed_and_local_path_scoped_sources_have_identical_content() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(temp.path().join(".claude/rules/nested")).expect("rules dir");
+    fs::write(
+        temp.path().join(".claude/rules/nested/rust.md"),
+        "---\npaths:\n  - src/**/*.rs\n---\n\nUse workspace errors.\n",
+    )
+    .expect("scoped rule");
+    let root = temp.path().to_string_lossy();
+
+    let local = read_workspace_instruction_sources(temp.path())
+        .await
+        .expect("local sources");
+    let port = read_workspace_instruction_sources_with_fs(&LocalWorkspaceFs, &root)
+        .await
+        .expect("port sources");
+
+    assert_eq!(port, local);
+    assert_eq!(port.len(), 1);
+    assert_eq!(port[0].path_patterns, vec!["src/**/*.rs"]);
+    assert_eq!(port[0].content, "Use workspace errors.\n");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Discover bounded Claude Code user and project `.claude/rules/**/*.md` sources with non-empty `paths` front matter while keeping unconditional Instructions on the existing startup path.
- Activate matching rules only after a successful workspace `Read` (including deferred `Read`), preserve user-before-workspace ordering, and persist source identities so an active context is not reinjected.
- Remove conditional reminders from every compaction input/output partition so a later matching read reloads current rule content.

## Design boundaries

- Reuses the existing Instructions discovery, workspace filesystem, rendering, session, and compression owners.
- Local sessions may read user and project Claude sources; remote sessions read only remote project sources.
- Invalid YAML, empty/unsafe paths, invalid globs, oversized sources, and failed reads fail closed or remain isolated.
- No watcher, UI, Plugin Host Runtime, MCP/LSP behavior, or second Rules product owner is introduced.
- Behavior follows Claude Code path-scoped rule semantics documented in https://code.claude.com/docs/en/memory and compaction behavior in https://code.claude.com/docs/en/context-window.

## Windows CI stability

- The prior Windows run timed out in a pre-existing persisted user-shell test while its detached turn was still completing real filesystem and SQLite writes; that path does not execute this PR's conditional Instructions logic.
- A separate `test(agent)` commit keeps the authoritative state-based settlement wait, but gives the four equivalent persisted shell-turn tests a shared 30-second hosted-runner budget. Successful tests still return immediately; a leaked settlement still fails with a bounded timeout.
- No production runtime or workflow file is changed. The originally failing test passed 100/100 on the final Windows binary (87-160 ms, 96.1 ms average).

## Verification

- `git diff --check gcwing/main...HEAD`
- `node scripts/check-core-boundaries.mjs`
- `pnpm run check:core-boundaries:test` (40/40)
- `pnpm run check:repo-hygiene`
- `cargo test --locked -p bitfun-services-core --no-default-features --features workspace-instructions,workspace-runtime,markdown`
- `cargo test --locked -p bitfun-claude-code-adapter`
- `cargo test --locked -p bitfun-core --lib conditional_ --no-default-features --features product-full -- --quiet` (7/7)
- `cargo test --locked -p bitfun-core --lib agentic::session::compression::compressor::tests --no-default-features --features product-full -- --quiet` (15/15)
- `cargo test --locked -p bitfun-core --lib -- --quiet` (1813 passed, 1 ignored)
- `cargo check --locked -p bitfun-core --no-default-features`
- Final failing-test stress run: 100/100

## Review notes

Independent adversarial reviews covered source containment and budgets, Windows BOM/CRLF parsing, local/remote ownership, deferred-read activation, session deduplication, compaction removal, reload-after-compaction, timeout masking, commit scope, and overdesign risk. The CI stability change was split from the feature commit, and no remaining P0-P2 findings were identified.