### PR TITLE
fix: use consistent workspace icons for active and inactive rows

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -2,7 +2,6 @@ import React, { lazy, Suspense, useCallback, useContext, useEffect, useMemo, use
 import { createPortal } from 'react-dom';
 import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot, Link2, ListChecks, Loader2, Clock3 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { DotMatrixArrowRightIcon } from './DotMatrixArrowRightIcon';
 import { Button, ConfirmDialog, Modal, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import { aiExperienceConfigService } from '@/infrastructure/config/services/AIExperienceConfigService';
@@ -790,15 +789,9 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
             data-workspace-id={workspace.id}
           >
             <span className="bitfun-nav-panel__assistant-item-avatar" aria-hidden="true">
-              {isActive ? (
-                <span className="bitfun-nav-panel__assistant-item-active-icon">
-                  <DotMatrixArrowRightIcon size={14} />
-                </span>
-              ) : (
-                <span className="bitfun-nav-panel__assistant-item-avatar-letter">
-                  {workspaceDisplayName.charAt(0)}
-                </span>
-              )}
+              <span className="bitfun-nav-panel__assistant-item-avatar-letter">
+                {workspaceDisplayName.charAt(0)}
+              </span>
               <span className={`bitfun-nav-panel__assistant-item-icon-toggle${sessionsCollapsed ? ' is-collapsed' : ''}`}>
                 <ChevronDown size={12} />
               </span>
@@ -1025,13 +1018,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         >
           <span className="bitfun-nav-panel__workspace-item-icon" aria-hidden="true">
             <span className="bitfun-nav-panel__workspace-item-icon-default">
-              {isActive ? (
-                <span className="bitfun-nav-panel__workspace-item-active-icon">
-                  <DotMatrixArrowRightIcon size={14} />
-                </span>
-              ) : (
-                <FolderOpen size={14} />
-              )}
+              <FolderOpen size={14} />
             </span>
             <span className={`bitfun-nav-panel__workspace-item-icon-toggle${sessionsCollapsed ? ' is-collapsed' : ''}`}>
               <ChevronDown size={14} />

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -10,6 +10,13 @@ function readWorkspaceListStylesheet(): string {
   return stylesheet.replace(/\r\n/g, '\n');
 }
 
+function readWorkspaceItemSource(): string {
+  return readFileSync(
+    fileURLToPath(new URL('./WorkspaceItem.tsx', import.meta.url)),
+    'utf8',
+  );
+}
+
 function extractBlock(stylesheet: string, selector: string): string {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = stylesheet.match(new RegExp(`${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`));
@@ -89,5 +96,15 @@ describe('WorkspaceListSection layout styles', () => {
       expect(block).toContain('width: 20px;');
       expect(block).toContain('height: 20px;');
     }
+  });
+
+  it('renders the same icon type for active and inactive workspace rows', () => {
+    const source = readWorkspaceItemSource();
+
+    // The active workspace row must not render a different icon type
+    // (e.g. an arrow) from its siblings (folders).
+    expect(source).not.toContain('DotMatrixArrowRightIcon');
+    expect(source).not.toContain('workspace-item-active-icon');
+    expect(source).not.toContain('assistant-item-active-icon');
   });
 });


### PR DESCRIPTION
## 动机

Workspace rows in the NavPanel rendered different icon types depending on active state: the active workspace showed a `DotMatrixArrowRightIcon` (dot-matrix arrow) while inactive siblings showed a `FolderOpen` icon. This made two parallel workspace paths look like they had a parent-child relationship rather than being equal, as reported in #1849.

## 改动思路

Remove the `isActive` conditional rendering that swapped in `DotMatrixArrowRightIcon` for active rows. Both the assistant-item avatar and the workspace-item icon now always render the same icon type regardless of active state. This is the smallest change that makes all workspace rows visually parallel.

## 关键代码

Before (active row rendered a different icon):
- Assistant avatar: `isActive ? DotMatrixArrowRightIcon : first-letter`
- Workspace icon: `isActive ? DotMatrixArrowRightIcon : FolderOpen`

After (always the same icon):
- Assistant avatar: always first-letter
- Workspace icon: always `FolderOpen`

## 具体改动

- `WorkspaceItem.tsx`: Removed `DotMatrixArrowRightIcon` import and both `isActive` conditional branches (assistant-item avatar + workspace-item icon). Active rows now use the same icon as inactive rows.
- `WorkspaceListSectionLayout.test.ts`: Added a layout test asserting the source does not contain `DotMatrixArrowRightIcon`, `workspace-item-active-icon`, or `assistant-item-active-icon`.

## 修复后复现

Open the Desktop app with two or more workspaces. Click between them. All workspace rows now show the same folder icon regardless of which is active.

## 验证

- `vitest run WorkspaceListSectionLayout.test.ts` — 3/3 passed (including new icon consistency test)
- `tsc --noEmit` (web-ui type-check) — passed, no errors

## 对主干的风险与未覆盖

- The unused `DotMatrixArrowRightIcon.tsx` component and its SCSS classes are left in place to keep the change minimal. They can be cleaned up separately.
- No runtime behavior change beyond icon rendering.

Fixes #1849
