### PR TITLE
fix: add ReviewFixer to builtin session primary agent whitelist (#2124)

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/registry/external.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/external.rs
@@ -1,7 +1,9 @@
 use super::types::{AgentCategory, AgentEntry, AgentInfo, AgentSource, SubAgentSource};
 use super::AgentRegistry;
 use crate::agentic::agents::{Agent, SubagentVisibilityPolicy};
-use crate::agentic::deep_review_policy::{CODE_REVIEW_AGENT_TYPE, DEEP_REVIEW_AGENT_TYPE};
+use crate::agentic::deep_review_policy::{
+    CODE_REVIEW_AGENT_TYPE, DEEP_REVIEW_AGENT_TYPE, REVIEW_FIXER_AGENT_TYPE,
+};
 use crate::agentic::workspace::canonical_local_workspace_path;
 use bitfun_agent_runtime::prompt_cache::prompt_cache_scope_key;
 use bitfun_core_types::{
@@ -616,17 +618,22 @@ fn local_binding(logical_id: &str, runtime_agent_key: &str) -> ExternalSubagentI
 /// Review child sessions are created by the product surfaces with
 /// `agentType=CodeReview` (standard) or `agentType=DeepReview` (strict) and
 /// must resolve through the primary-agent path for create, turn, restore, and
-/// compaction. Other subagents (e.g. `ReviewWorker`) stay restricted.
+/// compaction. `ReviewFixer` is submitted by the fix phase
+/// (`DeepReviewActionBar.handleStartFixing`) and must likewise resolve as a
+/// primary agent. Other subagents (e.g. `ReviewWorker`) stay restricted.
 fn is_builtin_session_primary_agent(id: &str) -> bool {
-    matches!(id, CODE_REVIEW_AGENT_TYPE | DEEP_REVIEW_AGENT_TYPE)
+    matches!(
+        id,
+        CODE_REVIEW_AGENT_TYPE | DEEP_REVIEW_AGENT_TYPE | REVIEW_FIXER_AGENT_TYPE
+    )
 }
 
 /// Whether a locally-resolved agent entry may act as a session primary agent.
 ///
 /// Used by both the explicit `ExternalSubagentRoute::Local` branch and the
-/// no-route fallback so review child sessions (CodeReview/DeepReview) resolve
-/// identically regardless of whether a workspace route table pins them to the
-/// local implementation.
+/// no-route fallback so review child sessions (CodeReview/DeepReview/ReviewFixer)
+/// resolve identically regardless of whether a workspace route table pins them
+/// to the local implementation.
 fn is_local_session_primary_entry(entry: &AgentEntry) -> bool {
     entry.category == AgentCategory::Mode
         || (entry.source == AgentSource::Builtin

--- a/src/crates/assembly/core/src/agentic/agents/registry/tests.rs
+++ b/src/crates/assembly/core/src/agentic/agents/registry/tests.rs
@@ -1594,7 +1594,7 @@ fn external_primary_route_follows_the_session_execution_worktree() {
 fn builtin_review_agents_resolve_as_local_session_primaries() {
     let registry = AgentRegistry::new();
 
-    for agent_type in ["CodeReview", "DeepReview"] {
+    for agent_type in ["CodeReview", "DeepReview", "ReviewFixer"] {
         let binding = registry
             .resolve_primary_agent_for_turn(agent_type, None, false, None)
             .unwrap_or_else(|| {
@@ -1641,13 +1641,14 @@ fn local_route_resolves_review_agents_as_session_primaries() {
         [
             ("CodeReview".to_string(), ExternalSubagentRoute::Local),
             ("DeepReview".to_string(), ExternalSubagentRoute::Local),
+            ("ReviewFixer".to_string(), ExternalSubagentRoute::Local),
             ("ReviewWorker".to_string(), ExternalSubagentRoute::Local),
         ]
         .into_iter()
         .collect(),
     );
 
-    for agent_type in ["CodeReview", "DeepReview"] {
+    for agent_type in ["CodeReview", "DeepReview", "ReviewFixer"] {
         let binding = registry
             .resolve_primary_agent_for_turn(agent_type, Some(&workspace), true, None)
             .unwrap_or_else(|| panic!("{agent_type} must resolve through an explicit Local route"));

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -14540,7 +14540,7 @@ mod tests {
     async fn review_agent_child_sessions_create_successfully() {
         let (coordinator, _session_manager) = test_coordinator();
 
-        for agent_type in ["CodeReview", "DeepReview"] {
+        for agent_type in ["CodeReview", "DeepReview", "ReviewFixer"] {
             let workspace = tempfile::tempdir().expect("review workspace");
             let session = coordinator
                 .create_session_with_workspace(


### PR DESCRIPTION
## Problem

Issue #2124: Starting the Review Fix phase fails with `Unknown session mode: ReviewFixer`.

PR #2106 fixed the first half of the external primary agent profile resolution issue — CodeReview and DeepReview were blocked at session creation because `is_builtin_session_primary_agent` did not whitelist them. However, the fix phase was missed: `ReviewFixer` (submitted by `DeepReviewActionBar.handleStartFixing → sendMessage(..., 'ReviewFixer', 'agentic')`) is still not in the whitelist.

## Root Cause

`src/crates/assembly/core/src/agentic/agents/registry/external.rs` — `is_builtin_session_primary_agent` only matched `CODE_REVIEW_AGENT_TYPE` and `DEEP_REVIEW_AGENT_TYPE`, not `REVIEW_FIXER_AGENT_TYPE`.

When the frontend submits `agentType='ReviewFixer'`, the coordinator calls `resolve_primary_agent_for_workspace` which hits `is_builtin_session_primary_agent`. Since `ReviewFixer` is not whitelisted, it falls through to the external-subagent resolution path and fails with `Unknown session mode: ReviewFixer`.

## Fix

Add `REVIEW_FIXER_AGENT_TYPE` to the `is_builtin_session_primary_agent` whitelist, so ReviewFixer resolves through the local primary-agent path for create, turn, restore, and compaction — same as CodeReview and DeepReview.

## Changes

1. **`external.rs`** — Import `REVIEW_FIXER_AGENT_TYPE` and add it to the `is_builtin_session_primary_agent` match. Update doc comments on `is_builtin_session_primary_agent` and `is_local_session_primary_entry`.

2. **`tests.rs`** — Add `"ReviewFixer"` to `builtin_review_agents_resolve_as_local_session_primaries` and `local_route_resolves_review_agents_as_session_primaries`.

3. **`coordinator.rs`** — Add `"ReviewFixer"` to `review_agent_child_sessions_create_successfully`.

## Validation

- `cargo check -p bitfun-core --no-default-features --features agent-runtime` — pass
- `cargo test ... builtin_review_agents_resolve_as_local_session_primaries` — 1 passed
- `cargo test ... local_route_resolves_review_agents_as_session_primaries` — 1 passed
- `cargo test ... review_agent_child_sessions_create_successfully` — 1 passed (with canvas-runtime)

## Related

- Fixes #2124
- Supersedes incomplete fix in #2106
