### PR TITLE
fix(welcome): handle future workspace access dates

### DIFF
--- a/src/web-ui/src/app/scenes/welcome/WelcomeScene.tsx
+++ b/src/web-ui/src/app/scenes/welcome/WelcomeScene.tsx
@@ -18,6 +18,7 @@ import { createLogger } from '@/shared/utils/logger';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
 import type { WorkspaceInfo } from '@/shared/types';
 import { getRecentWorkspaceLineParts } from '@/shared/utils/recentWorkspaceDisplay';
+import { formatRecentWorkspaceDate } from './recentWorkspaceDate';
 import './WelcomeScene.scss';
 
 const log = createLogger('WelcomeScene');
@@ -95,16 +96,7 @@ const WelcomeScene: React.FC = () => {
 
   const formatDate = useCallback((dateString: string) => {
     try {
-      const date = new Date(dateString);
-      const now = new Date();
-      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-      const dateStart = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
-      const diffDays = Math.round((todayStart - dateStart) / (1000 * 60 * 60 * 24));
-      if (diffDays <= 0) return t('time.today');
-      if (diffDays === 1) return t('time.yesterday');
-      if (diffDays < 7) return t('startup.daysAgo', { count: diffDays });
-      if (diffDays < 30) return t('startup.weeksAgo', { count: Math.ceil(diffDays / 7) });
-      return formatLocaleDate(date);
+      return formatRecentWorkspaceDate(dateString, new Date(), t, formatLocaleDate);
     } catch {
       return '';
     }

--- a/src/web-ui/src/app/scenes/welcome/recentWorkspaceDate.test.ts
+++ b/src/web-ui/src/app/scenes/welcome/recentWorkspaceDate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  differenceInLocalCalendarDays,
+  formatRecentWorkspaceDate,
+} from './recentWorkspaceDate';
+
+const t = vi.fn((key: string, options?: Record<string, unknown>) => (
+  options?.count === undefined ? key : `${key}:${options.count}`
+));
+const formatLocaleDate = vi.fn((date: Date) => `absolute:${date.toISOString()}`);
+
+describe('formatRecentWorkspaceDate', () => {
+  it('labels an earlier time on the same calendar day as today', () => {
+    const date = new Date(2026, 7, 6, 0, 1);
+
+    expect(formatRecentWorkspaceDate(
+      date.toISOString(),
+      new Date(2026, 7, 6, 23, 59),
+      t,
+      formatLocaleDate,
+    )).toBe('time.today');
+  });
+
+  it('labels the previous calendar day as yesterday even when less than 24 hours ago', () => {
+    const date = new Date(2026, 7, 5, 23, 59);
+
+    expect(formatRecentWorkspaceDate(
+      date.toISOString(),
+      new Date(2026, 7, 6, 0, 1),
+      t,
+      formatLocaleDate,
+    )).toBe('time.yesterday');
+  });
+
+  it.each([
+    ['spring-forward', 23, new Date('2026-03-09T04:30:00Z'), new Date('2026-03-08T05:30:00Z')],
+    ['fall-back', 25, new Date('2026-11-02T05:30:00Z'), new Date('2026-11-01T04:30:00Z')],
+  ])('uses calendar dates across a %s boundary', (_name, elapsedHours, now, date) => {
+    vi.spyOn(now, 'getFullYear').mockReturnValue(2026);
+    vi.spyOn(now, 'getMonth').mockReturnValue(_name === 'spring-forward' ? 2 : 10);
+    vi.spyOn(now, 'getDate').mockReturnValue(_name === 'spring-forward' ? 9 : 2);
+    vi.spyOn(date, 'getFullYear').mockReturnValue(2026);
+    vi.spyOn(date, 'getMonth').mockReturnValue(_name === 'spring-forward' ? 2 : 10);
+    vi.spyOn(date, 'getDate').mockReturnValue(_name === 'spring-forward' ? 8 : 1);
+
+    expect((now.getTime() - date.getTime()) / (60 * 60 * 1000)).toBe(elapsedHours);
+    expect(differenceInLocalCalendarDays(now, date)).toBe(1);
+  });
+
+  it('formats a future calendar date as an absolute date', () => {
+    const date = new Date(2026, 7, 7, 0, 20);
+
+    expect(formatRecentWorkspaceDate(
+      date.toISOString(),
+      new Date(2026, 7, 6, 23, 50),
+      t,
+      formatLocaleDate,
+    )).toBe(`absolute:${date.toISOString()}`);
+  });
+});

--- a/src/web-ui/src/app/scenes/welcome/recentWorkspaceDate.ts
+++ b/src/web-ui/src/app/scenes/welcome/recentWorkspaceDate.ts
@@ -1,0 +1,30 @@
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+type FormatLocaleDate = (date: Date) => string;
+
+function localCalendarDayNumber(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / MILLISECONDS_PER_DAY;
+}
+
+export function differenceInLocalCalendarDays(now: Date, date: Date): number {
+  return localCalendarDayNumber(now) - localCalendarDayNumber(date);
+}
+
+export function formatRecentWorkspaceDate(
+  dateString: string,
+  now: Date,
+  t: Translate,
+  formatLocaleDate: FormatLocaleDate,
+): string {
+  const date = new Date(dateString);
+  const diffDays = differenceInLocalCalendarDays(now, date);
+
+  if (diffDays === 0) return t('time.today');
+  if (diffDays === 1) return t('time.yesterday');
+  if (diffDays > 1 && diffDays < 7) return t('startup.daysAgo', { count: diffDays });
+  if (diffDays >= 7 && diffDays < 30) {
+    return t('startup.weeksAgo', { count: Math.ceil(diffDays / 7) });
+  }
+  return formatLocaleDate(date);
+}


### PR DESCRIPTION
## Summary

- Extract recent-workspace date formatting into a focused utility.
- Calculate elapsed days using local calendar dates instead of fixed 24-hour intervals.
- Display future calendar dates as localized absolute dates instead of incorrectly labeling them as “Today.”
- Add tests for same-day, midnight, DST, and future-date boundaries.

## Type and Areas

Type:

- Bug fix
- Regression fix
- Test

Areas:

- Web UI
- Welcome scene

## Motivation / Impact

Recent workspace timestamps can be ahead of the client calendar when a remote or Peer Device host clock is out of sync.

Previously, every future timestamp matched `diffDays <= 0` and was displayed as “Today,” even if it was days or weeks ahead. Future calendar dates now fall back to the localized absolute-date format.

Calendar-day differences are also calculated independently of elapsed hours, preserving correct behavior across 23-hour and 25-hour DST transitions.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/scenes/welcome/recentWorkspaceDate.test.ts`
  - Passed: 1 test file, 5 tests.
- `pnpm --dir src/web-ui exec eslint src/app/scenes/welcome/WelcomeScene.tsx src/app/scenes/welcome/recentWorkspaceDate.ts src/app/scenes/welcome/recentWorkspaceDate.test.ts`
  - Passed for source files; the test file was ignored by the repository ESLint pattern.
- `pnpm --dir src/web-ui exec eslint --no-ignore src/app/scenes/welcome/recentWorkspaceDate.test.ts`
  - Passed.
- `git diff --check`
  - Passed.
- `pnpm run type-check:web`
  - Blocked by pre-existing missing exports from `@/generated/api` referenced by `websocket-adapter.ts`; none of the changed files reported errors.
- UI interaction verification was not performed per repository instructions.

## Reviewer Notes

The fallback applies only to future calendar days. Future timestamps later on the current local calendar day still display as “Today.”

No user-facing strings or locale resources were added or changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.