### PR TITLE
fix(flow-chat): correct turn identity handling in paginated history

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -109,6 +109,7 @@ import { PendingQueuePanel } from './PendingQueuePanel';
 import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
 import { openBtwSessionInAuxPane, selectActiveBtwSessionTab } from '../services/btwSessionPane';
 import { resolveSessionRelationship } from '../utils/sessionMetadata';
+import { isProjectedSessionEmpty } from '../utils/flowChatTurnIdentity';
 import {
   DEFAULT_CHAT_INPUT_MODE_CONFIG_PATH,
   isChatInputActionVisibleForTarget,
@@ -1476,7 +1477,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const [recommendationContext, setRecommendationContext] = React.useState<{
     workspacePath?: string;
     sessionId?: string;
-    turnIndex?: number;
+    turnId?: string;
     modifiedFiles?: string[];
   } | null>(null);
   
@@ -2142,6 +2143,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [effectiveSendAgentType, t, workspace]);
 
+  const effectiveTargetSessionHasTurns = effectiveTargetSession
+    ? !isProjectedSessionEmpty(effectiveTargetSession)
+    : false;
   const dispatchControl = useMemo(() => {
     if (
       registration ||
@@ -2173,7 +2177,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       sourceWorkspacePath: workspacePath || undefined,
       locked:
         isNonLocalDispatchTarget(target) ||
-        (effectiveTargetSession?.dialogTurns.length ?? 0) > 0 ||
+        effectiveTargetSessionHasTurns ||
         !!derivedState?.isProcessing,
       onSelectTarget: handleSelectDispatchTarget,
       syncableJobId,
@@ -2186,7 +2190,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     effectiveTargetSession?.config.dispatchJobId,
     effectiveTargetSession?.config.dispatchJobState,
     effectiveTargetSession?.config.dispatchTarget,
-    effectiveTargetSession?.dialogTurns.length,
+    effectiveTargetSessionHasTurns,
     dispatchObserverJob?.baselineWorktreeMissing,
     dispatchObserverJob?.baselineWorktreePath,
     dispatchObserverJob?.branch,
@@ -2657,7 +2661,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         setRecommendationContext({
           workspacePath: sessionBoundWorkspacePath,
           sessionId: effectiveTargetSessionId,
-          turnIndex: lastTurn.backendTurnIndex ?? session.dialogTurns.length - 1,
+          turnId: lastTurn.id,
           modifiedFiles,
         });
       }

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -103,6 +103,11 @@ import {
   buildContinuousHistoryProjection,
   canRetainContinuousHistoryProjection,
 } from './continuousHistoryProjection';
+import {
+  canonicalSessionTurns,
+  projectedSessionTurnCount,
+  resolveTurnOrdinal,
+} from '../../utils/flowChatTurnIdentity';
 
 const log = createLogger('ModernFlowChatContainer');
 
@@ -125,7 +130,7 @@ interface ModernFlowChatContainerProps {
 interface FlowChatTurnSummary {
   turnId: string;
   turnIndex: number;
-  backendTurnIndex?: number;
+  storageTurnIndex?: number;
 }
 
 interface FlowChatHistoryPresentationState extends SessionHistoryPresentation {
@@ -306,11 +311,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     ? viewportIntent
     : null;
   const activeSessionKnownTurnCount = activeSession
-    ? Math.max(
-      activeSession.totalTurnCount ?? 0,
-      activeSession.turnCatalog?.totalTurnCount ?? 0,
-      activeSession.dialogTurns.length,
-    )
+    ? projectedSessionTurnCount(activeSession)
     : 0;
   const activeHistoryPresentationFitsSession = Boolean(
     activeHistoryPresentation
@@ -785,18 +786,15 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   }, [t]);
 
   const turnSummaries = useMemo<FlowChatTurnSummary[]>(() => {
-    const turns = activeSession?.dialogTurns ?? [];
-    const result: FlowChatTurnSummary[] = [];
-    for (const turn of turns) {
-      if (!turn.userMessage || turn.userMessage.metadata?.usageReportProvisional === true) continue;
-      result.push({
-        turnId: turn.id,
-        turnIndex: result.length + 1,
-        backendTurnIndex: turn.backendTurnIndex,
-      });
+    if (!activeSession) {
+      return [];
     }
-    return result;
-  }, [activeSession?.dialogTurns]);
+    return canonicalSessionTurns(activeSession).map((turn, index) => ({
+        turnId: turn.id,
+        turnIndex: (resolveTurnOrdinal(activeSession, turn) ?? index) + 1,
+        storageTurnIndex: turn.storageTurnIndex ?? turn.backendTurnIndex,
+      }));
+  }, [activeSession]);
   const renderedTurns = useMemo(
     () => renderedHistoryPresentation
       ? renderedHistoryPresentation.turns
@@ -804,28 +802,20 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     [activeSession?.dialogTurns, renderedHistoryPresentation],
   );
   const renderedTurnSummaries = useMemo<FlowChatTurnSummary[]>(() => {
-    const result: FlowChatTurnSummary[] = [];
-    for (const turn of renderedTurns) {
-      if (!turn.userMessage || turn.userMessage.metadata?.usageReportProvisional === true) continue;
-      result.push({
+    return renderedTurns
+      .filter(turn => turn.userMessage?.metadata?.usageReportProvisional !== true)
+      .map((turn, index) => ({
         turnId: turn.id,
-        turnIndex: result.length + 1,
-        backendTurnIndex: turn.backendTurnIndex,
-      });
-    }
-    return result;
+        turnIndex: index + 1,
+        storageTurnIndex: turn.storageTurnIndex ?? turn.backendTurnIndex,
+      }));
   }, [renderedTurns]);
   const activeTurnCatalog = activeSession?.turnCatalog;
   const turnCatalog = activeTurnCatalog?.sessionId === activeSession?.sessionId
     ? activeTurnCatalog
     : undefined;
-  const sessionTotalTurnCount = Math.max(
-    activeSession?.totalTurnCount ?? 0,
-    turnCatalog?.totalTurnCount ?? 0,
-    turnSummaries.length,
-  );
-  const absoluteTurnIndexOffset = activeSession?.isPartial === true
-    ? Math.max(0, sessionTotalTurnCount - turnSummaries.length)
+  const sessionTotalTurnCount = activeSession
+    ? projectedSessionTurnCount(activeSession)
     : 0;
   const absoluteRenderedTurnSummaries = useMemo<FlowChatTurnSummary[]>(() => {
     if (renderedHistoryPresentation) {
@@ -834,18 +824,14 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         turnIndex: renderedHistoryPresentation.range.startOrdinal + index + 1,
       }));
     }
-    if (absoluteTurnIndexOffset === 0 && activeSession?.isPartial !== true) {
-      return renderedTurnSummaries;
-    }
     return renderedTurnSummaries.map(turn => ({
       ...turn,
-      turnIndex: typeof turn.backendTurnIndex === 'number'
-        ? turn.backendTurnIndex + 1
-        : turn.turnIndex + absoluteTurnIndexOffset,
+      turnIndex: activeSession
+        ? (resolveTurnOrdinal(activeSession, turn.turnId) ?? turn.turnIndex - 1) + 1
+        : turn.turnIndex,
     }));
   }, [
-    absoluteTurnIndexOffset,
-    activeSession?.isPartial,
+    activeSession,
     renderedHistoryPresentation,
     renderedTurnSummaries,
   ]);
@@ -867,8 +853,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       range.turns.forEach((turn, index) => {
         const loaded = { turnId: turn.id, content: turn.userMessage?.content ?? '' };
         loadedByOrdinal.set(range.startOrdinal + index, loaded);
-        if (typeof turn.backendTurnIndex === 'number') {
-          loadedByStorageIndex.set(turn.backendTurnIndex, loaded);
+        const storageTurnIndex = turn.storageTurnIndex ?? turn.backendTurnIndex;
+        if (typeof storageTurnIndex === 'number') {
+          loadedByStorageIndex.set(storageTurnIndex, loaded);
         }
       });
     }
@@ -878,8 +865,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         content: dialogTurnById.get(summary.turnId)?.userMessage?.content ?? '',
       };
       loadedByOrdinal.set(Math.max(0, summary.turnIndex - 1), loaded);
-      if (typeof summary.backendTurnIndex === 'number') {
-        loadedByStorageIndex.set(summary.backendTurnIndex, loaded);
+      if (typeof summary.storageTurnIndex === 'number') {
+        loadedByStorageIndex.set(summary.storageTurnIndex, loaded);
       }
     }
 
@@ -918,8 +905,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         continue;
       }
       items.push({
-        itemKey: typeof summary.backendTurnIndex === 'number'
-          ? `storage:${summary.backendTurnIndex}`
+        itemKey: typeof summary.storageTurnIndex === 'number'
+          ? `storage:${summary.storageTurnIndex}`
           : `live:${summary.turnId}`,
         turnId: summary.turnId,
         ordinal: Math.max(0, summary.turnIndex - 1),
@@ -1066,10 +1053,10 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     return {
       ...navigationVisibleTurnInfo,
       turnIndex: absoluteRenderedTurnSummaryById.get(navigationVisibleTurnInfo.turnId)?.turnIndex
-        ?? navigationVisibleTurnInfo.turnIndex + absoluteTurnIndexOffset,
+        ?? navigationVisibleTurnInfo.turnIndex,
       totalTurns: sessionTotalTurnCount,
     };
-  }, [absoluteTurnIndexOffset, absoluteRenderedTurnSummaryById, navigationVisibleTurnInfo, sessionTotalTurnCount]);
+  }, [absoluteRenderedTurnSummaryById, navigationVisibleTurnInfo, sessionTotalTurnCount]);
   useEffect(() => {
     visibleTurnInfoRef.current = visibleTurnInfo;
   }, [visibleTurnInfo]);

--- a/src/web-ui/src/flow_chat/components/modern/continuousHistoryProjection.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/continuousHistoryProjection.test.ts
@@ -89,4 +89,29 @@ describe('continuousHistoryProjection', () => {
       CONTINUOUS_HISTORY_PROJECTION_MAX_VIRTUAL_ITEM_COUNT + 1,
     )).toBe(false);
   });
+
+  it('does not let a provisional usage report shift the canonical tail', () => {
+    const presentation = createPresentation(10);
+    const provisional = {
+      ...createTurn(99, 'usage'),
+      userMessage: {
+        ...createTurn(99, 'usage').userMessage,
+        metadata: {
+          localCommandKind: 'usage_report',
+          usageReportProvisional: true,
+          modelVisible: false,
+        },
+      },
+    };
+    const canonicalTail = [createTurn(8, 'canonical'), createTurn(9, 'canonical'), provisional];
+    const result = buildContinuousHistoryProjection({
+      sessionId: 'session-1',
+      dialogTurns: canonicalTail,
+      isPartial: true,
+      totalTurnCount: 10,
+    }, presentation);
+
+    expect(result?.turns.slice(8).map(turn => turn.id)).toEqual(['turn-8', 'turn-9']);
+    expect(result?.range.endOrdinalExclusive).toBe(10);
+  });
 });

--- a/src/web-ui/src/flow_chat/components/modern/continuousHistoryProjection.ts
+++ b/src/web-ui/src/flow_chat/components/modern/continuousHistoryProjection.ts
@@ -3,21 +3,22 @@ import type {
   Session,
   SessionHistoryPresentation,
 } from '../../types/flow-chat';
+import {
+  canonicalSessionTurns,
+  projectedSessionTurnCount,
+  resolveTurnOrdinal,
+} from '../../utils/flowChatTurnIdentity';
 
 export const CONTINUOUS_HISTORY_PROJECTION_MAX_TURN_COUNT = 24;
 export const CONTINUOUS_HISTORY_PROJECTION_MAX_VIRTUAL_ITEM_COUNT = 200;
 
 type ContinuousHistorySession = Pick<
   Session,
-  'dialogTurns' | 'totalTurnCount' | 'turnCatalog'
+  'sessionId' | 'dialogTurns' | 'isPartial' | 'totalTurnCount' | 'turnCatalog'
 >;
 
 function sessionTotalTurnCount(session: ContinuousHistorySession): number {
-  return Math.max(
-    session.totalTurnCount ?? 0,
-    session.turnCatalog?.totalTurnCount ?? 0,
-    session.dialogTurns.length,
-  );
+  return projectedSessionTurnCount(session);
 }
 
 export function buildContinuousHistoryProjection(
@@ -38,7 +39,8 @@ export function buildContinuousHistoryProjection(
     return null;
   }
 
-  const canonicalTailStartOrdinal = totalTurnCount - session.dialogTurns.length;
+  const canonicalTurns = canonicalSessionTurns(session);
+  const canonicalTailStartOrdinal = totalTurnCount - canonicalTurns.length;
   if (canonicalTailStartOrdinal > presentedTurnCount) {
     return null;
   }
@@ -47,9 +49,14 @@ export function buildContinuousHistoryProjection(
     { length: totalTurnCount },
     (_, ordinal) => presentation.turns[ordinal],
   );
-  for (let index = 0; index < session.dialogTurns.length; index += 1) {
-    const ordinal = canonicalTailStartOrdinal + index;
-    const canonicalTurn = session.dialogTurns[index];
+  const identitySession: ContinuousHistorySession = {
+    ...session,
+    isPartial: true,
+  };
+  for (let index = 0; index < canonicalTurns.length; index += 1) {
+    const canonicalTurn = canonicalTurns[index];
+    const ordinal = resolveTurnOrdinal(identitySession, canonicalTurn)
+      ?? canonicalTailStartOrdinal + index;
     const cachedTurn = turns[ordinal];
     if (cachedTurn && cachedTurn.id !== canonicalTurn.id) {
       return null;

--- a/src/web-ui/src/flow_chat/components/smart-recommendations/types.ts
+++ b/src/web-ui/src/flow_chat/components/smart-recommendations/types.ts
@@ -1,14 +1,12 @@
-/**
- * Smart recommendations types
- */
+/** Smart recommendations types. */
 
 export interface RecommendationAction {
   id: string;
   label: string;
-  /** Icon name from lucide */
+  /** Icon name from lucide. */
   icon?: string;
   description?: string;
-  /** Action type */
+  /** Action type. */
   type?: 'primary' | 'secondary' | 'danger';
   onClick: () => void | Promise<void>;
   disabled?: boolean;
@@ -18,8 +16,9 @@ export interface RecommendationAction {
 export interface RecommendationContext {
   workspacePath?: string;
   sessionId?: string;
-  turnIndex?: number;
-  /** List of modified files */
+  /** Stable Turn identity. Providers resolve ordinal or storage identity explicitly if needed. */
+  turnId?: string;
+  /** List of modified files. */
   modifiedFiles?: string[];
   [key: string]: any;
 }
@@ -27,24 +26,17 @@ export interface RecommendationContext {
 export interface IRecommendationProvider {
   id: string;
   name: string;
-  /** Higher value means higher priority */
+  /** Higher value means higher priority. */
   priority: number;
 
-  /**
-   * Check whether recommendations should be shown.
-   */
+  /** Check whether recommendations should be shown. */
   shouldShow(context: RecommendationContext): Promise<boolean>;
 
-  /**
-   * Fetch recommendation actions for the given context.
-   */
+  /** Fetch recommendation actions for the given context. */
   getActions(context: RecommendationContext): Promise<RecommendationAction[]>;
 
-  /**
-   * Dispose resources if needed.
-   */
+  /** Dispose resources if needed. */
   dispose?(): void;
 }
 
 export type RecommendationProviderFactory = () => IRecommendationProvider;
-

--- a/src/web-ui/src/flow_chat/deep-review/action-bar/DeepReviewActionBar.tsx
+++ b/src/web-ui/src/flow_chat/deep-review/action-bar/DeepReviewActionBar.tsx
@@ -65,6 +65,7 @@ import { openBtwSessionInAuxPane } from '../../services/btwSessionPane';
 import type { Session } from '../../types/flow-chat';
 import { useDeepReviewConsent } from '../../components/DeepReviewConsentDialog';
 import { deriveDeepReviewSessionConcurrencyGuard } from '../../utils/deepReviewCapacityGuard';
+import { isProjectedSessionEmpty } from '../../utils/flowChatTurnIdentity';
 import '../../components/btw/DeepReviewActionBar.scss';
 
 const log = createLogger('DeepReviewActionBar');
@@ -539,7 +540,8 @@ export const ReviewActionBar: React.FC<ReviewActionBarProps> = ({ childSessionId
     if (!['none', 'retry', 'failed', 'cancelled'].includes(currentFollowUpState)) {
       return;
     }
-    const recoverableEmptySessionRequestId = currentFollowUpSession?.dialogTurns.length === 0
+    const recoverableEmptySessionRequestId = currentFollowUpSession
+      && isProjectedSessionEmpty(currentFollowUpSession)
       ? currentFollowUpSession.btwOrigin?.requestId
       : undefined;
 

--- a/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
+++ b/src/web-ui/src/flow_chat/hooks/useFlowChat.ts
@@ -15,6 +15,7 @@ import {
   FlowTextItem
 } from '../types/flow-chat';
 import { flowChatStore } from '../store/FlowChatStore';
+import { isProjectedSessionEmpty } from '../utils/flowChatTurnIdentity';
 import { flowChatManager } from '../services/FlowChatManager';
 import type { UnlistenFn } from '@tauri-apps/api/event';
 import { i18nService } from '@/infrastructure/i18n';
@@ -270,7 +271,7 @@ export const useFlowChat = () => {
     };
 
     const isFirstMessage =
-      session && session.dialogTurns.length === 0 && session.titleStatus !== 'generated';
+      session && isProjectedSessionEmpty(session) && session.titleStatus !== 'generated';
     
     flowChatStore.addDialogTurn(targetSessionId, dialogTurn);
 

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -95,6 +95,7 @@ export class FlowChatManager {
       lastSaveHashes: new Map(),
       turnSaveInFlight: new Map(),
       turnSavePending: new Set(),
+      deferredStorageIdentitySaves: new Set(),
       runtimeStatusTimers: new Map(),
       userCancelledSessionIds: new Set(),
       handledTerminalTurnEvents: new Set(),

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -105,7 +105,9 @@ describe('dispatch optimistic turn reconciliation', () => {
       activeSessionId: 'dispatch-session',
     }));
 
-    __test_only__.handleDialogTurnStarted(createFlowChatContext(), {
+    const context = createFlowChatContext();
+    context.deferredStorageIdentitySaves?.add('dispatch-session:dispatch_pending_job-1');
+    __test_only__.handleDialogTurnStarted(context, {
       sessionId: 'dispatch-session',
       turnId: 'target-turn-1',
       turnIndex: 0,
@@ -132,6 +134,9 @@ describe('dispatch optimistic turn reconciliation', () => {
     });
     expect(turns?.[0]?.userMessage.metadata)
       .not.toHaveProperty('__bitfunOptimisticDispatchJobId');
+    expect(context.deferredStorageIdentitySaves).not.toContain(
+      'dispatch-session:dispatch_pending_job-1',
+    );
   });
 
   it('hydrates the real prompt into an audit-only dispatch placeholder', () => {
@@ -861,6 +866,7 @@ function createFlowChatContext(): FlowChatContext {
     lastSaveHashes: new Map(),
     turnSaveInFlight: new Map(),
     turnSavePending: new Set(),
+    deferredStorageIdentitySaves: new Set(),
     runtimeStatusTimers: new Map(),
     userCancelledSessionIds: new Set(),
     handledTerminalTurnEvents: new Set(),

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1540,7 +1540,6 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
   const tempTurnId = pendingImageAnalysisTurns.get(sessionId);
   const hadTempTurn = !!tempTurnId;
   if (tempTurnId) {
-    store.deleteDialogTurn(sessionId, tempTurnId);
     pendingImageAnalysisTurns.delete(sessionId);
 
     // State machine was already transitioned to PROCESSING by ImageAnalysisStarted.
@@ -1551,7 +1550,7 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
       ctx.currentDialogTurnId = turnId;
     }
 
-    log.info('Replaced temp image analysis turn with real turn', {
+    log.info('Adopting temp image analysis turn as real turn', {
       sessionId,
       tempTurnId,
       realTurnId: turnId,
@@ -1619,33 +1618,39 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
         )
       : undefined;
     if (optimisticTurn) {
-      store.updateDialogTurn(sessionId, optimisticTurn.id, turn => {
-        const optimisticMetadata = stripOptimisticTurnAdoption(
-          turn.userMessage.metadata,
-        );
-        const mergedMetadata =
-          optimisticMetadata || userMessageMetadata
-            ? { ...optimisticMetadata, ...userMessageMetadata }
-            : undefined;
-        return {
-          ...turn,
-          id: turnId,
-          kind: turn.kind || turnKind,
-          userMessage: {
-            ...turn.userMessage,
-            content: turn.userMessage.content || displayContent,
-            hasImages,
-            metadata: mergedMetadata,
-            images,
-          },
-          status: 'pending',
-          backendTurnIndex: typeof turnIndex === 'number' ? turnIndex : undefined,
-        };
+      const optimisticMetadata = stripOptimisticTurnAdoption(
+        optimisticTurn.userMessage.metadata,
+      );
+      const mergedMetadata =
+        optimisticMetadata || userMessageMetadata
+          ? { ...optimisticMetadata, ...userMessageMetadata }
+          : undefined;
+      store.replaceOptimisticDialogTurn(sessionId, optimisticTurn.id, {
+        ...optimisticTurn,
+        id: turnId,
+        kind: optimisticTurn.kind || turnKind,
+        userMessage: {
+          ...optimisticTurn.userMessage,
+          content: optimisticTurn.userMessage.content || displayContent,
+          hasImages,
+          metadata: mergedMetadata,
+          images,
+        },
+        status: 'pending',
+        storageTurnIndex: typeof turnIndex === 'number' ? turnIndex : undefined,
+        backendTurnIndex: typeof turnIndex === 'number' ? turnIndex : undefined,
       });
       dialogTurn = store.getState().sessions
         .get(sessionId)
         ?.dialogTurns.find((turn: DialogTurn) => turn.id === turnId);
       projectedNewTurn = !!dialogTurn;
+      const deferredOldKey = `${sessionId}:${optimisticTurn.id}`;
+      const deferredNewKey = `${sessionId}:${turnId}`;
+      const hadDeferredOldSave = context.deferredStorageIdentitySaves?.delete(deferredOldKey) === true;
+      const hadDeferredNewSave = context.deferredStorageIdentitySaves?.delete(deferredNewKey) === true;
+      if (hadDeferredOldSave || hadDeferredNewSave) {
+        void saveDialogTurnToDisk(context, sessionId, turnId);
+      }
     }
   }
 
@@ -1665,9 +1670,15 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
       modelRounds: [],
       status: 'pending',
       startTime: Date.now(),
+      storageTurnIndex: typeof turnIndex === 'number' ? turnIndex : undefined,
       backendTurnIndex: typeof turnIndex === 'number' ? turnIndex : undefined,
     };
-    store.addDialogTurn(sessionId, newTurn);
+    const replacedTempTurn = tempTurnId
+      ? store.replaceOptimisticDialogTurn(sessionId, tempTurnId, newTurn)
+      : false;
+    if (!replacedTempTurn) {
+      store.addDialogTurn(sessionId, newTurn);
+    }
     projectedNewTurn = true;
   }
 
@@ -1692,7 +1703,11 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
     return;
   }
 
-  if (typeof turnIndex === 'number' && dialogTurn.backendTurnIndex === undefined) {
+  if (
+    typeof turnIndex === 'number'
+    && dialogTurn.storageTurnIndex === undefined
+    && dialogTurn.backendTurnIndex === undefined
+  ) {
     store.updateDialogTurn(sessionId, turnId, turn => ({
       ...turn,
       kind: turn.kind || turnKind,
@@ -1700,8 +1715,13 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
         ...turn.userMessage,
         metadata: turn.userMessage.metadata || userMessageMetadata,
       },
+      storageTurnIndex: turnIndex,
       backendTurnIndex: turnIndex,
     }));
+    const deferredKey = `${sessionId}:${turnId}`;
+    if (context.deferredStorageIdentitySaves?.delete(deferredKey)) {
+      void saveDialogTurnToDisk(context, sessionId, turnId);
+    }
   }
   reconcileBackgroundSubagentSession(sessionId);
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -11,6 +11,7 @@ import { stateMachineManager } from '../../state-machine';
 import { SessionExecutionEvent, SessionExecutionState } from '../../state-machine/types';
 import { createLogger } from '@/shared/utils/logger';
 import type { FlowChatContext } from './types';
+import { isProjectedSessionEmpty } from '../../utils/flowChatTurnIdentity';
 import type { ImageContextData as ImageInputContextData } from '@/infrastructure/api/service-api/ImageContextTypes';
 import { pendingQueueManager } from './PendingQueueModule';
 import { isSessionInUseError } from '@/infrastructure/api/errors/TauriCommandError';
@@ -201,7 +202,8 @@ export async function sendMessage(
       throw new Error(`Session lost before starting dialog turn: ${sessionId}`);
     }
 
-    const isFirstMessage = readySession.dialogTurns.length === 0 && readySession.titleStatus !== 'generated';
+    const isFirstMessage = isProjectedSessionEmpty(readySession)
+      && readySession.titleStatus !== 'generated';
 
     const outcome = await driver.startTurn(
       context,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
@@ -53,6 +53,7 @@ function createDialogTurn(status: DialogTurn['status'] = 'processing'): DialogTu
     status,
     startTime: 900,
     endTime: status === 'completed' ? 1200 : undefined,
+    storageTurnIndex: 0,
   };
 }
 
@@ -75,6 +76,7 @@ function createContext(dialogTurn: DialogTurn): any {
     lastSaveHashes: new Map(),
     turnSaveInFlight: new Map(),
     turnSavePending: new Set(),
+    deferredStorageIdentitySaves: new Set(),
     flowChatStore: {
       getState: () => ({
         sessions: new Map([[SESSION_ID, session]]),
@@ -339,5 +341,49 @@ describe('PersistenceModule', () => {
     await vi.advanceTimersByTimeAsync(500);
     await flushMicrotasks();
     expect(mockSaveSessionTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers partial-history saves until a storage identity is available', async () => {
+    const turn = createDialogTurn('completed');
+    delete turn.storageTurnIndex;
+    const context = createContext(turn);
+    const session = context.flowChatStore.getState().sessions.get(SESSION_ID);
+    session.isPartial = true;
+    session.totalTurnCount = 23;
+    session.dialogTurns = [turn];
+
+    await saveDialogTurnToDisk(context, SESSION_ID, TURN_ID);
+
+    expect(mockSaveSessionTurn).not.toHaveBeenCalled();
+    expect(context.deferredStorageIdentitySaves).toContain(`${SESSION_ID}:${TURN_ID}`);
+
+    turn.storageTurnIndex = 140;
+    await saveDialogTurnToDisk(context, SESSION_ID, TURN_ID);
+    expect(mockSaveSessionTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ turnIndex: 140 }),
+      expect.any(String),
+      undefined,
+      undefined,
+    );
+  });
+
+  it('uses explicit storage identity even when local history is only a tail', async () => {
+    const turn = createDialogTurn('completed');
+    turn.storageTurnIndex = 140;
+    const context = createContext(turn);
+    const session = context.flowChatStore.getState().sessions.get(SESSION_ID);
+    session.isPartial = true;
+    session.totalTurnCount = 23;
+    session.dialogTurns = [turn];
+
+    await saveDialogTurnToDisk(context, SESSION_ID, TURN_ID);
+    await flushMicrotasks();
+
+    expect(mockSaveSessionTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ turnIndex: 140 }),
+      expect.any(String),
+      undefined,
+      undefined,
+    );
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/toolInvocationIdentity';
 import { requireSessionProjectWorkspacePath } from '../../utils/sessionWorkspace';
 import { resolveSessionDriverId } from '../../session-drivers/resolve';
+import { resolveStorageTurnIndex } from '../../utils/flowChatTurnIdentity';
 
 const log = createLogger('PersistenceModule');
 const COALESCED_IMMEDIATE_SAVE_DELAY_MS = 500;
@@ -222,6 +223,7 @@ export function cleanupSaveState(
     context.lastSaveTimestamps.delete(key);
     context.lastSaveHashes.delete(key);
     context.turnSavePending.delete(key);
+    context.deferredStorageIdentitySaves?.delete(key);
     context.turnSaveInFlight.delete(key);
   } else {
     const keysToDelete = new Set<string>();
@@ -254,12 +256,18 @@ export function cleanupSaveState(
         keysToDelete.add(key);
       }
     }
+    for (const key of context.deferredStorageIdentitySaves ?? []) {
+      if (key.startsWith(`${sessionId}:`)) {
+        keysToDelete.add(key);
+      }
+    }
 
     keysToDelete.forEach(key => {
       context.saveDebouncers.delete(key);
       context.lastSaveTimestamps.delete(key);
       context.lastSaveHashes.delete(key);
       context.turnSavePending.delete(key);
+      context.deferredStorageIdentitySaves?.delete(key);
       context.turnSaveInFlight.delete(key);
     });
   }
@@ -302,7 +310,12 @@ async function performSaveDialogTurnToDisk(
       return;
     }
 
-    const turnIndex = dialogTurn.backendTurnIndex ?? session.dialogTurns.indexOf(dialogTurn);
+    const turnIndex = resolveStorageTurnIndex(session, dialogTurn);
+    if (turnIndex === undefined) {
+      context.deferredStorageIdentitySaves?.add(`${sessionId}:${turnId}`);
+      log.debug('Dialog turn has no storage identity, deferring save', { sessionId, turnId });
+      return;
+    }
     const turnData = convertDialogTurnToBackendFormat(dialogTurn, turnIndex);
     await sessionAPI.saveSessionTurn(
       turnData,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -1302,6 +1302,24 @@ describe('SessionModule historical session coordination', () => {
     });
   });
 
+  it('does not recreate metadata-only non-empty history when context restore fails', async () => {
+    const { context } = createContext(createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      dialogTurns: [],
+      totalTurnCount: 23,
+    } as any));
+    agentApiMocks.ensureCoordinatorSession.mockRejectedValueOnce(
+      new Error('Session metadata not found')
+    );
+
+    await expect(ensureBackendSession(context, 'history-1')).rejects.toThrow();
+
+    expect(agentApiMocks.ensureCoordinatorSession).toHaveBeenCalledTimes(1);
+    expect(agentApiMocks.createSession).not.toHaveBeenCalled();
+  });
+
   it('does not recreate a session that another BitFun instance is writing', async () => {
     const { context } = createContext(createSession({
       isHistorical: false,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -49,6 +49,10 @@ import {
   sessionProjectWorkspacePath,
 } from '../../utils/sessionWorkspace';
 import { driverForCreation, driverForSession } from '../../session-drivers/registry';
+import {
+  isProjectedFirstRuntimeTurn,
+  isProjectedSessionEmpty,
+} from '../../utils/flowChatTurnIdentity';
 
 const log = createLogger('SessionModule');
 const pendingSessionCreations = new Map<string, Promise<string>>();
@@ -970,17 +974,17 @@ export async function ensureBackendSession(
   );
 
   const isHistoricalSession = latestSession.isHistorical === true;
-  const isFirstTurn = latestSession.dialogTurns.length <= 1;
+  const isFirstTurn = isProjectedFirstRuntimeTurn(latestSession);
   const requiresContextRestore =
     latestSession.contextRestoreState === 'pending' ||
     latestSession.contextRestoreState === 'failed';
   const needsBackendSetup = isHistoricalSession || isFirstTurn || requiresContextRestore;
-  const hasLoadedTurns = latestSession.dialogTurns.length > 0;
+  const hasProjectedTurns = !isProjectedSessionEmpty(latestSession);
   /** Avoid createSession when historical data is already loaded but backend files are missing (e.g. new SSH connection id). */
   const allowRecreateOnCoordinatorFailure =
     needsBackendSetup &&
-    !(requiresContextRestore && hasLoadedTurns) &&
-    !(isHistoricalSession && hasLoadedTurns);
+    !(requiresContextRestore && hasProjectedTurns) &&
+    !(isHistoricalSession && hasProjectedTurns);
 
   const markBackendContextReady = () => {
     if (!isHistoricalSession && !requiresContextRestore) return;

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
@@ -46,6 +46,8 @@ export interface FlowChatContext {
   turnSaveInFlight: Map<string, Promise<void>>;
   /** Pending save marks for coalesced serial execution */
   turnSavePending: Set<string>;
+  /** Turns requested for persistence before the backend supplied storage identity. */
+  deferredStorageIdentitySaves?: Set<string>;
   /** Transient runtime status timers: key = "sessionId:turnId:roundId:scope" */
   runtimeStatusTimers: Map<string, ReturnType<typeof setTimeout>>;
   /** Session IDs that the user explicitly cancelled; used to skip unread marking */

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -4504,6 +4504,229 @@ describe('FlowChatStore historical session hydration state', () => {
     });
   });
 
+  it('caches an optimistic turn after a partial restored tail at its absolute ordinal', async () => {
+    const catalog = createTurnCatalog(23);
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 23,
+        createdAt: 1,
+      },
+      turns: [20, 21, 22].map(index => createPersistedTurn(index)),
+      turnCatalog: catalog,
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 23,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[
+        'history-1',
+        createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        }),
+      ]]),
+      activeSessionId: 'history-1',
+    }));
+
+    await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+    flowChatStore.addDialogTurn('history-1', {
+      id: 'turn-23',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-23', content: 'new prompt', timestamp: 24 },
+      modelRounds: [],
+      status: 'pending',
+      startTime: 24,
+    });
+
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      isPartial: true,
+      loadedTurnCount: 4,
+      totalTurnCount: 24,
+    });
+    const loadedRanges = flowChatStore.getSessionHistoryViewState('history-1')?.loadedRanges ?? [];
+    expect(loadedRanges).toMatchObject([{
+      startOrdinal: 20,
+      endOrdinalExclusive: 24,
+    }]);
+    expect(loadedRanges[0]?.turns.map(turn => turn.id)).toEqual([
+      'turn-20',
+      'turn-21',
+      'turn-22',
+      'turn-23',
+    ]);
+    expect(loadedRanges.some(range =>
+      range.startOrdinal <= 3
+      && range.endOrdinalExclusive > 3
+      && range.turns.some(turn => turn.id === 'turn-23')
+    )).toBe(false);
+  });
+
+  it('adopts an optimistic partial-tail turn in place without incrementing projected history twice', async () => {
+    const catalog = createTurnCatalog(23);
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 23,
+        createdAt: 1,
+      },
+      turns: [20, 21, 22].map(index => createPersistedTurn(index)),
+      turnCatalog: catalog,
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 23,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([['history-1', createSession({
+        sessionId: 'history-1',
+        isHistorical: true,
+        historyState: 'metadata-only',
+      })]]),
+      activeSessionId: 'history-1',
+    }));
+    await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+    const optimistic = {
+      id: 'optimistic-23',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-23', content: 'new prompt', timestamp: 24 },
+      modelRounds: [],
+      status: 'pending' as const,
+      startTime: 24,
+    };
+    flowChatStore.addDialogTurn('history-1', optimistic);
+
+    expect(flowChatStore.replaceOptimisticDialogTurn('history-1', optimistic.id, {
+      ...optimistic,
+      id: 'turn-23',
+      storageTurnIndex: 140,
+      backendTurnIndex: 140,
+    })).toBe(true);
+
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      loadedTurnCount: 4,
+      totalTurnCount: 24,
+      dialogTurns: [
+        { id: 'turn-20' },
+        { id: 'turn-21' },
+        { id: 'turn-22' },
+        { id: 'turn-23', storageTurnIndex: 140 },
+      ],
+    });
+    expect(flowChatStore.getSessionHistoryViewState('history-1')?.loadedRanges)
+      .toMatchObject([{ startOrdinal: 20, endOrdinalExclusive: 24 }]);
+  });
+
+  it('shifts cached ordinals after removing a counted optimistic turn', async () => {
+    const catalog = createTurnCatalog(23);
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 23,
+        createdAt: 1,
+      },
+      turns: [20, 21, 22].map(index => createPersistedTurn(index)),
+      turnCatalog: catalog,
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 23,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([['history-1', createSession({
+        sessionId: 'history-1',
+        isHistorical: true,
+        historyState: 'metadata-only',
+      })]]),
+      activeSessionId: 'history-1',
+    }));
+    await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+
+    const createOptimisticTurn = (id: string, timestamp: number) => ({
+      id,
+      sessionId: 'history-1',
+      userMessage: { id: `user-${id}`, content: id, timestamp },
+      modelRounds: [],
+      status: 'pending' as const,
+      startTime: timestamp,
+    });
+    flowChatStore.addDialogTurn('history-1', createOptimisticTurn('optimistic-23', 24));
+    flowChatStore.addDialogTurn('history-1', createOptimisticTurn('optimistic-24', 25));
+
+    flowChatStore.deleteDialogTurn('history-1', 'optimistic-23');
+
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      loadedTurnCount: 4,
+      totalTurnCount: 24,
+      dialogTurns: [
+        { id: 'turn-20' },
+        { id: 'turn-21' },
+        { id: 'turn-22' },
+        { id: 'optimistic-24' },
+      ],
+    });
+    expect(flowChatStore.getSessionHistoryViewState('history-1')?.loadedRanges)
+      .toMatchObject([{ startOrdinal: 20, endOrdinalExclusive: 24 }]);
+  });
+
+  it('does not change projected counts when removing a provisional usage report', async () => {
+    const catalog = createTurnCatalog(23);
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 23,
+        createdAt: 1,
+      },
+      turns: [20, 21, 22].map(index => createPersistedTurn(index)),
+      turnCatalog: catalog,
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 3,
+      totalTurnCount: 23,
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([['history-1', createSession({
+        sessionId: 'history-1',
+        isHistorical: true,
+        historyState: 'metadata-only',
+      })]]),
+      activeSessionId: 'history-1',
+    }));
+    await flowChatStore.loadSessionHistory('history-1', 'D:/workspace/BitFun');
+    const provisional = flowChatStore.addLocalUsageReportTurn({
+      sessionId: 'history-1',
+      markdown: '# Loading',
+      reportId: 'usage-1',
+      schemaVersion: 1,
+      generatedAt: 24,
+      status: 'loading',
+    });
+
+    flowChatStore.deleteDialogTurn('history-1', provisional!.id);
+
+    expect(flowChatStore.getState().sessions.get('history-1')).toMatchObject({
+      loadedTurnCount: 3,
+      totalTurnCount: 23,
+      dialogTurns: [{ id: 'turn-20' }, { id: 'turn-21' }, { id: 'turn-22' }],
+    });
+    expect(flowChatStore.getSessionHistoryViewState('history-1')?.loadedRanges)
+      .toMatchObject([{ startOrdinal: 20, endOrdinalExclusive: 23 }]);
+  });
+
   it('invalidates cached history and catalog entries after truncating a complete session', async () => {
     const catalog = createTurnCatalog(10);
     const dialogTurns = Array.from({ length: 10 }, (_, index) => createPersistedTurn(index));

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -86,6 +86,14 @@ import {
 } from '@/features/dispatch/types';
 import { dispatchJobStore } from '@/features/dispatch/dispatchJobStore';
 import { resolveSessionDriverId } from '../session-drivers/resolve';
+import {
+  isProvisionalUsageReportTurn,
+  isProjectedSessionEmpty,
+  canonicalSessionTurns,
+  projectedSessionTurnCount,
+  resolveDialogTurnIdentity,
+  resolveStorageTurnIndex,
+} from '../utils/flowChatTurnIdentity';
 
 const log = createLogger('FlowChatStore');
 
@@ -362,12 +370,14 @@ function normalizeLiveItemStatus(
 }
 
 function compareDialogTurnOrder(left: DialogTurn, right: DialogTurn): number {
+  const leftStorageIndex = left.storageTurnIndex ?? left.backendTurnIndex;
+  const rightStorageIndex = right.storageTurnIndex ?? right.backendTurnIndex;
   if (
-    typeof left.backendTurnIndex === 'number' &&
-    typeof right.backendTurnIndex === 'number' &&
-    left.backendTurnIndex !== right.backendTurnIndex
+    typeof leftStorageIndex === 'number' &&
+    typeof rightStorageIndex === 'number' &&
+    leftStorageIndex !== rightStorageIndex
   ) {
-    return left.backendTurnIndex - right.backendTurnIndex;
+    return leftStorageIndex - rightStorageIndex;
   }
   return left.startTime - right.startTime;
 }
@@ -974,12 +984,6 @@ function mergeLoadedTurnRanges(
   }
 
   return merged;
-}
-
-function isProvisionalUsageReportTurn(turn: DialogTurn): boolean {
-  const metadata = turn.userMessage.metadata as LocalCommandMetadata | undefined;
-  return metadata?.localCommandKind === 'usage_report'
-    && metadata.usageReportProvisional === true;
 }
 
 function sliceLoadedTurnRange(
@@ -1606,11 +1610,7 @@ export class FlowChatStore {
       return null;
     }
 
-    const totalTurnCount = Math.max(
-      view.catalog?.totalTurnCount ?? 0,
-      session.totalTurnCount ?? 0,
-      session.dialogTurns.length,
-    );
+    const totalTurnCount = projectedSessionTurnCount(session);
     const normalizedTargetOrdinal = Math.max(0, Math.floor(targetOrdinal));
     const tailOrdinal = totalTurnCount - 1;
     const loadedRange = view.loadedRanges.find(range =>
@@ -1734,7 +1734,7 @@ export class FlowChatStore {
 
   private getSessionHistoryTailProtectedIntervals(
     sessionId: string,
-    view?: SessionHistoryViewState,
+    _view?: SessionHistoryViewState,
   ): OrdinalInterval[] {
     const session = this.state.sessions.get(sessionId);
     if (!session || session.dialogTurns.length === 0) {
@@ -1747,16 +1747,7 @@ export class FlowChatStore {
       return [];
     }
 
-    const catalog = view?.catalog?.sessionId === sessionId
-      ? view.catalog
-      : session.turnCatalog?.sessionId === sessionId
-        ? session.turnCatalog
-        : null;
-    const totalTurnCount = Math.max(
-      catalog?.totalTurnCount ?? 0,
-      session.totalTurnCount ?? 0,
-      session.dialogTurns.length,
-    );
+    const totalTurnCount = projectedSessionTurnCount(session);
     if (totalTurnCount <= 0) {
       return [];
     }
@@ -2007,9 +1998,10 @@ export class FlowChatStore {
     );
     const located = canonicalTailTurns
       .map(turn => {
+        const storageTurnIndex = resolveStorageTurnIndex(session, turn);
         const entry = entryByTurnId.get(turn.id)
-          ?? (typeof turn.backendTurnIndex === 'number'
-            ? entryByStorageIndex.get(turn.backendTurnIndex)
+          ?? (storageTurnIndex !== undefined
+            ? entryByStorageIndex.get(storageTurnIndex)
             : undefined);
         return entry ? { ordinal: entry.ordinal, turn } : null;
       })
@@ -2041,11 +2033,7 @@ export class FlowChatStore {
       return;
     }
 
-    const totalTurnCount = Math.max(
-      catalog?.totalTurnCount ?? 0,
-      session.totalTurnCount ?? 0,
-      canonicalTailTurns.length,
-    );
+    const totalTurnCount = projectedSessionTurnCount(session);
     const startOrdinal = Math.max(0, totalTurnCount - canonicalTailTurns.length);
     this.cacheSessionLoadedTurnRange(sessionId, {
       startOrdinal,
@@ -2353,8 +2341,9 @@ export class FlowChatStore {
       return false;
     }
 
+    const canonicalTurns = canonicalSessionTurns(session);
     const workspacePath = sessionProjectWorkspacePath(session);
-    if (!workspacePath || session.dialogTurns.length === 0) {
+    if (!workspacePath || canonicalTurns.length === 0) {
       return false;
     }
 
@@ -2364,7 +2353,7 @@ export class FlowChatStore {
       sessionId,
       sessionTraceId,
       reason,
-      loadedTurnCount: session.dialogTurns.length,
+      loadedTurnCount: canonicalTurns.length,
       totalTurnCount: session.totalTurnCount,
     });
     this.scheduleCompleteSessionHistoryLoad({
@@ -2372,7 +2361,7 @@ export class FlowChatStore {
       workspacePath,
       initialSessionTraceId: sessionTraceId,
       requireActiveSession: true,
-      expectedDialogTurnIds: session.dialogTurns.map(turn => turn.id),
+      expectedDialogTurnIds: canonicalTurns.map(turn => turn.id),
     });
     return true;
   }
@@ -2409,8 +2398,9 @@ export class FlowChatStore {
       request => request.sessionId === sessionId,
     );
     if (!hydrationRequest) {
+      const canonicalTurns = canonicalSessionTurns(session);
       const workspacePath = sessionProjectWorkspacePath(session);
-      if (!workspacePath || session.dialogTurns.length === 0) {
+      if (!workspacePath || canonicalTurns.length === 0) {
         this.fullHistoryProjectionApplyRequests.delete(sessionId);
         return false;
       }
@@ -2425,7 +2415,7 @@ export class FlowChatStore {
         requireActiveSession: false,
         startImmediately: true,
         initialSessionTraceId: sessionTraceId,
-        expectedDialogTurnIds: session.dialogTurns.map(turn => turn.id),
+        expectedDialogTurnIds: canonicalTurns.map(turn => turn.id),
       });
     } else {
       hydrationRequest.startNow?.();
@@ -2435,7 +2425,7 @@ export class FlowChatStore {
       sessionId,
       reason,
       remote: hydrationRequest.remote,
-      loadedTurnCount: session.dialogTurns.length,
+      loadedTurnCount: canonicalSessionTurns(session).length,
       totalTurnCount: session.totalTurnCount,
     });
     await hydrationRequest.promise;
@@ -2995,11 +2985,11 @@ export class FlowChatStore {
       }
       revealed = true;
       revealedTurnCount = previousWindow.length;
-      loadedTurnCount = mergedDialogTurns.length;
+      loadedTurnCount = canonicalSessionTurns({ dialogTurns: mergedDialogTurns }).length;
       totalTurnCount = Math.max(
         session.totalTurnCount ?? 0,
         projection.dialogTurns.length,
-        mergedDialogTurns.length,
+        loadedTurnCount,
       );
       remainingBefore = startIndex;
 
@@ -3086,6 +3076,7 @@ export class FlowChatStore {
         ...projection.dialogTurns.map(turn => currentDialogTurnsById.get(turn.id) ?? turn),
         ...appendedCurrentDialogTurns,
       ];
+      const mergedCanonicalTurnCount = canonicalSessionTurns({ dialogTurns: mergedDialogTurns }).length;
       preservedTurnCount = mergedDialogTurns.reduce(
         (count, turn) => count + (currentDialogTurnsById.get(turn.id) === turn ? 1 : 0),
         0,
@@ -3095,8 +3086,12 @@ export class FlowChatStore {
         ...session,
         dialogTurns: mergedDialogTurns,
         isPartial: false,
-        loadedTurnCount: mergedDialogTurns.length,
-        totalTurnCount: mergedDialogTurns.length,
+        loadedTurnCount: mergedCanonicalTurnCount,
+        totalTurnCount: Math.max(
+          session.totalTurnCount ?? 0,
+          projection.dialogTurns.length,
+          mergedCanonicalTurnCount,
+        ),
         contextRestoreState:
           session.contextRestoreState === 'ready' ? 'ready' : projection.contextRestoreState,
         mode: projection.restoredSessionInfo?.agentType || session.mode,
@@ -4023,8 +4018,8 @@ export class FlowChatStore {
         historyState: 'ready',
         contextRestoreState: 'ready',
         isPartial: false,
-        loadedTurnCount: session.dialogTurns.length,
-        totalTurnCount: session.dialogTurns.length,
+        loadedTurnCount: canonicalSessionTurns(session).length,
+        totalTurnCount: projectedSessionTurnCount(session),
         workspacePath: sourceWorkspacePath ?? session.workspacePath,
         projectWorkspacePath:
           sourceWorkspacePath ?? session.projectWorkspacePath,
@@ -4083,7 +4078,7 @@ export class FlowChatStore {
       const session = prev.sessions.get(sessionId);
       if (
         !session ||
-        session.dialogTurns.length > 0 ||
+        !isProjectedSessionEmpty(session) ||
         !session.config.dispatchTarget ||
         session.config.dispatchTarget.kind === 'local'
       ) {
@@ -4702,6 +4697,7 @@ export class FlowChatStore {
   }
 
   public addDialogTurn(sessionId: string, dialogTurn: DialogTurn): void {
+    let appendedTurn = false;
     this.setState(prev => {
       const session = prev.sessions.get(sessionId);
       if (!session) return prev;
@@ -4711,36 +4707,36 @@ export class FlowChatStore {
       }
 
       const updatedDialogTurns = [...session.dialogTurns, dialogTurn];
-      const catalogAlreadyCountsTurn = session.turnCatalog?.entries.some(entry =>
+      const updatedCanonicalTurnCount = canonicalSessionTurns({
+        dialogTurns: updatedDialogTurns,
+      }).length;
+      const storageTurnIndex = resolveStorageTurnIndex(session, dialogTurn);
+      const catalog = session.turnCatalog?.sessionId === sessionId
+        ? session.turnCatalog
+        : undefined;
+      const catalogAlreadyCountsTurn = catalog?.entries.some(entry =>
         entry.turnId === dialogTurn.id
         || (
-          typeof dialogTurn.backendTurnIndex === 'number'
-          && entry.storageTurnIndex === dialogTurn.backendTurnIndex
+          storageTurnIndex !== undefined
+          && entry.storageTurnIndex === storageTurnIndex
         )
       ) === true;
-      const previousTotalTurnCount = Math.max(
-        session.totalTurnCount ?? 0,
-        session.turnCatalog?.totalTurnCount ?? 0,
-        session.dialogTurns.length,
-      );
+      const previousTotalTurnCount = projectedSessionTurnCount(session);
       const updatedSession = {
         ...session,
         dialogTurns: updatedDialogTurns,
-        loadedTurnCount: session.isPartial === true
-          ? updatedDialogTurns.length
-          : session.loadedTurnCount,
-        totalTurnCount: session.isPartial === true
-          ? Math.max(
-            updatedDialogTurns.length,
-            previousTotalTurnCount + (catalogAlreadyCountsTurn ? 0 : 1),
-          )
-          : Math.max(session.totalTurnCount ?? 0, updatedDialogTurns.length),
+        loadedTurnCount: updatedCanonicalTurnCount,
+        totalTurnCount: Math.max(
+          updatedCanonicalTurnCount,
+          previousTotalTurnCount + (catalogAlreadyCountsTurn ? 0 : 1),
+        ),
         lastUserDialogMode: this.deriveLastUserDialogMode(updatedDialogTurns),
         lastActiveAt: Date.now()
       };
 
       const newSessions = new Map(prev.sessions);
       newSessions.set(sessionId, updatedSession);
+      appendedTurn = true;
 
       return {
         ...prev,
@@ -4748,22 +4744,17 @@ export class FlowChatStore {
       };
     });
     const updatedSession = this.state.sessions.get(sessionId);
-    if (updatedSession) {
+    if (appendedTurn && updatedSession) {
       const catalog = updatedSession.turnCatalog?.sessionId === sessionId
         ? updatedSession.turnCatalog
         : undefined;
-      const catalogEntry = catalog?.entries.find(entry =>
-        entry.turnId === dialogTurn.id
-        || (
-          typeof dialogTurn.backendTurnIndex === 'number'
-          && entry.storageTurnIndex === dialogTurn.backendTurnIndex
-        )
-      );
-      const ordinal = catalogEntry?.ordinal
-        ?? Math.max(0, updatedSession.dialogTurns.length - 1);
+      const identity = resolveDialogTurnIdentity(updatedSession, dialogTurn);
+      if (!identity) {
+        return;
+      }
       this.cacheSessionLoadedTurnRange(sessionId, {
-        startOrdinal: ordinal,
-        endOrdinalExclusive: ordinal + 1,
+        startOrdinal: identity.ordinal,
+        endOrdinalExclusive: identity.ordinal + 1,
         turns: [dialogTurn],
         lastAccessedAt: Date.now(),
         source: 'live',
@@ -4889,15 +4880,17 @@ export class FlowChatStore {
         }
         const metadata = { ...turn.userMessage.metadata } as LocalCommandMetadata;
         delete metadata.usageReportProvisional;
-        committedTurn = {
+        const nextTurn: DialogTurn = {
           ...turn,
+          storageTurnIndex: params.storageTurnIndex,
           backendTurnIndex: params.storageTurnIndex,
           userMessage: {
             ...turn.userMessage,
             metadata,
           },
         };
-        return committedTurn;
+        committedTurn = nextTurn;
+        return nextTurn;
       });
       const newSessions = new Map(prev.sessions);
       newSessions.set(params.sessionId, {
@@ -4905,7 +4898,7 @@ export class FlowChatStore {
         dialogTurns,
         turnCatalog: params.turnCatalog,
         totalTurnCount: params.totalTurnCount,
-        loadedTurnCount: dialogTurns.length,
+        loadedTurnCount: canonicalSessionTurns({ dialogTurns }).length,
       });
       return {
         ...prev,
@@ -4933,15 +4926,30 @@ export class FlowChatStore {
   }
 
   public deleteDialogTurn(sessionId: string, dialogTurnId: string): void {
+    let deletedTurn: DialogTurn | undefined;
+    let deletedOrdinal: number | undefined;
+    let shiftLaterOrdinals = false;
     this.setState(prev => {
       const session = prev.sessions.get(sessionId);
       if (!session) return prev;
 
+      deletedTurn = session.dialogTurns.find(turn => turn.id === dialogTurnId);
+      if (!deletedTurn) return prev;
+      deletedOrdinal = resolveDialogTurnIdentity(session, deletedTurn)?.ordinal;
       const updatedDialogTurns = session.dialogTurns.filter(turn => turn.id !== dialogTurnId);
+      const catalogCountsDeletedTurn = resolveStorageTurnIndex(session, deletedTurn) !== undefined;
+      const countedOptimisticTurn = !catalogCountsDeletedTurn
+        && !isProvisionalUsageReportTurn(deletedTurn);
+      shiftLaterOrdinals = countedOptimisticTurn;
+      const nextCanonicalTurnCount = canonicalSessionTurns({ dialogTurns: updatedDialogTurns }).length;
 
       const updatedSession = {
         ...session,
         dialogTurns: updatedDialogTurns,
+        loadedTurnCount: nextCanonicalTurnCount,
+        totalTurnCount: countedOptimisticTurn
+          ? Math.max(nextCanonicalTurnCount, projectedSessionTurnCount(session) - 1)
+          : session.totalTurnCount,
         lastUserDialogMode: this.deriveLastUserDialogMode(updatedDialogTurns),
         lastActiveAt: Date.now()
       };
@@ -4954,6 +4962,86 @@ export class FlowChatStore {
         sessions: newSessions
       };
     });
+    const view = this.sessionHistoryViews.get(sessionId);
+    if (view && deletedTurn && deletedOrdinal !== undefined) {
+      const retainedRanges: LoadedTurnRange[] = [];
+      for (const range of view.loadedRanges) {
+        let groupStartOrdinal: number | undefined;
+        let groupTurns: DialogTurn[] = [];
+        const flushGroup = () => {
+          if (groupStartOrdinal === undefined || groupTurns.length === 0) {
+            return;
+          }
+          retainedRanges.push({
+            ...range,
+            startOrdinal: groupStartOrdinal,
+            endOrdinalExclusive: groupStartOrdinal + groupTurns.length,
+            turns: groupTurns,
+          });
+          groupStartOrdinal = undefined;
+          groupTurns = [];
+        };
+
+        range.turns.forEach((turn, localIndex) => {
+          if (turn.id === dialogTurnId) {
+            flushGroup();
+            return;
+          }
+          const ordinal = range.startOrdinal + localIndex;
+          const nextOrdinal = shiftLaterOrdinals && ordinal > deletedOrdinal!
+            ? ordinal - 1
+            : ordinal;
+          if (
+            groupStartOrdinal !== undefined
+            && nextOrdinal !== groupStartOrdinal + groupTurns.length
+          ) {
+            flushGroup();
+          }
+          groupStartOrdinal ??= nextOrdinal;
+          groupTurns.push(turn);
+        });
+        flushGroup();
+      }
+      view.loadedRanges = retainedRanges;
+
+      if (shiftLaterOrdinals) {
+        const accessTimes = this.sessionHistoryTurnAccessTimes.get(sessionId);
+        if (accessTimes) {
+          const shiftedAccessTimes = new Map<number, number>();
+          for (const [ordinal, accessedAt] of accessTimes) {
+            if (ordinal === deletedOrdinal) {
+              continue;
+            }
+            shiftedAccessTimes.set(
+              ordinal > deletedOrdinal ? ordinal - 1 : ordinal,
+              accessedAt,
+            );
+          }
+          if (shiftedAccessTimes.size > 0) {
+            this.sessionHistoryTurnAccessTimes.set(sessionId, shiftedAccessTimes);
+          } else {
+            this.sessionHistoryTurnAccessTimes.delete(sessionId);
+          }
+        }
+        if (view.pendingTargetOrdinal !== null && view.pendingTargetOrdinal > deletedOrdinal) {
+          view.pendingTargetOrdinal -= 1;
+        }
+        if (view.activeRange) {
+          const startOrdinal = view.activeRange.startOrdinal > deletedOrdinal
+            ? view.activeRange.startOrdinal - 1
+            : view.activeRange.startOrdinal;
+          const endOrdinalExclusive = view.activeRange.endOrdinalExclusive > deletedOrdinal
+            ? view.activeRange.endOrdinalExclusive - 1
+            : view.activeRange.endOrdinalExclusive;
+          view.activeRange = endOrdinalExclusive > startOrdinal
+            ? { ...view.activeRange, startOrdinal, endOrdinalExclusive }
+            : null;
+        }
+      }
+    }
+    if (deletedTurn && !isProvisionalUsageReportTurn(deletedTurn)) {
+      this.seedSessionHistoryLoadedRanges(sessionId, 'live');
+    }
   }
 
   /**
@@ -5067,6 +5155,47 @@ export class FlowChatStore {
         sessions: newSessions
       };
     });
+  }
+
+  /**
+   * Replace a provisional Turn in place so projected counts and cached history
+   * keep one stable ordinal across runtime adoption.
+   */
+  public replaceOptimisticDialogTurn(
+    sessionId: string,
+    optimisticTurnId: string,
+    replacement: DialogTurn,
+  ): boolean {
+    let replaced = false;
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session) return prev;
+      const localIndex = session.dialogTurns.findIndex(turn => turn.id === optimisticTurnId);
+      if (localIndex < 0) return prev;
+
+      const dialogTurns = [...session.dialogTurns];
+      dialogTurns[localIndex] = replacement;
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        dialogTurns,
+        lastUserDialogMode: this.deriveLastUserDialogMode(dialogTurns),
+        lastActiveAt: Date.now(),
+      });
+      replaced = true;
+      return { ...prev, sessions: newSessions };
+    });
+
+    if (replaced) {
+      const view = this.sessionHistoryViews.get(sessionId);
+      if (view) {
+        view.loadedRanges = view.loadedRanges.map(range => ({
+          ...range,
+          turns: range.turns.map(turn => turn.id === optimisticTurnId ? replacement : turn),
+        }));
+      }
+    }
+    return replaced;
   }
 
   /**
@@ -5823,7 +5952,14 @@ export class FlowChatStore {
         return;
       }
 
-      const turnIndex = session.dialogTurns.findIndex(t => t.id === turnId);
+      const turnIndex = resolveStorageTurnIndex(session, dialogTurn);
+      if (turnIndex === undefined) {
+        log.debug('Cancelled dialog turn has no storage identity, deferring persistence', {
+          sessionId,
+          turnId,
+        });
+        return;
+      }
       
       const turnData = {
         turnId,
@@ -6812,8 +6948,8 @@ export class FlowChatStore {
             historyState: 'ready',
             contextRestoreState: 'ready',
             isPartial: false,
-            loadedTurnCount: session.dialogTurns.length,
-            totalTurnCount: session.dialogTurns.length,
+            loadedTurnCount: canonicalSessionTurns(session).length,
+            totalTurnCount: projectedSessionTurnCount(session),
           });
           return { ...prev, sessions: newSessions };
         });
@@ -7531,6 +7667,7 @@ export class FlowChatStore {
             timestamp: rawTokenUsage.timestamp,
           }
         : undefined,
+      storageTurnIndex: turn.turnIndex,
       backendTurnIndex: turn.turnIndex,
     };
     });

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -225,7 +225,7 @@ describe('sessionToVirtualItems explore grouping', () => {
     const repairedUserMessage = sessionToVirtualItems(repairedSession)
       .find(item => item.type === 'user-message');
 
-    expect(initialUserMessage).toMatchObject({ absoluteTurnIndex: 41 });
+    expect(initialUserMessage).toMatchObject({ absoluteTurnIndex: 20 });
     expect(repairedUserMessage).toMatchObject({ absoluteTurnIndex: 5 });
   });
 

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -254,6 +254,9 @@ export interface DialogTurn {
   errorDetail?: AiErrorDetail;
   tokenUsage?: TokenUsage;
   todos?: TodoItem[];
+  /** Backend persistence slot. It may be sparse and must not be used as ordinal. */
+  storageTurnIndex?: number;
+  /** @deprecated Compatibility for older restored projections. Use `storageTurnIndex`. */
   backendTurnIndex?: number;
   /** Whether the turn completed successfully. */
   success?: boolean;
@@ -261,6 +264,23 @@ export interface DialogTurn {
   finishReason?: string;
   /** Whether the turn produced a final assistant response visible to the user. */
   hasFinalResponse?: boolean;
+}
+
+declare const localTurnIndexBrand: unique symbol;
+declare const turnOrdinalBrand: unique symbol;
+declare const storageTurnIndexBrand: unique symbol;
+
+/** Position inside the currently loaded `dialogTurns` array. */
+export type LocalTurnIndex = number & { readonly [localTurnIndexBrand]: 'LocalTurnIndex' };
+/** Zero-based visible Turn position inside the complete Session history. */
+export type TurnOrdinal = number & { readonly [turnOrdinalBrand]: 'TurnOrdinal' };
+/** Opaque backend persistence slot. It may be sparse and differ from ordinal. */
+export type StorageTurnIndex = number & { readonly [storageTurnIndexBrand]: 'StorageTurnIndex' };
+
+export interface DialogTurnIdentity {
+  ordinal: TurnOrdinal;
+  storageTurnIndex?: StorageTurnIndex;
+  state: 'optimistic' | 'persisted';
 }
 
 export interface FlowChatState {
@@ -337,7 +357,7 @@ export interface Session {
    *
    * This array may temporarily contain provisional frontend Turns that have
    * not been persisted. Never derive a backend storage index from its length
-   * or local array position; use `DialogTurn.backendTurnIndex` and
+   * or local array position; use `DialogTurn.storageTurnIndex` and
    * `turnCatalog` for persisted identity and ordinals.
    */
   dialogTurns: DialogTurn[];

--- a/src/web-ui/src/flow_chat/utils/flowChatTurnIdentity.ts
+++ b/src/web-ui/src/flow_chat/utils/flowChatTurnIdentity.ts
@@ -1,0 +1,159 @@
+import type { LocalCommandMetadata } from '@/shared/types/session-history';
+import type {
+  DialogTurn,
+  DialogTurnIdentity,
+  LocalTurnIndex,
+  Session,
+  StorageTurnIndex,
+  TurnOrdinal,
+} from '../types/flow-chat';
+
+type TurnIdentitySession = Pick<
+  Session,
+  'sessionId' | 'dialogTurns' | 'isPartial' | 'totalTurnCount' | 'turnCatalog'
+>;
+
+export function asLocalTurnIndex(value: number): LocalTurnIndex {
+  return value as LocalTurnIndex;
+}
+
+export function asTurnOrdinal(value: number): TurnOrdinal {
+  return value as TurnOrdinal;
+}
+
+export function asStorageTurnIndex(value: number): StorageTurnIndex {
+  return value as StorageTurnIndex;
+}
+
+export function isProvisionalUsageReportTurn(turn: DialogTurn): boolean {
+  const metadata = turn.userMessage?.metadata as LocalCommandMetadata | undefined;
+  return metadata?.localCommandKind === 'usage_report'
+    && metadata.usageReportProvisional === true;
+}
+
+export function canonicalSessionTurns(
+  session: Pick<TurnIdentitySession, 'dialogTurns'>,
+): DialogTurn[] {
+  return session.dialogTurns.filter(turn => !isProvisionalUsageReportTurn(turn));
+}
+
+export function validSessionTurnCatalog(session: TurnIdentitySession) {
+  return session.turnCatalog?.sessionId === session.sessionId
+    ? session.turnCatalog
+    : undefined;
+}
+
+export function projectedSessionTurnCount(session: TurnIdentitySession): number {
+  const persistedTurnCount = canonicalSessionTurns(session).length;
+  return Math.max(
+    session.totalTurnCount ?? 0,
+    validSessionTurnCatalog(session)?.totalTurnCount ?? 0,
+    persistedTurnCount,
+  );
+}
+
+/** True only when the complete projected Session has no persisted Turn. */
+export function isProjectedSessionEmpty(session: TurnIdentitySession): boolean {
+  return projectedSessionTurnCount(session) === 0;
+}
+
+/** First runtime Turn, including the optimistic Turn already appended locally. */
+export function isProjectedFirstRuntimeTurn(session: TurnIdentitySession): boolean {
+  return projectedSessionTurnCount(session) <= 1;
+}
+
+export function resolveStorageTurnIndex(
+  session: TurnIdentitySession,
+  turnOrId: DialogTurn | string,
+): StorageTurnIndex | undefined {
+  const turn = typeof turnOrId === 'string'
+    ? session.dialogTurns.find(candidate => candidate.id === turnOrId)
+    : turnOrId;
+  const directStorageIndex = turn?.storageTurnIndex ?? turn?.backendTurnIndex;
+  if (directStorageIndex !== undefined) {
+    return asStorageTurnIndex(directStorageIndex);
+  }
+
+  const turnId = typeof turnOrId === 'string' ? turnOrId : turnOrId.id;
+  const catalogEntry = validSessionTurnCatalog(session)?.entries.find(
+    entry => entry.turnId === turnId,
+  );
+  return catalogEntry
+    ? asStorageTurnIndex(catalogEntry.storageTurnIndex)
+    : undefined;
+}
+
+function buildCatalogOrdinalMaps(session: TurnIdentitySession): {
+  ordinalByTurnId: Map<string, TurnOrdinal>;
+  ordinalByStorageIndex: Map<number, TurnOrdinal>;
+} {
+  const ordinalByTurnId = new Map<string, TurnOrdinal>();
+  const ordinalByStorageIndex = new Map<number, TurnOrdinal>();
+  for (const entry of validSessionTurnCatalog(session)?.entries ?? []) {
+    const ordinal = asTurnOrdinal(entry.ordinal);
+    if (entry.turnId) {
+      ordinalByTurnId.set(entry.turnId, ordinal);
+    }
+    ordinalByStorageIndex.set(entry.storageTurnIndex, ordinal);
+  }
+  return { ordinalByTurnId, ordinalByStorageIndex };
+}
+
+export function createTurnOrdinalResolver(
+  session: TurnIdentitySession,
+): (localIndex: LocalTurnIndex | number) => TurnOrdinal | undefined {
+  const { ordinalByTurnId, ordinalByStorageIndex } = buildCatalogOrdinalMaps(session);
+  const canonicalTurns = canonicalSessionTurns(session);
+  const fallbackStartOrdinal = session.isPartial === true
+    ? Math.max(0, projectedSessionTurnCount(session) - canonicalTurns.length)
+    : 0;
+  const fallbackOrdinalByTurnId = new Map<string, TurnOrdinal>();
+  canonicalTurns.forEach((turn, index) => {
+    fallbackOrdinalByTurnId.set(turn.id, asTurnOrdinal(fallbackStartOrdinal + index));
+  });
+
+  return (localIndex): TurnOrdinal | undefined => {
+    const turn = session.dialogTurns[localIndex];
+    if (!turn || isProvisionalUsageReportTurn(turn)) {
+      return undefined;
+    }
+
+    const storageTurnIndex = resolveStorageTurnIndex(session, turn);
+    return ordinalByTurnId.get(turn.id)
+      ?? (storageTurnIndex !== undefined
+        ? ordinalByStorageIndex.get(storageTurnIndex)
+        : undefined)
+      ?? fallbackOrdinalByTurnId.get(turn.id);
+  };
+}
+
+export function resolveTurnOrdinal(
+  session: TurnIdentitySession,
+  turnOrId: DialogTurn | string,
+): TurnOrdinal | undefined {
+  const turnId = typeof turnOrId === 'string' ? turnOrId : turnOrId.id;
+  const localIndex = session.dialogTurns.findIndex(turn => turn.id === turnId);
+  if (localIndex < 0) {
+    const catalogEntry = validSessionTurnCatalog(session)?.entries.find(
+      entry => entry.turnId === turnId,
+    );
+    return catalogEntry ? asTurnOrdinal(catalogEntry.ordinal) : undefined;
+  }
+  return createTurnOrdinalResolver(session)(asLocalTurnIndex(localIndex));
+}
+
+export function resolveDialogTurnIdentity(
+  session: TurnIdentitySession,
+  turnOrId: DialogTurn | string,
+): DialogTurnIdentity | undefined {
+  const ordinal = resolveTurnOrdinal(session, turnOrId);
+  if (ordinal === undefined) {
+    return undefined;
+  }
+  const storageTurnIndex = resolveStorageTurnIndex(session, turnOrId);
+  return {
+    ordinal,
+    storageTurnIndex,
+    state: storageTurnIndex === undefined ? 'optimistic' : 'persisted',
+  };
+}

--- a/src/web-ui/src/flow_chat/utils/flowChatTurnOrdinal.test.ts
+++ b/src/web-ui/src/flow_chat/utils/flowChatTurnOrdinal.test.ts
@@ -5,6 +5,12 @@ import {
   createAbsoluteSessionTurnIndexResolver,
   loadedSessionTurnIdForAbsoluteIndex,
 } from './flowChatTurnOrdinal';
+import {
+  isProjectedSessionEmpty,
+  projectedSessionTurnCount,
+  resolveDialogTurnIdentity,
+  resolveStorageTurnIndex,
+} from './flowChatTurnIdentity';
 
 function createPartialSession(): Session {
   return {
@@ -64,5 +70,66 @@ describe('FlowChat absolute Turn ordinal helpers', () => {
     expect(absoluteSessionTurnIndexForId(session, 'turn-98')).toBe(98);
     expect(loadedSessionTurnIdForAbsoluteIndex(session, 98)).toBe('turn-98');
     expect(createAbsoluteSessionTurnIndexResolver(session)(0)).toBe(98);
+    expect(resolveDialogTurnIdentity(session, 'turn-98')).toEqual({
+      ordinal: 97,
+      storageTurnIndex: 140,
+      state: 'persisted',
+    });
+  });
+
+  it('keeps optimistic ordinal separate from unavailable storage identity', () => {
+    const session = createPartialSession();
+    session.dialogTurns.push({
+      id: 'turn-101',
+      sessionId: session.sessionId,
+      userMessage: { id: 'user-101', content: 'new prompt', timestamp: 1001 },
+      modelRounds: [],
+      status: 'pending',
+      startTime: 1001,
+    });
+    session.totalTurnCount = 101;
+
+    expect(resolveDialogTurnIdentity(session, 'turn-101')).toEqual({
+      ordinal: 100,
+      storageTurnIndex: undefined,
+      state: 'optimistic',
+    });
+    expect(resolveStorageTurnIndex(session, 'turn-101')).toBeUndefined();
+  });
+
+  it('excludes provisional usage reports from projected counts and tail offsets', () => {
+    const session = createPartialSession();
+    session.dialogTurns.push({
+      id: 'usage-1',
+      sessionId: session.sessionId,
+      kind: 'local_command',
+      userMessage: {
+        id: 'usage-user-1',
+        content: 'report',
+        timestamp: 1002,
+        metadata: {
+          localCommandKind: 'usage_report',
+          usageReportProvisional: true,
+          modelVisible: false,
+        },
+      },
+      modelRounds: [],
+      status: 'completed',
+      startTime: 1002,
+    });
+
+    expect(projectedSessionTurnCount(session)).toBe(100);
+    expect(absoluteSessionTurnIndexForId(session, 'turn-98')).toBe(98);
+    expect(absoluteSessionTurnIndexForId(session, 'usage-1')).toBeUndefined();
+  });
+
+  it('does not treat metadata-only history as an empty Session', () => {
+    const session = createPartialSession();
+    session.dialogTurns = [];
+    session.isPartial = undefined;
+    session.totalTurnCount = 23;
+
+    expect(projectedSessionTurnCount(session)).toBe(23);
+    expect(isProjectedSessionEmpty(session)).toBe(false);
   });
 });

--- a/src/web-ui/src/flow_chat/utils/flowChatTurnOrdinal.ts
+++ b/src/web-ui/src/flow_chat/utils/flowChatTurnOrdinal.ts
@@ -1,87 +1,25 @@
 import type { Session } from '../types/flow-chat';
-
-function sessionTurnCatalog(session: Session) {
-  return session.turnCatalog?.sessionId === session.sessionId
-    ? session.turnCatalog
-    : undefined;
-}
+import {
+  createTurnOrdinalResolver,
+  resolveTurnOrdinal,
+  validSessionTurnCatalog,
+} from './flowChatTurnIdentity';
 
 export function absoluteSessionTurnIndexForLocalIndex(
   session: Session,
   localIndex: number,
 ): number {
-  const turn = session.dialogTurns[localIndex];
-  if (!turn) {
-    return localIndex + 1;
-  }
-
-  const catalog = sessionTurnCatalog(session);
-  const catalogEntry = catalog?.entries.find(entry =>
-    entry.turnId === turn.id
-    || (
-      typeof turn.backendTurnIndex === 'number'
-      && entry.storageTurnIndex === turn.backendTurnIndex
-    )
-  );
-  if (catalogEntry) {
-    return catalogEntry.ordinal + 1;
-  }
-  if (typeof turn.backendTurnIndex === 'number') {
-    return turn.backendTurnIndex + 1;
-  }
-  if (session.isPartial === true) {
-    const totalTurnCount = Math.max(
-      session.totalTurnCount ?? 0,
-      catalog?.totalTurnCount ?? 0,
-      session.dialogTurns.length,
-    );
-    return Math.max(0, totalTurnCount - session.dialogTurns.length) + localIndex + 1;
-  }
-  return localIndex + 1;
+  const ordinal = createTurnOrdinalResolver(session)(localIndex);
+  return ordinal === undefined ? localIndex + 1 : ordinal + 1;
 }
 
 export function createAbsoluteSessionTurnIndexResolver(
   session: Session,
 ): (localIndex: number) => number {
-  const catalog = sessionTurnCatalog(session);
-  const catalogOrdinalByTurnId = new Map<string, number>();
-  const catalogOrdinalByStorageIndex = new Map<number, number>();
-  for (const entry of catalog?.entries ?? []) {
-    if (entry.turnId) {
-      catalogOrdinalByTurnId.set(entry.turnId, entry.ordinal);
-    }
-    catalogOrdinalByStorageIndex.set(entry.storageTurnIndex, entry.ordinal);
-  }
-  const partialTurnOffset = session.isPartial === true
-    ? Math.max(
-        0,
-        Math.max(
-          session.totalTurnCount ?? 0,
-          catalog?.totalTurnCount ?? 0,
-          session.dialogTurns.length,
-        ) - session.dialogTurns.length,
-      )
-    : 0;
-
-  return (localIndex: number): number => {
-    const turn = session.dialogTurns[localIndex];
-    if (!turn) {
-      return localIndex + 1;
-    }
-
-    const catalogOrdinal = catalogOrdinalByTurnId.get(turn.id)
-      ?? (
-        typeof turn.backendTurnIndex === 'number'
-          ? catalogOrdinalByStorageIndex.get(turn.backendTurnIndex)
-          : undefined
-      );
-    if (catalogOrdinal !== undefined) {
-      return catalogOrdinal + 1;
-    }
-    if (typeof turn.backendTurnIndex === 'number') {
-      return turn.backendTurnIndex + 1;
-    }
-    return partialTurnOffset + localIndex + 1;
+  const resolveOrdinal = createTurnOrdinalResolver(session);
+  return localIndex => {
+    const ordinal = resolveOrdinal(localIndex);
+    return ordinal === undefined ? localIndex + 1 : ordinal + 1;
   };
 }
 
@@ -89,15 +27,8 @@ export function absoluteSessionTurnIndexForId(
   session: Session,
   turnId: string,
 ): number | undefined {
-  const catalogEntry = sessionTurnCatalog(session)?.entries.find(entry => entry.turnId === turnId);
-  if (catalogEntry) {
-    return catalogEntry.ordinal + 1;
-  }
-
-  const localIndex = session.dialogTurns.findIndex(turn => turn.id === turnId);
-  return localIndex >= 0
-    ? absoluteSessionTurnIndexForLocalIndex(session, localIndex)
-    : undefined;
+  const ordinal = resolveTurnOrdinal(session, turnId);
+  return ordinal === undefined ? undefined : ordinal + 1;
 }
 
 export function loadedSessionTurnIdForAbsoluteIndex(
@@ -105,14 +36,13 @@ export function loadedSessionTurnIdForAbsoluteIndex(
   turnIndex: number,
 ): string | undefined {
   const ordinal = turnIndex - 1;
-  const catalogTurnId = sessionTurnCatalog(session)?.entries.find(
+  const catalogTurnId = validSessionTurnCatalog(session)?.entries.find(
     entry => entry.ordinal === ordinal,
   )?.turnId;
   if (catalogTurnId) {
     return catalogTurnId;
   }
 
-  return session.dialogTurns.find((_, localIndex) =>
-    absoluteSessionTurnIndexForLocalIndex(session, localIndex) === turnIndex
-  )?.id;
+  const resolveOrdinal = createTurnOrdinalResolver(session);
+  return session.dialogTurns.find((_, localIndex) => resolveOrdinal(localIndex) === ordinal)?.id;
 }

--- a/src/web-ui/src/flow_chat/utils/reviewDetailState.test.ts
+++ b/src/web-ui/src/flow_chat/utils/reviewDetailState.test.ts
@@ -95,6 +95,19 @@ describe('deriveReviewDetailProjection', () => {
     });
   });
 
+  it('does not mark an unhydrated non-empty history as unavailable', () => {
+    const session = createSession({
+      historyState: 'ready',
+      dialogTurns: [],
+      totalTurnCount: 3,
+    });
+
+    expect(deriveReviewDetailProjection(session, false)).toEqual({
+      content: null,
+      execution: 'preparing',
+    });
+  });
+
   it('keeps an explicit user cancellation distinct from failure', () => {
     const session = createSession({
       historyState: 'ready',

--- a/src/web-ui/src/flow_chat/utils/reviewDetailState.ts
+++ b/src/web-ui/src/flow_chat/utils/reviewDetailState.ts
@@ -1,6 +1,7 @@
 import type { AnyFlowItem, DialogTurn, Session } from '../types/flow-chat';
 import type { VirtualItem } from '../store/modernFlowChatStore';
 import type { ReviewTaskOutcome } from './reviewTaskOutcome';
+import { isProjectedSessionEmpty } from './flowChatTurnIdentity';
 
 export type ReviewDetailContentState =
   | 'loading'
@@ -65,7 +66,7 @@ export function deriveReviewDetailProjection(
       ? 'loading'
       : session.historyState === 'failed'
         ? 'load-failed'
-        : session.historyState === 'ready' && session.dialogTurns.length === 0
+        : session.historyState === 'ready' && isProjectedSessionEmpty(session)
           ? 'unavailable'
           : null;
 

--- a/src/web-ui/src/flow_chat/utils/sessionMetadata.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionMetadata.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/shared/types/session-history';
 import type { Session } from '../types/flow-chat';
 import { resolveSessionTitle } from './sessionTitle';
+import { canonicalSessionTurns, projectedSessionTurnCount } from './flowChatTurnIdentity';
 
 const CHILD_SESSION_KIND_TAGS = new Set<SessionKind>(['btw', 'review', 'deep_review', 'miniapp', 'subagent']);
 const RELATIONSHIP_METADATA_KEYS = new Set([
@@ -197,10 +198,14 @@ export function deriveLastFinishedAtFromMetadata(
 }
 
 export function calculateSessionStats(
-  session: Pick<Session, 'dialogTurns'>
+  session: Pick<
+    Session,
+    'sessionId' | 'dialogTurns' | 'isPartial' | 'totalTurnCount' | 'turnCatalog'
+  >
 ): Pick<SessionMetadata, 'turnCount' | 'messageCount' | 'toolCallCount'> {
-  const turnCount = session.dialogTurns.length;
-  const messageCount = session.dialogTurns.reduce((sum, turn) => {
+  const loadedPersistedTurns = canonicalSessionTurns(session);
+  const turnCount = projectedSessionTurnCount(session);
+  const messageCount = loadedPersistedTurns.reduce((sum, turn) => {
     return (
       sum +
       1 +
@@ -209,7 +214,7 @@ export function calculateSessionStats(
       }, 0)
     );
   }, 0);
-  const toolCallCount = session.dialogTurns.reduce((sum, turn) => {
+  const toolCallCount = loadedPersistedTurns.reduce((sum, turn) => {
     return sum + turn.modelRounds.reduce((roundSum, round) => {
       return roundSum + round.items.filter(item => item.type === 'tool').length;
     }, 0);
@@ -341,6 +346,9 @@ export function buildSessionMetadata(
     | 'remoteSshHost'
     | 'todos'
     | 'dialogTurns'
+    | 'isPartial'
+    | 'totalTurnCount'
+    | 'turnCatalog'
     | 'sessionKind'
     | 'parentSessionId'
     | 'btwOrigin'

--- a/src/web-ui/src/flow_chat/utils/sessionWorktree.test.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionWorktree.test.ts
@@ -36,6 +36,19 @@ describe('session worktree control', () => {
     expect(isSessionWorktreeBindingLocked(session({ totalTurnCount: 1 }), false)).toBe(true);
   });
 
+  it('locks catalog-only history before its dialog turns are hydrated', () => {
+    expect(isSessionWorktreeBindingLocked(session({
+      turnCatalog: {
+        schemaVersion: 1,
+        sessionId: 'session-1',
+        revision: 'catalog-1',
+        totalTurnCount: 1,
+        complete: false,
+        entries: [],
+      },
+    }), false)).toBe(true);
+  });
+
   it('shows an armed worktree before it has been materialized', () => {
     const armed = session({
       workspacePath: '/repo',

--- a/src/web-ui/src/flow_chat/utils/sessionWorktree.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionWorktree.ts
@@ -1,18 +1,28 @@
 import type { Session } from '../types/flow-chat';
+import { isProjectedSessionEmpty } from './flowChatTurnIdentity';
 import { sessionProjectWorkspacePath } from './sessionWorkspace';
 
 type SessionWorktreeFacts = Pick<
   Session,
-  'dialogTurns' | 'totalTurnCount' | 'workspaceId' | 'workspacePath' | 'projectWorkspacePath' | 'config'
+  | 'sessionId'
+  | 'dialogTurns'
+  | 'isPartial'
+  | 'totalTurnCount'
+  | 'turnCatalog'
+  | 'workspaceId'
+  | 'workspacePath'
+  | 'projectWorkspacePath'
+  | 'config'
 >;
 
 export function isSessionWorktreeBindingLocked(
-  session: Pick<SessionWorktreeFacts, 'dialogTurns' | 'totalTurnCount'>,
+  session: Pick<
+    SessionWorktreeFacts,
+    'sessionId' | 'dialogTurns' | 'isPartial' | 'totalTurnCount' | 'turnCatalog'
+  >,
   isProcessing: boolean,
 ): boolean {
-  return session.dialogTurns.length > 0
-    || (session.totalTurnCount ?? 0) > 0
-    || isProcessing;
+  return !isProjectedSessionEmpty(session) || isProcessing;
 }
 
 export function isSessionWorktreeMaterialized(
@@ -66,6 +76,8 @@ export function sessionWorktreeBindingSubscriptionKey(session: SessionWorktreeFa
   return [
     session.dialogTurns.length,
     session.totalTurnCount ?? '',
+    session.turnCatalog?.revision ?? '',
+    session.turnCatalog?.totalTurnCount ?? '',
     session.workspaceId ?? '',
     session.workspacePath ?? '',
     session.projectWorkspacePath ?? '',


### PR DESCRIPTION
## Summary

Fix FlowChat turn navigation and lifecycle handling for sessions whose history is loaded incrementally.

- Separate local array indexes, visible session ordinals, and backend storage indexes.
- Resolve navigation rail labels and highlights from absolute session ordinals.
- Adopt optimistic turns in place when the authoritative backend turn arrives.
- Keep loaded history ranges, active windows, and access records aligned after optimistic turn deletion.
- Defer turn persistence until an authoritative storage index is available.
- Exclude provisional usage-report turns from canonical counts and history-tail calculations.
- Use projected session state for first-turn, empty-session, dispatch, worktree, and review decisions.
- Preserve `backendTurnIndex` as a compatibility field while migrating internal logic to `storageTurnIndex`.

## Type and Areas

Type:

Regression fix / refactor / test

Areas:

Web UI, FlowChat history navigation, session store, turn persistence

## Motivation / Impact

FlowChat restores only the latest history tail by default. Code that treated `dialogTurns.length` or a local array position as an absolute turn ordinal could assign a newly submitted turn to an existing navigation entry. This caused an older rail item to display the newest user message and become highlighted.

The new identity model keeps three concepts separate:

- Local index: position in the currently loaded `dialogTurns` array.
- Turn ordinal: position in the complete visible session history.
- Storage index: opaque backend persistence slot, which may be sparse and differ from the ordinal.

Users should no longer see existing turn-navigation entries overwritten or incorrectly highlighted when starting a new turn in a partially loaded historical session.

## Verification

Passed:

```text
pnpm --dir src/web-ui run test:run \
  src/flow_chat/utils/flowChatTurnOrdinal.test.ts \
  src/flow_chat/components/modern/continuousHistoryProjection.test.ts \
  src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts \
  src/flow_chat/store/FlowChatStore.test.ts \
  src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts \
  src/flow_chat/store/modernFlowChatStore.test.ts \
  src/flow_chat/utils/sessionMetadata.test.ts \
  src/flow_chat/services/flow-chat-manager/SessionModule.test.ts \
  src/flow_chat/services/flow-chat-manager/MessageModule.test.ts \
  src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx \
  src/flow_chat/services/usageReportService.test.ts \
  src/flow_chat/utils/reviewDetailState.test.ts \
  src/flow_chat/utils/sessionWorktree.test.ts
```

Result: 13 test files passed, 310 tests passed.

```text
pnpm --dir src/web-ui exec eslint <changed FlowChat source files>
```

Result: passed.

```text
git diff --check
```

Result: passed.

```text
pnpm run type-check:web
```

Result: blocked by pre-existing generated API export mismatches in `src/infrastructure/api/adapters/websocket-adapter.ts`. No type errors from this change were reported.

Manual UI verification was not performed, and no development server was started.

## Reviewer Notes

- `DialogTurn.storageTurnIndex` is the new explicit persistence identity.
- `DialogTurn.backendTurnIndex` remains temporarily supported for restored legacy projections and existing callers.
- Backend protocol DTOs still use `turnIndex`; those fields represent storage indexes and were not renamed.
- Optimistic turns intentionally have no storage identity until `DialogTurnStarted` supplies one.
- Provisional usage reports remain renderable but do not affect canonical history ordinals.
- The main regression cases cover a 23-turn session with only turns 20–22 loaded, followed by optimistic append, adoption, deletion, and persistence.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.