### PR TITLE
chore(release): bump version to 0.2.16

### DIFF
--- a/BitFun-Installer/package-lock.json
+++ b/BitFun-Installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-installer",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "type": "module",
   "description": "BitFun Custom Installer - Modern branded installation experience",

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-installer"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Custom Installer - Modern branded installation experience"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-acp"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -755,11 +755,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-content"
-version = "0.2.15"
+version = "0.2.16"
 
 [[package]]
 name = "bitfun-agent-runtime"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-agent-stream",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-runtime-ipc"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-events",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-stream"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-tools"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-core-types",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-ai-adapters"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-claude-code-adapter"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "arboard",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-codex-adapter"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core-types"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-desktop"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-events"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-external-sources"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bitfun-product-domains",
  "futures",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-harness"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "thiserror 2.0.19",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-service"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-opencode-adapter"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-plugin-runtime-client",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-page-function-runtime"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "rquickjs",
  "serde",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-plugin-runtime-client"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-runtime-ports",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-capabilities"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-domains"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "dirs 6.0.0",
  "hex",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-service"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-ports"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-services"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host-app"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-integrations"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-skin-market-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-skin-market-service"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-static-hook-support"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-call-jsonrepair"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -1615,11 +1615,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-packs"
-version = "0.2.15"
+version = "0.2.16"
 
 [[package]]
 name = "bitfun-transport"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-webdriver"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -10284,7 +10284,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10715,7 +10715,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tool-runtime"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bitfun-agent-tools",
  "bitfun-events",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ resolver = "2"
 
 # Shared package metadata — single source of truth for version
 [workspace.package]
-version = "0.2.15" # x-release-please-version
+version = "0.2.16" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "BitFun",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "BitFun",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "hasInstallScript": true,
       "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BitFun",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-server"
-version = "0.2.15" # x-release-please-version
+version = "0.2.16" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun standalone Remote Connect relay server"

--- a/src/crates/services/page-function-runtime/Cargo.toml
+++ b/src/crates/services/page-function-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-page-function-runtime"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Embedded JS Page Function runtime for BitFun Pages (rquickjs)"

--- a/src/crates/services/relay-service/Cargo.toml
+++ b/src/crates/services/relay-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-service"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Reusable relay runtime for BitFun Remote Connect"

--- a/src/miniapp-market-web/package.json
+++ b/src/miniapp-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-miniapp-market-web",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/mobile-web/package-lock.json
+++ b/src/mobile-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-mobile-web",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/skin-market-web/package.json
+++ b/src/skin-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-skin-market-web",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfun/web-ui",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": true,
   "description": "BitFun Web UI - 支持 Desktop 和 Server 两种部署方式",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump product manifests from 0.2.15 to 0.2.16
- synchronize frontend, installer, relay, and Rust workspace versions
- refresh npm and Cargo lockfile package versions

## Verification

- `cargo check -p bitfun-relay-server`
- `cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml`
- product JSON version consistency check
- `git diff --check`

## Notes

- `pnpm run check:repo-hygiene` was blocked locally by an unrelated untracked `generate_intro_doc.cjs` file containing a local absolute path; that file is not part of this PR.