### PR TITLE
fix: prevent stuck disabled message buttons after stop generation (#1508)

### DIFF
--- a/src/web-ui/src/flow_chat/utils/flowChatTurnOrdinal.ts
+++ b/src/web-ui/src/flow_chat/utils/flowChatTurnOrdinal.ts
@@ -28,7 +28,9 @@ export function absoluteSessionTurnIndexForId(
   turnId: string,
 ): number | undefined {
   const ordinal = resolveTurnOrdinal(session, turnId);
-  return ordinal === undefined ? undefined : ordinal + 1;
+  if (ordinal !== undefined) return ordinal + 1;
+  const localIndex = session.dialogTurns.findIndex(turn => turn.id === turnId);
+  return localIndex < 0 ? undefined : absoluteSessionTurnIndexForLocalIndex(session, localIndex);
 }
 
 export function loadedSessionTurnIdForAbsoluteIndex(


### PR DESCRIPTION
## Fix: Stuck disabled message buttons after Stop Generation (#1508)

### Problem

After clicking "Stop Generation" during an AI response, message action buttons (edit, rollback) become permanently unclickable. The tooltip shows "Session history is not ready yet" (`editDisabledHistoryNotReady`). This persists for the entire conversation and only resolves when a new conversation is started.

### Root Cause

`absoluteSessionTurnIndexForId` in `flowChatTurnOrdinal.ts` returns `undefined` when the turn catalog (`validSessionTurnCatalog`) is stale or invalid -- which happens after Stop Generation interrupts async session initialization and `markSessionFinished` creates a new session object via spread.

When `absoluteSessionTurnIndexForId` returns `undefined`, `UserMessageItem.tsx` computes `actionTurnIndex = -1`, which triggers the `!resolvedSessionId || actionTurnIndex < 0` condition that disables the edit/rollback buttons with the "history not ready" tooltip.

The sibling functions `absoluteSessionTurnIndexForLocalIndex` and `createAbsoluteSessionTurnIndexResolver` both already have a `localIndex + 1` fallback for when the ordinal resolver returns `undefined`. Only `absoluteSessionTurnIndexForId` was missing this fallback.

### Fix

Add a local-index fallback to `absoluteSessionTurnIndexForId`: when `resolveTurnOrdinal` returns `undefined`, find the turn's local index in `session.dialogTurns` and delegate to `absoluteSessionTurnIndexForLocalIndex` (which has the `localIndex + 1` fallback).

This makes all three turn-index resolution functions consistent in their fallback behavior.

### Validation

- `tsc --noEmit` on `src/web-ui` passes (no new type errors from this change)
- The fix is minimal -- 3 lines changed, no new dependencies, no API changes

### Testing

The fix can be verified by:
1. Start a conversation and send a message
2. While the AI is responding, click "Stop Generation"
3. After generation stops, hover over the edit/rollback buttons on any message
4. The buttons should be clickable (no "Session history is not ready yet" tooltip)

Fixes #1508
