### PR TITLE
fix(ci): pass public key when signing Windows installer

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -520,6 +520,7 @@ jobs:
         env:
           BITFUN_SIGNING_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           BITFUN_SIGNING_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          BITFUN_SIGNING_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
         run: bash scripts/sign-release-assets.sh release-manual-assets/*.exe
 
       - name: Collect updater assets

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -275,3 +275,21 @@ test('keeps Rust CI independent, restore-only on PRs, and target-focused', () =>
     'cargo test --locked -p tool-runtime --lib search::',
   );
 });
+
+test('passes the verification key when signing the versioned Windows installer', () => {
+  const workflow = yaml.parse(
+    readFileSync(
+      path.join(repoRoot, '.github/workflows/desktop-package.yml'),
+      'utf8',
+    ),
+  );
+  const signingStep = workflow.jobs['upload-release-assets'].steps.find(
+    (step) => step.name === 'Sign versioned Windows installer',
+  );
+
+  assert.equal(
+    signingStep?.env?.BITFUN_SIGNING_PUBKEY,
+    '${{ secrets.TAURI_UPDATER_PUBKEY }}',
+    'release signatures must be self-verified with the configured public key',
+  );
+});


### PR DESCRIPTION
## Summary

- Pass `TAURI_UPDATER_PUBKEY` to the versioned Windows installer signing step.
- Add a GitHub workflow contract test that keeps the self-verification key wired.

## Root cause

The versioned Windows installer signing step supplied the private key and password but omitted `BITFUN_SIGNING_PUBKEY`. `scripts/sign-release-assets.sh` created the signature and then failed its mandatory self-verification because the public key was empty.

## Impact

Manual Desktop Package release runs can sign and self-verify the versioned Windows installer before uploading release assets.

## Verification

- `pnpm run check:github-config`
- `node --test scripts/check-github-config.test.mjs`
- `git diff --check`