### PR TITLE
fix(review): allow ReviewFixer as builtin session primary agent

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/registry/external.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/external.rs
@@ -1,7 +1,9 @@
 use super::types::{AgentCategory, AgentEntry, AgentInfo, AgentSource, SubAgentSource};
 use super::AgentRegistry;
 use crate::agentic::agents::{Agent, SubagentVisibilityPolicy};
-use crate::agentic::deep_review_policy::{CODE_REVIEW_AGENT_TYPE, DEEP_REVIEW_AGENT_TYPE};
+use crate::agentic::deep_review_policy::{
+    CODE_REVIEW_AGENT_TYPE, DEEP_REVIEW_AGENT_TYPE, REVIEW_FIXER_AGENT_TYPE,
+};
 use crate::agentic::workspace::canonical_local_workspace_path;
 use bitfun_agent_runtime::prompt_cache::prompt_cache_scope_key;
 use bitfun_core_types::{
@@ -614,19 +616,23 @@ fn local_binding(logical_id: &str, runtime_agent_key: &str) -> ExternalSubagentI
 /// though they are not registered as `Mode` (review child sessions).
 ///
 /// Review child sessions are created by the product surfaces with
-/// `agentType=CodeReview` (standard) or `agentType=DeepReview` (strict) and
-/// must resolve through the primary-agent path for create, turn, restore, and
-/// compaction. Other subagents (e.g. `ReviewWorker`) stay restricted.
+/// `agentType=CodeReview` (standard), `agentType=DeepReview` (strict), or
+/// `agentType=ReviewFixer` (fix phase) and must resolve through the
+/// primary-agent path for create, turn, restore, and compaction. Other
+/// subagents (e.g. `ReviewWorker`) stay restricted.
 fn is_builtin_session_primary_agent(id: &str) -> bool {
-    matches!(id, CODE_REVIEW_AGENT_TYPE | DEEP_REVIEW_AGENT_TYPE)
+    matches!(
+        id,
+        CODE_REVIEW_AGENT_TYPE | DEEP_REVIEW_AGENT_TYPE | REVIEW_FIXER_AGENT_TYPE
+    )
 }
 
 /// Whether a locally-resolved agent entry may act as a session primary agent.
 ///
 /// Used by both the explicit `ExternalSubagentRoute::Local` branch and the
-/// no-route fallback so review child sessions (CodeReview/DeepReview) resolve
-/// identically regardless of whether a workspace route table pins them to the
-/// local implementation.
+/// no-route fallback so review child sessions (CodeReview/DeepReview/ReviewFixer)
+/// resolve identically regardless of whether a workspace route table pins them
+/// to the local implementation.
 fn is_local_session_primary_entry(entry: &AgentEntry) -> bool {
     entry.category == AgentCategory::Mode
         || (entry.source == AgentSource::Builtin

--- a/src/crates/assembly/core/src/agentic/agents/registry/tests.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/tests.rs
@@ -1594,7 +1594,7 @@ fn external_primary_route_follows_the_session_execution_worktree() {
 fn builtin_review_agents_resolve_as_local_session_primaries() {
     let registry = AgentRegistry::new();
 
-    for agent_type in ["CodeReview", "DeepReview"] {
+    for agent_type in ["CodeReview", "DeepReview", "ReviewFixer"] {
         let binding = registry
             .resolve_primary_agent_for_turn(agent_type, None, false, None)
             .unwrap_or_else(|| {
@@ -1641,13 +1641,14 @@ fn local_route_resolves_review_agents_as_session_primaries() {
         [
             ("CodeReview".to_string(), ExternalSubagentRoute::Local),
             ("DeepReview".to_string(), ExternalSubagentRoute::Local),
+            ("ReviewFixer".to_string(), ExternalSubagentRoute::Local),
             ("ReviewWorker".to_string(), ExternalSubagentRoute::Local),
         ]
         .into_iter()
         .collect(),
     );
 
-    for agent_type in ["CodeReview", "DeepReview"] {
+    for agent_type in ["CodeReview", "DeepReview", "ReviewFixer"] {
         let binding = registry
             .resolve_primary_agent_for_turn(agent_type, Some(&workspace), true, None)
             .unwrap_or_else(|| panic!("{agent_type} must resolve through an explicit Local route"));

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -14539,7 +14539,7 @@ mod tests {
     async fn review_agent_child_sessions_create_successfully() {
         let (coordinator, _session_manager) = test_coordinator();
 
-        for agent_type in ["CodeReview", "DeepReview"] {
+        for agent_type in ["CodeReview", "DeepReview", "ReviewFixer"] {
             let workspace = tempfile::tempdir().expect("review workspace");
             let session = coordinator
                 .create_session_with_workspace(


### PR DESCRIPTION
## Problem

The review fix phase fails with:
```
Failed to start dialog turn: Unknown session mode: ReviewFixer
```

## Root Cause

PR #2106 (commit `97a4afaa5`) added `CodeReview` and `DeepReview` to the `is_builtin_session_primary_agent` whitelist but missed `ReviewFixer`. The fix phase creates child sessions with `agentType=ReviewFixer`, which then fails to resolve through the primary-agent path because it's not in the whitelist.

## Fix

Add `REVIEW_FIXER_AGENT_TYPE` to the `is_builtin_session_primary_agent` whitelist in `external.rs`, so `ReviewFixer` child sessions resolve through the primary-agent path for create, turn, restore, and compaction — matching `CodeReview` and `DeepReview`.

### Changes

1. **`external.rs`**: Import `REVIEW_FIXER_AGENT_TYPE` and add it to the `is_builtin_session_primary_agent` `matches!` arm. Updated doc comments to mention `ReviewFixer`.
2. **`tests.rs`**: Added `ReviewFixer` to `builtin_review_agents_resolve_as_local_session_primaries` and `local_route_resolves_review_agents_as_session_primaries` test arrays.
3. **`coordinator.rs`**: Added `ReviewFixer` to the `review_agent_child_sessions_create_successfully` test array.

## Validation

- `cargo check -p bitfun-core` — passed
- `cargo test -p bitfun-core` — all 4 targeted tests pass:
  - `builtin_review_agents_resolve_as_local_session_primaries` ✅
  - `non_session_primary_subagents_and_unknown_ids_do_not_resolve` ✅ (ReviewWorker still restricted)
  - `local_route_resolves_review_agents_as_session_primaries` ✅
  - `review_agent_child_sessions_create_successfully` ✅

Closes #2124
