### PR TITLE
fix(agents): reduce Explore subagent overuse by strengthening prompt guidance

### DIFF
--- a/src/crates/assembly/agent-content/prompts/agents/agentic_mode.md
+++ b/src/crates/assembly/agent-content/prompts/agents/agentic_mode.md
@@ -88,6 +88,7 @@ The user will primarily request you perform software engineering tasks. This inc
 
 # Tool usage policy
 - Prefer the most direct tool path that preserves accuracy: use Read, Grep, and Glob for narrow lookups; use Task subagents for broad, multi-area, or independently delegable work.
+- Reserve the Explore subagent for truly open-ended exploration — broad architectural questions, unfamiliar code areas, or tracing across many modules. For targeted queries (known symbols, specific files, single search patterns), use Grep, Glob, and Read directly. Spawning Explore for simple lookups adds latency without improving results.
 - When the user explicitly asks to complete work and review it carefully, finish the implementation first, then dispatch one independent read-only `CodeReview` Task. Do not run concurrent review tasks or fan out `CodeReview` into architecture, performance, security, product, or other invented dimensions: broader coverage belongs to the unified `/review` path, which selects bounded review lenses and owns cost confirmation. Do not launch review by default for every task.
 - Treat reviewer output as adversarial evidence. The reviewer never fixes its own findings. Apply accepted fixes in the implementation agent. If substantive fixes make the original verdict stale and the risk warrants another pass, request at most one fresh independent re-review.
 - When WebFetch reports a redirect, follow the redirect URL if it is relevant and safe for the user's request.

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/schema.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/schema.rs
@@ -86,6 +86,7 @@ impl TaskTool {
 When to use:
 - Delegate when a specialized subagent or separate context is likely to improve coverage, independence, or parallelism.
 - Use direct tools instead for focused lookups, known paths, single symbols, or code that can be inspected with a few reads or searches.
+- The Explore subagent is for broad, open-ended codebase exploration. Do not spawn it for targeted lookups that a single Grep, Glob, or Read can handle — that adds latency without improving results.
 
 Supported actions:
 - `spawn`: create and run a new subagent. The result contains an `agent_id` for future `send_input` or `cancel`.


### PR DESCRIPTION
## Fixes #216

## Problem

The Explore subagent was being triggered too frequently for simple, targeted queries where direct Grep/Glob/Read would be faster and more accurate. This added unnecessary latency without improving results.

## Root Cause

While the strongest offending language ("VERY IMPORTANT... CRITICAL that you use the Task tool with subagent_type=Explore") had already been removed in a prior change, the remaining guidance was too generic about "Task subagents" and did not explicitly call out Explore-specific overuse patterns.

## Solution

Add explicit guidance in two places to reserve the Explore subagent for truly open-ended exploration:

1. **agentic_mode.md** (Tool usage policy): New bullet clarifying that Explore should be reserved for broad architectural questions, unfamiliar code areas, or multi-module tracing — and that spawning it for targeted lookups (known symbols, specific files, single search patterns) adds latency without improving results.

2. **task/schema.rs** (Task tool description): New bullet in the "When to use" section discouraging Explore for targeted lookups that a single Grep, Glob, or Read can handle.

## Validation

- `cargo check -p bitfun-core` — passes (only pre-existing dead-code warning)
- `cargo test -p bitfun-agent-content --test prompt_catalog_contracts` — 3/3 tests pass
- `rustfmt` on changed Rust file — clean
