### PR TITLE
fix(web-ui): prevent ACP session hydrate deadlock on re-switch

### DIFF
--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -31,6 +31,7 @@ import {
   resolveSessionTitle,
 } from '../../utils/sessionTitle';
 import { buildCreateSessionRelationship } from '../../utils/sessionMetadata';
+import { isAcpFlowSession } from '../../utils/acpSession';
 import {
   consumeRecentHistorySessionOpenIntent,
   hasRenderableSessionContent,
@@ -701,6 +702,7 @@ export async function switchChatSession(
         await hydrateHistoricalSession(context, sessionId, true, {
           isRetryStillRelevant: () => switchRequestId === latestSwitchRequestId,
           retryActiveStaleReuse: shouldActivateBeforeHydrate,
+          deferFullHistoryUntilActive: !isAcpFlowSession(session),
         });
       } catch {
         // The hydrate path already marks the session failed and notifies the user.


### PR DESCRIPTION
## Problem

When switching back to a previously-loaded ACP session, the UI shows a permanent loading overlay and never displays content. The agent appears stuck.

**Issue:** #1038

## Root Cause

A deadlock in `switchChatSession` (`SessionModule.ts`) for ACP sessions:

1. `shouldHydrateHistoricalSessionBeforeSwitch` returns `true` for `isHistorical` sessions with no renderable content
2. `shouldActivateBeforeHydrate` requires `consumeRecentHistorySessionOpenIntent(sessionId)` — but running ACP sessions never get an intent (they're filtered by `isRunning` in `SessionsSection.tsx`)
3. With `shouldActivateBeforeHydrate=false`, the flow is **hydrate-first-then-activate** (lines 700-728)
4. `hydrateHistoricalSession` defaults `deferFullHistoryUntilActive=true` (line 256)
5. When hydrate completes, `activeSessionId !== sessionId` is still true (activation hasn't happened yet) → `skipStaleLocalHydrateCommit` in `FlowChatStore.ts:7398-7401` fires and **discards** the loaded turns, resetting to `metadata-only`
6. Then `switchSession(sessionId)` activates it (line 728) — but with empty turns and `metadata-only` state, the overlay is stuck forever

## Fix

Pass `deferFullHistoryUntilActive: false` for ACP sessions in the `hydrateHistoricalSession` call within `switchChatSession`. This ensures the hydrate commit is **not discarded** even when activation happens after hydration. The subsequent `switchSession` call then activates a session that already has its loaded turns.

**Changes:**
- Import `isAcpFlowSession` from `../../utils/acpSession`
- Pass `deferFullHistoryUntilActive: !isAcpFlowSession(session)` to the hydrate call

Non-ACP sessions retain the default `true` behavior (defer until active), so this change has no effect on existing session switching behavior.

## Testing

- TypeScript compilation passes (no new type errors)
- Existing session switching behavior for non-ACP sessions is unchanged
- ACP sessions now properly commit their loaded history even when activation follows hydration
