### PR TITLE
chore(i18n): unify copy wording in zh-CN and zh-TW locale

### DIFF
--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -727,7 +727,7 @@
     "openBot": "打开机器人",
     "stateIdle": "就绪",
     "stateWaiting": "等待连接...",
-    "urlCopied": "已拷贝 URL",
+    "urlCopied": "已复制 URL",
     "copyUrl": "复制配对链接",
     "copyUrlFailed": "无法复制配对链接，请手动复制或检查剪贴板权限。",
     "weixinQrAlt": "微信登录二维码",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -899,8 +899,8 @@
     "unknownTool": "未知工具"
   },
   "transcriptExport": {
-    "copyFull": "拷贝完整过程",
-    "copyResult": "拷贝结果",
+    "copyFull": "复制完整过程",
+    "copyResult": "复制结果",
     "copyEmpty": "该对话没有可复制的内容",
     "exportEmpty": "该会话没有可导出的内容",
     "exportSuccess": "会话已导出：{{filePath}}",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -727,7 +727,7 @@
     "openBot": "開啟機器人",
     "stateIdle": "就緒",
     "stateWaiting": "等待連接...",
-    "urlCopied": "已拷貝 URL",
+    "urlCopied": "已複製 URL",
     "copyUrl": "複製配對連結",
     "copyUrlFailed": "無法複製配對連結，請手動複製或檢查剪貼簿權限。",
     "weixinQrAlt": "微信登入二維碼",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -899,8 +899,8 @@
     "unknownTool": "未知工具"
   },
   "transcriptExport": {
-    "copyFull": "拷貝完整過程",
-    "copyResult": "拷貝結果",
+    "copyFull": "複製完整過程",
+    "copyResult": "複製結果",
     "copyEmpty": "該對話沒有可複製的內容",
     "exportEmpty": "該工作階段沒有可匯出的內容",
     "exportSuccess": "工作階段已匯出：{{filePath}}",


### PR DESCRIPTION
## Summary

Standardize copy-related UI labels in both Chinese locales: zh-CN "拷贝" → "复制" and zh-TW "拷貝" → "複製", aligning with existing strings such as the "复制对话" copy-conversation tooltip (copyDialog). Pure UI copy change with no behavior impact.

All "拷贝"/"拷貝" in user-facing UI strings are now replaced in both locales; the only remaining "拷贝" matches in the repo are technical terms (e.g. "深拷贝"/"零拷贝") in `docs/performance/`, intentionally left unchanged.

## Type and Areas

Type:

UI/UX

Areas:

web UI

## Files changed

- `src/web-ui/src/locales/zh-CN/flow-chat.json` — `transcriptExport.copyFull` / `copyResult` ("拷贝完整过程" / "拷贝结果" → "复制完整过程" / "复制结果")
- `src/web-ui/src/locales/zh-CN/common.json` — `urlCopied` ("已拷贝 URL" → "已复制 URL")
- `src/web-ui/src/locales/zh-TW/flow-chat.json` — `copyFull` / `copyResult` ("拷貝完整過程" / "拷貝結果" → "複製完整過程" / "複製結果")
- `src/web-ui/src/locales/zh-TW/common.json` — `urlCopied` ("已拷貝 URL" → "已複製 URL")

## Motivation / Impact

The transcript export panel previously said "拷贝完整过程"/"拷贝结果" while the nearby copy-conversation tooltip already said "复制对话"; this change removes that inconsistency.

Unify terminology in user-facing copy. Users see "复制完整过程" / "复制结果" in the transcript export panel, and "已复制 URL" instead of "已拷贝 URL" in the pairing toast.

## Verification

- Lightly tested: confirmed the strings in both locale files; no keys added or removed, so i18n audits are unaffected.

## Reviewer Notes

N/A.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
