### PR TITLE
chore(release): bump version to 0.2.17

### DIFF
--- a/BitFun-Installer/package-lock.json
+++ b/BitFun-Installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-installer",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "type": "module",
   "description": "BitFun Custom Installer - Modern branded installation experience",

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-installer"
-version = "0.2.16"
+version = "0.2.17"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Custom Installer - Modern branded installation experience"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-acp"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -782,11 +782,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-content"
-version = "0.2.16"
+version = "0.2.17"
 
 [[package]]
 name = "bitfun-agent-runtime"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-agent-stream",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-runtime-ipc"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-events",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-stream"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-tools"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-core-types",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-ai-adapters"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server-client"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server-protocol"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "agent-client-protocol",
  "bitfun-core-types",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-claude-code-adapter"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-cli"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-codex-adapter"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core-types"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-desktop"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-events"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-external-sources"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bitfun-product-domains",
  "futures",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-harness"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "thiserror 2.0.19",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-service"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-opencode-adapter"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-plugin-runtime-client",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-page-function-runtime"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "rquickjs",
  "serde",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-plugin-runtime-client"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-runtime-ports",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-capabilities"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-domains"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "dirs 6.0.0",
  "hex",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-service"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-ports"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-services"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host-app"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-integrations"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-skin-market-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-skin-market-service"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-static-hook-support"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-call-jsonrepair"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -1678,11 +1678,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-packs"
-version = "0.2.16"
+version = "0.2.17"
 
 [[package]]
 name = "bitfun-transport"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-webdriver"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -10647,7 +10647,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11078,7 +11078,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tool-runtime"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anydoc",
  "bitfun-agent-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ resolver = "2"
 
 # Shared package metadata — single source of truth for version
 [workspace.package]
-version = "0.2.16" # x-release-please-version
+version = "0.2.17" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "BitFun",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "BitFun",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "hasInstallScript": true,
       "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BitFun",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-server"
-version = "0.2.16" # x-release-please-version
+version = "0.2.17" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun standalone Remote Connect relay server"

--- a/src/crates/services/page-function-runtime/Cargo.toml
+++ b/src/crates/services/page-function-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-page-function-runtime"
-version = "0.2.16"
+version = "0.2.17"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Embedded JS Page Function runtime for BitFun Pages (rquickjs)"

--- a/src/crates/services/relay-service/Cargo.toml
+++ b/src/crates/services/relay-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-service"
-version = "0.2.16"
+version = "0.2.17"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Reusable relay runtime for BitFun Remote Connect"

--- a/src/miniapp-market-web/package.json
+++ b/src/miniapp-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-miniapp-market-web",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/mobile-web/package-lock.json
+++ b/src/mobile-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-mobile-web",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/skin-market-web/package.json
+++ b/src/skin-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-skin-market-web",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfun/web-ui",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "description": "BitFun Web UI - 支持 Desktop 和 Server 两种部署方式",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump BitFun product, workspace, installer, and frontend package versions from 0.2.16 to 0.2.17.
- Keep npm lockfiles and local Cargo workspace package versions in sync.

## Verification

- cargo metadata --format-version 1 --no-deps --locked --offline
- JSON manifest version consistency check across 9 package manifests
- git diff --check
- pnpm run check:repo-hygiene: blocked by the pre-existing untracked generate_intro_doc.cjs, which contains a local absolute path and is not part of this PR

AI-assisted change; lightly tested with metadata and manifest validation.