### PR TITLE
fix: make workspace icons consistent between active and inactive states

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -2,7 +2,6 @@ import React, { lazy, Suspense, useCallback, useContext, useEffect, useMemo, use
 import { createPortal } from 'react-dom';
 import { Folder, FolderOpen, MoreHorizontal, FolderSearch, Plus, ChevronDown, Trash2, RotateCcw, Copy, FileText, GitBranch, Bot, Link2, ListChecks, Loader2, Clock3 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { DotMatrixArrowRightIcon } from './DotMatrixArrowRightIcon';
 import { Button, ConfirmDialog, Modal, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import { aiExperienceConfigService } from '@/infrastructure/config/services/AIExperienceConfigService';
@@ -790,15 +789,9 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
             data-workspace-id={workspace.id}
           >
             <span className="bitfun-nav-panel__assistant-item-avatar" aria-hidden="true">
-              {isActive ? (
-                <span className="bitfun-nav-panel__assistant-item-active-icon">
-                  <DotMatrixArrowRightIcon size={14} />
-                </span>
-              ) : (
-                <span className="bitfun-nav-panel__assistant-item-avatar-letter">
-                  {workspaceDisplayName.charAt(0)}
-                </span>
-              )}
+              <span className="bitfun-nav-panel__assistant-item-avatar-letter">
+                {workspaceDisplayName.charAt(0)}
+              </span>
               <span className={`bitfun-nav-panel__assistant-item-icon-toggle${sessionsCollapsed ? ' is-collapsed' : ''}`}>
                 <ChevronDown size={12} />
               </span>
@@ -1025,13 +1018,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         >
           <span className="bitfun-nav-panel__workspace-item-icon" aria-hidden="true">
             <span className="bitfun-nav-panel__workspace-item-icon-default">
-              {isActive ? (
-                <span className="bitfun-nav-panel__workspace-item-active-icon">
-                  <DotMatrixArrowRightIcon size={14} />
-                </span>
-              ) : (
-                <FolderOpen size={14} />
-              )}
+              <FolderOpen size={14} />
             </span>
             <span className={`bitfun-nav-panel__workspace-item-icon-toggle${sessionsCollapsed ? ' is-collapsed' : ''}`}>
               <ChevronDown size={14} />

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -301,24 +301,6 @@
     padding-right: 52px;
   }
 
-  &__workspace-item-active-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: inherit;
-  }
-
-  &__assistant-item-active-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: inherit;
-    transition: opacity $motion-fast $easing-standard,
-                transform $motion-fast $easing-standard;
-    opacity: 1;
-    transform: scale(1);
-  }
-
   &__workspace-item-avatar {
     position: relative;
     display: inline-flex;
@@ -1115,8 +1097,7 @@
     &:hover {
       background: color-mix(in srgb, var(--element-bg-medium) 60%, transparent);
 
-      .bitfun-nav-panel__assistant-item-avatar-letter,
-      .bitfun-nav-panel__assistant-item-active-icon {
+      .bitfun-nav-panel__assistant-item-avatar-letter {
         opacity: 0;
         transform: scale(0.6);
       }

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -10,6 +10,13 @@ function readWorkspaceListStylesheet(): string {
   return stylesheet.replace(/\r\n/g, '\n');
 }
 
+function readWorkspaceItemSource(): string {
+  return readFileSync(
+    fileURLToPath(new URL('./WorkspaceItem.tsx', import.meta.url)),
+    'utf8',
+  );
+}
+
 function extractBlock(stylesheet: string, selector: string): string {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = stylesheet.match(new RegExp(`${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`));
@@ -89,5 +96,18 @@ describe('WorkspaceListSection layout styles', () => {
       expect(block).toContain('width: 20px;');
       expect(block).toContain('height: 20px;');
     }
+  });
+
+  it('renders the same icon for active and inactive workspace rows', () => {
+    const source = readWorkspaceItemSource();
+    const stylesheet = readWorkspaceListStylesheet();
+
+    // Active and inactive workspace rows must not render different icon types
+    // (e.g. an arrow for active, folder for inactive).
+    expect(source).not.toContain('DotMatrixArrowRightIcon');
+    expect(source).not.toContain('workspace-item-active-icon');
+    expect(source).not.toContain('assistant-item-active-icon');
+    expect(stylesheet).not.toContain('workspace-item-active-icon');
+    expect(stylesheet).not.toContain('assistant-item-active-icon');
   });
 });


### PR DESCRIPTION
## Problem

Fixes #1849

When a workspace is active, it showed a \DotMatrixArrowRightIcon\ (arrow) instead of the normal folder/letter icon. This made active and inactive workspaces look like different entity types rather than siblings.

## Root Cause

In \WorkspaceItem.tsx\, both the assistant workspace branch and the normal workspace branch used \isActive ?\ to conditionally render different icons:
- Active: arrow icon (\DotMatrixArrowRightIcon\)
- Inactive: folder icon (\FolderOpen\) or letter avatar

## Fix

Remove the \isActive\ conditional from both branches so active and inactive workspaces always use the same icon:
- **Assistant workspaces**: always show the letter avatar
- **Normal workspaces**: always show \FolderOpen\

The active state is still visually indicated by the existing \is-active\ CSS class, \ria-current\, and \data-workspace-active\ attributes — only the icon swap was removed.

## Changes

- \WorkspaceItem.tsx\: Removed \DotMatrixArrowRightIcon\ import and the two \isActive ?\ icon conditionals
- \WorkspaceListSection.scss\: Removed dead \workspace-item-active-icon\ and \ssistant-item-active-icon\ CSS rules, and cleaned up hover selector that referenced \ssistant-item-active-icon\
- \WorkspaceListSectionLayout.test.ts\: Added test verifying source/stylesheet no longer contain \DotMatrixArrowRightIcon\ or \ctive-icon\ classes

## Testing

- Validated all assertions pass (no \DotMatrixArrowRightIcon\ or \ctive-icon\ references remain in source or stylesheet)
- \isActive\ is still used elsewhere in the component for \is-active\ class, \ria-current\, \data-workspace-active\, git info, and session logic — only the icon swap was removed
- \FolderOpen\ import was already present and remains used