### PR TITLE
test(cli): wait for idle before sending exit shortcut

### DIFF
--- a/src/apps/cli/tests/terminal_process_contracts.rs
+++ b/src/apps/cli/tests/terminal_process_contracts.rs
@@ -71,6 +71,7 @@ fn startup_bracketed_paste_attaches_an_image_path_without_rendering_the_path() {
         Duration::from_secs(30),
         "the image draft did not reach the model request",
     );
+    process.expect_idle_after_turn(1, Duration::from_secs(30));
     process.write(&[0x03]);
     let (status, output) = process.finish(Duration::from_secs(15));
     assert!(


### PR DESCRIPTION
- Prevent the startup image attachment contract from racing turn completion.
- Ensure Ctrl+C is interpreted as Exit instead of Interrupt after the model turn.
