### PR TITLE
fix(flow-chat): close slash picker when trigger is removed

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -41,7 +41,13 @@ import { SmartRecommendations } from './smart-recommendations';
 import { useCurrentWorkspace, useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { flowChatSessionConfigForCurrentWorkspace } from '@/app/utils/projectSessionWorkspace';
 import { createImageContextFromFile, createImageContextFromClipboard } from '../utils/imageUtils';
-import { getInlineSlashCommandPickerQuery, getSlashCommandPickerQuery, isSlashCommand, stripSlashCommand } from '../utils/slashCommand';
+import {
+  getInlineSkillPickerQuery,
+  getInlineSlashCommandPickerQuery,
+  getSlashCommandPickerQuery,
+  isSlashCommand,
+  stripSlashCommand,
+} from '../utils/slashCommand';
 import {
   resolveSlashActionInputValue,
   type SlashActionId,
@@ -1516,48 +1522,36 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   ]);
 
   useEffect(() => {
-    const inlineCommandQuery = getInlineSlashCommandPickerQuery(inlineTriggerState);
-    if (inlineCommandQuery !== null) {
-      setSlashCommandState(prev => ({
-        isActive: true,
-        kind: derivedState?.isProcessing && !isAcpInputSession ? 'actions' : 'all',
-        query: inlineCommandQuery,
-        selectedIndex: prev.query === inlineCommandQuery ? prev.selectedIndex : 0,
-      }));
-      return;
-    }
+    const closeInlineSkillPicker = () => {
+      setSlashCommandState(prev => (
+        prev.isActive && prev.kind === 'skills'
+          ? { isActive: false, kind: 'modes', query: '', selectedIndex: 0 }
+          : prev
+      ));
+    };
 
     if (isAcpInputSession || !canUseSkillsForTarget) {
-      if (slashCommandState.isActive && slashCommandState.kind === 'skills') {
-        setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
-      }
+      closeInlineSkillPicker();
       return;
     }
 
-    const inlineSlashSkillTrigger =
-      inlineTriggerState.isActive &&
-      (
-        inlineTriggerState.trigger === '$' ||
-        (inlineTriggerState.trigger === '/' && inlineTriggerState.startOffset > 0)
-      );
+    const inlineSkillQuery = getInlineSkillPickerQuery(inlineTriggerState);
 
-    if (inlineSlashSkillTrigger) {
+    if (inlineSkillQuery !== null) {
       setSlashCommandState(prev => ({
         isActive: true,
         kind: 'skills',
-        query: inlineTriggerState.query.toLowerCase(),
+        query: inlineSkillQuery,
         selectedIndex:
-          prev.kind === 'skills' && prev.query === inlineTriggerState.query.toLowerCase()
+          prev.kind === 'skills' && prev.query === inlineSkillQuery
             ? prev.selectedIndex
             : 0,
       }));
       return;
     }
 
-    if (slashCommandState.isActive && slashCommandState.kind === 'skills') {
-      setSlashCommandState({ isActive: false, kind: 'modes', query: '', selectedIndex: 0 });
-    }
-  }, [canUseSkillsForTarget, derivedState?.isProcessing, inlineTriggerState, isAcpInputSession, slashCommandState.isActive, slashCommandState.kind]);
+    closeInlineSkillPicker();
+  }, [canUseSkillsForTarget, inlineTriggerState, isAcpInputSession]);
 
   const previousComposerSessionIdRef = useRef<string | null>(null);
 

--- a/src/web-ui/src/flow_chat/utils/slashCommand.test.ts
+++ b/src/web-ui/src/flow_chat/utils/slashCommand.test.ts
@@ -2,12 +2,39 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getSlashCommandPickerQuery,
+  getInlineSkillPickerQuery,
   getInlineSlashCommandPickerQuery,
   isSlashCommandPickerQuery,
   isSlashCommand,
   matchesSlashCommand,
   stripSlashCommand,
 } from './slashCommand';
+
+describe('getInlineSkillPickerQuery', () => {
+  it('uses dollar and non-leading slash triggers for inline skills', () => {
+    expect(getInlineSkillPickerQuery({
+      isActive: true,
+      trigger: '$',
+      query: 'PDF',
+      startOffset: 0,
+    })).toBe('pdf');
+    expect(getInlineSkillPickerQuery({
+      isActive: true,
+      trigger: '/',
+      query: 'PDF',
+      startOffset: 12,
+    })).toBe('pdf');
+  });
+
+  it('does not let a leading slash trigger reopen the inline skill picker', () => {
+    expect(getInlineSkillPickerQuery({
+      isActive: true,
+      trigger: '/',
+      query: '',
+      startOffset: 0,
+    })).toBeNull();
+  });
+});
 
 describe('getInlineSlashCommandPickerQuery', () => {
   it('uses the active leading token even when text already follows the caret', () => {

--- a/src/web-ui/src/flow_chat/utils/slashCommand.ts
+++ b/src/web-ui/src/flow_chat/utils/slashCommand.ts
@@ -18,6 +18,19 @@ export function getInlineSlashCommandPickerQuery(
     : null;
 }
 
+export function getInlineSkillPickerQuery(
+  trigger: InlineSlashCommandTrigger,
+): string | null {
+  if (
+    !trigger.isActive ||
+    (trigger.trigger !== '$' && (trigger.trigger !== '/' || trigger.startOffset === 0))
+  ) {
+    return null;
+  }
+
+  return trigger.query.toLowerCase();
+}
+
 export function isSlashCommandPickerQuery(query: string): boolean {
   return typeof query === 'string' && !query.includes('/');
 }


### PR DESCRIPTION
## Summary

- Make the leading-slash command picker follow the current composer text exclusively.
- Limit inline skill-picker synchronization to `$` and non-leading `/` triggers.
- Prevent stale inline-trigger state from reopening the command picker after `/` is deleted or the picker is dismissed.
- Add regression coverage for leading-slash trigger classification.

## Type and Areas

Type:

Bug fix / regression fix / UI/UX / test

Areas:

Web UI / FlowChat

## Motivation / Impact

Deleting the `/` that opened the slash-command picker could leave the picker visible. `ChatInput` closed it based on the updated composer text, but a delayed inline-trigger snapshot could immediately reopen it.

The command picker now closes as soon as its leading `/` trigger is removed, while `$` and non-leading `/` inline skill triggers continue to work as before.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/utils/slashCommand.test.ts`
  - Passed: 1 test file, 17 tests.
- `pnpm run type-check:web`
  - Passed.
- `git diff --check`
  - Passed.
- Manual desktop interaction verification was not run.

## Reviewer Notes

- Leading `/` command-picker state remains owned by the full composer input path.
- Inline-trigger synchronization now only owns `$` and non-leading `/` skill pickers.
- No user-facing strings, locale resources, styles, or backend behavior changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.