### PR TITLE
feat(config): models-dev provider and model dropdowns in reasoning preset editor

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -3575,6 +3575,7 @@ const AIModelConfig: React.FC = () => {
             key={reasoningPanelDraft.key}
             value={reasoningPanelDraft.reasoning}
             generatedProjection={reasoningPanelProjection}
+            providerCatalog={modelCatalog?.provider_catalog}
             onCancel={() => setReasoningPanelDraftKey(null)}
             onApply={(reasoning) => {
               updateModelDraft(reasoningPanelDraft.modelName, {

--- a/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/component-library';
 import type { ReasoningCatalogProjection, ReasoningConfig } from '../types';
+import type { ProviderCatalog } from '@/infrastructure/api/service-api/AIApi';
 import {
   cloneReasoningConfig,
   validateReasoningConfig,
@@ -13,6 +14,7 @@ import './ReasoningConfigPanel.scss';
 interface ReasoningConfigPanelProps {
   value: ReasoningConfig;
   generatedProjection?: ReasoningCatalogProjection | null;
+  providerCatalog?: ProviderCatalog | null;
   onCancel: () => void;
   onApply: (value: ReasoningConfig) => void;
 }
@@ -20,6 +22,7 @@ interface ReasoningConfigPanelProps {
 export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
   value,
   generatedProjection,
+  providerCatalog,
   onCancel,
   onApply,
 }) => {
@@ -53,6 +56,7 @@ export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
         <ReasoningPresetEditor
           value={draft}
           generatedProjection={activeGeneratedProjection}
+          providerCatalog={providerCatalog}
           onChange={setDraft}
           onValidationChange={setEditorInvalid}
         />

--- a/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderCatalog } from '@/infrastructure/api/service-api/AIApi';
+import type { ReasoningConfig } from '../types';
+import ReasoningPresetEditor from './ReasoningPresetEditor';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+interface SelectSpyProps {
+  'aria-label'?: string;
+  value?: string | number | (string | number)[] | null;
+  options?: Array<{ label: string; value: string | number }>;
+  onChange?: (value: string | number | (string | number)[]) => void;
+  disabled?: boolean;
+  allowCustomValue?: boolean;
+}
+
+const selectProps: Record<string, SelectSpyProps> = {};
+
+vi.mock('@/component-library', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>{children}</button>
+  ),
+  IconButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>{children}</button>
+  ),
+  Select: (props: SelectSpyProps) => {
+    const label = props['aria-label'] ?? '';
+    selectProps[label] = props;
+    return (
+      <select
+        aria-label={label}
+        value={typeof props.value === 'string' ? props.value : ''}
+        disabled={props.disabled}
+        onChange={(event) => props.onChange?.(event.target.value)}
+      >
+        {props.options?.map(option => (
+          <option key={String(option.value)} value={String(option.value)}>{option.label}</option>
+        ))}
+      </select>
+    );
+  },
+  Switch: () => <input type="checkbox" />,
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  NumberInput: () => <input type="number" />,
+  Textarea: () => <textarea />,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const providerCatalog: ProviderCatalog = {
+  revision: 'test',
+  source: 'bundle',
+  providers: [
+    {
+      id: 'openbitfun',
+      display_order: 0,
+      name: 'OpenBitFun',
+      description: '',
+      requires_api_key: true,
+      catalog_provider_ids: ['deepseek', 'zhipuai'],
+      catalog_providers: [
+        { id: 'deepseek', name: 'DeepSeek' },
+        { id: 'zhipuai', name: 'Zhipu AI' },
+      ],
+      endpoints: [],
+      models: [
+        {
+          id: 'deepseek-v4-flash',
+          display_name: 'DeepSeek V4 Flash',
+          recommended: true,
+          source: 'merged',
+          catalog_provider_ids: ['deepseek'],
+          capabilities: { chat: true, tool_call: true, reasoning: true, attachment: false, structured_output: true },
+        },
+        {
+          id: 'deepseek-v4-pro',
+          recommended: true,
+          source: 'merged',
+          catalog_provider_ids: ['deepseek'],
+          capabilities: { chat: true, tool_call: true, reasoning: true, attachment: false, structured_output: true },
+        },
+        {
+          id: 'glm-5.2',
+          recommended: true,
+          source: 'merged',
+          catalog_provider_ids: ['zhipuai'],
+          capabilities: { chat: true, tool_call: true, reasoning: true, attachment: false, structured_output: true },
+        },
+        {
+          id: 'deepseek-v2',
+          recommended: false,
+          source: 'merged',
+          catalog_provider_ids: ['deepseek'],
+          capabilities: { chat: true, tool_call: true, reasoning: false, attachment: false, structured_output: false },
+        },
+      ],
+    },
+  ],
+};
+
+function renderEditor(value?: ReasoningConfig) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <ReasoningPresetEditor
+        value={value ?? { catalog: { source: 'models_dev', provider: '', model: '' }, presets: [] }}
+        onChange={vi.fn()}
+        providerCatalog={providerCatalog}
+      />,
+    );
+  });
+  return { container, root };
+}
+
+describe('ReasoningPresetEditor models-dev binding', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    for (const key of Object.keys(selectProps)) delete selectProps[key];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+  });
+
+  it('has an empty provider value when no provider is selected', () => {
+    act(() => {
+      root.render(
+        <ReasoningPresetEditor
+          value={{ catalog: { source: 'models_dev', provider: '', model: '' }, presets: [] }}
+          onChange={vi.fn()}
+          providerCatalog={providerCatalog}
+        />,
+      );
+    });
+    const provider = selectProps['reasoningPresets.catalogProvider'];
+    expect(provider).toBeTruthy();
+    expect(provider?.options?.map(o => o.value)).toEqual(['deepseek', 'zhipuai']);
+    expect(provider?.value).toBe('');
+  });
+
+  it('lists only reasoning-capable models of the selected provider', () => {
+    act(() => {
+      root.render(
+        <ReasoningPresetEditor
+          value={{ catalog: { source: 'models_dev', provider: 'deepseek', model: '' }, presets: [] }}
+          onChange={vi.fn()}
+          providerCatalog={providerCatalog}
+        />,
+      );
+    });
+    const model = selectProps['reasoningPresets.catalogModel'];
+    expect(model?.options?.map(o => o.value)).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro']);
+  });
+
+  it('returns empty model options for an unknown provider', () => {
+    act(() => {
+      root.render(
+        <ReasoningPresetEditor
+          value={{ catalog: { source: 'models_dev', provider: 'unknown', model: '' }, presets: [] }}
+          onChange={vi.fn()}
+          providerCatalog={providerCatalog}
+        />,
+      );
+    });
+    const model = selectProps['reasoningPresets.catalogModel'];
+    expect(model?.options ?? []).toHaveLength(0);
+  });
+
+  it('filters models by the selected provider (zhipuai only shows glm-5.2)', () => {
+    act(() => {
+      root.render(
+        <ReasoningPresetEditor
+          value={{ catalog: { source: 'models_dev', provider: 'zhipuai', model: '' }, presets: [] }}
+          onChange={vi.fn()}
+          providerCatalog={providerCatalog}
+        />,
+      );
+    });
+    const model = selectProps['reasoningPresets.catalogModel'];
+    expect(model?.options?.map(o => o.value)).toEqual(['glm-5.2']);
+  });
+
+  it('reflects the currently bound provider and model values', () => {
+    act(() => {
+      root.render(
+        <ReasoningPresetEditor
+          value={{ catalog: { source: 'models_dev', provider: 'zhipuai', model: 'glm-5.2' }, presets: [] }}
+          onChange={vi.fn()}
+          providerCatalog={providerCatalog}
+        />,
+      );
+    });
+    const provider = selectProps['reasoningPresets.catalogProvider'];
+    const model = selectProps['reasoningPresets.catalogModel'];
+    expect(provider?.value).toBe('zhipuai');
+    expect(model?.value).toBe('glm-5.2');
+  });
+});

--- a/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.tsx
@@ -27,6 +27,7 @@ import type {
   ReasoningPreset,
   ReasoningPresetAction,
 } from '../types';
+import type { ProviderCatalog } from '@/infrastructure/api/service-api/AIApi';
 import {
   availableReasoningActionTypes,
   cloneReasoningConfig,
@@ -40,6 +41,7 @@ interface ReasoningPresetEditorProps {
   value: ReasoningConfig;
   onChange: (value: ReasoningConfig) => void;
   generatedProjection?: ReasoningCatalogProjection | null;
+  providerCatalog?: ProviderCatalog | null;
   disabled?: boolean;
   onValidationChange?: (invalid: boolean) => void;
 }
@@ -71,6 +73,7 @@ export const ReasoningPresetEditor: React.FC<ReasoningPresetEditorProps> = ({
   value,
   onChange,
   generatedProjection,
+  providerCatalog,
   disabled = false,
   onValidationChange,
 }) => {
@@ -126,6 +129,36 @@ export const ReasoningPresetEditor: React.FC<ReasoningPresetEditorProps> = ({
     () => resolveDefaultReasoningEffortValue(generatedProjection),
     [generatedProjection],
   );
+
+  const modelsDevProviderOptions = useMemo<SelectOption[]>(() => {
+    const seen = new Map<string, string>();
+    for (const provider of providerCatalog?.providers ?? []) {
+      for (const cp of provider.catalog_providers ?? []) {
+        if (!seen.has(cp.id)) seen.set(cp.id, cp.name || cp.id);
+      }
+    }
+    const options = Array.from(seen, ([id, name]) => ({ label: name, value: id }));
+    options.sort((a, b) => a.label.localeCompare(b.label));
+    return options;
+  }, [providerCatalog]);
+
+  const modelsDevProviderId = catalog.source === 'models_dev' ? catalog.provider : '';
+
+  const modelsDevModelOptions = useMemo<SelectOption[]>(() => {
+    if (!modelsDevProviderId) return [];
+    const seen = new Set<string>();
+    const options: SelectOption[] = [];
+    for (const provider of providerCatalog?.providers ?? []) {
+      for (const model of provider.models) {
+        if (model.capabilities?.reasoning && model.catalog_provider_ids?.includes(modelsDevProviderId) && !seen.has(model.id)) {
+          seen.add(model.id);
+          options.push({ label: model.display_name || model.id, value: model.id });
+        }
+      }
+    }
+    options.sort((a, b) => a.label.localeCompare(b.label));
+    return options;
+  }, [providerCatalog, modelsDevProviderId]);
 
   const update = (next: ReasoningConfig) => onChange(cloneReasoningConfig(next));
   const updatePreset = (index: number, changes: Partial<ReasoningPreset>) => {
@@ -289,27 +322,35 @@ export const ReasoningPresetEditor: React.FC<ReasoningPresetEditorProps> = ({
           >
             <div className="bitfun-reasoning-preset-editor__binding-field">
               <span>{t('reasoningPresets.catalogProvider')}</span>
-              <Input
+              <Select
                 size="small"
                 aria-label={t('reasoningPresets.catalogProvider')}
                 value={catalog.provider}
+                options={modelsDevProviderOptions}
                 disabled={disabled}
-                onChange={(event) => update({
+                allowCustomValue
+                customValueHint={t('reasoningPresets.effortCustomValueHint')}
+                searchPlaceholder={t('reasoningPresets.catalogProvider')}
+                onChange={(next) => update({
                   ...value,
-                  catalog: { ...catalog, provider: event.target.value },
+                  catalog: { ...catalog, provider: String(next || '') },
                 })}
               />
             </div>
             <div className="bitfun-reasoning-preset-editor__binding-field">
               <span>{t('reasoningPresets.catalogModel')}</span>
-              <Input
+              <Select
                 size="small"
                 aria-label={t('reasoningPresets.catalogModel')}
                 value={catalog.model}
+                options={modelsDevModelOptions}
                 disabled={disabled}
-                onChange={(event) => update({
+                allowCustomValue
+                customValueHint={t('reasoningPresets.effortCustomValueHint')}
+                searchPlaceholder={t('reasoningPresets.catalogModel')}
+                onChange={(next) => update({
                   ...value,
-                  catalog: { ...catalog, model: event.target.value },
+                  catalog: { ...catalog, model: String(next || '') },
                 })}
               />
             </div>


### PR DESCRIPTION
## Summary

Replace the hand-written text inputs for the models.dev provider and model in the reasoning preset editor with cascading dropdowns backed by the merged provider catalog (`provider_catalog`).

Rather than requiring users to know which provider IDs (e.g. `zhipuai`) and model IDs are supported, the editor now:
- Lists all catalog providers as a searchable dropdown with an empty (unbound) option.
- After a provider is selected, lists only models that support reasoning for that provider.
- Keeps `allowCustomValue` so users can still enter provider/model IDs for scenarios not yet adapted in the catalog.

## Changes

- `src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.tsx`
  - Plumb a `providerCatalog` prop into the editor.
  - Derive provider options from `provider_catalog.providers[].catalog_providers` (deduped, sorted).
  - Derive cascading model options filtered by selected provider + `capabilities.reasoning`.
  - Convert the two `Input` fields to `Select` with `allowCustomValue` and empty-value handling.
- `src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx`
  - Accept and forward `providerCatalog` to `ReasoningPresetEditor`.
- `src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx`
  - Pass `modelCatalog?.provider_catalog` down to the panel.
- `src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.test.tsx` (new)
  - Tests: provider aggregation, empty/unknown provider, reasoning-capable model filtering, cascading filter, and value echo.

## Verification

- `tsc --noEmit` passes.
- New `ReasoningPresetEditor.test.tsx` (5 tests) and existing `ReasoningConfigPanel.test.tsx` (2 tests) pass via vitest.

<img width="1460" height="761" alt="PixPin_2026-08-08_00-48-19" src="https://github.com/user-attachments/assets/14d4d7fa-f139-4fe0-87b6-37408d5c6115" />
<img width="1464" height="620" alt="PixPin_2026-08-08_00-48-35" src="https://github.com/user-attachments/assets/958ccbd7-c532-4cdf-b5c8-0d89d03173a0" />
