### PR TITLE
fix(flow-chat): refresh context usage display right after compression completes

### DIFF
--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -15,6 +15,8 @@ import type { DialogTurn, FlowToolItem, FlowUserSteeringItem, ModelRound, Sessio
 import type { FlowChatContext } from './types';
 import { markOptimisticDispatchTurnMetadata } from '@/features/dispatch/optimisticDispatchTurn';
 
+const { handleCompressionCompleted } = __test_only__;
+
 vi.mock('../../../shared/notification-system/services/NotificationService', () => ({
   notificationService: {
     error: vi.fn(),
@@ -1126,5 +1128,77 @@ describe('handleDialogTurnComplete', () => {
       ?.dialogTurns[0];
     expect(finalizedTurn?.status).toBe('completed');
     expect(finalizedTurn?.endTime).toBe(eventOwnedEndTime);
+  });
+});
+
+describe('handleCompressionCompleted', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  afterEach(() => {
+    resetFlowChatStore();
+    stateMachineManager.clear();
+  });
+
+  it('writes the compacted token count into currentTokenUsage when applied', () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+
+    handleCompressionCompleted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      compressionId: 'compression-1',
+      applied: true,
+      tokensBefore: 90_000,
+      tokensAfter: 15_000,
+      compressionRatio: 0.17,
+      durationMs: 500,
+      hasSummary: true,
+      summarySource: 'model',
+    });
+
+    const session = FlowChatStore.getInstance().getState().sessions.get('session-1');
+    expect(session?.currentTokenUsage).toEqual({
+      inputTokens: 15_000,
+      outputTokens: undefined,
+      totalTokens: 15_000,
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it('does not touch currentTokenUsage when the compression was not applied', () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+
+    handleCompressionCompleted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      compressionId: 'compression-1',
+      applied: false,
+      tokensBefore: 90_000,
+      tokensAfter: 90_000,
+    });
+
+    const session = FlowChatStore.getInstance().getState().sessions.get('session-1');
+    expect(session?.currentTokenUsage).toBeUndefined();
+  });
+
+  it('ignores invalid tokensAfter values even when applied', () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+
+    handleCompressionCompleted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      compressionId: 'compression-1',
+      applied: true,
+      tokensAfter: undefined,
+    });
+
+    const session = FlowChatStore.getInstance().getState().sessions.get('session-1');
+    expect(session?.currentTokenUsage).toBeUndefined();
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -163,6 +163,7 @@ export const __test_only__ = {
   handleDialogTurnFailed,
   handleSubagentSessionLinked,
   handleModelRoundStart,
+  handleCompressionCompleted,
 };
 
 function shouldMarkUnreadCompletion(sessionId: string): boolean {
@@ -2241,12 +2242,12 @@ function handleCompressionStarted(_context: FlowChatContext, event: any): void {
  */
 function handleCompressionCompleted(context: FlowChatContext, event: any): void {
   const { 
-    sessionId, turnId, compressionId, compressionCount, 
+    sessionId, turnId, compressionId, compressionCount, applied,
     tokensBefore, tokensAfter, compressionRatio, durationMs, hasSummary, summarySource
   } = event;
   
   log.info('Context compression completed', {
-    sessionId, turnId, compressionId, compressionCount, 
+    sessionId, turnId, compressionId, compressionCount, applied,
     tokensBefore, tokensAfter, compressionRatio, durationMs
   });
   
@@ -2269,6 +2270,20 @@ function handleCompressionCompleted(context: FlowChatContext, event: any): void 
     status: 'completed',
     endTime: Date.now()
   } as any);
+
+  // Keep the input-box context usage display in sync: a completed compression
+  // shrinks the context immediately, but no TokenUsageUpdated event follows it
+  // (that event is only emitted after a model response). Reflect the compacted
+  // size here so the percentage and "last request input context" refresh right
+  // away. Do not pass a dialogTurnId: compression is not a model invocation, so
+  // it must not accumulate into the turn's token usage.
+  if (applied === true && typeof tokensAfter === 'number' && tokensAfter >= 0) {
+    store.updateTokenUsage(sessionId, {
+      inputTokens: tokensAfter,
+      totalTokens: tokensAfter,
+      outputTokens: undefined,
+    });
+  }
   
   immediateSaveDialogTurn(context, sessionId, turnId);
 }


### PR DESCRIPTION
## Problem

After a context compression completes, the input-box context usage percentage and the "last request input context" tooltip (e.g. `128.0K/128.1K (100%)`) kept showing the pre-compression values.

Root cause: `session.currentTokenUsage` is only written by the `TokenUsageUpdated` event, which is only emitted after a model response. A completed compression only emits `ContextCompressionCompleted` (which carries `tokens_after`), and the frontend handler only updated the compression tool card without writing the compacted size back to the store. For manual compression there is no following request, so the display stayed stale indefinitely.

## Fix

In `handleCompressionCompleted` (src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts), when `applied === true` and `tokensAfter` is a valid non-negative number, write it into `session.currentTokenUsage` via `store.updateTokenUsage` (without a `dialogTurnId`, so compression does not accumulate into the turn's token usage).

The existing subscription chain (ChatInput selector fingerprint -> setTokenUsage -> ModelSelector percentage + tooltip) picks the value up immediately, so the input box refreshes right after compression finishes. A later model response still overwrites it with the exact provider-reported usage.

No backend change: re-emitting `TokenUsageUpdated` after compression would be recorded by `TokenUsageSubscriber` as a model usage record and pollute usage statistics.

## Tests

- `EventHandlerModule.test.ts`: 3 new cases (applied -> currentTokenUsage updated; not applied -> unchanged; invalid `tokensAfter` -> unchanged). All 32 tests pass.
- `tsc --noEmit` for web-ui passes.

Verified manually with a built installer: after compression, the displayed token count updates immediately.
