### PR TITLE
fix: preserve turns added during hydration window in FlowChatStore

### DIFF
--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -7103,15 +7103,27 @@ export class FlowChatStore {
         const session = prev.sessions.get(sessionId);
         if (!session) return prev;
 
+        // Preserve turns that were added to the session during the async
+        // hydration window and are absent from the restored turns.
+        // Without this, the restored dialogTurns would overwrite any
+        // live turns added between the restore request and its response,
+        // causing message action buttons (copy/edit/rollback) to break
+        // because the turn IDs are no longer in the session's dialogTurns.
+        const restoredTurnIds = new Set(dialogTurns.map(turn => turn.id));
+        const turnsAddedDuringHydration = session.dialogTurns.filter(
+          turn => !restoredTurnIds.has(turn.id),
+        );
+        const mergedDialogTurns = [...dialogTurns, ...turnsAddedDuringHydration];
+
         const updatedSession = {
           ...session,
-          dialogTurns,
+          dialogTurns: mergedDialogTurns,
           isHistorical: false,
           historyState: 'ready' as const,
           contextRestoreState,
           isPartial: restoredHistoryPartial,
-          loadedTurnCount: restoredLoadedTurnCount ?? dialogTurns.length,
-          totalTurnCount: restoredTotalTurnCount ?? dialogTurns.length,
+          loadedTurnCount: restoredLoadedTurnCount ?? mergedDialogTurns.length,
+          totalTurnCount: restoredTotalTurnCount ?? mergedDialogTurns.length,
           turnCatalog: selectPreferredTurnCatalog(session.turnCatalog, restoredTurnCatalog),
           error: null,
           config: {


### PR DESCRIPTION
## Problem

When a user clicks "Stop Generation" during an AI response, message operation buttons (copy, edit, rollback) occasionally become permanently unclickable for the entire conversation session. The tooltip shows "会话历史尚未就绪" (session history not ready).

## Root Cause

The race condition occurs when restoring a historical session:

1. User opens a historical session → async hydration starts (backend call)
2. While async restore is in flight, user sends a message → new dialog turn added to store's `dialogTurns`
3. AI starts generating, user clicks Stop
4. Backend response arrives with restored turns that don't include the new turn (request was made before the turn was created)
5. Hydration commit at `FlowChatStore.ts` overwrites `dialogTurns` entirely with restored turns, **losing the new turn**
6. The lost turn's ID is no longer in `dialogTurns` → `absoluteSessionTurnIndexForId` returns `undefined` → `actionTurnIndex = -1` → buttons disabled, tooltip "会话历史尚未就绪"

## Fix

Merge restored turns with any turns that were added to the session during the async hydration window, following the existing merge pattern already used in `applyDialogTurnProjection` (lines ~3080-3088 of the same file).

```ts
const restoredTurnIds = new Set(dialogTurns.map(turn => turn.id));
const turnsAddedDuringHydration = session.dialogTurns.filter(
  turn => !restoredTurnIds.has(turn.id),
);
const mergedDialogTurns = [...dialogTurns, ...turnsAddedDuringHydration];
```

This ensures turns created between the restore request and its response are preserved, preventing the button-disabled state.

Fixes #1508
