### PR TITLE
fix: preserve relay SSH config search results

### DIFF
--- a/src/web-ui/src/features/relay-deploy/RelayDeployWizard.scss
+++ b/src/web-ui/src/features/relay-deploy/RelayDeployWizard.scss
@@ -134,6 +134,16 @@
     gap: 4px;
   }
 
+  &__search-empty {
+    display: grid;
+    place-items: center;
+    min-height: 42px;
+    padding: 8px 10px;
+    color: var(--bf-appearance-token-color-text-muted);
+    font-size: 12px;
+    text-align: center;
+  }
+
   &__server-item {
     display: flex;
     align-items: center;

--- a/src/web-ui/src/features/relay-deploy/RelayDeployWizard.tsx
+++ b/src/web-ui/src/features/relay-deploy/RelayDeployWizard.tsx
@@ -36,6 +36,7 @@ import {
   type DockerAccessMode,
   type RelayMirrorMode,
 } from './relayDeployApi';
+import { buildRelayServerSearchState, getRelayConnectionHost } from './serverSearch';
 import { ConnectedTerminal, getTerminalService } from '@/tools/terminal';
 import { createLogger } from '@/shared/utils/logger';
 import './RelayDeployWizard.scss';
@@ -478,9 +479,10 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
 
   const handleFillFromConfig = (entry: SSHConfigEntry) => {
     const hasKey = !!entry.identityFile?.trim();
+    const connectHost = getRelayConnectionHost(entry);
     setFormData({
       name: entry.host,
-      host: entry.host,
+      host: connectHost,
       port: entry.port ? String(entry.port) : '22',
       username: entry.user || '',
       authType: hasKey ? 'privateKey' : 'password',
@@ -676,31 +678,17 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
   };
 
   // ── derived view data ────────────────────────────────────────────────────
-  const filteredSavedConnections = savedConnections.filter((conn) => {
-    if (!savedSearch.trim()) return true;
-    const q = savedSearch.toLowerCase();
-    return (
-      conn.name.toLowerCase().includes(q) ||
-      conn.host.toLowerCase().includes(q) ||
-      conn.username.toLowerCase().includes(q)
-    );
-  });
-
-  const filteredSSHConfigHosts = sshConfigHosts.filter((entry) => {
-    const hostname = entry.hostname || entry.host;
-    const port = entry.port || 22;
-    const user = entry.user || '';
-    if (savedConnections.some((c) => c.host === hostname && c.port === port && c.username === user)) {
-      return false;
-    }
-    if (!configSearch.trim()) return true;
-    const q = configSearch.toLowerCase();
-    return (
-      entry.host.toLowerCase().includes(q) ||
-      hostname.toLowerCase().includes(q) ||
-      user.toLowerCase().includes(q)
-    );
-  });
+  const {
+    filteredSavedConnections,
+    filteredSSHConfigHosts,
+    hasSavedConnections,
+    hasSSHConfigHosts,
+  } = buildRelayServerSearchState(
+    savedConnections,
+    sshConfigHosts,
+    savedSearch,
+    configSearch,
+  );
 
   const accessMode = preflight?.dockerAccessMode;
   const dockerRecoverable = !!preflight && preflight.dockerInstalled
@@ -738,7 +726,7 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
     <div className="relay-deploy-wizard__scroll">
       <p className="relay-deploy-wizard__desc">{t('relayDeploy.selectServerDesc')}</p>
 
-      {savedConnections.length > 0 && (
+      {hasSavedConnections && (
         <div className="relay-deploy-wizard__section">
           <div className="relay-deploy-wizard__section-header">
             <h3 className="relay-deploy-wizard__section-title">{t('ssh.remote.savedConnections')}</h3>
@@ -752,7 +740,11 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
             />
           </div>
           <div className="relay-deploy-wizard__server-list">
-            {filteredSavedConnections.map((conn) => (
+            {filteredSavedConnections.length === 0 ? (
+              <div className="relay-deploy-wizard__search-empty" role="status">
+                {t('empty.noResults')}
+              </div>
+            ) : filteredSavedConnections.map((conn) => (
               <div
                 key={conn.id}
                 className="relay-deploy-wizard__server-item"
@@ -778,7 +770,7 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
         </div>
       )}
 
-      {filteredSSHConfigHosts.length > 0 && (
+      {hasSSHConfigHosts && (
         <div className="relay-deploy-wizard__section">
           <div className="relay-deploy-wizard__section-header">
             <h3 className="relay-deploy-wizard__section-title">{t('ssh.remote.sshConfigHosts')}</h3>
@@ -792,7 +784,11 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
             />
           </div>
           <div className="relay-deploy-wizard__server-list">
-            {filteredSSHConfigHosts.map((entry) => (
+            {filteredSSHConfigHosts.length === 0 ? (
+              <div className="relay-deploy-wizard__search-empty" role="status">
+                {t('empty.noResults')}
+              </div>
+            ) : filteredSSHConfigHosts.map((entry) => (
               <div
                 key={entry.host}
                 className="relay-deploy-wizard__server-item relay-deploy-wizard__server-item--config"
@@ -819,7 +815,7 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
         </div>
       )}
 
-      {(savedConnections.length > 0 || filteredSSHConfigHosts.length > 0) && (
+      {(hasSavedConnections || hasSSHConfigHosts) && (
         <div className="relay-deploy-wizard__divider"><span>{t('ssh.remote.newConnection')}</span></div>
       )}
 

--- a/src/web-ui/src/features/relay-deploy/serverSearch.test.ts
+++ b/src/web-ui/src/features/relay-deploy/serverSearch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SavedConnection, SSHConfigEntry } from '../ssh-remote/types';
+import { buildRelayServerSearchState, getRelayConnectionHost } from './serverSearch';
+
+const savedAliyun: SavedConnection = {
+  id: 'ssh-root@47.99.85.183',
+  name: 'Aliyun',
+  host: '47.99.85.183',
+  port: 22,
+  username: 'root',
+  authType: { type: 'Agent' },
+};
+
+const aliyunAlias: SSHConfigEntry = {
+  host: 'aliyun_wgq',
+  hostname: '47.99.85.183',
+  port: 22,
+  user: 'root',
+  agent: true,
+};
+
+describe('buildRelayServerSearchState', () => {
+  it('uses HostName for SSH config connections while retaining the alias for display', () => {
+    expect(getRelayConnectionHost(aliyunAlias)).toBe('47.99.85.183');
+  });
+
+  it('keeps an SSH config alias even when a saved connection uses the same endpoint', () => {
+    const state = buildRelayServerSearchState(
+      [savedAliyun],
+      [aliyunAlias],
+      '',
+      'aliyun_wgq',
+    );
+
+    expect(state.hasSSHConfigHosts).toBe(true);
+    expect(state.filteredSSHConfigHosts).toEqual([aliyunAlias]);
+  });
+
+  it('keeps the SSH config section visible when a search has no matches', () => {
+    const state = buildRelayServerSearchState(
+      [savedAliyun],
+      [aliyunAlias],
+      '',
+      'missing-server',
+    );
+
+    expect(state.hasSSHConfigHosts).toBe(true);
+    expect(state.filteredSSHConfigHosts).toEqual([]);
+  });
+});

--- a/src/web-ui/src/features/relay-deploy/serverSearch.ts
+++ b/src/web-ui/src/features/relay-deploy/serverSearch.ts
@@ -1,0 +1,42 @@
+import type { SavedConnection, SSHConfigEntry } from '../ssh-remote/types';
+
+export interface RelayServerSearchState {
+  filteredSavedConnections: SavedConnection[];
+  filteredSSHConfigHosts: SSHConfigEntry[];
+  hasSavedConnections: boolean;
+  hasSSHConfigHosts: boolean;
+}
+
+export function getRelayConnectionHost(entry: SSHConfigEntry): string {
+  return entry.hostname?.trim() || entry.host;
+}
+
+export function buildRelayServerSearchState(
+  savedConnections: SavedConnection[],
+  sshConfigHosts: SSHConfigEntry[],
+  savedSearch: string,
+  configSearch: string,
+): RelayServerSearchState {
+  const savedQuery = savedSearch.trim().toLowerCase();
+  const configQuery = configSearch.trim().toLowerCase();
+
+  return {
+    filteredSavedConnections: savedConnections.filter((connection) => (
+      !savedQuery
+      || connection.name.toLowerCase().includes(savedQuery)
+      || connection.host.toLowerCase().includes(savedQuery)
+      || connection.username.toLowerCase().includes(savedQuery)
+    )),
+    filteredSSHConfigHosts: sshConfigHosts.filter((entry) => {
+      if (!configQuery) return true;
+      const hostname = getRelayConnectionHost(entry);
+      return (
+        entry.host.toLowerCase().includes(configQuery)
+        || hostname.toLowerCase().includes(configQuery)
+        || (entry.user || '').toLowerCase().includes(configQuery)
+      );
+    }),
+    hasSavedConnections: savedConnections.length > 0,
+    hasSSHConfigHosts: sshConfigHosts.length > 0,
+  };
+}


### PR DESCRIPTION
## Summary
- keep the Relay deploy SSH Config section and search box visible when a query has no matches
- stop hiding SSH config aliases that resolve to the same endpoint as a saved connection
- use the SSH config HostName when filling a Relay connection so aliases such as `aliyun_wgq` connect to the resolved address

## Verification
- `pnpm --dir src/web-ui run test:run src/features/relay-deploy/serverSearch.test.ts` (3 passed)
- ESLint for changed TypeScript files
- `git diff --check`

Full Web UI type-check remains blocked by the pre-existing missing generated module `src/generated/api`.