### PR TITLE
fix: Detect successful tool-call loops and sanitize leaked XML in assistant text (#1492)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ external/
 /.flashgrep-index-engine/
 
 .design/
+
+target-isolated/
+

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,34 @@
+## Fix: Detect successful tool-call loops and sanitize leaked XML in assistant text (#1492)
+
+### Problem
+
+When LLM inference is abnormal (e.g. DeepSeek), tool call XML tags (`<tool_calls><invoke>`) leak into assistant text. The system detects and executes them, creating a recursive loop that infinitely expands context with repeated successful Write/Read/Exec calls.
+
+### Root Cause
+
+The existing loop protections only track **failed** tool rounds. A loop of **successful** Write/Read/Exec calls trips no detector. Additionally, `write_content_sanitizer.rs` exists to detect/strip leaked XML but had zero production callers — it was never wired into the assistant text path.
+
+### Fix
+
+**1. Detect successful tool-call loops** (`execution_engine.rs`)
+
+- Added `recent_successful_tool_signatures` and `successful_tool_recovery_attempts` tracking alongside the existing failed-tool tracking.
+- Modified round-signature tracking to also track successful rounds: when not all tools fail, push to `recent_successful_tool_signatures` and clear the failed streak.
+- Added two new detection blocks mirroring the existing failed-tool detectors:
+  - **Strict consecutive check**: `tail.windows(2).all(|w| w[0] == w[1])` — detects identical consecutive successful tool calls.
+  - **Periodic-pattern check**: `is_periodic_tool_signature_loop()` — detects repeating patterns of successful tool calls.
+- Both inject `LoopRecovery`/`PeriodicLoopRecovery` reminders, clear the successful streak, and finalize after max attempts with `finalization_reason = "repeated_successful_tool_calls"`.
+
+**2. Wire `write_content_sanitizer` into assistant text** (`round_executor.rs`)
+
+- Before building `Message::assistant_with_reasoning`, checks `contains_tool_invocation_artifacts(&clean_text)` and if true, strips with `strip_tool_invocation_artifacts(&clean_text)` and logs a warning.
+- Changed `clean_text` from `let` to `let mut` to allow mutation.
+
+### Validation
+
+- `cargo check -p bitfun-core` passes (exit code 0).
+- Existing `write_content_sanitizer` and `is_periodic_tool_signature_loop` unit tests are unchanged in behavior (these functions were not modified, only called from new sites).
+
+### Testing
+
+Closes #1492

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -3276,6 +3276,14 @@ impl ExecutionEngine {
         let mut recent_failed_tool_signatures: Vec<String> = Vec::new();
         let mut failed_tool_recovery_attempts: usize = 0;
         const MAX_FAILED_TOOL_RECOVERY_ATTEMPTS: usize = 3;
+
+        // Track consecutive identical SUCCESSFUL tool-call signatures.
+        // The failed-signature detectors above only fire when tool results
+        // are errors; a loop of successful calls (e.g. leaked tool-call XML
+        // causing repeated Write/Read/Exec) trips no detector. Issue #1492.
+        let mut recent_successful_tool_signatures: Vec<String> = Vec::new();
+        let mut successful_tool_recovery_attempts: usize = 0;
+        const MAX_SUCCESSFUL_TOOL_RECOVERY_ATTEMPTS: usize = 3;
         const MAX_PARTIAL_CONTINUATION_ATTEMPTS: usize = 3;
         let mut full_compression_count = 0usize;
         let mut compression_failure_count = 0u32;
@@ -3880,21 +3888,29 @@ impl ExecutionEngine {
 
             if let Some(round_signature) = Self::tool_call_signature(&round_result.tool_calls) {
                 recent_tool_signatures.push(round_signature.clone());
-                if Self::failed_tool_round_signature(
+                let all_failed = Self::failed_tool_round_signature(
                     &round_result.tool_calls,
                     &round_result.tool_result_messages,
                 )
-                .is_some()
-                {
+                .is_some();
+                if all_failed {
                     recent_failed_tool_signatures.push(round_signature);
+                    // A failed round breaks the successful-call streak.
+                    recent_successful_tool_signatures.clear();
+                    successful_tool_recovery_attempts = 0;
                 } else {
                     recent_failed_tool_signatures.clear();
                     failed_tool_recovery_attempts = 0;
+                    // Track successful rounds for successful-loop detection
+                    // (issue #1492: loops of successful calls trip no detector).
+                    recent_successful_tool_signatures.push(round_signature);
                 }
             } else {
                 recent_tool_signatures.clear();
                 recent_failed_tool_signatures.clear();
                 failed_tool_recovery_attempts = 0;
+                recent_successful_tool_signatures.clear();
+                successful_tool_recovery_attempts = 0;
             }
 
             let after_round_pressure = Self::estimate_auto_compression_pressure(
@@ -4021,6 +4037,105 @@ impl ExecutionEngine {
                             window_size, MAX_FAILED_TOOL_RECOVERY_ATTEMPTS
                     );
                     finalization_reason = Some("repeated_tool_failures");
+                    break;
+                }
+            }
+
+            // Repeated successful tool-call detection (issue #1492).
+            //
+            // The failed-tool detectors above only fire when tool results are
+            // errors. A loop of SUCCESSFUL tool calls (e.g. leaked tool-call
+            // XML causing repeated Write/Read/Exec with identical arguments,
+            // where each call "succeeds" but makes no real progress) trips no
+            // detector. The model stays stuck for hundreds of rounds, each
+            // round adding content to context without advancing the task,
+            // causing unbounded context expansion.
+            if recent_successful_tool_signatures.len() >= max_consec {
+                let tail = &recent_successful_tool_signatures
+                    [recent_successful_tool_signatures.len() - max_consec..];
+                if tail.windows(2).all(|w| w[0] == w[1]) {
+                    if successful_tool_recovery_attempts < MAX_SUCCESSFUL_TOOL_RECOVERY_ATTEMPTS {
+                        successful_tool_recovery_attempts += 1;
+                        warn!(
+                            "Repeated successful tool calls detected: {} consecutive rounds with identical tool signatures, injecting recovery prompt #{}",
+                            max_consec, successful_tool_recovery_attempts
+                        );
+                        let reminder = format!(
+                            "<system_reminder>Repeated tool calls detected: the same tool call with identical arguments has been executed {} times in a row. \
+                            This may indicate a tool-call XML leak causing infinite context expansion. You MUST now change your strategy: \
+                            (1) stop calling the same tool with the same arguments; \
+                            (2) if your recent output contains tool-call XML tags like <tool_calls>, <invoke>, or function_call, you may be leaking tool syntax as plain text — review and remove it; \
+                            (3) if you are stuck, provide a clear summary to the user. \
+                            Do NOT repeat the same tool call again.</system_reminder>",
+                            max_consec
+                        );
+                        let user_msg = Message::internal_reminder(
+                            InternalReminderKind::LoopRecovery,
+                            reminder,
+                        )
+                        .with_turn_id(context.dialog_turn_id.clone());
+                        messages.push(user_msg.clone());
+                        if let Err(e) = self
+                            .session_manager
+                            .add_message(&context.session_id, user_msg)
+                            .await
+                        {
+                            warn!("Failed to persist successful-tool recovery reminder: {}", e);
+                        }
+                        recent_successful_tool_signatures.clear();
+                    } else {
+                        warn!(
+                            "Repeated successful tool calls detected: {} consecutive rounds with identical tool signatures, max recovery attempts ({}) exhausted, finalizing without tools",
+                            max_consec, MAX_SUCCESSFUL_TOOL_RECOVERY_ATTEMPTS
+                        );
+                        finalization_reason = Some("repeated_successful_tool_calls");
+                        break;
+                    }
+                }
+            }
+
+            // Periodic-pattern loop detection for successful rounds.
+            if Self::is_periodic_tool_signature_loop(
+                &recent_successful_tool_signatures,
+                max_consec,
+            ) {
+                let window_size = max_consec.max(1).saturating_mul(2);
+                if successful_tool_recovery_attempts < MAX_SUCCESSFUL_TOOL_RECOVERY_ATTEMPTS {
+                    successful_tool_recovery_attempts += 1;
+                    warn!(
+                        "Repeated successful tool calls detected: last {} successful rounds form a periodic tool-call pattern, injecting recovery prompt #{}",
+                        window_size, successful_tool_recovery_attempts
+                    );
+                    let reminder = format!(
+                        "<system_reminder>Repeated tool calls detected: your last {} tool calls form a repeating pattern with no new progress. \
+                        This may indicate a tool-call XML leak causing infinite context expansion. \
+                        You MUST now change your strategy: \
+                        (1) stop calling the same tools with the same arguments; \
+                        (2) if your recent output contains tool-call XML tags, you may be leaking tool syntax as plain text — review and remove it; \
+                        (3) provide a clear summary to the user. \
+                        Do NOT repeat the same pattern of tool calls.</system_reminder>",
+                        window_size
+                    );
+                    let user_msg = Message::internal_reminder(
+                        InternalReminderKind::PeriodicLoopRecovery,
+                        reminder,
+                    )
+                    .with_turn_id(context.dialog_turn_id.clone());
+                    messages.push(user_msg.clone());
+                    if let Err(e) = self
+                        .session_manager
+                        .add_message(&context.session_id, user_msg)
+                        .await
+                    {
+                        warn!("Failed to persist periodic successful-tool recovery reminder: {}", e);
+                    }
+                    recent_successful_tool_signatures.clear();
+                } else {
+                    warn!(
+                        "Repeated successful tool calls detected: last {} successful rounds form a periodic pattern, max recovery attempts ({}) exhausted, finalizing without tools",
+                        window_size, MAX_SUCCESSFUL_TOOL_RECOVERY_ATTEMPTS
+                    );
+                    finalization_reason = Some("repeated_successful_tool_calls");
                     break;
                 }
             }

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -1179,7 +1179,19 @@ impl RoundExecutor {
         };
         let parsed_memory_citation =
             Self::parsed_memory_citation_from_stream_result(&stream_result);
-        let (clean_text, _) = strip_bitfun_memory_citations(&stream_result.full_text);
+        let (mut clean_text, _) = strip_bitfun_memory_citations(&stream_result.full_text);
+        // Sanitize leaked tool-invocation XML from assistant text content.
+        // When the model outputs raw tool-call XML as plain text (e.g. due to
+        // inference abnormalities like DeepSeek), the XML tags are re-sent each
+        // round and cause unbounded context expansion (issue #1492).
+        if super::write_content_sanitizer::contains_tool_invocation_artifacts(&clean_text) {
+            warn!(
+                "Tool-invocation artifacts detected in assistant text, stripping leaked XML (len={})",
+                clean_text.len()
+            );
+            clean_text =
+                super::write_content_sanitizer::strip_tool_invocation_artifacts(&clean_text);
+        }
         let assistant_message =
             Message::assistant_with_reasoning(reasoning, clean_text, tool_calls.clone())
                 .with_turn_id(context.dialog_turn_id.clone())


### PR DESCRIPTION
## Fix: Detect successful tool-call loops and sanitize leaked XML in assistant text (#1492)

### Problem

When LLM inference is abnormal (e.g. DeepSeek), tool call XML tags (`<tool_calls><invoke>`) leak into assistant text. The system detects and executes them, creating a recursive loop that infinitely expands context with repeated successful Write/Read/Exec calls.

### Root Cause

The existing loop protections only track **failed** tool rounds. A loop of **successful** Write/Read/Exec calls trips no detector. Additionally, `write_content_sanitizer.rs` exists to detect/strip leaked XML but had zero production callers — it was never wired into the assistant text path.

### Fix

**1. Detect successful tool-call loops** (`execution_engine.rs`)

- Added `recent_successful_tool_signatures` and `successful_tool_recovery_attempts` tracking alongside the existing failed-tool tracking.
- Modified round-signature tracking to also track successful rounds: when not all tools fail, push to `recent_successful_tool_signatures` and clear the failed streak.
- Added two new detection blocks mirroring the existing failed-tool detectors:
  - **Strict consecutive check**: `tail.windows(2).all(|w| w[0] == w[1])` — detects identical consecutive successful tool calls.
  - **Periodic-pattern check**: `is_periodic_tool_signature_loop()` — detects repeating patterns of successful tool calls.
- Both inject `LoopRecovery`/`PeriodicLoopRecovery` reminders, clear the successful streak, and finalize after max attempts with `finalization_reason = "repeated_successful_tool_calls"`.

**2. Wire `write_content_sanitizer` into assistant text** (`round_executor.rs`)

- Before building `Message::assistant_with_reasoning`, checks `contains_tool_invocation_artifacts(&clean_text)` and if true, strips with `strip_tool_invocation_artifacts(&clean_text)` and logs a warning.
- Changed `clean_text` from `let` to `let mut` to allow mutation.

### Validation

- `cargo check -p bitfun-core` passes (exit code 0).
- Existing `write_content_sanitizer` and `is_periodic_tool_signature_loop` unit tests are unchanged in behavior (these functions were not modified, only called from new sites).

### Testing

Closes #1492
