### PR TITLE
fix(ai): route subscription auth through the configured proxy

### DIFF
--- a/scripts/check-core-boundaries.test.mjs
+++ b/scripts/check-core-boundaries.test.mjs
@@ -1313,6 +1313,34 @@ test('direct Reqwest clients reject extra decoded dependency and package feature
   assert.match(messages, /bitfun-cli:default.*unreviewed Reqwest feature reference reqwest\?\/http3/);
 });
 
+test('AI adapters Reqwest profile owns the supported SOCKS transport', () => {
+  const baseFeatures = ['http2', 'json', 'stream', 'multipart', 'query', 'form'];
+  const valid = packageAt('bitfun-ai-adapters', 'src/crates/adapters/ai-adapters/Cargo.toml', [{
+    name: 'reqwest',
+    kind: null,
+    optional: false,
+    uses_default_features: false,
+    features: [...baseFeatures, 'rustls', 'socks'],
+  }]);
+  const missingSocks = packageAt(
+    'bitfun-ai-adapters',
+    'src/crates/adapters/ai-adapters/Cargo.toml',
+    [{
+      name: 'reqwest',
+      kind: null,
+      optional: false,
+      uses_default_features: false,
+      features: [...baseFeatures, 'rustls'],
+    }],
+  );
+
+  assert.deepEqual(findReqwestDependencyFeatureViolations([valid]), []);
+  const messages = findReqwestDependencyFeatureViolations([missingSocks])
+    .map((violation) => violation.message)
+    .join('\n');
+  assert.match(messages, /bitfun-ai-adapters.*missing features: socks/);
+});
+
 test('Reqwest metadata policy covers URL-only and future dependency owners', () => {
   const baseFeatures = ['http2', 'json', 'stream', 'multipart', 'query', 'form'];
   const core = {

--- a/scripts/core-boundaries/cargo-dependency-boundaries.mjs
+++ b/scripts/core-boundaries/cargo-dependency-boundaries.mjs
@@ -265,8 +265,12 @@ const REQWEST_PACKAGE_PROFILES = new Map([
     optional: true,
     servicesOwners: true,
   }],
+  ['bitfun-ai-adapters', {
+    dependencyFeatures: [...REQWEST_TRANSPORT_FEATURES, 'rustls', 'socks'],
+    optional: false,
+    allowedPackageFeatureRefs: new Set(['reqwest/rustls']),
+  }],
   ...[
-    'bitfun-ai-adapters',
     'bitfun-cli',
     'bitfun-desktop',
     'bitfun-miniapp-market-service',

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -16,7 +16,6 @@ export const requiredContentRules = [
   ...[
     'src/apps/cli/Cargo.toml',
     'src/apps/desktop/Cargo.toml',
-    'src/crates/adapters/ai-adapters/Cargo.toml',
     'src/crates/services/miniapp-market-service/Cargo.toml',
     'src/crates/services/skin-market-service/Cargo.toml',
   ].map((path) => ({
@@ -29,6 +28,17 @@ export const requiredContentRules = [
       },
     ],
   })),
+  {
+    path: 'src/crates/adapters/ai-adapters/Cargo.toml',
+    reason:
+      'the AI adapter owns Rustls HTTPS clients and the product-supported SOCKS proxy transport',
+    patterns: [
+      {
+        regex: /^reqwest\s*=\s*\{\s*workspace\s*=\s*true,\s*features\s*=\s*\[\s*"rustls"\s*,\s*"socks"\s*\]\s*\}/m,
+        message: 'AI adapter Reqwest dependency must explicitly enable rustls and socks',
+      },
+    ],
+  },
   {
     path: 'src/crates/services/services-core/src/lib.rs',
     reason:

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -5274,10 +5274,14 @@ pub async fn start_subscription_login(
     request: SubscriptionLoginRequest,
 ) -> Result<bitfun_core::infrastructure::subscription_auth::LoginStartResult, String> {
     let proxy_config = configured_ai_proxy(&state).await?;
-    bitfun_core::infrastructure::subscription_auth::start_login_with_proxy(
+    let options = bitfun_core::infrastructure::subscription_auth::SubscriptionHttpOptions::new(
+        proxy_config,
+        false,
+    );
+    bitfun_core::infrastructure::subscription_auth::start_login_with_options(
         request.provider,
         request.session_id,
-        proxy_config,
+        options,
     )
     .await
     .map_err(|e| format!("Failed to start subscription login: {e:#}"))
@@ -5320,9 +5324,13 @@ pub async fn refresh_subscription_account(
     request: SubscriptionProviderRequest,
 ) -> Result<bitfun_core::infrastructure::subscription_auth::SubscriptionAccount, String> {
     let proxy_config = configured_ai_proxy(&state).await?;
-    bitfun_core::infrastructure::subscription_auth::refresh_account_with_proxy(
+    let options = bitfun_core::infrastructure::subscription_auth::SubscriptionHttpOptions::new(
+        proxy_config,
+        false,
+    );
+    bitfun_core::infrastructure::subscription_auth::refresh_account_with_options(
         request.provider,
-        proxy_config.as_ref(),
+        &options,
     )
     .await
     .map_err(|e| format!("Failed to refresh subscription account: {e:#}"))

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -1156,9 +1156,14 @@ pub async fn initialize_ai(state: State<'_, AppState>) -> Result<String, String>
 
     let ai_config = bitfun_core::util::types::AIConfig::try_from(model_config.clone())
         .map_err(|e| format!("Failed to convert AI configuration: {}", e))?;
+    let proxy_config = if global_config.ai.proxy.enabled {
+        Some(global_config.ai.proxy.clone())
+    } else {
+        None
+    };
     let ai_client = bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(
         ai_config,
-        None,
+        proxy_config,
         stream_options,
     );
 
@@ -1193,16 +1198,26 @@ async fn create_transient_ai_client_for_config(
     let mut ai_config: bitfun_core::util::types::AIConfig = model_config
         .try_into()
         .map_err(|e| format!("Failed to convert configuration: {}", e))?;
-
-    bitfun_core::infrastructure::ai::client_factory::apply_subscription_auth(&auth, &mut ai_config)
-        .await
-        .map_err(|e| format!("Failed to resolve subscription auth: {}", e))?;
+    let skip_ssl_verify = ai_config.skip_ssl_verify;
 
     let proxy_config = if global_config.ai.proxy.enabled {
         Some(global_config.ai.proxy.clone())
     } else {
         None
     };
+    let subscription_options =
+        bitfun_core::infrastructure::subscription_auth::SubscriptionHttpOptions::new(
+            proxy_config.clone(),
+            skip_ssl_verify,
+        );
+
+    bitfun_core::infrastructure::ai::client_factory::apply_subscription_auth_with_options(
+        &auth,
+        &mut ai_config,
+        &subscription_options,
+    )
+    .await
+    .map_err(|e| format!("Failed to resolve subscription auth: {}", e))?;
 
     Ok(
         bitfun_core::infrastructure::ai::AIClient::new_with_runtime_options(
@@ -5231,6 +5246,22 @@ pub struct SubscriptionLoginRequest {
     pub session_id: String,
 }
 
+async fn configured_ai_proxy(
+    state: &State<'_, AppState>,
+) -> Result<Option<bitfun_core::service::config::types::ProxyConfig>, String> {
+    let global_config: bitfun_core::service::config::GlobalConfig = state
+        .config_service
+        .get_config(None)
+        .await
+        .map_err(|e| format!("Failed to get configuration: {}", e))?;
+
+    Ok(global_config
+        .ai
+        .proxy
+        .enabled
+        .then_some(global_config.ai.proxy))
+}
+
 #[tauri::command]
 pub async fn list_subscription_accounts(
 ) -> Result<Vec<bitfun_core::infrastructure::subscription_auth::SubscriptionAccount>, String> {
@@ -5239,11 +5270,14 @@ pub async fn list_subscription_accounts(
 
 #[tauri::command]
 pub async fn start_subscription_login(
+    state: State<'_, AppState>,
     request: SubscriptionLoginRequest,
 ) -> Result<bitfun_core::infrastructure::subscription_auth::LoginStartResult, String> {
-    bitfun_core::infrastructure::subscription_auth::start_login(
+    let proxy_config = configured_ai_proxy(&state).await?;
+    bitfun_core::infrastructure::subscription_auth::start_login_with_proxy(
         request.provider,
         request.session_id,
+        proxy_config,
     )
     .await
     .map_err(|e| format!("Failed to start subscription login: {e:#}"))
@@ -5282,9 +5316,14 @@ pub async fn logout_subscription_account(
 
 #[tauri::command]
 pub async fn refresh_subscription_account(
+    state: State<'_, AppState>,
     request: SubscriptionProviderRequest,
 ) -> Result<bitfun_core::infrastructure::subscription_auth::SubscriptionAccount, String> {
-    bitfun_core::infrastructure::subscription_auth::refresh_account(request.provider)
-        .await
-        .map_err(|e| format!("Failed to refresh subscription account: {e:#}"))
+    let proxy_config = configured_ai_proxy(&state).await?;
+    bitfun_core::infrastructure::subscription_auth::refresh_account_with_proxy(
+        request.provider,
+        proxy_config.as_ref(),
+    )
+    .await
+    .map_err(|e| format!("Failed to refresh subscription account: {e:#}"))
 }

--- a/src/crates/adapters/ai-adapters/Cargo.toml
+++ b/src/crates/adapters/ai-adapters/Cargo.toml
@@ -24,7 +24,7 @@ futures = { workspace = true }
 fs2 = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["rustls"] }
+reqwest = { workspace = true, features = ["rustls", "socks"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true, optional = true }

--- a/src/crates/adapters/ai-adapters/src/client/http.rs
+++ b/src/crates/adapters/ai-adapters/src/client/http.rs
@@ -118,4 +118,16 @@ mod tests {
 
         assert!(build_proxy(&config).is_ok());
     }
+
+    #[test]
+    fn accepts_explicit_socks5_proxy_configuration() {
+        let config = ProxyConfig {
+            enabled: true,
+            url: "socks5://127.0.0.1:1080".to_string(),
+            username: None,
+            password: None,
+        };
+
+        assert!(build_proxy(&config).is_ok());
+    }
 }

--- a/src/crates/adapters/ai-adapters/src/client/http.rs
+++ b/src/crates/adapters/ai-adapters/src/client/http.rs
@@ -63,9 +63,9 @@ pub(crate) fn create_http_client(
     }
 }
 
-fn build_proxy(config: &ProxyConfig) -> Result<Proxy> {
-    let mut proxy =
-        Proxy::all(&config.url).map_err(|e| anyhow!("Failed to create proxy: {}", e))?;
+pub(crate) fn build_proxy(config: &ProxyConfig) -> Result<Proxy> {
+    let proxy_url = normalize_proxy_url(&config.url);
+    let mut proxy = Proxy::all(&proxy_url).map_err(|e| anyhow!("Failed to create proxy: {}", e))?;
 
     if let (Some(username), Some(password)) = (&config.username, &config.password) {
         if !username.is_empty() && !password.is_empty() {
@@ -75,4 +75,47 @@ fn build_proxy(config: &ProxyConfig) -> Result<Proxy> {
     }
 
     Ok(proxy)
+}
+
+fn normalize_proxy_url(url: &str) -> String {
+    let trimmed = url.trim();
+    if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_proxy, normalize_proxy_url};
+    use crate::types::ProxyConfig;
+
+    #[test]
+    fn normalizes_bare_host_and_port_to_http_proxy_url() {
+        assert_eq!(
+            normalize_proxy_url("127.0.0.1:7897"),
+            "http://127.0.0.1:7897"
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_proxy_scheme() {
+        assert_eq!(
+            normalize_proxy_url("socks5://127.0.0.1:1080"),
+            "socks5://127.0.0.1:1080"
+        );
+    }
+
+    #[test]
+    fn accepts_bare_host_and_port_proxy_configuration() {
+        let config = ProxyConfig {
+            enabled: true,
+            url: "127.0.0.1:7897".to_string(),
+            username: None,
+            password: None,
+        };
+
+        assert!(build_proxy(&config).is_ok());
+    }
 }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/antigravity.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/antigravity.rs
@@ -7,7 +7,9 @@
 //! `opencode-antigravity-auth`.
 
 use super::store::{self, StoredCredential};
-use super::{jwt, oauth_server, pkce, pkce::Pkce, ResolvedCredential, StartedLogin};
+use super::{
+    jwt, oauth_server, pkce, pkce::Pkce, ResolvedCredential, StartedLogin, SubscriptionHttpOptions,
+};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -107,15 +109,17 @@ fn build_authorize_url(pkce: &Pkce, state: &str, redirect_uri: &str) -> String {
     format!("{AUTHORIZE_URL}?{query}")
 }
 
-fn http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("build antigravity http client")
+fn http_client(options: &SubscriptionHttpOptions) -> Result<reqwest::Client> {
+    super::build_http_client(options, "Antigravity")
 }
 
-async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result<TokenResponse> {
-    let client = http_client()?;
+async fn exchange_code(
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+    options: &SubscriptionHttpOptions,
+) -> Result<TokenResponse> {
+    let client = http_client(options)?;
     let secret = client_secret();
     let params = [
         ("grant_type", "authorization_code"),
@@ -143,8 +147,8 @@ async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result
         .context("parse antigravity token response")
 }
 
-async fn refresh(refresh_token: &str) -> Result<TokenResponse> {
-    let client = http_client()?;
+async fn refresh(refresh_token: &str, options: &SubscriptionHttpOptions) -> Result<TokenResponse> {
+    let client = http_client(options)?;
     let secret = client_secret();
     let params = [
         ("grant_type", "refresh_token"),
@@ -223,6 +227,7 @@ async fn persist_tokens(tokens: TokenResponse, expected_revision: u64) -> Result
 pub(crate) async fn begin_login(
     cancel: CancellationToken,
     expected_revision: u64,
+    options: SubscriptionHttpOptions,
 ) -> Result<StartedLogin> {
     let pkce = Pkce::generate();
     let state = pkce::random_state();
@@ -242,7 +247,7 @@ pub(crate) async fn begin_login(
                     .get("code")
                     .cloned()
                     .ok_or_else(|| anyhow!("antigravity callback missing code"))?;
-                exchange_code(&code, &verifier, &redirect_uri).await
+                exchange_code(&code, &verifier, &redirect_uri, &options).await
             },
             move |tokens| persist_tokens(tokens, expected_revision),
         )
@@ -259,7 +264,7 @@ pub(crate) async fn begin_login(
 
 /// Ensures the stored access token is fresh, refreshing it when needed. Returns
 /// the current `(access, expires_ms)`.
-async fn ensure_fresh() -> Result<(String, i64)> {
+async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<(String, i64)> {
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
@@ -279,7 +284,7 @@ async fn ensure_fresh() -> Result<(String, i64)> {
         return Ok((access, expires));
     }
 
-    let refreshed = refresh(&refresh_token).await?;
+    let refreshed = refresh(&refresh_token, options).await?;
     let new_access = refreshed
         .access_token
         .clone()
@@ -299,14 +304,38 @@ async fn ensure_fresh() -> Result<(String, i64)> {
         },
     )
     .await?;
-    super::require_current_store_revision(super::SubscriptionProvider::Antigravity, outcome)?;
-    log::info!("antigravity subscription tokens refreshed");
-    Ok((new_access, new_expires))
+    match outcome {
+        store::ConditionalCommitOutcome::Committed { .. } => {
+            log::info!("antigravity subscription tokens refreshed");
+            Ok((new_access, new_expires))
+        }
+        store::ConditionalCommitOutcome::Conflict { current_revision } => {
+            let current = super::load_current_store_after_conflict(
+                super::SubscriptionProvider::Antigravity,
+                current_revision,
+            )
+            .await?;
+            match current.credential {
+                Some(StoredCredential::Oauth {
+                    access, expires, ..
+                }) if expires > now_ms() => {
+                    log::info!(
+                        "antigravity refresh reused tokens committed by a concurrent refresh"
+                    );
+                    Ok((access, expires))
+                }
+                _ => Err(super::store_revision_conflict(
+                    super::SubscriptionProvider::Antigravity,
+                    current_revision,
+                )),
+            }
+        }
+    }
 }
 
 /// Resolves the runtime credential (refreshing tokens if required).
-pub(crate) async fn resolve() -> Result<ResolvedCredential> {
-    let (access, expires) = ensure_fresh().await?;
+pub(crate) async fn resolve(options: &SubscriptionHttpOptions) -> Result<ResolvedCredential> {
+    let (access, expires) = ensure_fresh(options).await?;
     let (ua_platform, meta_platform) = platform_tokens();
     let mut headers = HashMap::new();
     headers.insert(

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
@@ -5,7 +5,9 @@
 //! `chatgpt.com/backend-api/codex/responses`.
 
 use super::store::{self, StoredCredential};
-use super::{jwt, oauth_server, pkce::Pkce, ResolvedCredential, StartedLogin};
+use super::{
+    jwt, oauth_server, pkce::Pkce, ResolvedCredential, StartedLogin, SubscriptionHttpOptions,
+};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -63,15 +65,17 @@ fn build_authorize_url(pkce: &Pkce, state: &str, redirect_uri: &str) -> String {
     format!("{ISSUER}/oauth/authorize?{query}")
 }
 
-fn http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("build codex http client")
+fn http_client(options: &SubscriptionHttpOptions) -> Result<reqwest::Client> {
+    super::build_http_client(options, "Codex")
 }
 
-async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result<TokenResponse> {
-    let client = http_client()?;
+async fn exchange_code(
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+    options: &SubscriptionHttpOptions,
+) -> Result<TokenResponse> {
+    let client = http_client(options)?;
     let params = [
         ("grant_type", "authorization_code"),
         ("code", code),
@@ -95,8 +99,8 @@ async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result
     resp.json().await.context("parse codex token response")
 }
 
-async fn refresh(refresh_token: &str) -> Result<TokenResponse> {
-    let client = http_client()?;
+async fn refresh(refresh_token: &str, options: &SubscriptionHttpOptions) -> Result<TokenResponse> {
+    let client = http_client(options)?;
     let params = [
         ("grant_type", "refresh_token"),
         ("refresh_token", refresh_token),
@@ -171,6 +175,7 @@ async fn persist_tokens(tokens: TokenResponse, expected_revision: u64) -> Result
 pub(crate) async fn begin_login(
     cancel: CancellationToken,
     expected_revision: u64,
+    options: SubscriptionHttpOptions,
 ) -> Result<StartedLogin> {
     let pkce = Pkce::generate();
     let state = super::pkce::random_state();
@@ -190,7 +195,7 @@ pub(crate) async fn begin_login(
                     .get("code")
                     .cloned()
                     .ok_or_else(|| anyhow!("codex callback missing code"))?;
-                exchange_code(&code, &verifier, &redirect_uri).await
+                exchange_code(&code, &verifier, &redirect_uri, &options).await
             },
             move |tokens| persist_tokens(tokens, expected_revision),
         )
@@ -207,7 +212,7 @@ pub(crate) async fn begin_login(
 
 /// Ensures the stored access token is fresh, refreshing it when needed. Returns
 /// the current `(access, account_id, expires_ms)`.
-async fn ensure_fresh() -> Result<(String, Option<String>, i64)> {
+async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<(String, Option<String>, i64)> {
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
@@ -227,7 +232,7 @@ async fn ensure_fresh() -> Result<(String, Option<String>, i64)> {
         return Ok((access, account_id, expires));
     }
 
-    let refreshed = refresh(&refresh_token).await?;
+    let refreshed = refresh(&refresh_token, options).await?;
     let new_access = refreshed
         .access_token
         .clone()
@@ -248,9 +253,34 @@ async fn ensure_fresh() -> Result<(String, Option<String>, i64)> {
         },
     )
     .await?;
-    super::require_current_store_revision(super::SubscriptionProvider::Codex, outcome)?;
-    log::info!("codex subscription tokens refreshed");
-    Ok((new_access, new_account_id, new_expires))
+    match outcome {
+        store::ConditionalCommitOutcome::Committed { .. } => {
+            log::info!("codex subscription tokens refreshed");
+            Ok((new_access, new_account_id, new_expires))
+        }
+        store::ConditionalCommitOutcome::Conflict { current_revision } => {
+            let current = super::load_current_store_after_conflict(
+                super::SubscriptionProvider::Codex,
+                current_revision,
+            )
+            .await?;
+            match current.credential {
+                Some(StoredCredential::Oauth {
+                    access,
+                    expires,
+                    account_id,
+                    ..
+                }) if expires > now_ms() => {
+                    log::info!("codex refresh reused tokens committed by a concurrent refresh");
+                    Ok((access, account_id, expires))
+                }
+                _ => Err(super::store_revision_conflict(
+                    super::SubscriptionProvider::Codex,
+                    current_revision,
+                )),
+            }
+        }
+    }
 }
 
 async fn resolve_codex_cli_version() -> Option<String> {
@@ -286,8 +316,8 @@ fn parse_codex_cli_version(output: &str) -> Option<String> {
 }
 
 /// Resolves the runtime credential (refreshing tokens if required).
-pub(crate) async fn resolve() -> Result<ResolvedCredential> {
-    let (access, account_id, expires) = ensure_fresh().await?;
+pub(crate) async fn resolve(options: &SubscriptionHttpOptions) -> Result<ResolvedCredential> {
+    let (access, account_id, expires) = ensure_fresh(options).await?;
     let mut headers = HashMap::new();
     if let Some(account) = account_id {
         headers.insert("ChatGPT-Account-ID".to_string(), account);

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
@@ -46,8 +46,8 @@ pub enum SubscriptionProvider {
 /// future while token refresh and credential resolution only borrow them.
 #[derive(Debug, Clone, Default)]
 pub struct SubscriptionHttpOptions {
-    pub proxy_config: Option<ProxyConfig>,
-    pub skip_ssl_verify: bool,
+    proxy_config: Option<ProxyConfig>,
+    skip_ssl_verify: bool,
 }
 
 impl SubscriptionHttpOptions {
@@ -490,37 +490,6 @@ pub async fn start_login(
     start_login_with_options(provider, session_id, SubscriptionHttpOptions::default()).await
 }
 
-/// Starts a subscription login while applying the host's explicit AI proxy to
-/// provider-side token exchange requests.
-pub async fn start_login_with_proxy(
-    provider: SubscriptionProvider,
-    session_id: String,
-    proxy_config: Option<ProxyConfig>,
-) -> Result<LoginStartResult> {
-    start_login_with_options(
-        provider,
-        session_id,
-        SubscriptionHttpOptions::new(proxy_config, false),
-    )
-    .await
-}
-
-/// Starts a subscription login while applying the host's explicit AI proxy
-/// and TLS verification policy to provider-side token exchange requests.
-pub async fn start_login_with_proxy_and_ssl(
-    provider: SubscriptionProvider,
-    session_id: String,
-    proxy_config: Option<ProxyConfig>,
-    skip_ssl_verify: bool,
-) -> Result<LoginStartResult> {
-    start_login_with_options(
-        provider,
-        session_id,
-        SubscriptionHttpOptions::new(proxy_config, skip_ssl_verify),
-    )
-    .await
-}
-
 /// Starts a subscription login with an explicit transport policy.
 pub async fn start_login_with_options(
     provider: SubscriptionProvider,
@@ -823,27 +792,6 @@ pub async fn resolve(provider: SubscriptionProvider) -> Result<ResolvedCredentia
     resolve_with_options(provider, &SubscriptionHttpOptions::default()).await
 }
 
-/// Resolves a subscription credential while applying the host's explicit AI
-/// proxy to provider-side refresh requests.
-pub async fn resolve_with_proxy(
-    provider: SubscriptionProvider,
-    proxy_config: Option<&ProxyConfig>,
-) -> Result<ResolvedCredential> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
-    resolve_with_options(provider, &options).await
-}
-
-/// Resolves a subscription credential while applying the host's explicit AI
-/// proxy and TLS verification policy to provider-side refresh requests.
-pub async fn resolve_with_proxy_and_ssl(
-    provider: SubscriptionProvider,
-    proxy_config: Option<&ProxyConfig>,
-    skip_ssl_verify: bool,
-) -> Result<ResolvedCredential> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
-    resolve_with_options(provider, &options).await
-}
-
 /// Resolves a subscription credential with an explicit transport policy.
 pub async fn resolve_with_options(
     provider: SubscriptionProvider,
@@ -863,30 +811,6 @@ pub async fn resolve_opencode(plan: OpenCodePlan, format: &str) -> Result<Resolv
     resolve_opencode_with_options(plan, format, &SubscriptionHttpOptions::default()).await
 }
 
-/// Resolves an OpenCode credential for a concrete plan while applying the
-/// host's explicit AI proxy to provider-side refresh requests.
-pub async fn resolve_opencode_with_proxy(
-    plan: OpenCodePlan,
-    format: &str,
-    proxy_config: Option<&ProxyConfig>,
-) -> Result<ResolvedCredential> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
-    resolve_opencode_with_options(plan, format, &options).await
-}
-
-/// Resolves an OpenCode credential for a concrete plan while applying the
-/// host's explicit AI proxy and TLS verification policy to provider-side
-/// refresh requests.
-pub async fn resolve_opencode_with_proxy_and_ssl(
-    plan: OpenCodePlan,
-    format: &str,
-    proxy_config: Option<&ProxyConfig>,
-    skip_ssl_verify: bool,
-) -> Result<ResolvedCredential> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
-    resolve_opencode_with_options(plan, format, &options).await
-}
-
 /// Resolves an OpenCode credential with an explicit transport policy.
 pub async fn resolve_opencode_with_options(
     plan: OpenCodePlan,
@@ -899,27 +823,6 @@ pub async fn resolve_opencode_with_options(
 /// Forces a resolve (which refreshes and saves), then returns the account entry.
 pub async fn refresh_account(provider: SubscriptionProvider) -> Result<SubscriptionAccount> {
     refresh_account_with_options(provider, &SubscriptionHttpOptions::default()).await
-}
-
-/// Refreshes a subscription account while applying the host's explicit AI
-/// proxy to provider-side token refresh requests.
-pub async fn refresh_account_with_proxy(
-    provider: SubscriptionProvider,
-    proxy_config: Option<&ProxyConfig>,
-) -> Result<SubscriptionAccount> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
-    refresh_account_with_options(provider, &options).await
-}
-
-/// Refreshes a subscription account while applying the host's explicit AI
-/// proxy and TLS verification policy to provider-side requests.
-pub async fn refresh_account_with_proxy_and_ssl(
-    provider: SubscriptionProvider,
-    proxy_config: Option<&ProxyConfig>,
-    skip_ssl_verify: bool,
-) -> Result<SubscriptionAccount> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
-    refresh_account_with_options(provider, &options).await
 }
 
 /// Refreshes a subscription account with an explicit transport policy.

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
@@ -18,7 +18,8 @@ pub mod store;
 
 pub use store::{set_store_path_for_test, StoredCredential};
 
-use anyhow::{anyhow, Result};
+use crate::types::ProxyConfig;
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -37,6 +38,25 @@ pub enum SubscriptionProvider {
     Codex,
     Antigravity,
     Opencode,
+}
+
+/// Transport policy shared by subscription-auth requests.
+///
+/// The proxy is owned because login flows keep these options in a background
+/// future while token refresh and credential resolution only borrow them.
+#[derive(Debug, Clone, Default)]
+pub struct SubscriptionHttpOptions {
+    pub proxy_config: Option<ProxyConfig>,
+    pub skip_ssl_verify: bool,
+}
+
+impl SubscriptionHttpOptions {
+    pub fn new(proxy_config: Option<ProxyConfig>, skip_ssl_verify: bool) -> Self {
+        Self {
+            proxy_config,
+            skip_ssl_verify,
+        }
+    }
 }
 
 impl SubscriptionProvider {
@@ -246,6 +266,46 @@ fn validate_session_id(session_id: &str) -> Result<()> {
         .map_err(|_| anyhow!("subscription login session_id must be a valid UUID"))
 }
 
+/// Builds the HTTP client used by proxy-aware subscription-auth requests.
+///
+/// Subscription providers perform token exchange, refresh, or account
+/// discovery outside the normal AI request client, so they must receive the
+/// same explicit proxy configuration from the host. Keep environment proxy
+/// discovery disabled to match the main AI client, which is controlled by
+/// `ai.proxy`.
+pub(crate) fn build_http_client(
+    options: &SubscriptionHttpOptions,
+    provider: &str,
+) -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .tls_backend_rustls()
+        .timeout(Duration::from_secs(30))
+        .danger_accept_invalid_certs(options.skip_ssl_verify);
+
+    if options.skip_ssl_verify {
+        log::warn!(
+            "SSL certificate verification disabled for {provider} subscription authentication"
+        );
+    }
+
+    if let Some(proxy_config) = options
+        .proxy_config
+        .as_ref()
+        .filter(|config| config.enabled && !config.url.trim().is_empty())
+    {
+        let proxy = crate::client::http::build_proxy(proxy_config)
+            .map_err(|error| anyhow!("build {provider} subscription proxy: {error}"))?;
+        builder = builder.proxy(proxy);
+        log::info!("Using configured proxy for {provider} subscription authentication");
+    } else {
+        builder = builder.no_proxy();
+    }
+
+    builder
+        .build()
+        .with_context(|| format!("build {provider} subscription http client"))
+}
+
 /// Per-provider commit barrier for login cancellation/replacement and logout.
 /// Refresh deliberately does not hold this across an external request: its
 /// durable revision CAS lets logout commit immediately and reject stale tokens.
@@ -299,11 +359,39 @@ pub(crate) fn require_current_store_revision(
 ) -> Result<u64> {
     match outcome {
         store::ConditionalCommitOutcome::Committed { revision } => Ok(revision),
-        store::ConditionalCommitOutcome::Conflict { current_revision } => Err(anyhow!(
-            "{} credentials changed in another BitFun process (current revision {current_revision}); retry the operation",
-            provider.display_label()
-        )),
+        store::ConditionalCommitOutcome::Conflict { current_revision } => {
+            Err(store_revision_conflict(provider, current_revision))
+        }
     }
+}
+
+pub(crate) fn store_revision_conflict(
+    provider: SubscriptionProvider,
+    current_revision: u64,
+) -> anyhow::Error {
+    anyhow!(
+        "{} credentials changed in another BitFun process (current revision {current_revision}); retry the operation",
+        provider.display_label()
+    )
+}
+
+/// Reloads the credential after a refresh lost its conditional commit race.
+///
+/// The revision returned by the CAS conflict is the revision observed while
+/// holding the store lock. Reloading after releasing that lock gives the
+/// caller the credential that won the race, which may be safely reused when it
+/// is still valid.
+pub(crate) async fn load_current_store_after_conflict(
+    provider: SubscriptionProvider,
+    current_revision: u64,
+) -> Result<store::VersionedCredential> {
+    let current = store::load_entry_with_revision(provider.key()).await?;
+    log::debug!(
+        "{} refresh commit lost CAS at revision {current_revision}; reloaded current revision {}",
+        provider.display_label(),
+        current.revision
+    );
+    Ok(current)
 }
 
 fn build_account(
@@ -399,6 +487,46 @@ pub async fn start_login(
     provider: SubscriptionProvider,
     session_id: String,
 ) -> Result<LoginStartResult> {
+    start_login_with_options(provider, session_id, SubscriptionHttpOptions::default()).await
+}
+
+/// Starts a subscription login while applying the host's explicit AI proxy to
+/// provider-side token exchange requests.
+pub async fn start_login_with_proxy(
+    provider: SubscriptionProvider,
+    session_id: String,
+    proxy_config: Option<ProxyConfig>,
+) -> Result<LoginStartResult> {
+    start_login_with_options(
+        provider,
+        session_id,
+        SubscriptionHttpOptions::new(proxy_config, false),
+    )
+    .await
+}
+
+/// Starts a subscription login while applying the host's explicit AI proxy
+/// and TLS verification policy to provider-side token exchange requests.
+pub async fn start_login_with_proxy_and_ssl(
+    provider: SubscriptionProvider,
+    session_id: String,
+    proxy_config: Option<ProxyConfig>,
+    skip_ssl_verify: bool,
+) -> Result<LoginStartResult> {
+    start_login_with_options(
+        provider,
+        session_id,
+        SubscriptionHttpOptions::new(proxy_config, skip_ssl_verify),
+    )
+    .await
+}
+
+/// Starts a subscription login with an explicit transport policy.
+pub async fn start_login_with_options(
+    provider: SubscriptionProvider,
+    session_id: String,
+    options: SubscriptionHttpOptions,
+) -> Result<LoginStartResult> {
     validate_session_id(&session_id)?;
     let cancel = CancellationToken::new();
     let generation = next_generation();
@@ -433,16 +561,18 @@ pub async fn start_login(
 
     // The placeholder above makes cancellation visible even while a provider
     // is still binding its callback listener or requesting a device code.
-    let begin = async {
+    let begin_cancel = cancel.clone();
+    let begin = async move {
         match provider {
             SubscriptionProvider::Codex => {
-                codex::begin_login(cancel.clone(), expected_revision).await
+                codex::begin_login(begin_cancel.clone(), expected_revision, options.clone()).await
             }
             SubscriptionProvider::Antigravity => {
-                antigravity::begin_login(cancel.clone(), expected_revision).await
+                antigravity::begin_login(begin_cancel.clone(), expected_revision, options.clone())
+                    .await
             }
             SubscriptionProvider::Opencode => {
-                opencode::begin_login(cancel.clone(), expected_revision).await
+                opencode::begin_login(begin_cancel.clone(), expected_revision, options).await
             }
         }
     };
@@ -690,10 +820,39 @@ pub async fn logout(provider: SubscriptionProvider) -> Result<SubscriptionLogout
 
 /// Resolves a runtime credential for a provider, refreshing tokens if needed.
 pub async fn resolve(provider: SubscriptionProvider) -> Result<ResolvedCredential> {
+    resolve_with_options(provider, &SubscriptionHttpOptions::default()).await
+}
+
+/// Resolves a subscription credential while applying the host's explicit AI
+/// proxy to provider-side refresh requests.
+pub async fn resolve_with_proxy(
+    provider: SubscriptionProvider,
+    proxy_config: Option<&ProxyConfig>,
+) -> Result<ResolvedCredential> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
+    resolve_with_options(provider, &options).await
+}
+
+/// Resolves a subscription credential while applying the host's explicit AI
+/// proxy and TLS verification policy to provider-side refresh requests.
+pub async fn resolve_with_proxy_and_ssl(
+    provider: SubscriptionProvider,
+    proxy_config: Option<&ProxyConfig>,
+    skip_ssl_verify: bool,
+) -> Result<ResolvedCredential> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
+    resolve_with_options(provider, &options).await
+}
+
+/// Resolves a subscription credential with an explicit transport policy.
+pub async fn resolve_with_options(
+    provider: SubscriptionProvider,
+    options: &SubscriptionHttpOptions,
+) -> Result<ResolvedCredential> {
     match provider {
-        SubscriptionProvider::Codex => codex::resolve().await,
-        SubscriptionProvider::Antigravity => antigravity::resolve().await,
-        SubscriptionProvider::Opencode => opencode::resolve().await,
+        SubscriptionProvider::Codex => codex::resolve(options).await,
+        SubscriptionProvider::Antigravity => antigravity::resolve(options).await,
+        SubscriptionProvider::Opencode => opencode::resolve(options).await,
     }
 }
 
@@ -701,15 +860,77 @@ pub async fn resolve(provider: SubscriptionProvider) -> Result<ResolvedCredentia
 /// The adapter owns the endpoint mapping so an OAuth token can never be sent
 /// to an arbitrary URL supplied by model configuration.
 pub async fn resolve_opencode(plan: OpenCodePlan, format: &str) -> Result<ResolvedCredential> {
-    opencode::resolve_for(plan, format).await
+    resolve_opencode_with_options(plan, format, &SubscriptionHttpOptions::default()).await
+}
+
+/// Resolves an OpenCode credential for a concrete plan while applying the
+/// host's explicit AI proxy to provider-side refresh requests.
+pub async fn resolve_opencode_with_proxy(
+    plan: OpenCodePlan,
+    format: &str,
+    proxy_config: Option<&ProxyConfig>,
+) -> Result<ResolvedCredential> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
+    resolve_opencode_with_options(plan, format, &options).await
+}
+
+/// Resolves an OpenCode credential for a concrete plan while applying the
+/// host's explicit AI proxy and TLS verification policy to provider-side
+/// refresh requests.
+pub async fn resolve_opencode_with_proxy_and_ssl(
+    plan: OpenCodePlan,
+    format: &str,
+    proxy_config: Option<&ProxyConfig>,
+    skip_ssl_verify: bool,
+) -> Result<ResolvedCredential> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
+    resolve_opencode_with_options(plan, format, &options).await
+}
+
+/// Resolves an OpenCode credential with an explicit transport policy.
+pub async fn resolve_opencode_with_options(
+    plan: OpenCodePlan,
+    format: &str,
+    options: &SubscriptionHttpOptions,
+) -> Result<ResolvedCredential> {
+    opencode::resolve_for(plan, format, options).await
 }
 
 /// Forces a resolve (which refreshes and saves), then returns the account entry.
 pub async fn refresh_account(provider: SubscriptionProvider) -> Result<SubscriptionAccount> {
+    refresh_account_with_options(provider, &SubscriptionHttpOptions::default()).await
+}
+
+/// Refreshes a subscription account while applying the host's explicit AI
+/// proxy to provider-side token refresh requests.
+pub async fn refresh_account_with_proxy(
+    provider: SubscriptionProvider,
+    proxy_config: Option<&ProxyConfig>,
+) -> Result<SubscriptionAccount> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
+    refresh_account_with_options(provider, &options).await
+}
+
+/// Refreshes a subscription account while applying the host's explicit AI
+/// proxy and TLS verification policy to provider-side requests.
+pub async fn refresh_account_with_proxy_and_ssl(
+    provider: SubscriptionProvider,
+    proxy_config: Option<&ProxyConfig>,
+    skip_ssl_verify: bool,
+) -> Result<SubscriptionAccount> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
+    refresh_account_with_options(provider, &options).await
+}
+
+/// Refreshes a subscription account with an explicit transport policy.
+pub async fn refresh_account_with_options(
+    provider: SubscriptionProvider,
+    options: &SubscriptionHttpOptions,
+) -> Result<SubscriptionAccount> {
     match provider {
-        SubscriptionProvider::Opencode => opencode::refresh_profile().await?,
+        SubscriptionProvider::Opencode => opencode::refresh_profile(options).await?,
         _ => {
-            resolve(provider).await?;
+            resolve_with_options(provider, options).await?;
         }
     }
     Ok(account_snapshot(provider).await)

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
@@ -7,7 +7,7 @@
 use super::store::{self, StoredCredential};
 use super::{
     OpenCodePlan, ResolvedCredential, StartedLogin, SubscriptionApiOffering,
-    SubscriptionOfferingModel,
+    SubscriptionHttpOptions, SubscriptionOfferingModel,
 };
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
@@ -117,19 +117,16 @@ struct OpenCodeRoute {
     format: &'static str,
 }
 
-fn http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("build opencode http client")
+fn http_client(options: &SubscriptionHttpOptions) -> Result<reqwest::Client> {
+    super::build_http_client(options, "OpenCode")
 }
 
 fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
-async fn request_device_code() -> Result<DeviceCodeResponse> {
-    let client = http_client()?;
+async fn request_device_code(options: &SubscriptionHttpOptions) -> Result<DeviceCodeResponse> {
+    let client = http_client(options)?;
     let resp = client
         .post(format!("{SERVER}/auth/device/code"))
         .json(&serde_json::json!({ "client_id": CLIENT_ID }))
@@ -154,8 +151,8 @@ enum DevicePoll {
 }
 
 /// One poll attempt against the device-token endpoint.
-async fn poll_once(device_code: &str) -> Result<DevicePoll> {
-    let client = http_client()?;
+async fn poll_once(device_code: &str, options: &SubscriptionHttpOptions) -> Result<DevicePoll> {
+    let client = http_client(options)?;
     let resp = client
         .post(format!("{SERVER}/auth/device/token"))
         .json(&serde_json::json!({
@@ -437,7 +434,11 @@ async fn fetch_remote_offerings(
     }
 }
 
-async fn fetch_metadata(access: &str, existing: Option<&serde_json::Value>) -> serde_json::Value {
+async fn fetch_metadata(
+    access: &str,
+    existing: Option<&serde_json::Value>,
+    options: &SubscriptionHttpOptions,
+) -> serde_json::Value {
     let mut metadata = existing
         .and_then(serde_json::Value::as_object)
         .cloned()
@@ -446,7 +447,7 @@ async fn fetch_metadata(access: &str, existing: Option<&serde_json::Value>) -> s
         "server".to_string(),
         serde_json::Value::String(SERVER.to_string()),
     );
-    let client = match http_client() {
+    let client = match http_client(options) {
         Ok(client) => client,
         Err(_) => return serde_json::Value::Object(metadata),
     };
@@ -529,8 +530,8 @@ async fn persist_tokens(
     Ok(())
 }
 
-async fn refresh(refresh_token: &str) -> Result<TokenResponse> {
-    let client = http_client()?;
+async fn refresh(refresh_token: &str, options: &SubscriptionHttpOptions) -> Result<TokenResponse> {
+    let client = http_client(options)?;
     let resp = client
         .post(format!("{SERVER}/auth/device/token"))
         .json(&serde_json::json!({
@@ -571,8 +572,9 @@ fn absolute_verification_url(uri: &str) -> String {
 pub(crate) async fn begin_login(
     cancel: CancellationToken,
     expected_revision: u64,
+    options: SubscriptionHttpOptions,
 ) -> Result<StartedLogin> {
-    let device = request_device_code().await?;
+    let device = request_device_code(&options).await?;
     let interval = device.interval.unwrap_or(5).max(1);
     let device_code = device.device_code.clone();
     let user_code = device.user_code.clone();
@@ -586,14 +588,15 @@ pub(crate) async fn begin_login(
                 let mut wait = interval;
                 loop {
                     tokio::time::sleep(Duration::from_secs(wait)).await;
-                    match poll_once(&device_code).await? {
+                    match poll_once(&device_code, &options).await? {
                         DevicePoll::Authorized(tokens) => {
                             // Optional profile/org network calls belong to the
                             // cancellable authorization phase. The provider
                             // commit lock should cover only the credential
                             // store transaction, never up to 60 seconds of
                             // metadata fetching.
-                            let metadata = fetch_metadata(&tokens.access_token, None).await;
+                            let metadata =
+                                fetch_metadata(&tokens.access_token, None, &options).await;
                             return Ok((tokens, metadata));
                         }
                         DevicePoll::Pending => {
@@ -621,7 +624,7 @@ pub(crate) async fn begin_login(
     })
 }
 
-async fn ensure_fresh() -> Result<String> {
+async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<String> {
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
@@ -638,7 +641,7 @@ async fn ensure_fresh() -> Result<String> {
             if expires > now_ms() + REFRESH_LEEWAY_MS {
                 return Ok(access);
             }
-            let refreshed = refresh(&refresh_token).await?;
+            let refreshed = refresh(&refresh_token, options).await?;
             let new_expires = now_ms() + refreshed.expires_in * 1000;
             let outcome = store::upsert_if_revision(
                 STORE_KEY,
@@ -652,16 +655,46 @@ async fn ensure_fresh() -> Result<String> {
                 },
             )
             .await?;
-            super::require_current_store_revision(super::SubscriptionProvider::Opencode, outcome)?;
-            log::info!("opencode subscription tokens refreshed");
-            Ok(refreshed.access_token)
+            match outcome {
+                store::ConditionalCommitOutcome::Committed { .. } => {
+                    log::info!("opencode subscription tokens refreshed");
+                    Ok(refreshed.access_token)
+                }
+                store::ConditionalCommitOutcome::Conflict { current_revision } => {
+                    let current = super::load_current_store_after_conflict(
+                        super::SubscriptionProvider::Opencode,
+                        current_revision,
+                    )
+                    .await?;
+                    match current.credential {
+                        Some(StoredCredential::Api { key, .. }) => {
+                            log::info!(
+                                "opencode refresh reused the current API credential after a concurrent update"
+                            );
+                            Ok(key)
+                        }
+                        Some(StoredCredential::Oauth {
+                            access, expires, ..
+                        }) if expires > now_ms() => {
+                            log::info!(
+                                "opencode refresh reused tokens committed by a concurrent refresh"
+                            );
+                            Ok(access)
+                        }
+                        _ => Err(super::store_revision_conflict(
+                            super::SubscriptionProvider::Opencode,
+                            current_revision,
+                        )),
+                    }
+                }
+            }
         }
     }
 }
 
 /// Refreshes account/org/catalog metadata using a fresh credential.
-pub(crate) async fn refresh_profile() -> Result<()> {
-    let access = ensure_fresh().await?;
+pub(crate) async fn refresh_profile(options: &SubscriptionHttpOptions) -> Result<()> {
+    let access = ensure_fresh(options).await?;
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
@@ -671,7 +704,7 @@ pub(crate) async fn refresh_profile() -> Result<()> {
             metadata.as_ref()
         }
     };
-    let metadata = fetch_metadata(&access, existing_metadata).await;
+    let metadata = fetch_metadata(&access, existing_metadata, options).await;
     if existing_metadata == Some(&metadata) {
         return Ok(());
     }
@@ -701,8 +734,11 @@ pub(crate) async fn refresh_profile() -> Result<()> {
     Ok(())
 }
 
-async fn resolve_route(route: OpenCodeRoute) -> Result<ResolvedCredential> {
-    let api_key = ensure_fresh().await?;
+async fn resolve_route(
+    route: OpenCodeRoute,
+    options: &SubscriptionHttpOptions,
+) -> Result<ResolvedCredential> {
+    let api_key = ensure_fresh(options).await?;
     Ok(ResolvedCredential {
         api_key,
         base_url: Some(route.base_url.to_string()),
@@ -715,13 +751,17 @@ async fn resolve_route(route: OpenCodeRoute) -> Result<ResolvedCredential> {
 
 /// Resolves the legacy OpenCode target. Models saved before plan-aware auth
 /// are kept on their historical Zen Chat Completions route.
-pub(crate) async fn resolve() -> Result<ResolvedCredential> {
-    resolve_route(route_for(OpenCodePlan::Zen, "openai")?).await
+pub(crate) async fn resolve(options: &SubscriptionHttpOptions) -> Result<ResolvedCredential> {
+    resolve_route(route_for(OpenCodePlan::Zen, "openai")?, options).await
 }
 
 /// Resolves a concrete OpenCode plan and wire format to a trusted endpoint.
-pub(crate) async fn resolve_for(plan: OpenCodePlan, format: &str) -> Result<ResolvedCredential> {
-    resolve_route(route_for(plan, format)?).await
+pub(crate) async fn resolve_for(
+    plan: OpenCodePlan,
+    format: &str,
+    options: &SubscriptionHttpOptions,
+) -> Result<ResolvedCredential> {
+    resolve_route(route_for(plan, format)?, options).await
 }
 
 /// Provider metadata used to seed a new model entry.

--- a/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
@@ -17,7 +17,7 @@ use crate::infrastructure::subscription_auth::{
     SubscriptionProvider as AdapterProvider,
 };
 use crate::service::config::types::{
-    model_runtime_binding_fingerprint, AuthConfig, OpenCodePlan, ProxyConfig, SubscriptionProvider,
+    model_runtime_binding_fingerprint, AuthConfig, OpenCodePlan, SubscriptionProvider,
 };
 use crate::service::config::{get_global_config_service, ConfigService};
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -449,27 +449,15 @@ fn to_adapter_opencode_plan(plan: OpenCodePlan) -> AdapterOpenCodePlan {
     }
 }
 
-/// Resolves subscription authentication while passing the global AI proxy to
-/// provider-side token refresh requests.
-pub async fn apply_subscription_auth_with_proxy(
+/// Resolve a subscription `AuthConfig` and overlay it onto the runtime
+/// `AIConfig`. No-op when `auth == AuthConfig::ApiKey`. Returns the resolved
+/// credential's expiry (Unix seconds) so callers can invalidate cached
+/// clients before the token goes stale.
+pub async fn apply_subscription_auth(
     auth: &AuthConfig,
     ai_config: &mut AIConfig,
-    proxy_config: Option<&ProxyConfig>,
 ) -> Result<Option<i64>> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
-    apply_subscription_auth_with_options(auth, ai_config, &options).await
-}
-
-/// Resolves subscription authentication while passing the global AI proxy and
-/// model TLS verification policy to provider-side token refresh requests.
-pub async fn apply_subscription_auth_with_proxy_and_ssl(
-    auth: &AuthConfig,
-    ai_config: &mut AIConfig,
-    proxy_config: Option<&ProxyConfig>,
-    skip_ssl_verify: bool,
-) -> Result<Option<i64>> {
-    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
-    apply_subscription_auth_with_options(auth, ai_config, &options).await
+    apply_subscription_auth_with_options(auth, ai_config, &SubscriptionHttpOptions::default()).await
 }
 
 /// Resolves subscription authentication with an explicit transport policy.

--- a/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
@@ -13,10 +13,11 @@ use crate::infrastructure::ai::reasoning_catalog::{
 };
 use crate::infrastructure::ai::{build_stream_options_for_model, AIClient};
 use crate::infrastructure::subscription_auth::{
-    self, OpenCodePlan as AdapterOpenCodePlan, SubscriptionProvider as AdapterProvider,
+    self, OpenCodePlan as AdapterOpenCodePlan, SubscriptionHttpOptions,
+    SubscriptionProvider as AdapterProvider,
 };
 use crate::service::config::types::{
-    model_runtime_binding_fingerprint, AuthConfig, OpenCodePlan, SubscriptionProvider,
+    model_runtime_binding_fingerprint, AuthConfig, OpenCodePlan, ProxyConfig, SubscriptionProvider,
 };
 use crate::service::config::{get_global_config_service, ConfigService};
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -42,7 +43,7 @@ struct CachedAIClient {
 }
 
 /// Once a cached subscription credential is within this window of expiry, the
-/// client is rebuilt so `apply_subscription_auth` refreshes the token. Kept
+/// client is rebuilt so subscription authentication refreshes the token. Kept
 /// equal to the providers' refresh leeway so the rebuilt client always gets a
 /// fresh token.
 const SUBSCRIPTION_CREDENTIAL_STALE_LEEWAY_SECS: i64 = 5 * 60;
@@ -310,14 +311,20 @@ impl AIClientFactory {
 
         let mut ai_config = AIConfig::try_from(model_config.clone())
             .map_err(|e| anyhow!("AI configuration conversion failed: {}", e))?;
-        let credential_expires_at =
-            apply_subscription_auth(&model_config.auth, &mut ai_config).await?;
-
+        let skip_ssl_verify = ai_config.skip_ssl_verify;
         let proxy_config = if global_config.ai.proxy.enabled {
             Some(global_config.ai.proxy.clone())
         } else {
             None
         };
+        let subscription_options =
+            SubscriptionHttpOptions::new(proxy_config.clone(), skip_ssl_verify);
+        let credential_expires_at = apply_subscription_auth_with_options(
+            &model_config.auth,
+            &mut ai_config,
+            &subscription_options,
+        )
+        .await?;
 
         let stream_options = build_stream_options_for_model(&global_config.ai, Some(model_config));
         let client = apply_default_reasoning_preset(
@@ -442,26 +449,51 @@ fn to_adapter_opencode_plan(plan: OpenCodePlan) -> AdapterOpenCodePlan {
     }
 }
 
-/// Resolve a subscription `AuthConfig` and overlay it onto the runtime
-/// `AIConfig`. No-op when `auth == AuthConfig::ApiKey`. Returns the resolved
-/// credential's expiry (Unix seconds) so callers can invalidate cached
-/// clients before the token goes stale.
-pub async fn apply_subscription_auth(
+/// Resolves subscription authentication while passing the global AI proxy to
+/// provider-side token refresh requests.
+pub async fn apply_subscription_auth_with_proxy(
     auth: &AuthConfig,
     ai_config: &mut AIConfig,
+    proxy_config: Option<&ProxyConfig>,
+) -> Result<Option<i64>> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), false);
+    apply_subscription_auth_with_options(auth, ai_config, &options).await
+}
+
+/// Resolves subscription authentication while passing the global AI proxy and
+/// model TLS verification policy to provider-side token refresh requests.
+pub async fn apply_subscription_auth_with_proxy_and_ssl(
+    auth: &AuthConfig,
+    ai_config: &mut AIConfig,
+    proxy_config: Option<&ProxyConfig>,
+    skip_ssl_verify: bool,
+) -> Result<Option<i64>> {
+    let options = SubscriptionHttpOptions::new(proxy_config.cloned(), skip_ssl_verify);
+    apply_subscription_auth_with_options(auth, ai_config, &options).await
+}
+
+/// Resolves subscription authentication with an explicit transport policy.
+pub async fn apply_subscription_auth_with_options(
+    auth: &AuthConfig,
+    ai_config: &mut AIConfig,
+    options: &SubscriptionHttpOptions,
 ) -> Result<Option<i64>> {
     let resolved = match auth {
         AuthConfig::ApiKey => return Ok(None),
         AuthConfig::Subscription { provider, plan } => {
             let resolved = match (*provider, *plan) {
                 (SubscriptionProvider::Opencode, Some(plan)) => {
-                    subscription_auth::resolve_opencode(
+                    subscription_auth::resolve_opencode_with_options(
                         to_adapter_opencode_plan(plan),
                         &ai_config.format,
+                        options,
                     )
                     .await
                 }
-                (_, None) => subscription_auth::resolve(to_adapter_provider(*provider)).await,
+                (_, None) => {
+                    subscription_auth::resolve_with_options(to_adapter_provider(*provider), options)
+                        .await
+                }
                 (_, Some(plan)) => Err(anyhow!(
                     "OpenCode plan {plan:?} cannot be used with provider {provider:?}"
                 )),


### PR DESCRIPTION
## Summary

Subscription OAuth login, token refresh, and credential resolution now honor the global AI proxy (`ai.proxy`). This applies to the Codex, Antigravity, and OpenCode subscription providers, whose token exchange, refresh, and account-discovery requests run outside the normal AI request client and previously ignored the proxy configuration.

Bare `host:port` proxy URLs (e.g. `127.0.0.1:7897`) are normalized to `http://host:port`; explicit schemes such as `socks5://` are preserved.

TLS verification for subscription-auth requests now follows the model configuration (`skip_ssl_verify`) and uses the same TLS backend as the main AI client.

## Changes

- **ai-adapters**: `build_http_client` builds a proxy/TLS-aware client shared by all three subscription providers; `build_proxy` normalizes bare proxy URLs. `SubscriptionHttpOptions` carries the transport policy (proxy + `skip_ssl_verify`) through login, refresh, and resolution.
- **core**: `client_factory` resolves subscription credentials with the model's proxy and TLS settings.
- **desktop**: `commands` passes the configured AI proxy into subscription login and account refresh.

## Also included

When a local token refresh loses its conditional-commit race to a concurrent refresh, the credential committed by the winner is reused if still valid, instead of always failing on a revision conflict.

## Verification

- `cargo fmt` (changed files via `format-changed-rust`)
- `cargo check` for `bitfun-ai-adapters` (with `subscription-auth`), `bitfun-core`, `bitfun-desktop`
- `cargo test` for `bitfun-ai-adapters` (full suite), `bitfun-core`, `bitfun-desktop`

## Review follow-up

- Restored the public `apply_subscription_auth` compatibility entry point.
- Collapsed the new transport variants to the legacy APIs plus one explicit options-based path per operation.
- Enabled Reqwest SOCKS transport in `bitfun-ai-adapters`, with a crate-specific dependency boundary contract and regression coverage.

## Additional verification

- `cargo test -p bitfun-ai-adapters --features subscription-auth` (271 passed)
- `cargo test -p bitfun-core --no-default-features --features ai-adapter-runtime --lib infrastructure::ai::client_factory::tests` (6 passed)
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop` (283 passed, 2 ignored)
- `pnpm run check:core-boundaries:test` (68 passed)
- `pnpm run check:core-boundaries`
- `git diff --check`