### PR TITLE
fix(markdown-editor): preserve LaTeX backslashes for KaTeX rendering

### DIFF
--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
@@ -143,8 +143,10 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 
   const toNormalizedMarkdown = useCallback((raw: string) => {
     const nextEditability = analyzeMarkdownEditability(raw);
-    const nextContent =
-      nextEditability.mode === 'unsafe' ? raw : nextEditability.canonicalMarkdown;
+    // Use raw content instead of canonicalMarkdown to avoid doubling
+    // backslashes in LaTeX commands (e.g. \int → \\int), which breaks
+    // KaTeX rendering. The tiptap editor normalizes content internally.
+    const nextContent = raw;
     return { nextEditability, nextContent };
   }, []);
 
@@ -262,9 +264,9 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
     } else if (initialContent !== undefined) {
       const nextEditability = analyzeMarkdownEditability(initialContent);
-      const nextContent = nextEditability.mode === 'unsafe'
-        ? initialContent
-        : nextEditability.canonicalMarkdown;
+      // Use raw content instead of canonicalMarkdown to avoid doubling
+      // backslashes in LaTeX commands, which breaks KaTeX rendering.
+      const nextContent = initialContent;
 
       setEditability(nextEditability);
       setContent(nextContent);

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
@@ -334,4 +334,18 @@ describe('tiptap markdown compatibility', () => {
     expect(analysis.containsRawHtmlBlocks).toBe(true);
     expect(doc.content?.[0]?.type).toBe('rawHtmlBlock');
   });
+
+  it('doubles backslashes in LaTeX math during canonical round-trip', () => {
+    const markdown = String.raw`$$\int_0^1 x^2 dx = \frac13$$`;
+    const analysis = analyzeMarkdownEditability(markdown);
+
+    // Root cause of #1952: escapeMarkdownPlainText doubles every backslash
+    // during canonical serialization, turning \int into \\int, \frac into
+    // \\frac, etc. KaTeX interprets \\ as a line break, so the math renders
+    // incorrectly. This is why MarkdownEditor uses raw content instead of
+    // canonicalMarkdown for display.
+    expect(analysis.canonicalMarkdown).toContain(String.raw`\\int`);
+    expect(analysis.canonicalMarkdown).toContain(String.raw`\\frac`);
+    expect(analysis.canonicalMarkdown).not.toBe(markdown);
+  });
 });


### PR DESCRIPTION
## Problem

Markdown files containing LaTeX math (e.g. \$$\int_0^1 x^2 dx = \frac13\) fail to render correctly in the file viewer preview. KaTeX interprets the doubled backslashes (\\\\\int\) as line breaks instead of LaTeX commands (\\\\\int\).

## Root Cause

\MarkdownEditor.tsx\ normalizes content through \nalyzeMarkdownEditability\, which canonicalizes markdown via a tiptap round-trip. The serialization step calls \scapeMarkdownPlainText\ (tiptapMarkdown.ts:638) which doubles every backslash: \\\\\int\ becomes \\\\\\\\\int\. This corrupted content is then passed to the preview renderer and KaTeX.

## Fix

Use raw markdown content instead of \canonicalMarkdown\ in both content normalization paths:
1. \	oNormalizedMarkdown\ callback (used by file loading and content updates)
2. \initialContent\ loading path (used when content is passed directly)

The tiptap editor normalizes content internally, so the canonical form is not needed for display purposes.

## Test

Added a root-cause test in \	iptapMarkdown.test.ts\ that documents the backslash-doubling behavior of \nalyzeMarkdownEditability\ on LaTeX math content.

## Validation

- \	iptapMarkdown.test.ts\: 20/20 tests pass (including new root-cause test)
- \MarkdownEditor.test.tsx\: 2/2 tests pass (no regression)

Closes #1952