### PR TITLE
fix(installer): align AI config and add CI compilation check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,12 @@ jobs:
       - name: Check compilation
         run: cargo check --locked --workspace
 
+      # The installer is intentionally excluded from the root Cargo workspace,
+      # so the workspace check above cannot catch drift in its shared Rust APIs.
+      - name: Check installer compilation
+        if: runner.os == 'Windows'
+        run: cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml
+
       - name: Run core and desktop library tests
         run: cargo test --locked -p bitfun-core -p bitfun-desktop --lib
 

--- a/BitFun-Installer/src-tauri/src/installer/ai_config.rs
+++ b/BitFun-Installer/src-tauri/src/installer/ai_config.rs
@@ -1,7 +1,7 @@
 //! Map installer `ModelConfig` to shared AI adapter config.
 
 use crate::installer::types::ModelConfig;
-use bitfun_ai_adapters::types::{resolve_request_url, AIConfig, ReasoningMode};
+use bitfun_ai_adapters::types::{resolve_request_url, AIConfig};
 use log::warn;
 
 /// Build `AIConfig` for the shared AI client.
@@ -47,13 +47,10 @@ pub(super) fn ai_config_from_installer_model(m: &ModelConfig) -> Result<AIConfig
         max_tokens: None,
         temperature: None,
         top_p: None,
-        reasoning_mode: ReasoningMode::Default,
         inline_think_in_text: false,
         custom_headers: m.custom_headers.clone(),
         custom_headers_mode: m.custom_headers_mode.clone(),
         skip_ssl_verify: m.skip_ssl_verify.unwrap_or(false),
-        reasoning_effort: None,
-        thinking_budget_tokens: None,
         custom_request_body,
         custom_request_body_mode: None,
     })

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -258,6 +258,14 @@ test('keeps Rust CI independent, restore-only on PRs, and target-focused', () =>
     commandByStep.get('Run subscription authentication tests'),
     'cargo test --locked -p bitfun-ai-adapters --features subscription-auth --lib subscription_auth',
   );
+  const installerCheck = rustJob.steps.find(
+    (step) => step.name === 'Check installer compilation',
+  );
+  assert.equal(installerCheck?.if, "runner.os == 'Windows'");
+  assert.equal(
+    installerCheck?.run,
+    'cargo check --manifest-path BitFun-Installer/src-tauri/Cargo.toml',
+  );
   assert.equal(
     commandByStep.get('Run file watch contract tests'),
     'cargo test --locked -p bitfun-services-integrations --no-default-features --features file-watch --test file_watch_contracts',


### PR DESCRIPTION
- Remove deprecated reasoning fields from the installer AIConfig mapping.
- Add a Windows CI compilation check for the standalone installer crate.
- Extend GitHub workflow contract tests to enforce the installer check.

Fixes #2107
