### PR TITLE
fix(runtime): register session mode port on desktop session surface

### DIFF
--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -1723,14 +1723,22 @@ pub async fn update_session_mode(
         request.include_internal,
     )
     .await?;
-    runtime
+    let result = runtime
         .agent_runtime()
         .update_session_mode(AgentSessionModeUpdateRequest {
             session_id,
             mode_id: request.mode_id,
         })
-        .await
-        .map_err(|error| format!("Failed to update session mode: {}", error.into_message()))
+        .await;
+    if let Err(error) = &result {
+        log::error!(
+            "update_session_mode failed: session_id={}, mode_id={}, error={}",
+            request.session_id,
+            request.mode_id,
+            error
+        );
+    }
+    result.map_err(|error| format!("Failed to update session mode: {}", error.into_message()))
 }
 
 #[tauri::command]

--- a/src/crates/assembly/core/src/agentic/agents/registry/external.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/external.rs
@@ -435,19 +435,29 @@ impl AgentRegistry {
                     .and_then(|routes| routes.get(&logical_key))
                     .cloned()
                 {
-                    let binding = match route {
+                    let binding = match &route {
                         ExternalSubagentRoute::Local => self
                             .find_agent_entry(logical_id, Some(workspace_root))
                             .filter(|entry| entry.category == AgentCategory::Mode)
                             .map(|entry| local_primary_binding(entry.agent.id())),
                         ExternalSubagentRoute::External(runtime_key) => {
-                            self.external_subagents.acquire_primary(&runtime_key)
+                            self.external_subagents.acquire_primary(runtime_key)
                         }
                         ExternalSubagentRoute::Unavailable => None,
                     };
-                    return binding.filter(|binding| {
+                    let binding = binding.filter(|binding| {
                         expected_owner.is_none_or(|owner| binding.route_owner == owner)
                     });
+                    if binding.is_none() {
+                        log::warn!(
+                            "External route shadowed primary agent resolution: logical_id={}, workspace_root={:?}, route={:?}, expected_owner={:?}",
+                            logical_key,
+                            workspace_key,
+                            route,
+                            expected_owner,
+                        );
+                    }
+                    return binding;
                 }
             }
         }

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -1413,6 +1413,14 @@ impl ConversationCoordinator {
         );
 
         if !external_sources_supported {
+            if local_binding.is_none() {
+                warn!(
+                    "Primary agent resolution failed (local only): agent_type={}, workspace_root={:?}, is_external_route={}",
+                    agent_type,
+                    workspace_root,
+                    registry.is_external_subagent_route(agent_type, workspace_root),
+                );
+            }
             return local_binding.ok_or_else(|| {
                 BitFunError::Validation(format!("Unknown session mode: {agent_type}"))
             });
@@ -1439,6 +1447,10 @@ impl ConversationCoordinator {
             if expected_owner == Some(SessionAgentRouteOwner::External)
                 || registry.is_external_subagent_route(agent_type, workspace_root)
             {
+                warn!(
+                    "External agent source discovery failed; external candidate unavailable: agent_type={}, workspace_root={:?}, error={}",
+                    agent_type, workspace_root, error
+                );
                 return Err(BitFunError::Validation(format!(
                     "candidate_unavailable: external main agent {agent_type} could not be refreshed"
                 )));
@@ -1451,6 +1463,10 @@ impl ConversationCoordinator {
                 );
                 return Ok(local_binding);
             }
+            warn!(
+                "External agent source discovery failed and no fallback binding exists: agent_type={}, workspace_root={:?}, error={}",
+                agent_type, workspace_root, error
+            );
             return Err(BitFunError::Service(format!(
                 "External agent source discovery failed: {error}"
             )));
@@ -1464,6 +1480,13 @@ impl ConversationCoordinator {
                 expected_owner,
             )
             .ok_or_else(|| {
+                warn!(
+                    "Primary agent resolution failed (external-aware): agent_type={}, workspace_root={:?}, expected_owner={:?}, is_external_route={}",
+                    agent_type,
+                    workspace_root,
+                    expected_owner,
+                    registry.is_external_subagent_route(agent_type, workspace_root),
+                );
                 if expected_owner == Some(SessionAgentRouteOwner::External)
                     || registry.is_external_subagent_route(agent_type, workspace_root)
                 {
@@ -10510,10 +10533,19 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             None,
         )
         .await?;
-
-        self.session_manager
+        let result = self
+            .session_manager
             .update_session_agent_binding(session_id, mode_id, binding.route_owner)
-            .await
+            .await;
+        if let Err(error) = &result {
+            log::error!(
+                "update_session_mode binding update failed: session_id={}, mode_id={}, error={}",
+                session_id,
+                mode_id,
+                error
+            );
+        }
+        result
     }
 
     /// Update the session-level prompt-cache guard mode for the latest

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -3483,6 +3483,14 @@ impl SessionManager {
                     .save_session(&workspace_path, &updated_session)
                     .await
                 {
+                    error!(
+                        "Session agent binding persistence failed: session_id={}, agent_type={}, route_owner={:?}, storage_path={}, error={}",
+                        session_id,
+                        agent_type,
+                        route_owner,
+                        workspace_path.display(),
+                        error,
+                    );
                     if let Err(rollback_error) = self
                         .persistence_manager
                         .save_session(&workspace_path, &original_session)

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -1195,6 +1195,7 @@ impl CoreServiceAgentRuntime {
             scheduled_session_management_port(coordinator.clone(), scheduler.clone());
         let workspace_references: Arc<dyn AgentWorkspaceReferencePort> = coordinator.clone();
         let session_revert = scheduled_session_revert_port(coordinator.clone(), scheduler.clone());
+        let session_mode: Arc<dyn AgentSessionModePort> = coordinator.clone();
         let session_model: Arc<dyn AgentSessionModelPort> = coordinator.clone();
         let session_compaction: Arc<dyn AgentSessionCompactionPort> = coordinator.clone();
         let local_command_turn: Arc<dyn AgentLocalCommandTurnPort> = coordinator.clone();
@@ -1207,6 +1208,7 @@ impl CoreServiceAgentRuntime {
             .with_session_management_port(session_management)
             .with_workspace_reference_port(workspace_references)
             .with_session_revert_port(session_revert)
+            .with_session_mode_port(session_mode)
             .with_session_model_port(session_model)
             .with_session_compaction_port(session_compaction)
             .with_local_command_turn_port(local_command_turn)
@@ -2359,6 +2361,25 @@ mod tests {
             "let local_command_turn: Arc<dyn AgentLocalCommandTurnPort> = coordinator.clone();"
         ));
         assert!(builder.contains(".with_local_command_turn_port(local_command_turn)"));
+    }
+
+    #[test]
+    fn session_surface_runtime_registers_session_mode_port() {
+        let source = include_str!("service_agent_runtime.rs");
+        let builder = source
+            .split("pub(crate) fn session_surface_agent_runtime")
+            .nth(1)
+            .and_then(|source| {
+                source
+                    .split("pub(crate) fn agent_runtime_with_scheduler_ports")
+                    .next()
+            })
+            .expect("session surface runtime builder");
+
+        assert!(builder.contains(
+            "let session_mode: Arc<dyn AgentSessionModePort> = coordinator.clone();"
+        ));
+        assert!(builder.contains(".with_session_mode_port(session_mode)"));
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -3938,9 +3938,14 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       }
     : null, [effectiveTargetSession, effectiveTargetSessionId]);
   const reportModeSelectionFailure = useCallback((error: unknown, modeId: string) => {
-      log.error('Failed to update Session agent mode', { error, modeId });
+      log.error('Failed to update Session agent mode', {
+        error,
+        modeId,
+        sessionId: effectiveTargetSessionId,
+        target: sessionModeSelectionTarget,
+      });
       notificationService.error(t('chatInput.modeChangeFailed'));
-  }, [t]);
+  }, [effectiveTargetSessionId, sessionModeSelectionTarget, t]);
   const {
     isModeChangePending,
     publishModeSelection,


### PR DESCRIPTION
## Problem

Switching any Session from the default Agent mode to another mode (e.g. Agent -> Plan) in the desktop app always failed with "切换智能体模式失败，请重试" (Failed to switch agent mode, please retry).

## Root cause

The desktop session surface runtime (`CoreServiceAgentRuntime::session_surface_agent_runtime`, the only runtime surface used by the desktop app) never registered the `session_mode` port. Every `update_session_mode` call therefore hit the missing-port guard in `AgentRuntime::update_session_mode` and returned `PortErrorKind::NotAvailable` with "agent session mode port is not registered". This affected all sessions and all target modes. Model switching was unaffected because `session_model` was registered.

The port registration was missing since the desktop session lifecycle convergence (`f98306168d`).

## Fix

- Register the coordinator-backed `AgentSessionModePort` in `session_surface_agent_runtime`.
- Add a source contract test (`session_surface_runtime_registers_session_mode_port`) so the registration cannot silently regress again.
- Add failure-path diagnostics (desktop command error, coordinator binding failure, registry resolution failure incl. external-route shadowing, persistence failure, frontend log with session target) so regressions are diagnosable from `app.log`.

## Verification

- `cargo check -p bitfun-core --features product-full` and `cargo check -p bitfun-desktop`: pass
- Coordinator session-mode tests, `service_agent_runtime` tests (including the new contract test), and registry external-route tests: all pass
- Frontend type-check and Vite build pass
