### PR TITLE
fix(web-ui): restore MCP deletion and voice input

### DIFF
--- a/src/apps/desktop/Info.plist
+++ b/src/apps/desktop/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>BitFun uses the microphone for voice input and local speech transcription.</string>
+</dict>
+</plist>

--- a/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   finishInputSession: vi.fn(),
   cancelInputSession: vi.fn(async () => undefined),
   notificationInfo: vi.fn(),
+  notificationError: vi.fn(),
 }));
 
 vi.mock('@/infrastructure/api', () => ({
@@ -83,7 +84,7 @@ vi.mock('@/shared/notification-system', () => ({
   notificationService: {
     info: mocks.notificationInfo,
     warning: vi.fn(),
-    error: vi.fn(),
+    error: mocks.notificationError,
   },
 }));
 
@@ -137,6 +138,7 @@ describe('useComposerVoiceInput completion modes', () => {
     mocks.finishInputSession.mockClear();
     mocks.cancelInputSession.mockClear();
     mocks.notificationInfo.mockClear();
+    mocks.notificationError.mockClear();
     activateInput = vi.fn();
     focusInputSoon = vi.fn();
     insertText = vi.fn(() => 'Existing draft Transcribed request');
@@ -220,5 +222,33 @@ describe('useComposerVoiceInput completion modes', () => {
     expect(insertText).not.toHaveBeenCalled();
     expect(submitText).not.toHaveBeenCalled();
     expect(mocks.notificationInfo).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the idle control actionable when microphone capture is unavailable', async () => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: undefined,
+    });
+    await act(async () => {
+      root.render(
+        <Probe
+          activateInput={activateInput}
+          focusInputSoon={focusInputSoon}
+          insertText={insertText}
+          submitText={submitText}
+          onController={(next) => { controller = next; }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(controller?.disabled).toBe(false);
+    await act(async () => {
+      controller?.toggle();
+      await Promise.resolve();
+    });
+
+    expect(controller?.phase).toBe('idle');
+    expect(mocks.notificationError).toHaveBeenCalledWith('input.voiceInput.unsupported');
   });
 });

--- a/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.ts
+++ b/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.ts
@@ -623,9 +623,10 @@ export function useComposerVoiceInput({
     return () => window.removeEventListener('keydown', handleKeyDown, true);
   }, [cancelRecording, phase]);
 
-  const disabled = phase === 'recording'
-    ? false
-    : !settings?.enabled || !speechRuntimeSupported || !isMediaCaptureSupported() || phase === 'preparing' || phase === 'transcribing';
+  // Keep the idle control clickable when capture is unavailable so the
+  // start handler can explain the unsupported state instead of silently
+  // presenting a disabled button.
+  const disabled = phase === 'preparing' || phase === 'transcribing';
   const tooltip = useMemo(() => {
     if (!settings?.enabled) return t('input.voiceInput.disabled');
     if (!speechRuntimeSupported || !isMediaCaptureSupported()) return t('input.voiceInput.unsupported');

--- a/src/web-ui/src/infrastructure/config/components/McpToolsConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/McpToolsConfig.test.tsx
@@ -12,6 +12,8 @@ const loadJsonConfigMock = vi.hoisted(() => vi.fn());
 const saveJsonConfigMock = vi.hoisted(() => vi.fn());
 const initializeServersMock = vi.hoisted(() => vi.fn());
 const startServerMock = vi.hoisted(() => vi.fn());
+const deleteServerMock = vi.hoisted(() => vi.fn());
+const confirmDangerMock = vi.hoisted(() => vi.fn());
 const notificationMocks = vi.hoisted(() => ({
   success: vi.fn(),
   warning: vi.fn(),
@@ -35,6 +37,10 @@ vi.mock('@/infrastructure/runtime', () => ({
 vi.mock('@/shared/notification-system', () => ({
   useNotification: () => notificationMocks,
 }));
+vi.mock('@/component-library', async () => {
+  const actual = await vi.importActual<typeof import('@/component-library')>('@/component-library');
+  return { ...actual, confirmDanger: confirmDangerMock };
+});
 vi.mock('../../api/service-api/MCPAPI', () => ({
   MCPAPI: {
     getServers: getServersMock,
@@ -42,6 +48,7 @@ vi.mock('../../api/service-api/MCPAPI', () => ({
     saveMCPJsonConfig: saveJsonConfigMock,
     initializeServers: initializeServersMock,
     startServer: startServerMock,
+    deleteServer: deleteServerMock,
   },
 }));
 vi.mock('../../api/service-api/SystemAPI', () => ({ systemAPI: {} }));
@@ -67,6 +74,8 @@ describe('McpToolsConfig remote behavior', () => {
     saveJsonConfigMock.mockReset().mockResolvedValue(undefined);
     initializeServersMock.mockReset().mockResolvedValue(undefined);
     startServerMock.mockReset().mockResolvedValue(undefined);
+    deleteServerMock.mockReset().mockResolvedValue(undefined);
+    confirmDangerMock.mockReset().mockResolvedValue(true);
     notificationMocks.success.mockReset();
     notificationMocks.warning.mockReset();
     notificationMocks.error.mockReset();
@@ -261,5 +270,46 @@ describe('McpToolsConfig remote behavior', () => {
     expect(notificationMocks.success).not.toHaveBeenCalled();
     expect(notificationMocks.error).not.toHaveBeenCalled();
     expect(getServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes a server after confirmation and reloads the list', async () => {
+    peerState.active = false;
+    const server = {
+      id: 'local-test',
+      name: 'Local test server',
+      status: 'Stopped',
+      serverType: 'local',
+      transport: 'stdio',
+      enabled: true,
+      autoStart: false,
+      commandAvailable: true,
+      startSupported: true,
+    };
+    getServersMock
+      .mockResolvedValueOnce([server])
+      .mockResolvedValueOnce([]);
+
+    await act(async () => {
+      root.render(<McpToolsConfig />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const deleteButton = container.querySelector<HTMLButtonElement>('[aria-label="actions.delete"]');
+    expect(deleteButton).not.toBeNull();
+    await act(async () => {
+      deleteButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(confirmDangerMock).toHaveBeenCalledWith(
+      'actions.delete',
+      'messages.deleteConfirm',
+      { confirmText: 'actions.delete', cancelText: 'actions.cancel' },
+    );
+    expect(deleteServerMock).toHaveBeenCalledWith({ serverId: 'local-test' });
+    expect(getServersMock).toHaveBeenCalledTimes(2);
+    expect(container.textContent).not.toContain('Local test server');
   });
 });

--- a/src/web-ui/src/infrastructure/config/components/McpToolsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/McpToolsConfig.tsx
@@ -18,7 +18,14 @@ import {
   KeyRound,
   Trash2,
 } from 'lucide-react';
-import { Button, Textarea, IconButton, Modal, ToolProcessingDots } from '@/component-library';
+import {
+  Button,
+  Textarea,
+  IconButton,
+  Modal,
+  ToolProcessingDots,
+  confirmDanger,
+} from '@/component-library';
 import {
   ConfigPageHeader,
   ConfigPageLayout,
@@ -869,7 +876,14 @@ const McpToolsConfig: React.FC = () => {
   const handleDeleteServer = async (server: MCPServerInfo) => {
     const capabilityEpoch = currentCapabilityEpoch();
     if (capabilityEpoch === null) return;
-    const confirmed = await window.confirm(tMcp('messages.deleteConfirm'));
+    const confirmed = await confirmDanger(
+      tMcp('actions.delete'),
+      tMcp('messages.deleteConfirm'),
+      {
+        confirmText: tMcp('actions.delete'),
+        cancelText: tMcp('actions.cancel'),
+      },
+    );
     if (!confirmed || !capabilityIsCurrent(capabilityEpoch)) return;
 
     try {


### PR DESCRIPTION
## Summary

- replace the MCP delete path native `window.confirm` call with the shared in-app danger confirmation dialog
- keep the idle voice control actionable so unsupported capture states produce visible feedback instead of a dead button
- declare the macOS microphone usage description required by packaged voice input
- add focused regressions for confirmed MCP deletion and unavailable microphone capture

## Type and Areas

Type:

Regression fix

Areas:

Web UI, desktop/Tauri

## Motivation / Impact

MCP server deletion could appear unresponsive when the host-native confirmation dialog was unavailable. Voice input could also present a disabled control with no actionable explanation, and packaged macOS builds did not declare microphone usage. These changes restore both user workflows while keeping unsupported states explicit.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/voice/useComposerVoiceInput.test.tsx src/infrastructure/config/components/McpToolsConfig.test.tsx` - 11 tests passed
- `pnpm --dir src/web-ui exec eslint src/flow_chat/components/voice/useComposerVoiceInput.ts src/infrastructure/config/components/McpToolsConfig.tsx` - passed
- `plutil -lint src/apps/desktop/Info.plist` - passed
- `git diff --check upstream/main...HEAD` - passed

## Reviewer Notes

The branch is based on current `upstream/main`, including the existing file mention picker positioning fix. This PR does not duplicate that change.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.