### PR TITLE
fix: add multi-window session support (#1318)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 # Build outputs - Rust/Tauri
 target/
 **/target/
+target-isolated/
 # The deployable Rust services use the workspace lockfile for reproducible
 # container builds.
 !Cargo.lock

--- a/src/apps/desktop/capabilities/default.json
+++ b/src/apps/desktop/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "BitFun default capabilities",
-  "windows": ["main", "agent-companion-pet", "spotlight"],
+  "windows": ["main", "agent-companion-pet", "spotlight", "session-window-*"],
   "permissions": [
     "log:default",
     "autostart:default",

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -1767,6 +1767,7 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         RemoteWorkspacePolicy::LocalOnly,
     ),
     ("show_main_window", RemoteWorkspacePolicy::LocalOnly),
+    ("create_session_window", RemoteWorkspacePolicy::LocalOnly),
     (
         "speech_append_audio_chunk",
         RemoteWorkspacePolicy::LocalOnly,

--- a/src/apps/desktop/src/appearance.rs
+++ b/src/apps/desktop/src/appearance.rs
@@ -1,6 +1,6 @@
 //! Desktop appearance bootstrap and window creation.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
@@ -1025,6 +1025,68 @@ pub async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
         total_started_at.elapsed().as_millis()
     );
     Ok(())
+}
+
+static SESSION_WINDOW_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Create a new session window so the user can work on multiple sessions in
+/// parallel. Each window gets a unique label (`session-window-<n>`) and loads
+/// the full app UI via `?bitfunWindow=session`. Session windows close normally
+/// (no tray/minimize interception) and are excluded from the main window's
+/// close-request event handling.
+#[tauri::command]
+pub async fn create_session_window(app: tauri::AppHandle) -> Result<String, String> {
+    let id = SESSION_WINDOW_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let label = format!("session-window-{id}");
+    let url = app_url("?bitfunWindow=session");
+
+    let mut builder = tauri::WebviewWindowBuilder::new(&app, &label, url)
+        .title("BitFun")
+        .inner_size(
+            crate::MAIN_WINDOW_DEFAULT_WIDTH,
+            crate::MAIN_WINDOW_DEFAULT_HEIGHT,
+        )
+        .min_inner_size(
+            crate::MAIN_WINDOW_MIN_WIDTH,
+            crate::MAIN_WINDOW_MIN_HEIGHT,
+        )
+        .center()
+        .resizable(true)
+        .fullscreen(false)
+        .visible(false)
+        .disable_drag_drop_handler();
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder
+            .decorations(true)
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .traffic_light_position(tauri::LogicalPosition::new(12.0, 15.0))
+            .hidden_title(true);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        builder = builder.decorations(false);
+    }
+
+    let window = builder.build().map_err(|e| {
+        error!("Failed to create session window: error={}", e);
+        format!("Failed to create session window: {e}")
+    })?;
+
+    window.show().map_err(|e| {
+        error!("Failed to show session window: {}", e);
+        format!("Failed to show session window: {e}")
+    })?;
+
+    window.set_focus().map_err(|e| {
+        error!("Failed to focus session window: {}", e);
+        format!("Failed to focus session window: {e}")
+    })?;
+
+    debug!("Session window created: label={}", label);
+    Ok(label)
 }
 
 #[cfg(test)]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1118,6 +1118,7 @@ pub async fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             appearance::show_main_window,
+            appearance::create_session_window,
             hide_main_window_after_close_request,
             api::agentic_api::create_session,
             api::agentic_api::update_session_mode,

--- a/src/web-ui/src/app/components/NavBar/NavBar.tsx
+++ b/src/web-ui/src/app/components/NavBar/NavBar.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { useCallback, useMemo, useRef } from 'react';
-import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Plus } from 'lucide-react';
 import { Tooltip } from '@/component-library';
 import { useNavSceneStore } from '../../stores/navSceneStore';
 import { useI18n } from '../../../infrastructure/i18n';
@@ -80,6 +80,15 @@ const NavBar: React.FC<NavBarProps> = ({
     onMaximize?.();
   }, [onMaximize]);
 
+  const handleNewWindow = useCallback(async () => {
+    try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      await invoke('create_session_window');
+    } catch (error) {
+      log.error('Failed to create session window', error);
+    }
+  }, []);
+
   const rootClassName = `bitfun-nav-bar${isCollapsed ? ' bitfun-nav-bar--collapsed' : ''}${isMacOS ? ' bitfun-nav-bar--macos' : ''} ${className}`;
 
   if (isCollapsed) {
@@ -142,6 +151,20 @@ const NavBar: React.FC<NavBarProps> = ({
           aria-label={t('nav.forward')}
         >
           <ArrowRight size={15} />
+        </button>
+      </Tooltip>
+
+      {/* New window */}
+      <Tooltip content={t('nav.newWindow')} placement="bottom" followCursor>
+        <button
+          type="button"
+          className="bitfun-nav-bar__btn"
+          data-bf-component="nav-bar"
+          data-bf-part="newWindow"
+          onClick={handleNewWindow}
+          aria-label={t('nav.newWindow')}
+        >
+          <Plus size={15} />
         </button>
       </Tooltip>
 

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -15,6 +15,7 @@ const log = createLogger('PeerDeviceTransport');
 const LOCAL_ONLY_COMMANDS = new Set([
   'show_main_window',
   'hide_main_window_after_close_request',
+  'create_session_window',
   'quit_app',
   'minimize_to_tray',
   'initialize_tray_after_startup',

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -73,6 +73,7 @@
     "forward": "Forward",
     "backShortcut": "Back (Alt+←)",
     "forwardShortcut": "Forward (Alt+→)",
+    "newWindow": "New Window",
     "items": {
       "sessions": "Sessions",
       "project": "Directory",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -73,6 +73,7 @@
     "forward": "前进",
     "backShortcut": "后退 (Alt+←)",
     "forwardShortcut": "前进 (Alt+→)",
+    "newWindow": "新建窗口",
     "items": {
       "sessions": "会话",
       "project": "目录",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -73,6 +73,7 @@
     "forward": "前進",
     "backShortcut": "後退 (Alt+←)",
     "forwardShortcut": "前進 (Alt+→)",
+    "newWindow": "新建視窗",
     "items": {
       "sessions": "會話",
       "project": "目錄",


### PR DESCRIPTION
## Summary

Implements multi-window session support, allowing users to open additional BitFun session windows from the NavBar.

## Changes

- **`src/apps/desktop/src/appearance.rs`**: Added `create_session_window` Tauri command using an atomic counter (`SESSION_WINDOW_COUNTER`) for unique window labels, platform-specific decorations matching the main window, and `app_url("?bitfunWindow=session")` URL parameter.
- **`src/apps/desktop/src/lib.rs`**: Registered `appearance::create_session_window` in the `invoke_handler`.
- **`src/apps/desktop/src/api/remote_workspace_policy.rs`**: Added `LocalOnly` remote workspace policy for `create_session_window`.
- **`src/apps/desktop/capabilities/default.json`**: Added `"session-window-*"` to the window capability pattern.
- **`src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts`**: Added `create_session_window` to the `LOCAL_ONLY_COMMANDS` set.
- **`src/web-ui/src/app/components/NavBar/NavBar.tsx`**: Added a "New Window" button with a `Plus` icon that invokes `create_session_window` via dynamic import.
- **i18n**: Added `newWindow` key to `common.json` for en-US, zh-CN, and zh-TW locales.

## Validation

- `cargo check -p bitfun-desktop` passes (exit code 0)
- Remote workspace policy contract verified: `create_session_window` is registered in both `generate_handler!` and `REMOTE_WORKSPACE_COMMAND_POLICIES`

Closes #1318
