### PR TITLE
fix(compression): add timeout to AI compression summary call

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -463,6 +463,11 @@ pub struct ExecutionEngine {
 impl ExecutionEngine {
     const AUTO_COMPRESSION_SAFETY_RESERVE_TOKENS: usize = 10_000;
     const MAX_COMPRESSION_OVERFLOW_ATTEMPTS: usize = 4;
+    /// Maximum wall-clock time to wait for an AI model compression summary.
+    /// If exceeded, fall back to local structured compression to avoid
+    /// blocking the conversation round loop.
+    const COMPRESSION_MODEL_SUMMARY_TIMEOUT: std::time::Duration =
+        std::time::Duration::from_secs(30);
     const MAX_MAIN_CONTEXT_OVERFLOW_RECOVERIES: usize = 2;
     const FINALIZE_AFTER_REPEATED_TOOL_FAILURES_REMINDER: &'static str = "This turn must end now because repeated tool failures have prevented further progress. Ignore any unfinished work. Your task now is to give the user a final answer. Do not call any more tools; any tool call will fail. Respond in plain text only. Summarize what was completed, what failed, the evidence available from the tool results, and the single best next step for the user.";
     const FINALIZE_AFTER_MAX_ROUNDS_REMINDER: &'static str = "This turn must end now because it has reached the round limit. Ignore any unfinished work. Your task now is to give the user a final answer. Do not call any more tools; any tool call will fail. Respond in plain text only. Summarize the most useful completed work and evidence collected so far, and clearly distinguish resolved items from anything still unresolved.";
@@ -2070,8 +2075,9 @@ impl ExecutionEngine {
                 plan.recent_tail_messages.len()
             );
 
-            let summary_result = self
-                .generate_compression_model_summary(CompressionModelSummaryInput {
+            let summary_result = match tokio::time::timeout(
+                Self::COMPRESSION_MODEL_SUMMARY_TIMEOUT,
+                self.generate_compression_model_summary(CompressionModelSummaryInput {
                     ai_client: ai_client.clone(),
                     runtime_messages: &plan.summary_request_messages,
                     dialog_turn_id,
@@ -2080,8 +2086,22 @@ impl ExecutionEngine {
                     prepended_prompt_reminders,
                     primary_supports_image_understanding,
                     trace_config: trace_config.clone(),
-                })
-                .await;
+                }),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_elapsed) => {
+                    warn!(
+                        "Compression model summary timed out after {:?}, falling back to structured local compression",
+                        Self::COMPRESSION_MODEL_SUMMARY_TIMEOUT
+                    );
+                    Err(BitFunError::Timeout(format!(
+                        "Compression model summary timed out after {:?}",
+                        Self::COMPRESSION_MODEL_SUMMARY_TIMEOUT
+                    )))
+                }
+            };
 
             match summary_result {
                 Ok(summary) => {


### PR DESCRIPTION
## Summary

Fixes #1529

The context compression AI model call blocks the conversation round loop synchronously. When the model is slow or unresponsive, the entire conversation freezes with no fallback path.

## Problem

In `build_planned_compression_result`, the call to `generate_compression_model_summary` (which internally calls `request_compression_summary_with_retry` with up to 2 retries and exponential backoff) runs without any time bound. If the AI provider is slow or hangs, the conversation is blocked for the full duration of all retry attempts with no escape.

The previous fix attempt (#2051) changed the safety reserve threshold, which the issue owner rejected because it doesn't address the core synchronous blocking problem.

## Fix

Wrap `generate_compression_model_summary` in `tokio::time::timeout(30s)`. On timeout:
1. Return `BitFunError::Timeout(...)`
2. This error does NOT match `is_recoverable_context_overflow()`, so it falls into the **existing** generic error fallback path (`Err(err) =>` branch)
3. The fallback keeps the selected compression plan but sets `model_summary = None`
4. `compress_plan_with_contract` then uses local structured compression instead of the AI summary

No new code paths are introduced — the timeout simply activates an existing fallback that was already handling other non-overflow errors (network failures, auth errors, etc.).

## Changes

- Added `COMPRESSION_MODEL_SUMMARY_TIMEOUT` constant (30 seconds)
- Wrapped the `generate_compression_model_summary` call in `tokio::time::timeout` with a warning log on timeout

## Validation

- `cargo check -p bitfun-core` — compiles cleanly (exit code 0, no new warnings)
- The existing fallback path at the `Err(err) =>` branch handles timeout errors identically to other non-overflow failures

## Why 30 seconds?

- A typical compression summary request completes within 5-15 seconds
- 30 seconds allows for one retry within the existing retry logic (500ms base delay + 2 attempts)
- If the call hasn't completed in 30s, the model is likely stuck, and local compression is a better user experience than indefinite blocking
