### PR TITLE
perf(auth): reduce default Argon2 memory cost

### DIFF
--- a/src/crates/services/relay-service/src/admin.rs
+++ b/src/crates/services/relay-service/src/admin.rs
@@ -34,7 +34,8 @@ pub struct AdminKdfParams {
 impl Default for AdminKdfParams {
     fn default() -> Self {
         Self {
-            m: 65536,
+            // Resource-aware baseline: 16 MiB, 3 iterations, 4 lanes.
+            m: 16 * 1024,
             t: 3,
             p: 4,
         }

--- a/src/crates/services/relay-service/src/routes/auth.rs
+++ b/src/crates/services/relay-service/src/routes/auth.rs
@@ -83,7 +83,7 @@ fn decoy_login_challenge(username: &str) -> LoginChallengeResponse {
     LoginChallengeResponse {
         salt: BASE64.encode(&salt_material[..16]),
         kdf_salt: BASE64.encode(&kdf_salt_material[..16]),
-        argon2_params: r#"{"m":65536,"t":3,"p":4}"#.to_string(),
+        argon2_params: r#"{"m":16384,"t":3,"p":4}"#.to_string(),
         wrapped_master_key: format!(
             "{}.{}",
             BASE64.encode(ciphertext),
@@ -905,6 +905,10 @@ mod tests {
         let first_body = to_bytes(first.into_body(), 16 * 1024).await.unwrap();
         let first_json: LoginChallengeResponse = serde_json::from_slice(&first_body).unwrap();
         assert!(first_json.login_idempotency_supported);
+        let params: serde_json::Value = serde_json::from_str(&first_json.argon2_params).unwrap();
+        assert_eq!(params["m"], 16 * 1024);
+        assert_eq!(params["t"], 3);
+        assert_eq!(params["p"], 4);
         assert_eq!(BASE64.decode(&first_json.salt).unwrap().len(), 16);
         assert_eq!(BASE64.decode(&first_json.kdf_salt).unwrap().len(), 16);
         let (ciphertext, nonce) = first_json.wrapped_master_key.split_once('.').unwrap();

--- a/src/crates/services/services-integrations/src/remote_connect/account.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/account.rs
@@ -30,7 +30,7 @@ const NONCE_LEN: usize = 12;
 /// so the client can rebuild the identical KDF on login.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KdfParams {
-    /// Memory cost in KiB (e.g. 65536 = 64 MB).
+    /// Memory cost in KiB (e.g. 16384 = 16 MiB).
     pub m: u32,
     /// Time cost (iterations).
     pub t: u32,
@@ -40,9 +40,9 @@ pub struct KdfParams {
 
 impl Default for KdfParams {
     fn default() -> Self {
-        // OWASP-recommended Argon2id baseline: 64 MB, 3 iterations, 4 lanes.
+        // Resource-aware Argon2id baseline: 16 MiB, 3 iterations, 4 lanes.
         Self {
-            m: 65536,
+            m: 16 * 1024,
             t: 3,
             p: 4,
         }


### PR DESCRIPTION
## Summary

- reduce the default Argon2id memory cost for newly provisioned or reset Relay accounts from 64 MiB to 16 MiB
- keep the unknown-account login challenge aligned with the new default and assert its KDF contract
- update the Remote Connect client default and documentation to match

Existing accounts retain their persisted KDF parameters, so this change does not automatically migrate credentials or invalidate existing synchronized data.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-relay-service`
- `cargo test -p bitfun-services-integrations --features remote-connect`