### PR TITLE
fix(flow-chat): restore mode switching and prevent footer gaps

### DIFF
--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -1290,6 +1290,7 @@ impl CoreServiceAgentRuntime {
             scheduled_session_management_port(coordinator.clone(), scheduler.clone());
         let workspace_references: Arc<dyn AgentWorkspaceReferencePort> = coordinator.clone();
         let session_revert = scheduled_session_revert_port(coordinator.clone(), scheduler.clone());
+        let session_mode: Arc<dyn AgentSessionModePort> = coordinator.clone();
         let session_model: Arc<dyn AgentSessionModelPort> = coordinator.clone();
         let session_compaction: Arc<dyn AgentSessionCompactionPort> = coordinator.clone();
         let local_command_turn: Arc<dyn AgentLocalCommandTurnPort> = coordinator.clone();
@@ -1302,6 +1303,7 @@ impl CoreServiceAgentRuntime {
             .with_session_management_port(session_management)
             .with_workspace_reference_port(workspace_references)
             .with_session_revert_port(session_revert)
+            .with_session_mode_port(session_mode)
             .with_session_model_port(session_model)
             .with_session_compaction_port(session_compaction)
             .with_local_command_turn_port(local_command_turn)
@@ -2436,7 +2438,7 @@ mod tests {
     }
 
     #[test]
-    fn session_surface_runtime_registers_local_command_turn_port() {
+    fn session_surface_runtime_registers_explicit_session_mutation_ports() {
         let source = include_str!("service_agent_runtime.rs");
         let builder = source
             .split("pub(crate) fn session_surface_agent_runtime")
@@ -2452,6 +2454,9 @@ mod tests {
             "let local_command_turn: Arc<dyn AgentLocalCommandTurnPort> = coordinator.clone();"
         ));
         assert!(builder.contains(".with_local_command_turn_port(local_command_turn)"));
+        assert!(builder
+            .contains("let session_mode: Arc<dyn AgentSessionModePort> = coordinator.clone();"));
+        assert!(builder.contains(".with_session_mode_port(session_mode)"));
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -107,6 +107,13 @@ temporary tail space, but keeps its own semantics:
 
 The rendered footer height is the sum of all active reservations.
 
+A non-zero `collapse` reservation must have an explicit semantic owner: an
+active or retained tool collapse, input-stack shrink, preserved-element range,
+late-shrink clamp, or protected-range transfer from a pin. Ordinary Virtuoso
+measurement convergence has no such owner. An idle measurement with no owner
+must only rebase the measured height and must never create Footer space from a
+negative `scrollHeight` delta alone.
+
 Reservation state is ref-owned first and mirrored into React state. A Virtuoso
 Footer remount must synchronously read the ref-owned value; otherwise one stale
 React commit can remove exactly the reserved scroll range for a frame.
@@ -199,11 +206,12 @@ Active preservation blocks automatic tail takeover, while retained preservation
 allows the tail controller to take ownership when its normal distance and intent
 rules say that following should resume.
 
-There is no persistent raw `scrollTop` lock or scroll-listener lock. For an unsignaled
-shrink with no semantic element anchor, `restoreScrollPositionOnce()` performs
-one clamped `scrollTop` fallback using the pre-change position. It is a bounded
-last resort, not a second controller: subsequent layout changes are handled by
-the semantic anchor (when present), the reservation model, or follow mode.
+There is no persistent raw `scrollTop` lock or scroll-listener lock. An
+unsignaled shrink may adjust an already owned protected range, but it may not
+create a collapse reservation from idle geometry alone. Without a semantic
+owner, the list accepts the new Virtuoso measurement and rebases its height and
+scroll baselines. Subsequent layout changes are handled by the semantic anchor
+(when present), the owned reservation transaction, or follow mode.
 
 An element anchor also owns the minimum physical scroll range needed to restore
 its offset. After writing `scrollTop`, the coordinator remeasures the actual DOM
@@ -692,6 +700,10 @@ If a future collapsible component shows the same "header drops" or "flash on col
 - Unsignaled shrink reconciliation must not reduce a protected collapse floor;
   only measured growth, downward navigation, bottom arrival, or an explicit
   reservation reset may consume it.
+- Unsignaled shrink reconciliation must not create a collapse reservation when
+  no collapse transaction owns the range. Session-open and history-projection
+  handoffs rebase their measurements instead of treating estimate convergence
+  as content collapse.
 - Pre-collapse intent must capture the anchor before the component shrinks.
 - Compensation must not be consumed too early during active layout transitions.
 - Session changes and empty-list resets must clear compensation and anchor state.

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -553,6 +553,72 @@ describe('VirtualMessageList session boundary', () => {
     expect(scroller.scrollHeight).toBeLessThan(40_000);
   });
 
+  it('does not convert Virtuoso estimate convergence into anonymous footer space', () => {
+    stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b']);
+    stateMocks.virtualItems = ['turn-a', 'turn-b'].flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList isViewportActive />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    const footer = container.querySelector<HTMLElement>('.message-list-footer');
+    expect(scroller).not.toBeNull();
+    expect(footer).not.toBeNull();
+    if (!scroller || !footer) {
+      return;
+    }
+
+    let naturalContentHeight = 14_457;
+    let scrollTop = 13_561.3330078125;
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, get: () => 1_020 },
+      scrollHeight: {
+        configurable: true,
+        get: () => naturalContentHeight + (Number.parseFloat(footer.style.height) || 0),
+      },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+    });
+    vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 0,
+      bottom: 1_020,
+      height: 1_020,
+    }));
+
+    act(() => {
+      root.render(<VirtualMessageList isViewportActive />);
+      resizeObserverMocks.callbacks.at(-1)?.();
+    });
+    for (let frame = 0; frame < 4; frame += 1) {
+      flushAnimationFrame();
+    }
+    const baselineFooterHeight = Number.parseFloat(footer.style.height);
+
+    const convergenceSteps = [10_902, 7_529, 4_601, 3_693];
+    for (const nextNaturalContentHeight of convergenceSteps) {
+      naturalContentHeight = nextNaturalContentHeight;
+      scrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+      act(() => {
+        resizeObserverMocks.callbacks.at(-1)?.();
+      });
+      for (let frame = 0; frame < 4; frame += 1) {
+        flushAnimationFrame();
+      }
+    }
+
+    expect(Number.parseFloat(footer.style.height)).toBeCloseTo(baselineFooterHeight, 2);
+    expect(scroller.scrollHeight).toBeLessThan(4_000);
+  });
+
   it('reconciles a stream that ends while its viewport is inactive after reactivation', () => {
     flowDiagnosticsMocks.enabled = true;
     const listRef = React.createRef<VirtualMessageListRef>();
@@ -1263,6 +1329,22 @@ describe('VirtualMessageList session boundary', () => {
     }, 2).collapse).toEqual({
       kind: 'collapse',
       px: 2,
+      floorPx: 0,
+    });
+    expect(reconcileUnsignaledShrinkReservation({
+      ...protectedState,
+      collapse: { kind: 'collapse', px: 0, floorPx: 0 },
+    }, 907.333, false).collapse).toEqual({
+      kind: 'collapse',
+      px: 0,
+      floorPx: 0,
+    });
+    expect(reconcileUnsignaledShrinkReservation({
+      ...protectedState,
+      collapse: { kind: 'collapse', px: 0, floorPx: 0 },
+    }, 907.333, true).collapse).toEqual({
+      kind: 'collapse',
+      px: 907.333,
       floorPx: 0,
     });
   });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -299,6 +299,19 @@ interface RetainedCollapseAnchorState {
   toolName: string | null;
 }
 
+type CollapseReservationOwnerKind =
+  | 'tool-collapse'
+  | 'retained-collapse'
+  | 'input-stack-shrink'
+  | 'preserved-element'
+  | 'late-shrink-clamp'
+  | 'protected-range';
+
+interface CollapseReservationOwnerState {
+  kind: CollapseReservationOwnerKind;
+  generation: number;
+}
+
 interface HistoryPresentationCommitQuietWaiter {
   cancel: () => void;
   restart: () => void;
@@ -572,6 +585,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const previousActiveSessionIdForOpenHandoffRef = useRef<string | null | undefined>(undefined);
   const viewportCoordinatorRef = useRef(new FlowChatViewportCoordinator());
   const bottomReservationStateRef = useRef<BottomReservationState>(createInitialBottomReservationState());
+  const collapseReservationOwnerRef = useRef<CollapseReservationOwnerState | null>(null);
+  const collapseReservationOwnerGenerationRef = useRef(0);
   const restoreScrollerMethodsRef = useRef<(() => void) | null>(null);
   const previousMeasuredHeightRef = useRef<number | null>(null);
   const previousScrollTopRef = useRef(0);
@@ -754,6 +769,24 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return getReservationTotalPx(state.collapse) + getReservationTotalPx(state.pin);
   }, []);
 
+  const acquireCollapseReservationOwner = useCallback((kind: CollapseReservationOwnerKind) => {
+    const currentOwner = collapseReservationOwnerRef.current;
+    if (currentOwner?.kind === kind) {
+      return currentOwner;
+    }
+    const nextOwner: CollapseReservationOwnerState = {
+      kind,
+      generation: collapseReservationOwnerGenerationRef.current + 1,
+    };
+    collapseReservationOwnerGenerationRef.current = nextOwner.generation;
+    collapseReservationOwnerRef.current = nextOwner;
+    return nextOwner;
+  }, []);
+
+  const clearCollapseReservationOwner = useCallback(() => {
+    collapseReservationOwnerRef.current = null;
+  }, []);
+
   const clearRetainedCollapseSettlement = useCallback(() => {
     retainedCollapseSettleGenerationRef.current += 1;
     retainedCollapseGeometryGenerationRef.current = 0;
@@ -809,6 +842,18 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       clientHeight: scroller.clientHeight,
     };
   }, [canCoordinateViewport]);
+
+  const rebaseViewportMeasurements = useCallback(() => {
+    const scroller = scrollerElementRef.current;
+    if (!canProcessViewportGeometry(scroller)) {
+      previousMeasuredHeightRef.current = null;
+      previousScrollerGeometryRef.current = null;
+      return;
+    }
+    previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller);
+    previousScrollTopRef.current = scroller.scrollTop;
+    recordScrollerGeometry(scroller);
+  }, [canProcessViewportGeometry, recordScrollerGeometry, snapshotMeasuredContentHeight]);
 
   const recordScrollerGeometryIfLayoutStable = useCallback((scroller: HTMLElement) => {
     const previousGeometry = previousScrollerGeometryRef.current;
@@ -1006,7 +1051,47 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   ) => {
     const previous = bottomReservationStateRef.current;
     const rawNext = typeof updater === 'function' ? updater(previous) : updater;
-    const next = sanitizeBottomReservationState(rawNext);
+    const sanitizedNext = sanitizeBottomReservationState(rawNext);
+    const hasNextCollapseReservation = (
+      sanitizedNext.collapse.px > COMPENSATION_EPSILON_PX ||
+      sanitizedNext.collapse.floorPx > COMPENSATION_EPSILON_PX
+    );
+    const next = hasNextCollapseReservation && collapseReservationOwnerRef.current === null
+      ? sanitizeBottomReservationState({
+        ...sanitizedNext,
+        collapse: {
+          ...sanitizedNext.collapse,
+          px: 0,
+          floorPx: 0,
+        },
+      })
+      : sanitizedNext;
+    if (
+      hasNextCollapseReservation &&
+      collapseReservationOwnerRef.current === null &&
+      flowChatDiagnostics.isEnabled()
+    ) {
+      flowChatDiagnostics.trace({
+        hypothesis: 'C',
+        location: 'VirtualMessageList.updateBottomReservationState',
+        message: 'Anonymous collapse reservation was rejected',
+        data: () => ({
+          before: previous,
+          rejected: sanitizedNext,
+          accepted: next,
+          coordinatorMode: viewportCoordinatorRef.current.getMode(),
+          isFollowingOutput: isFollowingOutputRef.current,
+          isStreamingOutput: isStreamingOutputRef.current,
+        }),
+      });
+    }
+    if (
+      next.collapse.px <= COMPENSATION_EPSILON_PX &&
+      !pendingCollapseIntentRef.current.active &&
+      retainedCollapseAnchorRef.current === null
+    ) {
+      clearCollapseReservationOwner();
+    }
     if (
       flowChatDiagnostics.isEnabled() &&
       !areBottomReservationStatesEqual(previous, next)
@@ -1018,6 +1103,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         data: () => ({
           before: previous,
           after: next,
+          collapseReservationOwner: collapseReservationOwnerRef.current,
           coordinatorMode: viewportCoordinatorRef.current.getMode(),
           isFollowingOutput: isFollowingOutputRef.current,
           isStreamingOutput: isStreamingOutputRef.current,
@@ -1028,7 +1114,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     setBottomReservationState(prev => {
       return areBottomReservationStatesEqual(next, prev) ? prev : next;
     });
-  }, []);
+  }, [clearCollapseReservationOwner]);
 
   const clearTurnPinRequest = useCallback(() => {
     turnPinRequestGenerationRef.current += 1;
@@ -1086,8 +1172,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }, []);
 
   const resetBottomReservations = useCallback(() => {
+    clearCollapseReservationOwner();
     updateBottomReservationState(createInitialBottomReservationState());
-  }, [updateBottomReservationState]);
+  }, [clearCollapseReservationOwner, updateBottomReservationState]);
 
   const consumeBottomCompensation = useCallback((
     amountPx: number,
@@ -1114,14 +1201,18 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return resolvedNextState;
   }, [updateBottomReservationState]);
 
-  const applyFooterCompensationNow = useCallback((compensation: number | BottomReservationState) => {
+  const applyFooterCompensationNow = useCallback((compensation: BottomReservationState) => {
     const footer = footerElementRef.current;
     const scroller = scrollerElementRef.current;
     if (!footer || !scroller) return;
 
-    const compensationPx = typeof compensation === 'number'
+    const appliedState = areBottomReservationStatesEqual(
+      compensation,
+      bottomReservationStateRef.current,
+    )
       ? compensation
-      : getTotalBottomCompensationPx(compensation);
+      : bottomReservationStateRef.current;
+    const compensationPx = getTotalBottomCompensationPx(appliedState);
     applyFooterHeightToElement(footer, compensationPx);
     void footer.offsetHeight;
     void scroller.scrollHeight;
@@ -1146,6 +1237,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     const currentState = bottomReservationStateRef.current;
     const nextState = createInitialBottomReservationState();
     pendingCollapseIntentRef.current = createInactiveCollapseIntentState();
+    retainedCollapseAnchorRef.current = null;
+    clearCollapseReservationOwner();
 
     if (areBottomReservationStatesEqual(currentState, nextState)) {
       return;
@@ -1162,6 +1255,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, [
     applyFooterCompensationNow,
+    clearCollapseReservationOwner,
     recordScrollerGeometry,
     snapshotMeasuredContentHeight,
     updateBottomReservationState,
@@ -1180,6 +1274,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     });
     const reservationChanged = !areBottomReservationStatesEqual(currentState, nextState);
     if (reservationChanged) {
+      if (
+        nextState.collapse.px > COMPENSATION_EPSILON_PX &&
+        collapseReservationOwnerRef.current === null
+      ) {
+        acquireCollapseReservationOwner('preserved-element');
+      }
       updateBottomReservationState(nextState);
       applyFooterCompensationNow(nextState);
     }
@@ -1220,6 +1320,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return reservationChanged || scrollTopChanged;
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
     recordScrollerGeometry,
     snapshotMeasuredContentHeight,
     updateBottomReservationState,
@@ -1265,6 +1366,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         }
         retainedCollapseAnchorRef.current = null;
         retainedCollapseGeometryGenerationRef.current = 0;
+        if (bottomReservationStateRef.current.collapse.px <= COMPENSATION_EPSILON_PX) {
+          clearCollapseReservationOwner();
+        }
         if (flowChatDiagnostics.isEnabled()) {
           flowChatDiagnostics.trace({
             hypothesis: 'F',
@@ -1310,6 +1414,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, [
     applyFooterCompensationNow,
+    clearCollapseReservationOwner,
     preserveCollapseAnchorScrollTop,
     updateBottomReservationState,
   ]);
@@ -1349,11 +1454,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     anchor: RetainedCollapseAnchorState,
     reason: string,
   ) => {
+    acquireCollapseReservationOwner(
+      anchor.toolName === 'late-shrink-clamp' ? 'late-shrink-clamp' : 'retained-collapse',
+    );
     const scroller = scrollerElementRef.current;
     const currentState = bottomReservationStateRef.current;
     if (currentState.collapse.px <= COMPENSATION_EPSILON_PX) {
       clearRetainedCollapseSettlement();
       retainedCollapseAnchorRef.current = null;
+      clearCollapseReservationOwner();
       return;
     }
     const previousRetainedAnchor = retainedCollapseAnchorRef.current;
@@ -1406,6 +1515,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
+    clearCollapseReservationOwner,
     clearRetainedCollapseSettlement,
     preserveCollapseAnchorScrollTop,
     scheduleRetainedCollapseSettlement,
@@ -1591,12 +1702,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         },
       };
 
+    if (
+      options.mode !== 'pinned-item' &&
+      collapseReservationOwnerRef.current === null
+    ) {
+      acquireCollapseReservationOwner('preserved-element');
+    }
     updateBottomReservationState(nextState);
     applyFooterCompensationNow(nextState);
     previousMeasuredHeightRef.current = snapshotMeasuredContentHeight(scroller, nextState);
     return true;
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
     canProcessViewportGeometry,
     snapshotMeasuredContentHeight,
     updateBottomReservationState,
@@ -1652,6 +1770,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         px: currentCollapsePx + shrinkAmount,
       },
     };
+    if (collapseReservationOwnerRef.current === null) {
+      acquireCollapseReservationOwner('input-stack-shrink');
+    }
     updateBottomReservationState(nextReservationState);
     applyFooterCompensationNow(nextReservationState);
 
@@ -1704,6 +1825,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
     canProcessViewportGeometry,
     inputStackFooterPx,
     updateBottomReservationState,
@@ -1946,16 +2068,17 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     const resolvedIntentCompensation = hasValidCollapseIntent
       ? collapseIntent.baseTotalCompensationPx + Math.max(0, cumulativeShrinkPx - collapseIntent.distanceFromBottomBeforeCollapse)
       : 0;
-    const reconciledUnsignaledState = hasValidCollapseIntent
+    const reconciledOwnedState = hasValidCollapseIntent
       ? null
       : reconcileUnsignaledShrinkReservation(
         bottomReservationStateRef.current,
         fallbackRequiredCollapseCompensation,
+        collapseReservationOwnerRef.current !== null,
       );
     const nextTotalCompensation = hasValidCollapseIntent
       ? Math.max(currentTotalCompensation, resolvedIntentCompensation)
       : getTotalBottomCompensationPx(
-        reconciledUnsignaledState ?? bottomReservationStateRef.current,
+        reconciledOwnedState ?? bottomReservationStateRef.current,
       );
     if (hasValidCollapseIntent) {
       pendingCollapseIntentRef.current = {
@@ -1974,7 +2097,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return;
     }
 
-    const nextReservationState: BottomReservationState = reconciledUnsignaledState ?? {
+    const nextReservationState: BottomReservationState = reconciledOwnedState ?? {
       ...bottomReservationStateRef.current,
       collapse: {
         ...bottomReservationStateRef.current.collapse,
@@ -2340,6 +2463,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     const snapshot = historyProjectionHandoffRef.current;
     historyProjectionHandoffRef.current = null;
     setHistoryProjectionHandoff(null);
+    if (reason === 'session-reset' || reason === 'session-changed') {
+      previousMeasuredHeightRef.current = null;
+      previousScrollerGeometryRef.current = null;
+    }
 
     if (snapshot) {
       startupTrace.markPhase('flowchat_history_projection_handoff_cleared', {
@@ -2351,6 +2478,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, []);
   clearHistoryProjectionHandoffRef.current = clearHistoryProjectionHandoff;
+
+  useLayoutEffect(() => {
+    rebaseViewportMeasurements();
+  }, [historyProjectionHandoff, rebaseViewportMeasurements]);
 
   const scheduleHistoryProjectionHandoffRelease = useCallback((frames = 1) => {
     if (historyProjectionHandoffReleaseFrameRef.current !== null) {
@@ -3191,6 +3322,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       updateBottomReservationState(nextState);
       applyFooterCompensationNow(nextState);
     }
+    if (nextState.collapse.px <= COMPENSATION_EPSILON_PX) {
+      clearCollapseReservationOwner();
+    }
     if (flowChatDiagnostics.isEnabled()) {
       flowChatDiagnostics.trace({
         hypothesis: 'A',
@@ -3244,6 +3378,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }, [
     applyFooterCompensationNow,
     clearCollapseIntentScheduling,
+    clearCollapseReservationOwner,
     drainCollapseReservationPreservingPinnedItem,
     reconcilePendingStickyPinGrowthSettlement,
     recordScrollerGeometry,
@@ -4134,6 +4269,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         })
         : null;
       if (followingTailShrinkClampRecovery) {
+        acquireCollapseReservationOwner('late-shrink-clamp');
         retainedCollapseAnchorRef.current = {
           anchorScrollTop: followingTailShrinkClampRecovery.targetScrollTop,
           toolId: null,
@@ -4452,6 +4588,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         filePath?: string | null;
         reason?: string | null;
       }>).detail;
+      acquireCollapseReservationOwner('tool-collapse');
       const previousIntent = pendingCollapseIntentRef.current;
       clearRetainedCollapseSettlement();
       if (flowChatDiagnostics.isEnabled()) {
@@ -4648,6 +4785,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     };
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
     canProcessViewportGeometry,
     cancelLatestEndAnchorStabilization,
     clearBottomReservationsForUserBrowsing,
@@ -5110,6 +5248,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     clearPendingStickyPinGrowth('clear-all-reservations');
     pendingCollapseIntentRef.current = createInactiveCollapseIntentState();
     retainedCollapseAnchorRef.current = null;
+    clearCollapseReservationOwner();
 
     if (!hasActiveReservation) {
       return;
@@ -5128,6 +5267,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     applyFooterCompensationNow,
     clearTurnPinRequest,
     clearCollapseIntentScheduling,
+    clearCollapseReservationOwner,
     clearPendingStickyPinGrowth,
     recordScrollerGeometry,
     snapshotMeasuredContentHeight,
@@ -5176,6 +5316,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       preserveCurrentRange: options?.preserveCurrentRange === true,
       ownsElementAnchor: viewportCoordinatorRef.current.ownsElementAnchor(),
     });
+    if (
+      nextReservationState.collapse.px > COMPENSATION_EPSILON_PX &&
+      collapseReservationOwnerRef.current === null
+    ) {
+      acquireCollapseReservationOwner('protected-range');
+    }
     if (flowChatDiagnostics.isEnabled()) {
       flowChatDiagnostics.trace({
         hypothesis: 'A',
@@ -5199,6 +5345,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
     clearPendingStickyPinGrowth,
     clearTurnPinRequest,
     recordScrollerGeometry,
@@ -5520,6 +5667,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           ownsElementAnchor: true,
         },
       );
+      if (
+        releasedReservationState.collapse.px > COMPENSATION_EPSILON_PX &&
+        collapseReservationOwnerRef.current === null
+      ) {
+        acquireCollapseReservationOwner('protected-range');
+      }
       updateBottomReservationState(releasedReservationState);
       applyFooterCompensationNow(releasedReservationState);
     }
@@ -5570,6 +5723,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
   }, [
     applyFooterCompensationNow,
+    acquireCollapseReservationOwner,
     clearCollapseIntentScheduling,
     clearPendingStickyPinGrowth,
     clearTurnPinRequest,

--- a/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatScrollStability.ts
@@ -240,7 +240,22 @@ export function settleRetainedCollapseReservationForAnchor(
 export function reconcileUnsignaledShrinkReservation(
   currentState: BottomReservationState,
   fallbackRequiredCollapsePx: number,
+  hasCollapseOwner = (
+    currentState.collapse.px > COMPENSATION_EPSILON_PX ||
+    currentState.collapse.floorPx > COMPENSATION_EPSILON_PX
+  ),
 ): BottomReservationState {
+  if (!hasCollapseOwner) {
+    return sanitizeBottomReservationState({
+      ...currentState,
+      collapse: {
+        ...currentState.collapse,
+        px: 0,
+        floorPx: 0,
+      },
+    });
+  }
+
   return sanitizeBottomReservationState({
     ...currentState,
     collapse: {


### PR DESCRIPTION
## Summary

- Register `AgentSessionModePort` in the session-surface runtime so explicit session mode changes reach the runtime.
- Require every non-zero collapse reservation to have an explicit semantic owner.
- Prevent Virtuoso estimate convergence from creating anonymous synthetic Footer space.
- Rebase viewport measurement baselines during session and history-projection transitions.
- Add regression coverage and update the FlowChat scroll-stability contract.

Fixes #2083 

## Type and Areas

Type:

Regression fix

Areas:

Rust core, Web UI, FlowChat virtualization, docs, tests

## Motivation / Impact

Session mode changes could fail because the session-surface runtime did not expose `AgentSessionModePort`.

Separately, Virtuoso estimate convergence could be interpreted as an unsignaled content collapse. This created a large synthetic Footer reservation and left excessive blank space below the conversation.

This change restores session mode switching and limits collapse compensation to explicitly owned semantic transactions.

## Verification

- `pnpm exec eslint src/flow_chat/components/ChatInput.tsx src/flow_chat/hooks/useSessionModeSelection.ts src/flow_chat/components/modern/ModernFlowChatContainer.tsx src/flow_chat/components/modern/VirtualMessageList.tsx src/flow_chat/components/modern/flowChatScrollStability.ts`
  - Passed.
- `pnpm --dir src/web-ui exec vitest run --pool=threads --maxWorkers=1 src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx src/flow_chat/components/modern/VirtualMessageList.layout.test.ts src/flow_chat/components/modern/flowChatCollapseMotion.test.ts src/flow_chat/components/modern/FlowChatViewportCoordinator.test.ts src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx`
  - 5 test files passed.
  - 105 tests passed.
- `git diff --check`
  - Passed.
- Manual reproduction confirmed that session mode switching works and the excessive bottom whitespace no longer occurs.
- `pnpm run type-check:web`
  - Blocked by pre-existing missing exports in `websocket-adapter.ts`, unrelated to this change.

## Reviewer Notes

- Collapse reservations now require one of the recognized semantic owners, such as a tool collapse, retained collapse, input-stack shrink, preserved element, late-shrink clamp, or protected range.
- Ownerless measurement shrink only rebases viewport measurements and cannot allocate Footer space.
- No migration or user-facing string changes are required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.