### PR TITLE
fix: strip tool invocation artifacts from assistant text to prevent context explosion (#1492)

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -5,6 +5,9 @@
 use super::model_exchange_trace::prepare_model_exchange_trace;
 use super::stream_processor::{StreamProcessOptions, StreamProcessor, StreamResult};
 use super::types::{FinishReason, RoundContext, RoundResult};
+use super::write_content_sanitizer::{
+    contains_tool_invocation_artifacts, strip_tool_invocation_artifacts,
+};
 use crate::agentic::core::{Message, ToolCall};
 use crate::agentic::events::{
     AgenticEvent, EventPriority, EventQueue, ModelRoundAttemptDiagnostic,
@@ -1180,6 +1183,12 @@ impl RoundExecutor {
         let parsed_memory_citation =
             Self::parsed_memory_citation_from_stream_result(&stream_result);
         let (clean_text, _) = strip_bitfun_memory_citations(&stream_result.full_text);
+        let clean_text = if contains_tool_invocation_artifacts(&clean_text) {
+            warn!("Detected tool invocation artifacts in assistant text, stripping to prevent context explosion");
+            strip_tool_invocation_artifacts(&clean_text)
+        } else {
+            clean_text
+        };
         let assistant_message =
             Message::assistant_with_reasoning(reasoning, clean_text, tool_calls.clone())
                 .with_turn_id(context.dialog_turn_id.clone())

--- a/src/crates/assembly/core/src/agentic/execution/write_content_sanitizer.rs
+++ b/src/crates/assembly/core/src/agentic/execution/write_content_sanitizer.rs
@@ -120,4 +120,27 @@ mod tests {
             "export const value = 1;"
         );
     }
+
+    /// Regression test for issue #1492: when a model leaks `<tool_calls>` XML as
+    /// plain text content instead of structured tool-call deltas, the assistant
+    /// text must be detected and stripped so the artifacts do not pollute the
+    /// next round's context and cause infinite recursion.
+    #[test]
+    fn strips_leaked_tool_calls_xml_from_assistant_text() {
+        let leaked = concat!(
+            "I'll help you with that.\n",
+            "<tool_calls>\n",
+            "<invoke name=\"Read\">\n",
+            "<parameter name=\"file_path\">src/main.rs</parameter>\n",
+            "</invoke>\n",
+            "</tool_calls>\n",
+            "Let me read the file first."
+        );
+        assert!(contains_tool_invocation_artifacts(leaked));
+        let stripped = strip_tool_invocation_artifacts(leaked);
+        assert!(!stripped.contains("<tool_calls"));
+        assert!(!stripped.contains("<invoke"));
+        assert!(stripped.contains("I'll help you with that."));
+        assert!(stripped.contains("Let me read the file first."));
+    }
 }


### PR DESCRIPTION
## Fix #1492: Strip tool invocation artifacts from assistant text to prevent context explosion

### Problem

When a model outputs `<tool_calls>` XML as plain text content (instead of structured tool-call deltas), the system re-parses it as actual tool calls, causing infinite recursion and context explosion. The leaked XML passes through to the next round's context unchanged.

### Root Cause

In `round_executor.rs`, after receiving the assistant's text content, the code calls `strip_bitfun_memory_citations()` but does NOT check for tool invocation artifacts. Leaked `<tool_calls>` XML passes through as-is to the next round's context, where it gets re-parsed and causes the infinite loop described in #1492.

### Fix

The `write_content_sanitizer.rs` module already has reusable `contains_tool_invocation_artifacts()` and `strip_tool_invocation_artifacts()` functions — they were previously only applied to Write tool `content` arguments. This PR applies them to assistant text output as well:

1. **`round_executor.rs`**: After `strip_bitfun_memory_citations`, conditionally check and strip tool invocation artifacts from the assistant text, with a `warn!` log for observability.
2. **`write_content_sanitizer.rs`**: Added regression test `strips_leaked_tool_calls_xml_from_assistant_text` covering the exact #1492 scenario.

### Validation

- `cargo check -p bitfun-core` — passes
- `cargo test -p bitfun-core write_content_sanitizer -- --nocapture` — all 5 tests pass (4 original + 1 new regression test)

### Files Changed

- `src/crates/assembly/core/src/agentic/execution/round_executor.rs` (9 lines added)
- `src/crates/assembly/core/src/agentic/execution/write_content_sanitizer.rs` (23 lines added)

Closes #1492
