### PR TITLE
feat: add DeepResearch support to session tools

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/session_control_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/session_control_tool.rs
@@ -280,6 +280,7 @@ Arguments:
   - "agentic": Coding-focused agent for implementation, debugging, and code changes.
   - "Plan": Planning agent for clarifying requirements and producing an implementation plan before coding.
   - "Cowork": Collaborative agent for office-style work such as research, documentation, presentations, etc.
+  - "DeepResearch": Research agent for systematic investigation and evidence-driven reports.
 - "session_id": Required for cancel and delete."#
                 .to_string(),
         )
@@ -316,7 +317,7 @@ Arguments:
                 },
                 "agent_type": {
                     "type": "string",
-                    "enum": ["agentic", "Plan", "Cowork"],
+                    "enum": ["agentic", "Plan", "Cowork", "DeepResearch"],
                     "description": "Optional agent type when creating a session. Defaults to agentic."
                 }
             },

--- a/src/crates/assembly/core/src/agentic/tools/implementations/session_message_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/session_message_tool.rs
@@ -274,6 +274,12 @@ enum SessionMessageAgentType {
     Plan,
     #[serde(rename = "Cowork", alias = "cowork", alias = "COWORK")]
     Cowork,
+    #[serde(
+        rename = "DeepResearch",
+        alias = "deepresearch",
+        alias = "DEEPRESEARCH"
+    )]
+    DeepResearch,
 }
 
 impl SessionMessageAgentType {
@@ -282,6 +288,7 @@ impl SessionMessageAgentType {
             Self::Agentic => "agentic",
             Self::Plan => "Plan",
             Self::Cowork => "Cowork",
+            Self::DeepResearch => "DeepResearch",
         }
     }
 }
@@ -313,6 +320,7 @@ Allowed agent types when creating a session:
 - "agentic": Coding-focused agent for implementation, debugging, and code changes.
 - "Plan": Planning agent for clarifying requirements and producing an implementation plan before coding.
 - "Cowork": Collaborative agent for office-style work such as research, documentation, presentations, etc.
+- "DeepResearch": Research agent for systematic investigation and evidence-driven reports.
 "#
                 .to_string(),
         )
@@ -348,7 +356,7 @@ Allowed agent types when creating a session:
                 },
                 "agent_type": {
                     "type": "string",
-                    "enum": ["agentic", "Plan", "Cowork"],
+                    "enum": ["agentic", "Plan", "Cowork", "DeepResearch"],
                     "description": "Required when session_id is omitted. Not allowed when sending to an existing session."
                 }
             },
@@ -951,7 +959,7 @@ mod tests {
                     "workspace": workspace.as_string(),
                     "session_id": "worker_1",
                     "message": "hello",
-                    "agent_type": "Plan",
+                    "agent_type": "DeepResearch",
                 }),
                 Some(&session_context("source_1")),
             )
@@ -1021,7 +1029,7 @@ mod tests {
                     "workspace": workspace.as_string(),
                     "message": "hello",
                     "session_name": "Worker Session",
-                    "agent_type": "agentic",
+                    "agent_type": "DeepResearch",
                 }),
                 Some(&session_context("source_1")),
             )

--- a/src/crates/execution/agent-runtime/src/session_control.rs
+++ b/src/crates/execution/agent-runtime/src/session_control.rs
@@ -32,6 +32,12 @@ pub enum SessionControlAgentType {
     Plan,
     #[serde(rename = "Cowork", alias = "cowork", alias = "COWORK")]
     Cowork,
+    #[serde(
+        rename = "DeepResearch",
+        alias = "deepresearch",
+        alias = "DEEPRESEARCH"
+    )]
+    DeepResearch,
 }
 
 impl SessionControlAgentType {
@@ -40,6 +46,7 @@ impl SessionControlAgentType {
             Self::Agentic => "agentic",
             Self::Plan => "Plan",
             Self::Cowork => "Cowork",
+            Self::DeepResearch => "DeepResearch",
         }
     }
 }

--- a/src/crates/execution/agent-runtime/tests/agent_session_contracts/session_control_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/agent_session_contracts/session_control_contracts.rs
@@ -51,7 +51,7 @@ fn rejects_current_session_mutation_when_context_matches() {
 fn validates_create_requires_workspace_and_creator_session() {
     let mut input = base_input(SessionControlAction::Create);
     input.workspace = Some(std::env::temp_dir().to_string_lossy().to_string());
-    input.agent_type = Some(SessionControlAgentType::Plan);
+    input.agent_type = Some(SessionControlAgentType::DeepResearch);
 
     let missing_creator =
         validate_session_control_input(&input, SessionControlValidationContext::default());
@@ -89,8 +89,8 @@ fn renders_tool_message_without_core_context() {
 fn builds_stable_result_messages() {
     let workspace = std::env::temp_dir().to_string_lossy().to_string();
     assert_eq!(
-        session_control_created_result_message("session_a", &workspace, "Plan"),
-        format!("Created session 'session_a' in workspace '{workspace}' using agent type 'Plan'.")
+        session_control_created_result_message("session_a", &workspace, "DeepResearch"),
+        format!("Created session 'session_a' in workspace '{workspace}' using agent type 'DeepResearch'.")
     );
     assert_eq!(
         session_control_cancel_result_message("worker_1", &workspace, Some("turn_1")),


### PR DESCRIPTION
## Summary

Add `DeepResearch` as an allowed agent type for the `SessionControl` and `SessionMessage` tools.

The existing `agentic`, `Plan`, and `Cowork` agent types remain supported.

## Type and Areas

Type:

Feature

Areas:

Rust core, Agent Runtime

## Motivation / Impact

This enables agents to create and message `DeepResearch` sessions through the session tools.

The new agent type is available in:

- Tool descriptions.
- Input schemas.
- Session message deserialization.
- Session control runtime contracts.

DeepResearch also supports the existing canonical name and lowercase aliases.

## Verification

- `cargo test --locked -p bitfun-agent-runtime --test agent_session_contracts session_control_contracts`
  - 6 passed.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime --lib agentic::tools::implementations::session_`
  - 24 passed.
- `git diff --cached --check`
  - Passed.

## Reviewer Notes

- `Plan` and `Cowork` remain available.
- `DeepResearch` is exposed as `DeepResearch` with `deepresearch` and `DEEPRESEARCH` deserialization aliases.
- No UI changes or manual UI verification were required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.