### PR TITLE
fix(flow-chat): reconcile usage reports with persisted turn identity

### DIFF
--- a/docs/architecture/agent-runtime-services-design.md
+++ b/docs/architecture/agent-runtime-services-design.md
@@ -68,7 +68,7 @@ Agent Runtime API 的逻辑归属与物理部署分离：相同归属模块可�
 私有 SDK Host 或目标机器 Runtime 中。任何 Rust 部署都只管理自己进程树内的服务与 Node/Bun Plugin Host；不能因为多个
 GUI/TUI/Remote Client 连接就复制 Runtime 状态模块，或按 Client/Workspace 创建 Plugin Host。
 
-Rust Runtime SDK 以 `AGENT_RUNTIME_SDK_API_VERSION` 标记兼容边界。当前接口版本为 v4 preview：
+Rust Runtime SDK 以 `AGENT_RUNTIME_SDK_API_VERSION` 标记兼容边界。当前接口版本为 v5 preview：
 小版本更新允许增加可选 builder hook、有默认实现的端口方法或注册表查询能力，但不得向外部可用
 Rust 结构体字面量（struct literal）构造的 DTO 直接增加字段，也不得改变既有端口语义、错误分类、session / turn 标识含义或
 默认 feature 依赖。任何需要调用方改写现有嵌入代码的变更，必须提升接口版本并提供兼容迁移路径。

--- a/src/apps/cli/src/agent/runtime_client.rs
+++ b/src/apps/cli/src/agent/runtime_client.rs
@@ -432,6 +432,7 @@ impl CliAgentRuntimeClient {
         self.embedded_runtime("recording local command turns")?
             .record_completed_local_command_turn(request)
             .await
+            .map(|_| ())
             .map_err(|error| anyhow::anyhow!(error.into_message()))
     }
 

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -1317,6 +1317,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
     ("read_mcp_resource", RemoteWorkspacePolicy::LegacyUnaudited),
     ("record_file_change", RemoteWorkspacePolicy::LegacyUnaudited),
     (
+        "record_local_command_turn",
+        RemoteWorkspacePolicy::RemoteRouted,
+    ),
+    (
         "refresh_model_client",
         RemoteWorkspacePolicy::LegacyUnaudited,
     ),

--- a/src/apps/desktop/src/api/session_api.rs
+++ b/src/apps/desktop/src/api/session_api.rs
@@ -12,7 +12,7 @@ use bitfun_core::agentic::persistence::{SessionBranchResult, SessionMetadataPage
 use bitfun_core::service::remote_ssh::normalize_remote_workspace_path;
 use bitfun_core::service::session::{
     DialogTurnData, SessionKind, SessionMetadata, SessionStatus, SessionTranscriptExport,
-    SessionTranscriptExportOptions,
+    SessionTranscriptExportOptions, SessionTurnCatalog,
 };
 use bitfun_core::service::session_usage::SessionUsageReport;
 use bitfun_core::service::workspace::WorkspaceKind;
@@ -87,6 +87,25 @@ pub struct SaveSessionTurnRequest {
     pub remote_connection_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_ssh_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordLocalCommandTurnRequest {
+    pub turn_data: DialogTurnData,
+    pub workspace_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordLocalCommandTurnResponse {
+    pub turn_id: String,
+    pub storage_turn_index: usize,
+    pub total_turn_count: usize,
+    pub turn_catalog: SessionTurnCatalog,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -481,6 +500,36 @@ pub async fn save_session_turn(
         &request.workspace_path,
     );
     Ok(())
+}
+
+#[tauri::command]
+pub async fn record_local_command_turn(
+    request: RecordLocalCommandTurnRequest,
+    runtime: State<'_, DesktopRuntimeContext>,
+) -> Result<RecordLocalCommandTurnResponse, String> {
+    let recorded = runtime
+        .session_application()
+        .record_local_command_turn(
+            desktop_session_scope(
+                request.workspace_path.clone(),
+                request.remote_connection_id,
+                request.remote_ssh_host,
+            ),
+            &request.turn_data,
+        )
+        .await
+        .map_err(|error| format!("Failed to record local command turn: {error}"))?;
+
+    crate::api::remote_connect_api::notify_session_changed(
+        &request.turn_data.session_id,
+        &request.workspace_path,
+    );
+    Ok(RecordLocalCommandTurnResponse {
+        turn_id: recorded.turn_id,
+        storage_turn_index: recorded.storage_turn_index,
+        total_turn_count: recorded.total_turn_count,
+        turn_catalog: recorded.turn_catalog,
+    })
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1417,6 +1417,7 @@ pub async fn run() {
             load_session_turns,
             get_session_usage_report,
             save_session_turn,
+            record_local_command_turn,
             save_session_metadata,
             export_session_transcript,
             delete_persisted_session,

--- a/src/apps/desktop/src/runtime/session_application.rs
+++ b/src/apps/desktop/src/runtime/session_application.rs
@@ -129,6 +129,14 @@ pub(crate) struct DesktopSessionViewRestore {
     pub timings: SessionViewRestoreTiming,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct DesktopRecordedLocalCommandTurn {
+    pub turn_id: String,
+    pub storage_turn_index: usize,
+    pub total_turn_count: usize,
+    pub turn_catalog: SessionTurnCatalog,
+}
+
 #[derive(Debug)]
 pub(crate) struct DesktopSessionWithTurnsRestore {
     pub session: Session,
@@ -493,6 +501,7 @@ impl DesktopSessionApplication {
                 .agent_runtime
                 .record_completed_local_command_turn(local_command)
                 .await
+                .map(|_| ())
                 .map_err(desktop_runtime_session_error);
         }
         let mutation = self
@@ -504,6 +513,55 @@ impl DesktopSessionApplication {
             .save_persisted_dialog_turn(&mutation, turn)
             .await
             .map_err(desktop_core_session_error)
+    }
+
+    pub(crate) async fn record_local_command_turn(
+        &self,
+        request: DesktopSessionScopeRequest,
+        turn: &DialogTurnData,
+    ) -> DesktopSessionApplicationResult<DesktopRecordedLocalCommandTurn> {
+        let scope = self.resolved_scope(request).await;
+        self.ensure_runtime_ownership(&scope)?;
+        let storage_path = self.storage_path(&scope);
+        self.compatibility
+            .ensure_session_loaded_from_storage_path(&storage_path, &turn.session_id, false)
+            .await
+            .map_err(desktop_core_session_error)?;
+        let local_command = local_command_turn_record_request(turn)?.ok_or_else(|| {
+            DesktopSessionApplicationError::Validation(
+                "record_local_command_turn accepts only local_command Turns".to_string(),
+            )
+        })?;
+        let recorded = self
+            .agent_runtime
+            .record_completed_local_command_turn(local_command)
+            .await
+            .map_err(desktop_runtime_session_error)?;
+        let (_, _, total_turn_count, turn_catalog, _) = self
+            .compatibility
+            .restore_session_view_from_storage_path(&storage_path, &turn.session_id, false, Some(1))
+            .await
+            .map_err(desktop_core_session_error)?;
+        let catalog_entry = turn_catalog
+            .entries
+            .iter()
+            .find(|entry| {
+                entry.turn_id.as_deref() == Some(recorded.turn_id.as_str())
+                    && entry.storage_turn_index == recorded.storage_turn_index
+            })
+            .ok_or_else(|| {
+                DesktopSessionApplicationError::OutcomeUnknown(format!(
+                    "Recorded local command Turn is missing from the authoritative catalog: {}",
+                    recorded.turn_id
+                ))
+            })?;
+
+        Ok(DesktopRecordedLocalCommandTurn {
+            turn_id: recorded.turn_id,
+            storage_turn_index: catalog_entry.storage_turn_index,
+            total_turn_count,
+            turn_catalog,
+        })
     }
 
     pub(crate) async fn touch_session(

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -11302,7 +11302,8 @@ impl bitfun_runtime_ports::AgentLocalCommandTurnPort for ConversationCoordinator
     async fn record_completed_local_command_turn(
         &self,
         request: bitfun_runtime_ports::AgentLocalCommandTurnRecordRequest,
-    ) -> bitfun_runtime_ports::PortResult<()> {
+    ) -> bitfun_runtime_ports::PortResult<bitfun_runtime_ports::AgentLocalCommandTurnRecordResult>
+    {
         self.ensure_session_runtime_ownership(&request.session_id, None)
             .map_err(runtime_port_error_preserving_message)?;
         let mutation_guard = self
@@ -11341,7 +11342,12 @@ impl bitfun_runtime_ports::AgentLocalCommandTurnPort for ConversationCoordinator
             .await;
         drop(mutation_guard);
         result
-            .map(|_| ())
+            .map(
+                |turn| bitfun_runtime_ports::AgentLocalCommandTurnRecordResult {
+                    turn_id: turn.turn_id,
+                    storage_turn_index: turn.turn_index,
+                },
+            )
             .map_err(runtime_port_error_preserving_message)
     }
 }

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -1197,6 +1197,7 @@ impl CoreServiceAgentRuntime {
         let session_revert = scheduled_session_revert_port(coordinator.clone(), scheduler.clone());
         let session_model: Arc<dyn AgentSessionModelPort> = coordinator.clone();
         let session_compaction: Arc<dyn AgentSessionCompactionPort> = coordinator.clone();
+        let local_command_turn: Arc<dyn AgentLocalCommandTurnPort> = coordinator.clone();
         let interaction_response: Arc<dyn AgentInteractionResponsePort> = coordinator;
         let dialog_turn: Arc<dyn AgentDialogTurnPort> = scheduler.clone();
         let cancellation: Arc<dyn AgentTurnCancellationPort> = scheduler;
@@ -1208,6 +1209,7 @@ impl CoreServiceAgentRuntime {
             .with_session_revert_port(session_revert)
             .with_session_model_port(session_model)
             .with_session_compaction_port(session_compaction)
+            .with_local_command_turn_port(local_command_turn)
             .with_dialog_turn_port(dialog_turn)
             .with_cancellation_port(cancellation)
             .with_interaction_response_port(interaction_response)
@@ -2338,6 +2340,25 @@ mod tests {
         let _ = assert_agent_runtime_with_lifecycle_delivery;
         let _ = assert_agent_runtime_with_scheduler_ports;
         let _ = assert_remote_control_port;
+    }
+
+    #[test]
+    fn session_surface_runtime_registers_local_command_turn_port() {
+        let source = include_str!("service_agent_runtime.rs");
+        let builder = source
+            .split("pub(crate) fn session_surface_agent_runtime")
+            .nth(1)
+            .and_then(|source| {
+                source
+                    .split("pub(crate) fn agent_runtime_with_scheduler_ports")
+                    .next()
+            })
+            .expect("session surface runtime builder");
+
+        assert!(builder.contains(
+            "let local_command_turn: Arc<dyn AgentLocalCommandTurnPort> = coordinator.clone();"
+        ));
+        assert!(builder.contains(".with_local_command_turn_port(local_command_turn)"));
     }
 
     #[test]

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -1224,6 +1224,17 @@ pub struct AgentLocalCommandTurnRecordRequest {
     pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
+/// The authoritative persisted identity assigned to a completed local command Turn.
+///
+/// The product-facing adapter may use this result to reconcile a provisional UI
+/// projection. Catalog data remains owned by the session persistence boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentLocalCommandTurnRecordResult {
+    pub turn_id: String,
+    pub storage_turn_index: usize,
+}
+
 /// Starts one user-authored shell command as a normal, model-visible tool turn.
 ///
 /// The caller provides the exact turn identity so interactive adapters can
@@ -2440,7 +2451,7 @@ pub trait AgentLocalCommandTurnPort: Send + Sync {
     async fn record_completed_local_command_turn(
         &self,
         request: AgentLocalCommandTurnRecordRequest,
-    ) -> PortResult<()>;
+    ) -> PortResult<AgentLocalCommandTurnRecordResult>;
 }
 
 #[async_trait::async_trait]
@@ -4197,6 +4208,20 @@ mod tests {
         assert_eq!(json["metadata"]["kind"], "usage_report");
         assert!(json.get("turnKind").is_none());
         assert!(json.get("modelVisible").is_none());
+    }
+
+    #[test]
+    fn local_command_turn_result_serializes_authoritative_identity() {
+        let result = AgentLocalCommandTurnRecordResult {
+            turn_id: "turn_8".to_string(),
+            storage_turn_index: 7,
+        };
+
+        let json = serde_json::to_value(result).expect("serialize local command turn result");
+
+        assert_eq!(json["turnId"], "turn_8");
+        assert_eq!(json["storageTurnIndex"], 7);
+        assert_eq!(json.as_object().map(|value| value.len()), Some(2));
     }
 
     #[test]

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -13,26 +13,26 @@ use bitfun_runtime_ports::{
     AgentBackgroundResultRequest, AgentDialogSteerRequest, AgentDialogTurnPort,
     AgentDialogTurnRequest, AgentInputAttachment, AgentLifecycleDeliveryPort,
     AgentLocalCommandTurnPort, AgentLocalCommandTurnRecordRequest,
-    AgentMessageWorkspaceReferencesRequest, AgentSessionArchiveRequest,
-    AgentSessionArchiveStateRequest, AgentSessionClosePort, AgentSessionCompactionPort,
-    AgentSessionCompactionRequest, AgentSessionCompactionResult, AgentSessionCreateRequest,
-    AgentSessionCreateResult, AgentSessionDeleteRequest, AgentSessionForkAtTurnRequest,
-    AgentSessionForkBeforeTurnRequest, AgentSessionForkPort, AgentSessionForkRequest,
-    AgentSessionForkResult, AgentSessionLineageCancellationRequest, AgentSessionLineageInspection,
-    AgentSessionLineagePort, AgentSessionLineageRequest, AgentSessionLineageSnapshot,
-    AgentSessionLineageTranscriptRequest, AgentSessionListRequest, AgentSessionManagementPort,
-    AgentSessionModePort, AgentSessionModeUpdateRequest, AgentSessionModelPort,
-    AgentSessionModelUpdateRequest, AgentSessionRenameRequest, AgentSessionRevertPort,
-    AgentSessionRevertRequest, AgentSessionRevertResult, AgentSessionSummary,
-    AgentSessionUsagePort, AgentSessionUsageRequest, AgentSessionWorkspaceBinding,
-    AgentSessionWorkspaceRequest, AgentSubmissionPort, AgentSubmissionRequest,
-    AgentSubmissionResult, AgentSubmissionSource, AgentThreadGoalCreateRequest,
-    AgentThreadGoalDeliveryRequest, AgentThreadGoalGetRequest, AgentThreadGoalManagementPort,
-    AgentThreadGoalUpdateStatusRequest, AgentTransientSessionDiscardRequest,
-    AgentTurnCancellationPort, AgentTurnCancellationRequest, AgentTurnCancellationResult,
-    AgentTurnSettlementPort, AgentTurnSettlementRequest, AgentUserShellCommandPort,
-    AgentUserShellCommandRequest, AgentUserShellCommandResult, AgentWorkspaceReference,
-    AgentWorkspaceReferencePort, AgentWorkspaceReferenceSearchRequest,
+    AgentLocalCommandTurnRecordResult, AgentMessageWorkspaceReferencesRequest,
+    AgentSessionArchiveRequest, AgentSessionArchiveStateRequest, AgentSessionClosePort,
+    AgentSessionCompactionPort, AgentSessionCompactionRequest, AgentSessionCompactionResult,
+    AgentSessionCreateRequest, AgentSessionCreateResult, AgentSessionDeleteRequest,
+    AgentSessionForkAtTurnRequest, AgentSessionForkBeforeTurnRequest, AgentSessionForkPort,
+    AgentSessionForkRequest, AgentSessionForkResult, AgentSessionLineageCancellationRequest,
+    AgentSessionLineageInspection, AgentSessionLineagePort, AgentSessionLineageRequest,
+    AgentSessionLineageSnapshot, AgentSessionLineageTranscriptRequest, AgentSessionListRequest,
+    AgentSessionManagementPort, AgentSessionModePort, AgentSessionModeUpdateRequest,
+    AgentSessionModelPort, AgentSessionModelUpdateRequest, AgentSessionRenameRequest,
+    AgentSessionRevertPort, AgentSessionRevertRequest, AgentSessionRevertResult,
+    AgentSessionSummary, AgentSessionUsagePort, AgentSessionUsageRequest,
+    AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest, AgentSubmissionPort,
+    AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource,
+    AgentThreadGoalCreateRequest, AgentThreadGoalDeliveryRequest, AgentThreadGoalGetRequest,
+    AgentThreadGoalManagementPort, AgentThreadGoalUpdateStatusRequest,
+    AgentTransientSessionDiscardRequest, AgentTurnCancellationPort, AgentTurnCancellationRequest,
+    AgentTurnCancellationResult, AgentTurnSettlementPort, AgentTurnSettlementRequest,
+    AgentUserShellCommandPort, AgentUserShellCommandRequest, AgentUserShellCommandResult,
+    AgentWorkspaceReference, AgentWorkspaceReferencePort, AgentWorkspaceReferenceSearchRequest,
     AgentWorkspaceReferenceSearchResult, DialogSteerOutcome, DialogSubmitOutcome,
     PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PluginRuntimeBinding, PortError,
     PortErrorKind, PortResult, RuntimeEventEnvelope, SessionTranscript, SessionTranscriptReader,
@@ -1134,7 +1134,7 @@ impl AgentRuntime {
     pub async fn record_completed_local_command_turn(
         &self,
         request: AgentLocalCommandTurnRecordRequest,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<AgentLocalCommandTurnRecordResult, RuntimeError> {
         let port = self
             .local_command_turn
             .as_ref()
@@ -1932,9 +1932,18 @@ mod tests {
         async fn record_completed_local_command_turn(
             &self,
             request: AgentLocalCommandTurnRecordRequest,
-        ) -> PortResult<()> {
-            self.local_command_turns.lock().unwrap().push(request);
-            Ok(())
+        ) -> PortResult<AgentLocalCommandTurnRecordResult> {
+            let mut turns = self.local_command_turns.lock().unwrap();
+            let storage_turn_index = turns.len();
+            let turn_id = request
+                .turn_id
+                .clone()
+                .unwrap_or_else(|| format!("local-command-{storage_turn_index}"));
+            turns.push(request);
+            Ok(AgentLocalCommandTurnRecordResult {
+                turn_id,
+                storage_turn_index,
+            })
         }
     }
 
@@ -2756,7 +2765,7 @@ mod tests {
         let mut metadata = serde_json::Map::new();
         metadata.insert("kind".to_string(), serde_json::json!("usage_report"));
 
-        runtime
+        let result = runtime
             .record_completed_local_command_turn(AgentLocalCommandTurnRecordRequest {
                 session_id: "session_1".to_string(),
                 content: "report".to_string(),
@@ -2766,6 +2775,9 @@ mod tests {
             })
             .await
             .expect("record local command turn");
+
+        assert_eq!(result.turn_id, "turn_1");
+        assert_eq!(result.storage_turn_index, 0);
 
         let requests = ports.local_command_turns.lock().unwrap();
         assert_eq!(requests.len(), 1);

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -61,13 +61,13 @@ pub use bitfun_runtime_ports::{
     AgentBackgroundResultRequest, AgentDialogSteerRequest, AgentDialogTurnExecution,
     AgentDialogTurnPort, AgentDialogTurnRequest, AgentInputAttachment, AgentLifecycleDeliveryPort,
     AgentLocalCommandTurnPort, AgentLocalCommandTurnRecordRequest,
-    AgentMessageWorkspaceReferencesRequest, AgentSessionArchiveRequest,
-    AgentSessionArchiveStateRequest, AgentSessionClosePort, AgentSessionCompactionPort,
-    AgentSessionCompactionRequest, AgentSessionCompactionResult, AgentSessionComposerUpdate,
-    AgentSessionCreateRequest, AgentSessionCreateResult, AgentSessionDeleteRequest,
-    AgentSessionForkAtTurnRequest, AgentSessionForkBeforeTurnRequest, AgentSessionForkPort,
-    AgentSessionForkRequest, AgentSessionForkResult, AgentSessionLifecycleStatus,
-    AgentSessionLineageCancellationRequest, AgentSessionLineageEntry,
+    AgentLocalCommandTurnRecordResult, AgentMessageWorkspaceReferencesRequest,
+    AgentSessionArchiveRequest, AgentSessionArchiveStateRequest, AgentSessionClosePort,
+    AgentSessionCompactionPort, AgentSessionCompactionRequest, AgentSessionCompactionResult,
+    AgentSessionComposerUpdate, AgentSessionCreateRequest, AgentSessionCreateResult,
+    AgentSessionDeleteRequest, AgentSessionForkAtTurnRequest, AgentSessionForkBeforeTurnRequest,
+    AgentSessionForkPort, AgentSessionForkRequest, AgentSessionForkResult,
+    AgentSessionLifecycleStatus, AgentSessionLineageCancellationRequest, AgentSessionLineageEntry,
     AgentSessionLineageInspection, AgentSessionLineagePort, AgentSessionLineageRequest,
     AgentSessionLineageSnapshot, AgentSessionLineageTranscriptRequest, AgentSessionListRequest,
     AgentSessionManagementPort, AgentSessionModePort, AgentSessionModeUpdateRequest,
@@ -491,7 +491,7 @@ impl AgentRuntime {
     pub async fn record_completed_local_command_turn(
         &self,
         request: AgentLocalCommandTurnRecordRequest,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<AgentLocalCommandTurnRecordResult, RuntimeError> {
         self.inner
             .record_completed_local_command_turn(request)
             .await

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -788,7 +788,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     const turns = activeSession?.dialogTurns ?? [];
     const result: FlowChatTurnSummary[] = [];
     for (const turn of turns) {
-      if (!turn.userMessage) continue;
+      if (!turn.userMessage || turn.userMessage.metadata?.usageReportProvisional === true) continue;
       result.push({
         turnId: turn.id,
         turnIndex: result.length + 1,
@@ -806,7 +806,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const renderedTurnSummaries = useMemo<FlowChatTurnSummary[]>(() => {
     const result: FlowChatTurnSummary[] = [];
     for (const turn of renderedTurns) {
-      if (!turn.userMessage) continue;
+      if (!turn.userMessage || turn.userMessage.metadata?.usageReportProvisional === true) continue;
       result.push({
         turnId: turn.id,
         turnIndex: result.length + 1,

--- a/src/web-ui/src/flow_chat/services/usageReportService.test.ts
+++ b/src/web-ui/src/flow_chat/services/usageReportService.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SessionUsageReport } from '@/infrastructure/api/service-api/SessionAPI';
+import type {
+  SessionUsageReport,
+} from '@/infrastructure/api/service-api/SessionAPI';
+import type { DialogTurnData } from '@/shared/types/session-history';
 import type { FlowChatState, Session } from '../types/flow-chat';
 import { flowChatStore } from '../store/FlowChatStore';
 
 const sessionApiMocks = vi.hoisted(() => ({
   getSessionUsageReport: vi.fn(),
   saveSessionTurn: vi.fn(),
+  recordLocalCommandTurn: vi.fn(),
 }));
 
 vi.mock('@/infrastructure/api/service-api/SessionAPI', () => ({
@@ -105,7 +109,28 @@ describe('runUsageReportCommand', () => {
     }));
     sessionApiMocks.getSessionUsageReport.mockReset();
     sessionApiMocks.saveSessionTurn.mockReset();
+    sessionApiMocks.recordLocalCommandTurn.mockReset();
     sessionApiMocks.saveSessionTurn.mockResolvedValue(undefined);
+    sessionApiMocks.recordLocalCommandTurn.mockImplementation(
+      async (turnData: DialogTurnData) => ({
+        turnId: turnData.turnId,
+        storageTurnIndex: 0,
+        totalTurnCount: 1,
+        turnCatalog: {
+          schemaVersion: 1,
+          sessionId: turnData.sessionId,
+          revision: 'catalog-1',
+          totalTurnCount: 1,
+          complete: true,
+          entries: [{
+            ordinal: 0,
+            storageTurnIndex: 0,
+            turnId: turnData.turnId,
+            previewTruncated: false,
+          }],
+        },
+      }),
+    );
   });
 
   afterEach(() => {
@@ -163,7 +188,43 @@ describe('runUsageReportCommand', () => {
       remoteSshHost: undefined,
       includeHiddenSubagents: true,
     });
-    expect(sessionApiMocks.saveSessionTurn).toHaveBeenCalledTimes(1);
+    expect(sessionApiMocks.recordLocalCommandTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnId: finalTurn?.id,
+        turnIndex: 0,
+        kind: 'local_command',
+      }),
+      'D:/workspace/BitFun',
+      undefined,
+      undefined,
+    );
+    const persistedTurn = sessionApiMocks.recordLocalCommandTurn.mock.calls[0][0] as DialogTurnData;
+    expect(persistedTurn.userMessage.metadata).not.toHaveProperty('usageReportProvisional');
+    expect(sessionApiMocks.saveSessionTurn).not.toHaveBeenCalled();
+    expect(finalTurn?.backendTurnIndex).toBe(0);
+    expect(finalTurn?.userMessage.metadata?.usageReportProvisional).toBeUndefined();
+    expect(flowChatStore.getState().sessions.get('session-1')).toMatchObject({
+      totalTurnCount: 1,
+      turnCatalog: { totalTurnCount: 1 },
+    });
+  });
+
+  it('removes the provisional report when authoritative persistence fails', async () => {
+    sessionApiMocks.getSessionUsageReport.mockResolvedValue(usageReport());
+    sessionApiMocks.recordLocalCommandTurn.mockRejectedValueOnce(new Error('record failed'));
+    const { runUsageReportCommand } = await import('./usageReportService');
+
+    await expect(runUsageReportCommand({
+      session: createSession(),
+      isProcessing: false,
+      busyMessage: 'busy',
+      noWorkspaceMessage: 'missing workspace',
+      failedTitle: 'failed',
+      unknownErrorMessage: 'unknown',
+      loadingMarkdown: 'Generating usage report...',
+    })).rejects.toThrow('record failed');
+
+    expect(flowChatStore.getState().sessions.get('session-1')?.dialogTurns).toEqual([]);
   });
 
   it('infers legacy model rows from the session model without showing raw missing-model copy', async () => {

--- a/src/web-ui/src/flow_chat/services/usageReportService.ts
+++ b/src/web-ui/src/flow_chat/services/usageReportService.ts
@@ -65,7 +65,7 @@ export async function runUsageReportCommand(
     generatedAt: requestedAt,
     status: 'loading',
   });
-  let finalizedPendingTurn = false;
+  let provisionalTurnId = pendingTurn?.id;
 
   try {
     const rawReport = params.fetchReport
@@ -94,21 +94,28 @@ export async function runUsageReportCommand(
         generatedAt: report.generatedAt,
         report: report as unknown as Record<string, any>,
       });
-    finalizedPendingTurn = !!pendingTurn;
+    provisionalTurnId = turn?.id ?? provisionalTurnId;
 
     if (turn && params.persistTurn !== false) {
-      await sessionAPI.saveSessionTurn(
+      const recorded = await sessionAPI.recordLocalCommandTurn(
         toPersistedLocalReportTurn(turn),
         projectWorkspacePath,
         params.session.remoteConnectionId,
         params.session.remoteSshHost,
       );
+      if (!flowChatStore.commitLocalUsageReportTurn({
+        sessionId: params.session.sessionId,
+        dialogTurnId: turn.id,
+        ...recorded,
+      })) {
+        throw new Error('Failed to reconcile persisted usage report turn');
+      }
     }
 
     return { inserted: !!turn, report };
   } catch (error) {
-    if (pendingTurn && !finalizedPendingTurn) {
-      flowChatStore.deleteDialogTurn(params.session.sessionId, pendingTurn.id);
+    if (provisionalTurnId) {
+      flowChatStore.deleteDialogTurn(params.session.sessionId, provisionalTurnId);
     }
     notificationService.error(
       error instanceof Error ? error.message : params.unknownErrorMessage,
@@ -292,9 +299,12 @@ export function renderUsageReportMarkdown(report: SessionUsageReport): string {
 }
 
 function toPersistedLocalReportTurn(turn: DialogTurn): DialogTurnData {
+  const metadata = { ...turn.userMessage.metadata };
+  delete metadata.usageReportProvisional;
   return {
     turnId: turn.id,
-    turnIndex: turn.backendTurnIndex ?? 0,
+    // Local commands receive their storage identity only after persistence.
+    turnIndex: 0,
     sessionId: turn.sessionId,
     timestamp: turn.startTime,
     kind: 'local_command',
@@ -302,7 +312,7 @@ function toPersistedLocalReportTurn(turn: DialogTurn): DialogTurnData {
       id: turn.userMessage.id,
       content: turn.userMessage.content,
       timestamp: turn.userMessage.timestamp,
-      metadata: turn.userMessage.metadata,
+      metadata,
     },
     modelRounds: [],
     startTime: turn.startTime,

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -4303,6 +4303,108 @@ describe('FlowChatStore historical session hydration state', () => {
     expect(apiMocks.loadSessionTurnWindow).toHaveBeenCalledTimes(1);
   });
 
+  it('commits a provisional usage report at its authoritative ordinal without corrupting the restored tail', async () => {
+    const catalog = createTurnCatalog(7);
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 7,
+        createdAt: 1,
+      },
+      turns: [4, 5, 6].map(index => createPersistedTurn(index)),
+      turnCatalog: catalog,
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 7,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[
+        'history-1',
+        createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        }),
+      ]]),
+      activeSessionId: 'history-1',
+    }));
+
+    await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+    const provisional = flowChatStore.addLocalUsageReportTurn({
+      sessionId: 'history-1',
+      markdown: '# Session Usage Report',
+      reportId: 'usage-1',
+      schemaVersion: 1,
+      generatedAt: 10,
+    });
+    expect(provisional?.backendTurnIndex).toBeUndefined();
+    expect(provisional?.userMessage.metadata?.usageReportProvisional).toBe(true);
+    expect(flowChatStore.getSessionHistoryViewState('history-1')?.loadedRanges).toMatchObject([{
+      startOrdinal: 4,
+      endOrdinalExclusive: 7,
+    }]);
+
+    const authoritativeCatalog = {
+      ...createTurnCatalog(8, 'catalog-2'),
+      entries: [
+        ...createTurnCatalog(8, 'catalog-2').entries.slice(0, 7),
+        {
+          ordinal: 7,
+          storageTurnIndex: 7,
+          turnId: provisional?.id,
+          preview: 'Session Usage Report',
+          previewTruncated: false,
+        },
+      ],
+    };
+    expect(flowChatStore.commitLocalUsageReportTurn({
+      sessionId: 'history-1',
+      dialogTurnId: provisional!.id,
+      turnId: provisional!.id,
+      storageTurnIndex: 7,
+      totalTurnCount: 8,
+      turnCatalog: authoritativeCatalog,
+    })).toBe(true);
+
+    const session = flowChatStore.getState().sessions.get('history-1');
+    expect(session).toMatchObject({
+      isPartial: true,
+      loadedTurnCount: 4,
+      totalTurnCount: 8,
+    });
+    expect(session?.dialogTurns.find(turn => turn.id === 'turn-4')?.backendTurnIndex).toBe(4);
+    const committedReport = session?.dialogTurns.find(turn => turn.id === provisional?.id);
+    expect(committedReport?.backendTurnIndex).toBe(7);
+    expect(committedReport?.userMessage.metadata).not.toHaveProperty('usageReportProvisional');
+    expect(flowChatStore.getSessionHistoryViewState('history-1')?.loadedRanges).toMatchObject([{
+      startOrdinal: 4,
+      endOrdinalExclusive: 8,
+    }]);
+
+    apiMocks.loadSessionTurnWindow.mockResolvedValueOnce({
+      status: 'ready',
+      catalogRevision: authoritativeCatalog.revision,
+      totalTurnCount: 8,
+      startOrdinal: 0,
+      endOrdinalExclusive: 4,
+      targetTurnId: 'turn-3',
+      turns: [0, 1, 2, 3].map(index => createPersistedTurn(index)),
+    });
+    await expect(flowChatStore.loadSessionTurnWindow('history-1', 3)).resolves.toMatchObject({
+      status: 'ready',
+      isCurrent: true,
+    });
+    expect(flowChatStore.activateSessionHistoryWindowFromTail('history-1', 3)?.range).toMatchObject({
+      startOrdinal: 0,
+      endOrdinalExclusive: 8,
+      mode: 'history-window',
+    });
+  });
+
   it('invalidates cached history and catalog entries after truncating a complete session', async () => {
     const catalog = createTurnCatalog(10);
     const dialogTurns = Array.from({ length: 10 }, (_, index) => createPersistedTurn(index));

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -976,6 +976,12 @@ function mergeLoadedTurnRanges(
   return merged;
 }
 
+function isProvisionalUsageReportTurn(turn: DialogTurn): boolean {
+  const metadata = turn.userMessage.metadata as LocalCommandMetadata | undefined;
+  return metadata?.localCommandKind === 'usage_report'
+    && metadata.usageReportProvisional === true;
+}
+
 function sliceLoadedTurnRange(
   range: LoadedTurnRange,
   startOrdinal: number,
@@ -1734,6 +1740,12 @@ export class FlowChatStore {
     if (!session || session.dialogTurns.length === 0) {
       return [];
     }
+    const canonicalTailTurns = session.dialogTurns.filter(
+      turn => !isProvisionalUsageReportTurn(turn),
+    );
+    if (canonicalTailTurns.length === 0) {
+      return [];
+    }
 
     const catalog = view?.catalog?.sessionId === sessionId
       ? view.catalog
@@ -1750,7 +1762,7 @@ export class FlowChatStore {
     }
 
     return [{
-      startOrdinal: Math.max(0, totalTurnCount - session.dialogTurns.length),
+      startOrdinal: Math.max(0, totalTurnCount - canonicalTailTurns.length),
       endOrdinalExclusive: totalTurnCount,
     }];
   }
@@ -1978,7 +1990,10 @@ export class FlowChatStore {
     if (catalog) {
       view.catalog = catalog;
     }
-    if (session.dialogTurns.length === 0) {
+    const canonicalTailTurns = session.dialogTurns.filter(
+      turn => !isProvisionalUsageReportTurn(turn),
+    );
+    if (canonicalTailTurns.length === 0) {
       return;
     }
 
@@ -1990,7 +2005,7 @@ export class FlowChatStore {
     const entryByStorageIndex = new Map(
       (catalog?.entries ?? []).map(entry => [entry.storageTurnIndex, entry]),
     );
-    const located = session.dialogTurns
+    const located = canonicalTailTurns
       .map(turn => {
         const entry = entryByTurnId.get(turn.id)
           ?? (typeof turn.backendTurnIndex === 'number'
@@ -2005,7 +2020,7 @@ export class FlowChatStore {
     );
     const now = Date.now();
 
-    if (uniqueLocated.length === session.dialogTurns.length) {
+    if (uniqueLocated.length === canonicalTailTurns.length) {
       let groupStart = 0;
       for (let index = 1; index <= uniqueLocated.length; index += 1) {
         const continues = index < uniqueLocated.length
@@ -2029,13 +2044,13 @@ export class FlowChatStore {
     const totalTurnCount = Math.max(
       catalog?.totalTurnCount ?? 0,
       session.totalTurnCount ?? 0,
-      session.dialogTurns.length,
+      canonicalTailTurns.length,
     );
-    const startOrdinal = Math.max(0, totalTurnCount - session.dialogTurns.length);
+    const startOrdinal = Math.max(0, totalTurnCount - canonicalTailTurns.length);
     this.cacheSessionLoadedTurnRange(sessionId, {
       startOrdinal,
-      endOrdinalExclusive: startOrdinal + session.dialogTurns.length,
-      turns: [...session.dialogTurns],
+      endOrdinalExclusive: startOrdinal + canonicalTailTurns.length,
+      turns: [...canonicalTailTurns],
       lastAccessedAt: now,
       source,
     }, catalog ?? null);
@@ -4715,8 +4730,8 @@ export class FlowChatStore {
       modelVisible: false,
       usageReport: params.report,
       usageReportStatus: params.status ?? 'completed',
+      usageReportProvisional: true,
     };
-    const turnIndex = session.dialogTurns.length;
     const dialogTurn: DialogTurn = {
       id: `local-usage-${params.reportId}`,
       sessionId: params.sessionId,
@@ -4731,7 +4746,6 @@ export class FlowChatStore {
       status: params.status === 'loading' ? 'processing' : 'completed',
       startTime: params.generatedAt,
       endTime: params.generatedAt,
-      backendTurnIndex: turnIndex,
     };
 
     this.setState(prev => {
@@ -4754,6 +4768,104 @@ export class FlowChatStore {
       };
     });
     return dialogTurn;
+  }
+
+  public commitLocalUsageReportTurn(params: {
+    sessionId: string;
+    dialogTurnId: string;
+    turnId: string;
+    storageTurnIndex: number;
+    totalTurnCount: number;
+    turnCatalog: SessionTurnCatalog;
+  }): boolean {
+    if (
+      params.turnCatalog.sessionId !== params.sessionId
+      || params.totalTurnCount !== params.turnCatalog.totalTurnCount
+      || !Number.isInteger(params.storageTurnIndex)
+      || params.storageTurnIndex < 0
+    ) {
+      log.warn('Cannot commit local usage report with an invalid authoritative catalog', {
+        sessionId: params.sessionId,
+        dialogTurnId: params.dialogTurnId,
+        turnId: params.turnId,
+        storageTurnIndex: params.storageTurnIndex,
+      });
+      return false;
+    }
+    const catalogEntry = params.turnCatalog.entries.find(entry =>
+      entry.turnId === params.turnId
+      && entry.storageTurnIndex === params.storageTurnIndex
+    );
+    if (!catalogEntry) {
+      log.warn('Cannot commit local usage report missing from authoritative catalog', {
+        sessionId: params.sessionId,
+        dialogTurnId: params.dialogTurnId,
+        turnId: params.turnId,
+        storageTurnIndex: params.storageTurnIndex,
+      });
+      return false;
+    }
+
+    let committedTurn: DialogTurn | null = null;
+    this.setState(prev => {
+      const session = prev.sessions.get(params.sessionId);
+      const provisionalTurn = session?.dialogTurns.find(turn => turn.id === params.dialogTurnId);
+      if (
+        !session
+        || !provisionalTurn
+        || provisionalTurn.id !== params.turnId
+        || !isProvisionalUsageReportTurn(provisionalTurn)
+      ) {
+        return prev;
+      }
+
+      const dialogTurns = session.dialogTurns.map(turn => {
+        if (turn.id !== params.dialogTurnId) {
+          return turn;
+        }
+        const metadata = { ...turn.userMessage.metadata } as LocalCommandMetadata;
+        delete metadata.usageReportProvisional;
+        committedTurn = {
+          ...turn,
+          backendTurnIndex: params.storageTurnIndex,
+          userMessage: {
+            ...turn.userMessage,
+            metadata,
+          },
+        };
+        return committedTurn;
+      });
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(params.sessionId, {
+        ...session,
+        dialogTurns,
+        turnCatalog: params.turnCatalog,
+        totalTurnCount: params.totalTurnCount,
+        loadedTurnCount: dialogTurns.length,
+      });
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
+
+    if (!committedTurn) {
+      log.warn('Cannot commit missing provisional local usage report', {
+        sessionId: params.sessionId,
+        dialogTurnId: params.dialogTurnId,
+      });
+      return false;
+    }
+
+    this.ensureSessionHistoryView(params.sessionId, params.turnCatalog).catalog = params.turnCatalog;
+    this.cacheSessionLoadedTurnRange(params.sessionId, {
+      startOrdinal: catalogEntry.ordinal,
+      endOrdinalExclusive: catalogEntry.ordinal + 1,
+      turns: [committedTurn],
+      lastAccessedAt: Date.now(),
+      source: 'live',
+    }, params.turnCatalog, catalogEntry.ordinal);
+    return true;
   }
 
   public deleteDialogTurn(sessionId: string, dialogTurnId: string): void {

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -328,6 +328,18 @@ export interface Session {
   titleI18nKey?: string;
   titleI18nParams?: Record<string, unknown>;
   titleStatus?: 'generating' | 'generated' | 'failed';
+  /**
+   * In-memory canonical working set for this session.
+   *
+   * Live and fully hydrated sessions normally contain all canonical Turns.
+   * When `isPartial` is true, this contains only the restored live tail;
+   * older paged windows remain in `SessionHistoryViewState.loadedRanges`.
+   *
+   * This array may temporarily contain provisional frontend Turns that have
+   * not been persisted. Never derive a backend storage index from its length
+   * or local array position; use `DialogTurn.backendTurnIndex` and
+   * `turnCatalog` for persisted identity and ordinals.
+   */
   dialogTurns: DialogTurn[];
   
   // Derived status from deriveSessionStatus():

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionAPI } from './SessionAPI';
+import type { DialogTurnData } from '@/shared/types/session-history';
 
 const invokeMock = vi.hoisted(() => vi.fn());
 
@@ -182,6 +183,58 @@ describe('SessionAPI paged metadata reads', () => {
         session_id: 'session-1',
         workspace_path: '/repo',
         include_hidden_subagents: false,
+      },
+    });
+  });
+
+  it('records local command turns through the authoritative catalog command', async () => {
+    const turnData: DialogTurnData = {
+      turnId: 'local-usage-1',
+      turnIndex: 0,
+      sessionId: 'session-1',
+      timestamp: 10,
+      kind: 'local_command',
+      userMessage: {
+        id: 'local-usage-user-1',
+        content: '# Session Usage Report',
+        timestamp: 10,
+        metadata: { localCommandKind: 'usage_report', modelVisible: false },
+      },
+      modelRounds: [],
+      startTime: 10,
+      endTime: 10,
+      status: 'completed',
+    };
+    const response = {
+      turnId: 'local-usage-1',
+      storageTurnIndex: 7,
+      totalTurnCount: 8,
+      turnCatalog: {
+        schemaVersion: 1,
+        sessionId: 'session-1',
+        revision: 'catalog-8',
+        totalTurnCount: 8,
+        complete: true,
+        entries: [{
+          ordinal: 7,
+          storageTurnIndex: 7,
+          turnId: 'local-usage-1',
+          previewTruncated: false,
+        }],
+      },
+    };
+    invokeMock.mockResolvedValueOnce(response);
+
+    await expect(
+      sessionAPI.recordLocalCommandTurn(turnData, '/repo', 'remote-1', 'host'),
+    ).resolves.toBe(response);
+
+    expect(invokeMock).toHaveBeenCalledWith('record_local_command_turn', {
+      request: {
+        turn_data: turnData,
+        workspace_path: '/repo',
+        remote_connection_id: 'remote-1',
+        remote_ssh_host: 'host',
       },
     });
   });

--- a/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SessionAPI.ts
@@ -1,7 +1,11 @@
 
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
-import type { SessionMetadata, DialogTurnData } from '@/shared/types/session-history';
+import type {
+  DialogTurnData,
+  SessionMetadata,
+  SessionTurnCatalog,
+} from '@/shared/types/session-history';
 import { normalizeRemoteSessionScope } from '@/shared/utils/remoteSessionScope';
 
 export type UiSessionMetadataField =
@@ -218,6 +222,13 @@ export interface SessionUsageReport {
   };
 }
 
+export interface RecordLocalCommandTurnResponse {
+  turnId: string;
+  storageTurnIndex: number;
+  totalTurnCount: number;
+  turnCatalog: SessionTurnCatalog;
+}
+
 function remoteSessionFields(
   remoteConnectionId?: string,
   remoteSshHost?: string
@@ -372,6 +383,28 @@ export class SessionAPI {
       });
     } catch (error) {
       throw createTauriCommandError('save_session_turn', error, { turnData, workspacePath });
+    }
+  }
+
+  async recordLocalCommandTurn(
+    turnData: DialogTurnData,
+    workspacePath: string,
+    remoteConnectionId?: string,
+    remoteSshHost?: string,
+  ): Promise<RecordLocalCommandTurnResponse> {
+    try {
+      return await api.invoke('record_local_command_turn', {
+        request: {
+          turn_data: turnData,
+          workspace_path: workspacePath,
+          ...remoteSessionFields(remoteConnectionId, remoteSshHost),
+        },
+      });
+    } catch (error) {
+      throw createTauriCommandError('record_local_command_turn', error, {
+        turnData,
+        workspacePath,
+      });
     }
   }
 

--- a/src/web-ui/src/shared/types/session-history.ts
+++ b/src/web-ui/src/shared/types/session-history.ts
@@ -137,6 +137,8 @@ export interface LocalCommandMetadata {
   modelVisible: false;
   usageReport?: Record<string, any>;
   usageReportStatus?: 'loading' | 'completed';
+  /** Frontend-only until the backend returns its authoritative turn catalog entry. */
+  usageReportProvisional?: boolean;
   threadGoalKickoff?: boolean;
   threadGoalObjectiveUpdated?: boolean;
   threadGoalContinuation?: boolean;


### PR DESCRIPTION
## Summary

- Register the local-command Turn persistence port in the session-surface Agent Runtime.
- Keep usage-report Turns provisional until backend persistence succeeds.
- Return the authoritative Turn ID, storage index, total count, and Turn catalog after recording a local command.
- Reconcile the provisional report with persisted session history instead of deriving its identity from the in-memory `dialogTurns` position.
- Exclude provisional reports from history-tail boundaries and Turn rails, and remove them when persistence fails.
- Add regression coverage for runtime assembly, local-command persistence, partial-history pagination, and usage-report reconciliation.

Fixes: N/A

## Type and Areas

Type:

Regression fix

Areas:

Rust Agent Runtime, runtime contracts, product assembly, desktop/Tauri session API, web UI FlowChat, session persistence

## Motivation / Impact

Usage reports are displayed as synthetic local-command Turns, but the frontend previously assigned their `backendTurnIndex` from `session.dialogTurns.length`.

That value is not a persisted identity: for partially loaded sessions, `dialogTurns` contains only the restored live tail and may also contain provisional frontend-only Turns. Treating its array position as a storage index corrupted the loaded history range. As a result, scrolling upward could incorrectly show “older history is not ready,” and the Turn rail could associate an existing Turn with the newly generated report.

The desktop session surface also omitted the local-command Turn port, causing persistence to fail with:

`agent local command turn port is not registered`

This PR fixes both parts of the persistence path:

- The session-surface runtime now registers the coordinator-owned local-command Turn port.
- Local-command persistence returns the authoritative Turn ID and storage index.
- The desktop API returns the refreshed Turn catalog and total Turn count.
- FlowChat keeps the report provisional until that response arrives, then commits it at the authoritative ordinal and updates the loaded history cache.
- Provisional reports do not participate in persisted pagination boundaries or Turn-rail numbering.
- Failed persistence removes the provisional report instead of leaving inconsistent local state.

Users can generate a usage report without breaking earlier-history pagination or Turn-rail alignment.

## Verification

- `pnpm run fmt:rs`
  - Completed successfully.
- `cargo test -p bitfun-agent-runtime local_command_turn`
  - Passed: 2 focused tests.
- `pnpm run type-check:web`
  - Passed.
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/usageReportService.test.ts src/flow_chat/store/FlowChatStore.test.ts src/infrastructure/api/service-api/SessionAPI.test.ts`
  - Passed: 3 test files, 98 tests.
- `git diff --check`
  - Passed.

## Reviewer Notes

- `dialogTurns` remains an in-memory working set, not an authoritative persisted sequence. In partially loaded sessions it contains only the restored tail; older paged ranges remain in `SessionHistoryViewState.loadedRanges`. A comment now documents this boundary.
- Persisted identity must come from `DialogTurn.backendTurnIndex` and `turnCatalog`, never from a local array position.
- `usageReportProvisional` is frontend-only and is removed before persistence and after successful reconciliation.
- The new desktop command is explicitly marked `RemoteRouted`, so remote workspace behavior follows the existing session routing boundary.
- `AgentLocalCommandTurnPort::record_completed_local_command_turn` now returns `AgentLocalCommandTurnRecordResult` instead of `()`. The Rust Runtime SDK compatibility documentation is aligned to preview API v5.
- No data migration is required. Existing persisted usage-report Turns continue to load through the existing local-command representation.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.