### PR TITLE
fix(web-ui): prevent file mention picker positioning regression

### DIFF
--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.scss
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.scss
@@ -33,6 +33,10 @@
 
   &--overlay {
     position: fixed;
+    // The non-portalled picker is positioned with `bottom`; clear that
+    // constraint when the overlay is placed by the viewport anchor hook.
+    bottom: auto;
+    left: auto;
     z-index: $z-popover;
     width: min(400px, calc(100vw - 16px));
     min-width: min(260px, calc(100vw - 16px));


### PR DESCRIPTION
- Reset inherited `bottom` and `left` styles for portalled mention overlays.
- Let anchored viewport positioning control the picker placement.
- Verify with `FileMentionPickerOverlay.test.tsx`.
