### PR TITLE
docs(agents): expand remote scenario guardrails

### DIFF
--- a/AGENTS-CN.md
+++ b/AGENTS-CN.md
@@ -128,13 +128,53 @@ await api.invoke('your_command', { request: { ... } });
 - 桌面端专属集成应放在 `src/apps/desktop`，再通过类型化能力接口回流；需要事件投递时，使用已有生产 transport adapter。
 - 在共享 core 中避免使用 `tauri::AppHandle` 等宿主 API；优先使用 `bitfun_events::EventEmitter` 等共享抽象。
 
-### 远程兼容
+### 远程场景
 
-- 新增功能时，从一开始就要考虑远程工作区和远程控制同步适配。只支持本地的行为很容易让远程场景功能缺失。
-- 如果某个功能无法合理支持远程工作区，必须做能力屏蔽，或展示明确的不支持提示，不能让它以通用错误的形式失败。
-- 每个桌面端 Tauri 命令都必须在
- `src/apps/desktop/src/api/remote_workspace_policy.rs` 中声明远程工作区策略；
- 该文件的契约测试会拒绝没有显式策略的新命令，并禁止 legacy-unaudited 存量清单增长。
+BitFun 不是只在本地运行的桌面应用：工作区、执行这一轮的 runtime、以及正在操作的人，
+可能分别位于三台机器。下面四种场景是每次改动都要一并覆盖的一等目标，不是事后再补的适配。
+
+| 场景 | 含义 | 设计入口 |
+|---|---|---|
+| 远程工作区 | 当前工作区位于 SSH 主机、跳板机链路或 Docker 容器；文件、终端、搜索和 Agent 子进程都必须在那一侧执行 | [remote-workspace-transport.md](docs/architecture/remote-workspace-transport.md)、[remote-workspaces.md](docs/features/remote-workspaces.md) |
+| 远程控制 | 手机端 mobile web，或飞书 / Telegram / 微信 Bot，通过 Remote Connect relay 驱动 Desktop 或 CLI 宿主上的会话 | [`src/mobile-web`](src/mobile-web/AGENTS.md)、[services-integrations](src/crates/services/services-integrations/AGENTS.md) 的 `remote_connect`、[relay-service](src/crates/services/relay-service/AGENTS.md) |
+| 多端互控（Peer Device Mode） | 同账号的一台设备成为另一台的数据平面：控制端外壳仍在本地，invoke 和事件来自 peer | [peer-device-mode.md](docs/architecture/peer-device-mode.md)、[peer-device README](src/web-ui/src/infrastructure/peer-device/README.md) |
+| Dispatch 分离任务 | 控制端把持久化任务提交到另一台 BitFun 宿主后即可断开；目标端拥有 job、session、worktree、事件日志和权限信箱 | [detached-task-dispatch.md](docs/architecture/detached-task-dispatch.md) |
+
+四种场景共同适用的规则：
+
+- 远程路径要和功能一起设计。默认 UI、进程和文件系统在同一台机器上的能力属于未完成，
+  而不是“第一阶段”。
+- 不支持要显式暴露。确实无法支持时，应屏蔽入口或返回明确的不支持状态；静默回落本地、
+  假成功、空载荷和通用错误都算回归，其中回落本地还会把本地内容泄露给远端控制方。
+- 阻塞式交互必须可以远程应答。新增的权限确认、对话框和选择器都要经既有的 dialog /
+  权限信箱编排送达当前操作端；只能靠桌面窗口解除的阻塞会让远程控制和 Dispatch 任务死锁。
+- 要能扛断线。远程形态会重连、按 cursor 重放并重新 hydrate，因此优先使用可恢复 cursor
+  和幂等变更，不要依赖“客户端恰好在线”才存在的状态。
+- 远程工作区路径在任何客户端 OS 上都是 POSIX 路径。不得用宿主 `std::path` 语义切分或
+  拼接，也不得把控制端的路径直接拿到 peer 宿主上复用。
+
+各场景的具体约束：
+
+- **远程工作区**：每个桌面端 Tauri 命令都必须在
+  [`remote_workspace_policy.rs`](src/apps/desktop/src/api/remote_workspace_policy.rs)
+  中声明策略；该文件的契约测试会拒绝没有显式策略的新命令，并禁止 `LegacyUnaudited`
+  存量清单增长。
+- **远程控制**：mobile web 和 IM Bot 是通过 `RemoteCommand` wire 协议和 bot command
+  router / menu 触达会话的，不走 Web UI。新增或迁移会话级能力时——工作区与助手选择、
+  会话生命周期、模式、模型、审批、附件——要同步扩展这些形态，或让它们给出明确的
+  不支持回复。
+- **多端互控**：产品命令默认代理到 peer 执行。必须留在控制端的命令（窗口装饰、更新器、
+  账号身份、本地 OS 自动化）要在三份保持同步的清单中一起禁用：
+  [`peer_host_invoke.rs`](src/apps/desktop/src/api/peer_host_invoke.rs)、
+  [`deny.rs`](src/apps/cli/src/peer_host/deny.rs) 和
+  [`peer-device-adapter.ts`](src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts)。
+  改动 session、account 或 hydrate 路径前，先读 peer-device README 的 invariants。
+- **Dispatch 分离任务**：任务在目标端以 CLI delivery profile 无界面运行，没有交互宿主，
+  也不保证控制端在线。控制端只是观察者，不是 runtime 或文件系统代理。不要引入依赖提交方
+  常驻的行为；dispatch 协议版本和目标端必备 capability 属于兼容契约——新的目标端要求要走
+  协商 capability，而不是默认假设。
+
+改动说明中要写清楚在哪些远程场景下验证过。只跑本地测试不能作为远程行为的证据。
 
 ### Agent loop 行为
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,14 +145,66 @@ await api.invoke('your_command', { request: { ... } });
 - Desktop-only host adapters belong in `src/apps/desktop`, then flow through typed capability interfaces and, when event delivery is needed, the production transport adapter.
 - In shared core, avoid host-specific APIs such as `tauri::AppHandle`; use shared abstractions such as `bitfun_events::EventEmitter`.
 
-### Remote compatibility
+### Remote scenarios
 
-- When adding features, consider remote workspace and remote control synchronization support from the start. Local-only behavior can silently leave remote scenarios incomplete.
-- If a feature cannot reasonably support remote workspaces, gate it or show a clear unsupported-state message instead of letting it fail with a generic error.
-- Every desktop Tauri command must declare its remote-workspace policy in
- `src/apps/desktop/src/api/remote_workspace_policy.rs`; the contract test there
- rejects new commands without an explicit policy and forbids growing the
- legacy-unaudited backlog.
+BitFun is not a local-only desktop app. The workspace, the runtime that executes
+a turn, and the person driving it can each sit on a different machine. Treat the
+four scenarios below as first-class targets of every change, not as a later port.
+
+| Scenario | What it means | Design entry point |
+|---|---|---|
+| Remote workspace | The active workspace lives on an SSH host, a jump-host chain, or a Docker container; files, terminal, search, and Agent subprocesses must execute there | [remote-workspace-transport.md](docs/architecture/remote-workspace-transport.md), [remote-workspaces.md](docs/features/remote-workspaces.md) |
+| Remote control | Mobile web, or a Feishu / Telegram / WeChat bot, drives a session on a Desktop or CLI host through the Remote Connect relay | [`src/mobile-web`](src/mobile-web/AGENTS.md), `remote_connect` in [services-integrations](src/crates/services/services-integrations/AGENTS.md), [relay-service](src/crates/services/relay-service/AGENTS.md) |
+| Peer Device Mode | One same-account device becomes the data plane of another: the controller shell stays local, invokes and events come from the peer | [peer-device-mode.md](docs/architecture/peer-device-mode.md), [peer-device README](src/web-ui/src/infrastructure/peer-device/README.md) |
+| Detached Dispatch | A controller submits a durable job to another BitFun host and may then disconnect; the target owns the job, session, worktree, event log, and permission mailbox | [detached-task-dispatch.md](docs/architecture/detached-task-dispatch.md) |
+
+Rules that apply to all four:
+
+- Design the remote path together with the feature. A capability that assumes UI,
+  process, and filesystem share one machine is incomplete, not "phase one".
+- Degrade loudly. When a scenario cannot be supported, gate the entry point or
+  return a clear unsupported state. Silent local fallback, fake success, empty
+  payloads, and generic errors are all regressions; local fallback additionally
+  leaks local content to a remote controller.
+- Keep blocking interaction answerable from a distance. New permission prompts,
+  dialogs, and pickers must reach the driving surface through the existing dialog
+  and permission-mailbox orchestration. A turn that only the desktop window can
+  unblock deadlocks remote control and dispatch jobs.
+- Survive disconnect. Remote surfaces reconnect, replay by cursor, and re-hydrate,
+  so prefer resumable cursors and idempotent mutations over state that exists only
+  while a client happens to be attached.
+- Remote workspace paths are POSIX on every client OS. Do not split or join them
+  with host `std::path` semantics, and do not reuse a controller-side path on a
+  peer host.
+
+Per-scenario obligations:
+
+- **Remote workspace**: every desktop Tauri command declares its policy in
+  [`remote_workspace_policy.rs`](src/apps/desktop/src/api/remote_workspace_policy.rs).
+  The contract test there rejects new commands without an explicit policy and
+  forbids growing the `LegacyUnaudited` backlog.
+- **Remote control**: mobile web and IM bots reach sessions through the
+  `RemoteCommand` wire protocol and the bot command router / menu, not through the
+  Web UI. When a session-level capability is added or moved — workspace or
+  assistant selection, session lifecycle, mode, model, approval, attachment —
+  extend those surfaces or make them answer with an explicit unsupported reply.
+- **Peer Device Mode**: product commands are proxied to the peer by default. A
+  command that must stay on the controller (window chrome, updater, account
+  identity, local OS automation) has to be denied in all three lists that are kept
+  in sync: [`peer_host_invoke.rs`](src/apps/desktop/src/api/peer_host_invoke.rs),
+  [`deny.rs`](src/apps/cli/src/peer_host/deny.rs), and
+  [`peer-device-adapter.ts`](src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts).
+  Read the peer-device README invariants before changing session, account, or
+  hydrate paths.
+- **Detached Dispatch**: jobs run headless on the target under the CLI delivery
+  profile, with no interactive host and no guaranteed controller connection. The
+  controller is an observer, never a runtime or filesystem proxy. Do not add
+  behavior that requires a live submitter, and treat the dispatch protocol version
+  and required target capabilities as a compatibility contract — a new target-side
+  requirement needs a negotiated capability, not an assumption.
+
+State which remote scenarios a change was exercised in. Local-only tests are not
+evidence of remote behavior.
 
 ### Agent loop behavior
 


### PR DESCRIPTION
## Summary

The root agent guide only warned about remote SSH workspaces, so changes routinely shipped complete for the local desktop and incomplete for the other remote paths. This replaces the three-bullet **Remote compatibility** section in `AGENTS.md` / `AGENTS-CN.md` with a fuller **Remote scenarios** section covering all four:

- **Remote workspace** — SSH host, jump-host chain, or Docker container.
- **Remote control** — mobile web and Feishu / Telegram / WeChat bots over the Remote Connect relay.
- **Peer Device Mode** — one same-account device as the data plane of another.
- **Detached Dispatch** — durable jobs owned by another BitFun host.

Each row links to its design entry point, followed by cross-cutting rules and per-scenario obligations.

## Type and Areas

Type: docs

Areas: docs (root agent guide, English + 中文)

## Motivation / Impact

Remote SSH workspaces already had an enforcement point (the `remote_workspace_policy.rs` contract test), so agents remembered them. The other three scenarios had none, and the guide never named them — the predictable result is a feature that works locally, silently falls back or deadlocks under remote control, and gets fixed one bug report at a time.

The new section makes each scenario's obligation concrete and points at the code that enforces it:

- Cross-cutting rules: design the remote path with the feature; degrade loudly rather than falling back to the local host (which also leaks local content to a remote controller); keep blocking prompts answerable from a distance, or turns deadlock for remote control and dispatch; survive disconnect via resumable cursors and idempotent mutations; remote workspace paths are POSIX on every client OS.
- Per-scenario: the remote-workspace policy registry; the `RemoteCommand` wire protocol and bot command router for remote control; the **three** peer deny lists that must stay in sync (`peer_host_invoke.rs`, CLI `deny.rs`, `peer-device-adapter.ts`); and for dispatch, that the controller is an observer, never a runtime or filesystem proxy, with target capabilities as a negotiated contract.
- Closing rule: state which remote scenarios a change was exercised in — local-only tests are not evidence of remote behavior.

No runtime or user-facing change.

## Verification

```bash
pnpm run check:repo-hygiene
```

Passed (2 content files scanned, 5900 filenames checked).

Also verified by hand that all 12 paths linked from the new section exist, and that the claims match the current code rather than restating intent: the `RemoteWorkspacePolicy` variants and `LegacyUnaudited` freeze rule, the deny-list sync comment in `peer_host_invoke.rs`, the dispatch protocol v4 verbs and required target capabilities, and the three IM bot providers.

No runtime checks were run — the change is docs-only and touches no build, test, or source path.

## Reviewer Notes

- The section heading changed (`Remote compatibility` → `Remote scenarios`, `远程兼容` → `远程场景`). Nothing in the repo referenced the old heading.
- The existing `remote_workspace_policy.rs` rule is preserved verbatim in substance; it is now one of four per-scenario obligations rather than the whole section.
- `AGENTS-CN.md` is a full mirror, not a summary.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
