### PR TITLE
fix(flow-chat): keep completed round footers below transcript

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -216,6 +216,10 @@ subpixel scroll limit.
 Physical-bottom synchronization must yield whenever the coordinator owns an
 element anchor. It also yields while streaming `following-tail` owns the
 viewport, because the single tail loop is the writer for content-growth motion.
+Outside tail follow, physical-bottom synchronization is limited to a real
+viewport `clientHeight` change. A message, round footer, or other content growth
+changes `scrollHeight` only and must remain below the existing viewport instead
+of moving the transcript upward to reach the new physical bottom.
 A sticky pin intentionally sits at the physical bottom created by its
 reservation; treating that geometry as tail-follow causes every content growth
 measurement to push the pinned header upward before the coordinator can restore

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -1411,27 +1411,34 @@ describe('VirtualMessageList session boundary', () => {
     });
   });
 
-  it('does not let physical-bottom follow compete with a semantic element anchor', () => {
+  it('syncs the physical bottom only for a real viewport-height change', () => {
     expect(shouldSyncPhysicalBottom({
-      viewportGeometryChanged: true,
+      viewportHeightChanged: true,
       collapseProtectionActive: false,
       wasAtPhysicalBottom: true,
       ownsElementAnchor: true,
       isFollowingTail: false,
     })).toBe(false);
     expect(shouldSyncPhysicalBottom({
-      viewportGeometryChanged: true,
+      viewportHeightChanged: true,
       collapseProtectionActive: false,
       wasAtPhysicalBottom: true,
       ownsElementAnchor: false,
       isFollowingTail: false,
     })).toBe(true);
     expect(shouldSyncPhysicalBottom({
-      viewportGeometryChanged: true,
+      viewportHeightChanged: true,
       collapseProtectionActive: false,
       wasAtPhysicalBottom: true,
       ownsElementAnchor: false,
       isFollowingTail: true,
+    })).toBe(false);
+    expect(shouldSyncPhysicalBottom({
+      viewportHeightChanged: false,
+      collapseProtectionActive: false,
+      wasAtPhysicalBottom: true,
+      ownsElementAnchor: false,
+      isFollowingTail: false,
     })).toBe(false);
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -950,11 +950,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return false;
     }
 
-    const viewportGeometryChanged =
-      Math.abs(scroller.scrollHeight - previousGeometry.scrollHeight) > COMPENSATION_EPSILON_PX ||
+    // A growing message/footer changes scrollHeight, not the viewport. Only a
+    // client-height change is a real viewport resize that should preserve a
+    // physical-bottom anchor; otherwise a newly appended footer would push the
+    // existing transcript upward by re-pinning to the new bottom.
+    const viewportHeightChanged =
       Math.abs(scroller.clientHeight - previousGeometry.clientHeight) > COMPENSATION_EPSILON_PX;
     if (
-      !viewportGeometryChanged ||
+      !viewportHeightChanged ||
       pendingCollapseIntentRef.current.active ||
       retainedCollapseAnchorRef.current !== null
     ) {
@@ -976,7 +979,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       viewportCoordinatorRef.current.getMode() === 'following-tail'
     );
     const willWrite = shouldSyncPhysicalBottom({
-      viewportGeometryChanged,
+      viewportHeightChanged,
       collapseProtectionActive: pendingCollapseIntentRef.current.active,
       wasAtPhysicalBottom,
       ownsElementAnchor,
@@ -1716,12 +1719,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     const currentScrollTop = scroller.scrollTop;
     const previousScrollTop = previousScrollTopRef.current;
     const previousScrollerGeometry = previousScrollerGeometryRef.current;
-    const viewportGeometryChanged = Boolean(
+    const viewportHeightChanged = Boolean(
       previousScrollerGeometry &&
-      (
-        Math.abs(scroller.scrollHeight - previousScrollerGeometry.scrollHeight) > COMPENSATION_EPSILON_PX ||
-        Math.abs(scroller.clientHeight - previousScrollerGeometry.clientHeight) > COMPENSATION_EPSILON_PX
-      )
+      Math.abs(scroller.clientHeight - previousScrollerGeometry.clientHeight) > COMPENSATION_EPSILON_PX
     );
     const wasAtPhysicalBottom = Boolean(
       previousScrollerGeometry &&
@@ -1783,7 +1783,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           collapseIntentActive: pendingCollapseIntentRef.current.active,
           retainedCollapseAnchor: retainedCollapseAnchorRef.current,
           wasAtPhysicalBottom,
-          viewportGeometryChanged,
+          viewportHeightChanged,
         }),
       });
     }
@@ -1799,7 +1799,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       retainedCollapseAnchorRef.current !== null
     );
     if (shouldSyncPhysicalBottom({
-      viewportGeometryChanged,
+      viewportHeightChanged,
       collapseProtectionActive: hasCollapseAnchorProtection,
       wasAtPhysicalBottom,
       ownsElementAnchor,
@@ -5434,10 +5434,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
 
     const scroller = scrollerElementRef.current;
-    const distanceFromBottomBefore = scroller
-      ? Math.max(0, scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop)
-      : 0;
-    const wasNearBottom = distanceFromBottomBefore <= 80;
 
     // Collapse compensation can be much larger than the tail space needed to
     // keep a sticky user message pinned. Transfer it to the pin reservation in
@@ -5506,11 +5502,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       }
       if (scroller && ownsElementAnchorBefore) {
         viewportCoordinatorRef.current.restoreElementAnchor(scroller, 'stream-end-reservation-transfer');
-      }
-      // Footer height shrank: if we were following the bottom, re-pin in the
-      // same turn to avoid a one-frame whole-pane jump that looks like a flash.
-      if (scroller && wasNearBottom && !ownsElementAnchorBefore) {
-        scroller.scrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
       }
     }
 

--- a/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
@@ -424,14 +424,14 @@ export function consumeBottomReservationForContentGrowth(
 }
 
 export function shouldSyncPhysicalBottom(options: {
-  viewportGeometryChanged: boolean;
+  viewportHeightChanged: boolean;
   collapseProtectionActive: boolean;
   wasAtPhysicalBottom: boolean;
   ownsElementAnchor: boolean;
   isFollowingTail: boolean;
 }): boolean {
   return (
-    options.viewportGeometryChanged &&
+    options.viewportHeightChanged &&
     !options.collapseProtectionActive &&
     options.wasAtPhysicalBottom &&
     !options.ownsElementAnchor &&


### PR DESCRIPTION
## Summary

Prevent completed round footers from pushing the existing transcript upward when they are appended.

Fixes #

## Type and Areas

Type:

Bug fix / regression fix / UI/UX / test / docs

Areas:

Web UI — FlowChat scrolling and viewport stability

## Motivation / Impact

The completed round footer remains rendered and reserved as introduced by `fbde2aee12`, but its height no longer causes the list to re-pin to the new physical bottom.

Message and footer growth now stays below the existing viewport. Physical-bottom synchronization is retained for genuine viewport `clientHeight` changes, such as input or panel resizing.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx src/flow_chat/components/modern/VirtualMessageList.layout.test.ts`
  - 2 test files passed
  - 76 tests passed
- `pnpm --dir src/web-ui run lint` passed
- `git diff --check` passed
- `pnpm run type-check:web` was blocked by existing generated API mismatches in `websocket-adapter.ts`:
  - missing `AgentSessionArchiveStateRequest`
  - missing `AgentSessionForkAtTurnRequest`
  - missing `ConfigUpdate`
  - missing `ForkSessionResponse`
  - related missing agent profile config types
- Manual UI verification was not run.

## Reviewer Notes

- The footer reservation and delayed visibility behavior from `fbde2aee12` is preserved.
- This change removes only the legacy physical-bottom re-pinning caused by content-height changes.
- Viewport-height resize handling remains unchanged.
- No user-facing strings or locale resources were changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, including the blocked type-check.
- [x] User-facing strings, docs, and locales are updated where applicable.