### PR TITLE
fix(settings): refine session title model configuration

### DIFF
--- a/src/shared/ai-provider-catalog/providers.json
+++ b/src/shared/ai-provider-catalog/providers.json
@@ -74,7 +74,7 @@
       "region": "cn",
       "name": "Qwen (Alibaba)",
       "description": "Alibaba Qwen series",
-      "help_url": "https://dashscope.console.aliyun.com/apiKey",
+      "help_url": "https://bailian.console.aliyun.com",
       "requires_api_key": true,
       "catalog_provider_ids": ["alibaba"],
       "endpoints": [

--- a/src/web-ui/src/infrastructure/config/components/AIFeaturesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIFeaturesConfig.scss
@@ -81,22 +81,8 @@
     white-space: nowrap;
   }
 
-  &__row-control--model {
-    width: 100%;
-    align-items: stretch;
-
-    .model-selection-radio {
-      width: auto;
-      justify-content: flex-end;
-    }
-
-    .model-selection-radio--horizontal .model-selection-radio__option--custom {
-      flex-grow: 0;
-    }
-  }
-
-  .bitfun-config-page-row.bitfun-func-agent-config__model-row {
-    grid-template-columns: minmax(0, 4fr) minmax(0, 6fr);
+  &__appearance-host {
+    display: contents;
   }
 
   &__warning {

--- a/src/web-ui/src/infrastructure/config/components/SessionTitleConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionTitleConfig.tsx
@@ -1,18 +1,22 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Switch } from '@/component-library';
+import { Select, Switch } from '@/component-library';
 import { useNotification, notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
 import { aiExperienceConfigService, type AIExperienceSettings } from '../services/AIExperienceConfigService';
 import { configManager } from '../services/ConfigManager';
 import type { AIModelConfig } from '../types';
 import { ConfigPageRow, ConfigPageSection } from './common';
-import { ModelSelectionRadio } from './ModelSelectionRadio';
+import { type ModelSelectOption, useModelSelectPresentation } from './ModelSelectPresentation';
 import './AIFeaturesConfig.scss';
 
 const log = createLogger('SessionTitleConfig');
 
 const AGENT_SESSION_TITLE = 'session-title-func-agent';
+
+function normalizeSelectValue(value: string | number | (string | number)[]): string {
+  return String(Array.isArray(value) ? (value[0] ?? '') : value);
+}
 
 export const SessionTitleConfig: React.FC = () => {
   const { t } = useTranslation('settings/ai-model');
@@ -21,6 +25,7 @@ export const SessionTitleConfig: React.FC = () => {
   const [settings, setSettings] = useState<AIExperienceSettings | null>(null);
   const [models, setModels] = useState<AIModelConfig[]>([]);
   const [funcAgentModels, setFuncAgentModels] = useState<Record<string, string>>({});
+  const { buildModelOption, renderModelOption, renderModelValue } = useModelSelectPresentation();
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -57,6 +62,15 @@ export const SessionTitleConfig: React.FC = () => {
 
   const enabledModels = models.filter((model) => model.enabled);
   const sessionTitleModelId = funcAgentModels[AGENT_SESSION_TITLE] || 'fast';
+  const modelOptions = useMemo<ModelSelectOption[]>(() => [
+    { label: t('sessionTitle.model.fast'), value: 'fast' },
+    { label: t('sessionTitle.model.primary'), value: 'primary' },
+    ...enabledModels
+      .filter((model): model is AIModelConfig & { id: string } => (
+        typeof model.id === 'string' && model.id.trim().length > 0
+      ))
+      .map(buildModelOption),
+  ], [buildModelOption, enabledModels, t]);
 
   const updateEnabled = async (checked: boolean) => {
     if (!settings) return;
@@ -114,31 +128,44 @@ export const SessionTitleConfig: React.FC = () => {
       data-bf-part="root"
       title={t('sessionTitle.title')}
       description={t('sessionTitle.subtitle')}
-    >
-      <ConfigPageRow label={t('sessionTitle.enable')} align="center">
-        <div className="bitfun-func-agent-config__row-control" data-bf-component="session-title-config" data-bf-part="enableControl">
+      extra={(
+        <div
+          className="bitfun-func-agent-config__appearance-host"
+          data-bf-component="session-title-config"
+          data-bf-part="enableControl"
+        >
           <Switch
             checked={settings?.enable_session_title_generation ?? false}
             onChange={(e) => void updateEnabled(e.target.checked)}
             size="small"
             disabled={isLoading || !settings}
+            aria-label={t('sessionTitle.title')}
           />
         </div>
-      </ConfigPageRow>
+      )}
+    >
       <ConfigPageRow
-        className="bitfun-func-agent-config__model-row"
         label={t('sessionTitle.model.label')}
         description={enabledModels.length === 0 ? t('sessionTitle.models.empty') : undefined}
         align="center"
       >
-        <div className="bitfun-func-agent-config__row-control bitfun-func-agent-config__row-control--model" data-bf-component="session-title-config" data-bf-part="modelControl">
-          <ModelSelectionRadio
-            value={sessionTitleModelId}
-            models={enabledModels}
-            onChange={(modelId) => void handleModelChange(modelId)}
-            layout="horizontal"
+        <div
+          className="bitfun-func-agent-config__appearance-host"
+          data-bf-component="session-title-config"
+          data-bf-part="modelControl"
+        >
+          <Select
             size="small"
+            searchable
+            className="model-select-presentation__select"
+            dropdownClassName="model-select-presentation__dropdown"
+            options={modelOptions}
+            value={sessionTitleModelId}
+            onChange={(value) => void handleModelChange(normalizeSelectValue(value))}
+            renderOption={renderModelOption}
+            renderValue={renderModelValue}
             disabled={isLoading}
+            triggerTestId="settings-session-title-model-select"
           />
         </div>
       </ConfigPageRow>

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -27,10 +27,9 @@
   "sessionTitle": {
     "title": "Auto Session Title",
     "subtitle": "AI automatically generates concise titles for new conversations",
-    "enable": "Enable",
     "loadFailed": "Failed to load session title settings",
     "model": {
-      "label": "Model",
+      "label": "Session Title Generation Model",
       "primary": "Primary Model",
       "fast": "Fast Model"
     },

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -27,10 +27,9 @@
   "sessionTitle": {
     "title": "会话标题自动生成",
     "subtitle": "新对话时 AI 自动生成简洁标题",
-    "enable": "启用",
     "loadFailed": "加载会话标题配置失败",
     "model": {
-      "label": "模型",
+      "label": "会话标题生成模型",
       "primary": "主力模型",
       "fast": "快速模型"
     },

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -27,10 +27,9 @@
   "sessionTitle": {
     "title": "會話標題自動生成",
     "subtitle": "新對話時 AI 自動生成簡潔標題",
-    "enable": "啟用",
     "loadFailed": "載入會話標題設定失敗",
     "model": {
-      "label": "模型",
+      "label": "會話標題生成模型",
       "primary": "主力模型",
       "fast": "快速模型"
     },


### PR DESCRIPTION
- move the auto-title toggle into the section header
- replace model radio options with a searchable model selector
- align session-title labels and remove obsolete layout styles
- update the Qwen help link to the Bailian console
