### PR TITLE
feat(release): add public beta packaging channel

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -7,9 +7,21 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Tag name to build (e.g. v0.2.0). Leave empty to build from HEAD."
+        description: "Release tag (stable: v0.2.18, beta: v0.2.18-beta.1)."
         required: false
         type: string
+      checkout_ref:
+        description: "Commit, branch, or tag to build. Defaults to tag_name, then HEAD."
+        required: false
+        type: string
+      release_channel:
+        description: "Immutable update channel compiled into the Desktop artifact."
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - beta
       upload_to_release:
         description: "Upload built artifacts to the release specified by tag_name."
         required: false
@@ -26,8 +38,8 @@ permissions:
   packages: write
 
 concurrency:
-  group: desktop-package-${{ github.event.release.tag_name || inputs.tag_name || github.sha }}
-  cancel-in-progress: true
+  group: desktop-package-${{ (github.event.release.prerelease || inputs.release_channel == 'beta') && 'beta' || github.event.release.tag_name || inputs.tag_name || github.sha }}
+  cancel-in-progress: false
 
 jobs:
   # ── Resolve version info ───────────────────────────────────────────
@@ -39,9 +51,12 @@ jobs:
       release_tag: ${{ steps.meta.outputs.release_tag }}
       upload_to_release: ${{ steps.meta.outputs.upload_to_release }}
       checkout_ref: ${{ steps.meta.outputs.checkout_ref }}
+      release_channel: ${{ steps.meta.outputs.release_channel }}
       relay_image_only: ${{ steps.meta.outputs.relay_image_only }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Resolve version metadata
         id: meta
@@ -51,6 +66,8 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref }}
+          INPUT_RELEASE_CHANNEL: ${{ inputs.release_channel }}
           INPUT_UPLOAD_TO_RELEASE: ${{ inputs.upload_to_release }}
           INPUT_RELAY_IMAGE_ONLY: ${{ inputs.relay_image_only }}
         run: |
@@ -61,13 +78,21 @@ jobs:
             VERSION="${TAG#v}"
             UPLOAD="true"
             CHECKOUT_REF="${TAG}"
+            if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+              CHANNEL="beta"
+            else
+              CHANNEL="stable"
+            fi
           elif [[ -n "${INPUT_TAG_NAME}" ]]; then
             TAG="${INPUT_TAG_NAME}"
             VERSION="${TAG#v}"
+            CHANNEL="${INPUT_RELEASE_CHANNEL:-stable}"
             # A one-off image backfill must use the workflow branch: an older
             # tag does not contain Dockerfile.release or this publishing job.
             if [[ "${INPUT_RELAY_IMAGE_ONLY}" == "true" ]]; then
               CHECKOUT_REF="${GITHUB_SHA}"
+            elif [[ -n "${INPUT_CHECKOUT_REF}" ]]; then
+              CHECKOUT_REF="${INPUT_CHECKOUT_REF}"
             else
               CHECKOUT_REF="${TAG}"
             fi
@@ -81,12 +106,32 @@ jobs:
             TAG="v${VERSION}"
             UPLOAD="false"
             CHECKOUT_REF="${GITHUB_SHA}"
+            CHANNEL="${INPUT_RELEASE_CHANNEL:-stable}"
           fi
+
+          node --input-type=module -e \
+            "import { validateReleaseVersion } from './scripts/release-channel.mjs'; validateReleaseVersion(process.argv[1], process.argv[2]);" \
+            "${CHANNEL}" "${VERSION}"
+
+          git fetch origin main --tags --force
+          CHECKOUT_SHA="$(git rev-parse "${CHECKOUT_REF}^{commit}")"
+          if [[ "${GITHUB_REPOSITORY}" == "GCWing/BitFun" ]] && \
+             ! git merge-base --is-ancestor "${CHECKOUT_SHA}" origin/main; then
+            echo "Ref ${CHECKOUT_REF} (${CHECKOUT_SHA}) is not part of the protected main history." >&2
+            exit 1
+          fi
+          TAG_SHA="$(git rev-parse --verify --quiet "${TAG}^{commit}" || true)"
+          if [[ -n "${TAG_SHA}" && "${TAG_SHA}" != "${CHECKOUT_SHA}" ]]; then
+            echo "Existing tag ${TAG} points to ${TAG_SHA}, not requested commit ${CHECKOUT_SHA}." >&2
+            exit 1
+          fi
+          CHECKOUT_REF="${CHECKOUT_SHA}"
 
           echo "version=$VERSION"          >> "$GITHUB_OUTPUT"
           echo "release_tag=$TAG"          >> "$GITHUB_OUTPUT"
           echo "upload_to_release=$UPLOAD" >> "$GITHUB_OUTPUT"
           echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+          echo "release_channel=$CHANNEL"  >> "$GITHUB_OUTPUT"
           echo "relay_image_only=${INPUT_RELAY_IMAGE_ONLY:-false}" >> "$GITHUB_OUTPUT"
 
   # ── Build per platform ─────────────────────────────────────────────
@@ -98,7 +143,7 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=6144
       BITFUN_ENABLE_UPDATER_ARTIFACTS: ${{ needs.prepare.outputs.upload_to_release }}
-      TAURI_UPDATER_ENDPOINT: https://github.com/GCWing/BitFun/releases/latest/download/latest.json
+      BITFUN_RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
       TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
       # Same trust root, compiled into the Desktop binary so one-click relay
       # deploy can verify the signed checksum locally and hand the remote host
@@ -233,6 +278,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Project beta build version
+        if: needs.prepare.outputs.release_channel == 'beta'
+        run: node scripts/set-build-version.mjs --version "${{ needs.prepare.outputs.version }}"
+
       - name: Verify release version metadata
         run: node scripts/verify-release-version-sync.mjs --version "${{ needs.prepare.outputs.version }}"
 
@@ -348,7 +397,7 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
           IMAGE_ONLY: ${{ needs.prepare.outputs.relay_image_only }}
-          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         run: |
           set -euo pipefail
           asset_version="${RELEASE_VERSION%%+*}"
@@ -363,7 +412,7 @@ jobs:
               if [[ "${RELEASE_TAG}" == "${latest_release}" ]]; then
                 echo "${IMAGE}:latest"
               fi
-            elif [[ "${RELEASE_PRERELEASE:-false}" != "true" ]]; then
+            elif [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
               # The normal release workflow can create the GitHub Release only
               # after packaging, so it cannot rely on /releases/latest yet.
               echo "${IMAGE}:latest"
@@ -621,6 +670,9 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.release_tag }}
+          target_commitish: ${{ needs.prepare.outputs.checkout_ref }}
+          prerelease: ${{ needs.prepare.outputs.release_channel == 'beta' }}
+          name: ${{ needs.prepare.outputs.release_channel == 'beta' && format('BitFun {0} Beta', needs.prepare.outputs.version) || format('BitFun {0}', needs.prepare.outputs.version) }}
           generate_release_notes: true
           files: release-upload-assets/*
           fail_on_unmatched_files: true
@@ -660,6 +712,58 @@ jobs:
             "https://github.com/GCWing/BitFun/releases/download/${{ needs.prepare.outputs.release_tag }}/relay-image.json.sig" \
             -o /dev/null
 
+      - name: Resolve beta channel promotion
+        id: beta-channel
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
+        run: |
+          set -euo pipefail
+          if ! gh release view channel-beta --repo GCWing/BitFun >/dev/null 2>&1; then
+            if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
+              echo "promote=false" >>"$GITHUB_OUTPUT"
+              echo "No beta channel exists; stable release does not need to create one."
+              exit 0
+            fi
+          else
+            curl -fsSL --retry 5 --retry-delay 3 \
+              "https://github.com/GCWing/BitFun/releases/download/channel-beta/latest.json" \
+              -o current.beta.json || true
+          fi
+          args=(--candidate latest.published.json --github-output "$GITHUB_OUTPUT")
+          if [[ -s current.beta.json ]]; then
+            args+=(--current current.beta.json)
+          fi
+          node scripts/plan-channel-promotion.mjs "${args[@]}"
+
+      - name: Publish beta channel manifest
+        if: steps.beta-channel.outputs.promote == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
+        run: |
+          set -euo pipefail
+          if ! gh release view channel-beta --repo GCWing/BitFun >/dev/null 2>&1; then
+            gh release create channel-beta \
+              --repo GCWing/BitFun \
+              --target "${CHECKOUT_REF}" \
+              --prerelease \
+              --title "BitFun Beta Update Channel" \
+              --notes "Mutable updater pointer. Installable beta releases use immutable version tags."
+          fi
+          mkdir -p beta-channel
+          cp latest.published.json beta-channel/latest.json
+          gh release upload channel-beta beta-channel/latest.json \
+            --repo GCWing/BitFun \
+            --clobber
+          curl -fsSL --retry 5 --retry-delay 3 \
+            "https://github.com/GCWing/BitFun/releases/download/channel-beta/latest.json" \
+            -o channel-beta.published.json
+          test "$(jq -r '.version' channel-beta.published.json)" = \
+            "${{ steps.beta-channel.outputs.candidate_version }}"
+
       # Nudge the openbitfun.com mirror to sync now instead of on its next
       # 10-minute cron tick. Until the mirror has these bytes, CN clients have
       # only the GitHub origin to fall back to. Best effort: the cron run is
@@ -670,6 +774,7 @@ jobs:
         env:
           SYNC_WEBHOOK_URL: ${{ secrets.OPENBITFUN_SYNC_WEBHOOK_URL }}
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         run: |
           set -euo pipefail
           if [[ -z "${SYNC_WEBHOOK_URL:-}" ]]; then
@@ -678,6 +783,6 @@ jobs:
           fi
           curl -fsSL -X POST --retry 3 --retry-delay 5 --max-time 30 \
             -H 'Content-Type: application/json' \
-            -d "{\"tag\":\"${RELEASE_TAG}\"}" \
+            -d "{\"tag\":\"${RELEASE_TAG}\",\"channel\":\"${RELEASE_CHANNEL}\"}" \
             "${SYNC_WEBHOOK_URL}" >/dev/null
           echo "Mirror sync requested for ${RELEASE_TAG}."

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -144,11 +144,13 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=6144
       BITFUN_ENABLE_UPDATER_ARTIFACTS: ${{ needs.prepare.outputs.upload_to_release }}
       BITFUN_RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
+      TAURI_UPDATER_ENDPOINT: ${{ github.repository != 'GCWing/BitFun' && needs.prepare.outputs.release_channel == 'beta' && format('https://github.com/{0}/releases/download/channel-beta/latest.json', github.repository) || '' }}
+      TAURI_UPDATER_FALLBACK_ENDPOINT: ${{ github.repository != 'GCWing/BitFun' && needs.prepare.outputs.release_channel == 'beta' && format('https://github.com/{0}/releases/download/channel-beta/latest.json', github.repository) || '' }}
       TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
       # Same trust root, compiled into the Desktop binary so one-click relay
       # deploy can verify the signed checksum locally and hand the remote host
       # a hash it does not have to trust the mirror for.
-      BITFUN_RELEASE_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
+      BITFUN_RELEASE_PUBKEY: ${{ secrets.BITFUN_RELEASE_PUBKEY || secrets.TAURI_UPDATER_PUBKEY }}
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
@@ -307,7 +309,9 @@ jobs:
   linux-binaries:
     name: Linux CLI and Relay Server
     needs: prepare
-    if: needs.prepare.outputs.relay_image_only != 'true'
+    if: >-
+      needs.prepare.outputs.relay_image_only != 'true' &&
+      needs.prepare.outputs.release_channel == 'stable'
     uses: ./.github/workflows/linux-binaries.yml
     secrets:
       release_signing_key: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -325,7 +329,8 @@ jobs:
     needs: [prepare, linux-binaries]
     if: >-
       always() &&
-      (needs.prepare.outputs.upload_to_release == 'true' ||
+      ((needs.prepare.outputs.upload_to_release == 'true' &&
+        needs.prepare.outputs.release_channel == 'stable') ||
        needs.prepare.outputs.relay_image_only == 'true') &&
       (needs.prepare.outputs.relay_image_only == 'true' ||
        needs.linux-binaries.result == 'success')
@@ -518,8 +523,9 @@ jobs:
       always() &&
       needs.prepare.outputs.upload_to_release == 'true' &&
       needs.package.result == 'success' &&
-      needs.linux-binaries.result == 'success' &&
-      needs.publish-relay-image.result == 'success'
+      (needs.prepare.outputs.release_channel == 'beta' ||
+       (needs.linux-binaries.result == 'success' &&
+        needs.publish-relay-image.result == 'success'))
     runs-on: ubuntu-latest
     env:
       REQUIRED_UPDATER_PLATFORMS: windows-x86_64,darwin-x86_64,darwin-aarch64,linux-x86_64,linux-aarch64
@@ -536,6 +542,7 @@ jobs:
           merge-multiple: true
 
       - name: Download Linux binary artifacts
+        if: needs.prepare.outputs.release_channel == 'stable'
         uses: actions/download-artifact@v7
         with:
           pattern: bitfun-linux-${{ needs.prepare.outputs.release_tag }}-*
@@ -543,19 +550,24 @@ jobs:
           merge-multiple: true
 
       - name: Download Relay image descriptor
+        if: needs.prepare.outputs.release_channel == 'stable'
         uses: actions/download-artifact@v7
         with:
           name: bitfun-relay-image-${{ needs.prepare.outputs.release_tag }}
           path: relay-image-assets
 
       - name: List release assets
+        env:
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         run: |
           echo "Release assets:"
           find release-assets -type f | sort
-          echo "Linux CLI and Relay Server assets:"
-          find linux-release-assets -type f | sort
-          echo "Relay image descriptor:"
-          find relay-image-assets -type f | sort
+          if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
+            echo "Linux CLI and Relay Server assets:"
+            find linux-release-assets -type f | sort
+            echo "Relay image descriptor:"
+            find relay-image-assets -type f | sort
+          fi
 
       - name: Prepare versioned Windows installer
         run: |
@@ -587,7 +599,7 @@ jobs:
             --manual-assets-dir release-manual-assets \
             --version "${{ needs.prepare.outputs.version }}" \
             --tag "${{ needs.prepare.outputs.release_tag }}" \
-            --repo "GCWing/BitFun" \
+            --repo "${{ github.repository }}" \
             --out release-updater-assets/latest.json \
             --required-platforms "${REQUIRED_UPDATER_PLATFORMS}"
 
@@ -600,6 +612,7 @@ jobs:
             --required-manual-platforms "windows-x86_64"
 
       - name: Generate Linux binaries manifest
+        if: needs.prepare.outputs.release_channel == 'stable'
         run: |
           node scripts/generate-linux-binaries-manifest.mjs \
             --assets-dir linux-release-assets \
@@ -637,7 +650,8 @@ jobs:
           # can fetch a key for is not verifiable.
           printf '%s' "${BITFUN_SIGNING_PUBKEY}" | base64 -d >release-assets/minisign.pub
 
-      - name: Stage uniquely named release assets
+      - name: Stage stable release assets
+        if: needs.prepare.outputs.release_channel == 'stable'
         shell: bash
         run: |
           set -euo pipefail
@@ -666,6 +680,27 @@ jobs:
             relay-image-assets/relay-image.json \
             relay-image-assets/relay-image.json.sig
 
+      - name: Stage beta release assets
+        if: needs.prepare.outputs.release_channel == 'beta'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar
+          node scripts/stage-github-release-assets.mjs \
+            --out-dir release-upload-assets \
+            release-updater-assets/* \
+            release-manual-assets/*.exe \
+            release-manual-assets/*.exe.sig \
+            release-assets/**/*.AppImage \
+            release-assets/**/*.AppImage.sig \
+            release-assets/**/*.deb \
+            release-assets/**/*.deb.sig \
+            release-assets/**/*.dmg \
+            release-assets/**/*.dmg.sig \
+            release-assets/**/*.rpm \
+            release-assets/**/*.rpm.sig \
+            release-assets/minisign.pub
+
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
@@ -680,7 +715,7 @@ jobs:
       - name: Verify published updater manifest
         run: |
           curl -fsSL --retry 5 --retry-delay 3 \
-            "https://github.com/GCWing/BitFun/releases/download/${{ needs.prepare.outputs.release_tag }}/latest.json" \
+            "https://github.com/${{ github.repository }}/releases/download/${{ needs.prepare.outputs.release_tag }}/latest.json" \
             -o latest.published.json
           node scripts/verify-tauri-latest-json.mjs \
             --manifest latest.published.json \
@@ -690,6 +725,7 @@ jobs:
             --check-urls true
 
       - name: Verify published Linux binaries manifest
+        if: needs.prepare.outputs.release_channel == 'stable'
         run: |
           curl -fsSL --retry 5 --retry-delay 3 \
             "https://github.com/GCWing/BitFun/releases/download/${{ needs.prepare.outputs.release_tag }}/linux-binaries.json" \
@@ -701,6 +737,7 @@ jobs:
           done < <(jq -r '.platforms[].cli.url' linux-binaries.published.json)
 
       - name: Verify published Relay image descriptor
+        if: needs.prepare.outputs.release_channel == 'stable'
         run: |
           curl -fsSL --retry 5 --retry-delay 3 \
             "https://github.com/GCWing/BitFun/releases/download/${{ needs.prepare.outputs.release_tag }}/relay-image.json" \
@@ -720,7 +757,7 @@ jobs:
           RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         run: |
           set -euo pipefail
-          if ! gh release view channel-beta --repo GCWing/BitFun >/dev/null 2>&1; then
+          if ! gh release view channel-beta --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
               echo "promote=false" >>"$GITHUB_OUTPUT"
               echo "No beta channel exists; stable release does not need to create one."
@@ -728,7 +765,7 @@ jobs:
             fi
           else
             curl -fsSL --retry 5 --retry-delay 3 \
-              "https://github.com/GCWing/BitFun/releases/download/channel-beta/latest.json" \
+              "https://github.com/${GITHUB_REPOSITORY}/releases/download/channel-beta/latest.json" \
               -o current.beta.json || true
           fi
           args=(--candidate latest.published.json --github-output "$GITHUB_OUTPUT")
@@ -745,9 +782,9 @@ jobs:
           CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
         run: |
           set -euo pipefail
-          if ! gh release view channel-beta --repo GCWing/BitFun >/dev/null 2>&1; then
+          if ! gh release view channel-beta --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             gh release create channel-beta \
-              --repo GCWing/BitFun \
+              --repo "${GITHUB_REPOSITORY}" \
               --target "${CHECKOUT_REF}" \
               --prerelease \
               --title "BitFun Beta Update Channel" \
@@ -756,10 +793,10 @@ jobs:
           mkdir -p beta-channel
           cp latest.published.json beta-channel/latest.json
           gh release upload channel-beta beta-channel/latest.json \
-            --repo GCWing/BitFun \
+            --repo "${GITHUB_REPOSITORY}" \
             --clobber
           curl -fsSL --retry 5 --retry-delay 3 \
-            "https://github.com/GCWing/BitFun/releases/download/channel-beta/latest.json" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/channel-beta/latest.json" \
             -o channel-beta.published.json
           test "$(jq -r '.version' channel-beta.published.json)" = \
             "${{ steps.beta-channel.outputs.candidate_version }}"
@@ -770,6 +807,7 @@ jobs:
       # still the source of truth, so a failed or unconfigured ping never fails
       # the release. Receiver setup: scripts/openbitfun-release-sync.sh.
       - name: Request openbitfun mirror sync
+        if: github.repository == 'GCWing/BitFun'
         continue-on-error: true
         env:
           SYNC_WEBHOOK_URL: ${{ secrets.OPENBITFUN_SYNC_WEBHOOK_URL }}

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -648,7 +648,8 @@ jobs:
 
           # Publish the public key alongside the signatures: a signature nobody
           # can fetch a key for is not verifiable.
-          printf '%s' "${BITFUN_SIGNING_PUBKEY}" | base64 -d >release-assets/minisign.pub
+          node scripts/write-minisign-public-key.mjs \
+            --out release-assets/minisign.pub
 
       - name: Stage stable release assets
         if: needs.prepare.outputs.release_channel == 'stable'
@@ -757,17 +758,33 @@ jobs:
           RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         run: |
           set -euo pipefail
-          if ! gh release view channel-beta --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
-              echo "promote=false" >>"$GITHUB_OUTPUT"
-              echo "No beta channel exists; stable release does not need to create one."
-              exit 0
-            fi
-          else
-            curl -fsSL --retry 5 --retry-delay 3 \
-              "https://github.com/${GITHUB_REPOSITORY}/releases/download/channel-beta/latest.json" \
-              -o current.beta.json || true
-          fi
+          channel_status="$(curl -sS --retry 5 --retry-delay 3 \
+            --output channel.release.json \
+            --write-out '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/channel-beta")"
+          case "${channel_status}" in
+            200)
+              echo "channel_exists=true" >>"$GITHUB_OUTPUT"
+              curl -fsSL --retry 5 --retry-delay 3 \
+                "https://github.com/${GITHUB_REPOSITORY}/releases/download/channel-beta/latest.json" \
+                -o current.beta.json
+              ;;
+            404)
+              echo "channel_exists=false" >>"$GITHUB_OUTPUT"
+              if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
+                echo "promote=false" >>"$GITHUB_OUTPUT"
+                echo "No beta channel exists; stable release does not need to create one."
+                exit 0
+              fi
+              ;;
+            *)
+              echo "Could not inspect channel-beta release (GitHub API returned ${channel_status})." >&2
+              exit 1
+              ;;
+          esac
           args=(--candidate latest.published.json --github-output "$GITHUB_OUTPUT")
           if [[ -s current.beta.json ]]; then
             args+=(--current current.beta.json)
@@ -780,9 +797,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CHECKOUT_REF: ${{ needs.prepare.outputs.checkout_ref }}
+          CHANNEL_EXISTS: ${{ steps.beta-channel.outputs.channel_exists }}
         run: |
           set -euo pipefail
-          if ! gh release view channel-beta --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          if [[ "${CHANNEL_EXISTS}" != "true" ]]; then
             gh release create channel-beta \
               --repo "${GITHUB_REPOSITORY}" \
               --target "${CHECKOUT_REF}" \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,6 +68,7 @@ jobs:
     if: needs.check-changes.outputs.should_build == 'true'
     env:
       NODE_OPTIONS: --max-old-space-size=6144
+      BITFUN_RELEASE_CHANNEL: nightly
       # Nightly relay archives are signed too (linux-binaries.yml receives the
       # key), so nightly Desktop needs the same trust root to verify them.
       BITFUN_RELEASE_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}
@@ -176,28 +177,8 @@ jobs:
           set -euo pipefail
 
           echo "Patching version to $NIGHTLY_VERSION"
-
-          # Patch package.json
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-            pkg.version = process.env.NIGHTLY_VERSION.split('+')[0];
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-            for (const file of ['BitFun-Installer/package.json', 'BitFun-Installer/package-lock.json']) {
-              const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
-              data.version = pkg.version;
-              if (data.packages?.['']) data.packages[''].version = pkg.version;
-              fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
-            }
-          "
-
-          # Patch Cargo workspace version (semver: nightly suffix uses hyphen)
-          # Cargo.toml only accepts: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRE
-          CARGO_VERSION="$(echo "$NIGHTLY_VERSION" | sed 's/+.*//')"
-          sed -i.bak "s/^version = \".*\" # x-release-please-version/version = \"${CARGO_VERSION}\" # x-release-please-version/" Cargo.toml
-          rm -f Cargo.toml.bak
-          sed -i.bak "0,/^version = \".*\"/s//version = \"${CARGO_VERSION}\"/" BitFun-Installer/src-tauri/Cargo.toml
-          rm -f BitFun-Installer/src-tauri/Cargo.toml.bak
+          ASSET_VERSION="${NIGHTLY_VERSION%%+*}"
+          node scripts/set-build-version.mjs --version "$ASSET_VERSION"
 
           echo "package.json version: $(jq -r '.version' package.json)"
           echo "Cargo.toml version:   $(grep 'x-release-please-version' Cargo.toml)"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,10 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=6144
       BITFUN_RELEASE_CHANNEL: nightly
+      # Nightly does not publish a Tauri latest.json feed yet. Preserve its
+      # existing stable updater endpoints until that publishing path exists.
+      TAURI_UPDATER_ENDPOINT: https://github.com/GCWing/BitFun/releases/latest/download/latest.json
+      TAURI_UPDATER_FALLBACK_ENDPOINT: https://openbitfun.com/release/latest.json
       # Nightly relay archives are signed too (linux-binaries.yml receives the
       # key), so nightly Desktop needs the same trust root to verify them.
       BITFUN_RELEASE_PUBKEY: ${{ secrets.TAURI_UPDATER_PUBKEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -447,7 +447,8 @@ jobs:
 
           # Publish the public key alongside the signatures: a signature nobody
           # can fetch a key for is not verifiable.
-          printf '%s' "${BITFUN_SIGNING_PUBKEY}" | base64 -d >release-assets/minisign.pub
+          node scripts/write-minisign-public-key.mjs \
+            --out release-assets/minisign.pub
 
       - name: Create nightly release
         uses: softprops/action-gh-release@v3

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -28,13 +28,17 @@ Public beta assets are stored on the immutable version tag. After every asset
 and signature is verified, the workflow updates only the `latest.json` asset on
 the `channel-beta` pre-release. Beta Desktop builds read that pointer and fall
 back to `https://openbitfun.com/release/beta/latest.json`.
+The beta release contains Desktop and Installer assets only. CLI and Relay
+floating releases remain stable-only.
 
 The selected ref must resolve to a commit in the protected `main` history. The
 workflow pins that SHA before dispatching platform jobs and rejects an existing
 release tag if it points somewhere else. Configure the signing secrets and the
 public beta approval policy so untrusted pull-request code cannot access them.
 This protected-history requirement applies to the canonical `GCWing/BitFun`
-repository; forks may run artifact-only packaging from their own test branches.
+repository; forks may run packaging from their own test branches. A fork beta
+uses that fork's `channel-beta` release as both updater origins, so it cannot
+silently consume or mutate the canonical beta channel.
 
 A stable release promotes the beta pointer only when its version is not older
 than the current beta. This lets beta users move from `0.2.18-beta.N` to

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,0 +1,55 @@
+# Release Channels
+
+BitFun packages use an immutable build-time release channel. End users do not
+switch channels at runtime.
+
+## Stable
+
+Stable releases continue to be driven by a version bump on `main`. The
+`Release On Version Bump` workflow creates `vMAJOR.MINOR.PATCH` and dispatches
+`Desktop Package` with the default `stable` channel.
+
+## Beta
+
+Run `Desktop Package` manually with:
+
+- `tag_name`: the immutable release tag, for example `v0.2.18-beta.1`;
+- `checkout_ref`: the commit or branch to build when the tag does not exist;
+- `release_channel`: `beta`;
+- `upload_to_release`: disabled for internal Actions artifacts, enabled for a
+  public GitHub pre-release.
+
+Beta versions target the next stable version. If stable is `0.2.17`, the first
+candidate is `0.2.18-beta.1`, not `0.2.17-beta.1`. Do not use SemVer build
+metadata in a published package version; the release already records the Git
+commit separately.
+
+Public beta assets are stored on the immutable version tag. After every asset
+and signature is verified, the workflow updates only the `latest.json` asset on
+the `channel-beta` pre-release. Beta Desktop builds read that pointer and fall
+back to `https://openbitfun.com/release/beta/latest.json`.
+
+The selected ref must resolve to a commit in the protected `main` history. The
+workflow pins that SHA before dispatching platform jobs and rejects an existing
+release tag if it points somewhere else. Configure the signing secrets and the
+public beta approval policy so untrusted pull-request code cannot access them.
+This protected-history requirement applies to the canonical `GCWing/BitFun`
+repository; forks may run artifact-only packaging from their own test branches.
+
+A stable release promotes the beta pointer only when its version is not older
+than the current beta. This lets beta users move from `0.2.18-beta.N` to
+`0.2.18` without allowing a late workflow to roll the channel backward.
+
+Beta and stable currently share the same bundle identity and data directories.
+Installing beta replaces stable; side-by-side installation is not supported.
+
+## Mirror
+
+The mirror script defaults to stable. Run a separate beta sync with:
+
+```bash
+BITFUN_RELEASE_CHANNEL=beta scripts/openbitfun-release-sync.sh
+```
+
+The beta invocation writes below `/release/beta` and intentionally skips the
+stable-only CLI and Relay floating manifests.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:core-boundaries": "node scripts/check-core-boundaries.mjs",
     "check:core-boundaries:test": "node --test scripts/check-core-boundaries.test.mjs",
     "check:github-config": "pnpm --dir src/web-ui exec node ../../scripts/check-github-config.mjs && node --test scripts/check-github-config.test.mjs",
+    "test:release-packaging": "node --test scripts/release-channel.test.mjs scripts/desktop-tauri-build.test.mjs scripts/version-generation.test.mjs scripts/tauri-release-manifest.test.mjs",
     "fmt:rs": "node scripts/format-changed-rust.mjs",
     "lint:rs": "cargo clippy --workspace --exclude bitfun-desktop --all-targets",
     "lint:rs:desktop": "pnpm run prepare:mobile-web && cargo clippy -p bitfun-desktop --all-targets",

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -377,23 +377,26 @@ test('stages unique release asset names before publishing', () => {
     ),
   );
   const steps = workflow.jobs['upload-release-assets'].steps;
-  const stagingIndex = steps.findIndex(
-    (step) => step.name === 'Stage uniquely named release assets',
-  );
+  const stagingIndexes = [
+    steps.findIndex((step) => step.name === 'Stage stable release assets'),
+    steps.findIndex((step) => step.name === 'Stage beta release assets'),
+  ];
   const uploadIndex = steps.findIndex((step) => step.name === 'Upload to release');
 
-  assert.notEqual(stagingIndex, -1);
+  assert.equal(stagingIndexes.every((index) => index >= 0), true);
   assert.notEqual(uploadIndex, -1);
-  assert.ok(stagingIndex < uploadIndex);
-  assert.match(
-    steps[stagingIndex].run,
-    /node scripts\/stage-github-release-assets\.mjs/,
-  );
-  assert.doesNotMatch(
-    steps[stagingIndex].run,
-    /release-assets\/\*\*\/\*\.sig(?:\s|\\)/,
-    'raw updater signatures have colliding names across macOS architectures',
-  );
+  for (const stagingIndex of stagingIndexes) {
+    assert.ok(stagingIndex < uploadIndex);
+    assert.match(
+      steps[stagingIndex].run,
+      /node scripts\/stage-github-release-assets\.mjs/,
+    );
+    assert.doesNotMatch(
+      steps[stagingIndex].run,
+      /release-assets\/\*\*\/\*\.sig(?:\s|\\)/,
+      'raw updater signatures have colliding names across macOS architectures',
+    );
+  }
   assert.equal(steps[uploadIndex].with.files, 'release-upload-assets/*');
 });
 
@@ -420,7 +423,9 @@ test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
     packageJob.env.BITFUN_RELEASE_CHANNEL,
     '${{ needs.prepare.outputs.release_channel }}',
   );
-  assert.equal(packageJob.env.TAURI_UPDATER_ENDPOINT, undefined);
+  assert.match(packageJob.env.TAURI_UPDATER_ENDPOINT, /github\.repository/);
+  assert.match(packageJob.env.TAURI_UPDATER_ENDPOINT, /channel-beta/);
+  assert.match(packageJob.env.BITFUN_RELEASE_PUBKEY, /BITFUN_RELEASE_PUBKEY/);
   const patchIndex = packageJob.steps.findIndex(
     (step) => step.name === 'Project beta build version',
   );
@@ -446,6 +451,15 @@ test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
     (step) => step.name === 'Publish beta channel manifest',
   );
   assert.ok(verifyIndexPublished >= 0 && verifyIndexPublished < promoteIndex);
+  assert.match(workflow.jobs['linux-binaries'].if, /release_channel == 'stable'/);
+  assert.equal(
+    uploadSteps.find((step) => step.name === 'Stage beta release assets').if,
+    "needs.prepare.outputs.release_channel == 'beta'",
+  );
+  assert.match(
+    uploadSteps.find((step) => step.name === 'Generate updater manifest').run,
+    /github\.repository/,
+  );
 });
 
 test('beta publishing cannot advance the Relay latest image tag', () => {

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -396,3 +396,83 @@ test('stages unique release asset names before publishing', () => {
   );
   assert.equal(steps[uploadIndex].with.files, 'release-upload-assets/*');
 });
+
+test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
+  const workflow = yaml.parse(
+    readFileSync(
+      path.join(repoRoot, '.github/workflows/desktop-package.yml'),
+      'utf8',
+    ),
+  );
+  const inputs = workflow.on.workflow_dispatch.inputs;
+  assert.deepEqual(inputs.release_channel.options, ['stable', 'beta']);
+  assert.equal(inputs.release_channel.default, 'stable');
+
+  const prepareStep = workflow.jobs.prepare.steps.find(
+    (step) => step.name === 'Resolve version metadata',
+  );
+  assert.match(prepareStep.run, /GITHUB_REPOSITORY.*GCWing\/BitFun/);
+  assert.match(prepareStep.run, /merge-base --is-ancestor/);
+  assert.match(prepareStep.run, /rev-parse --verify --quiet/);
+
+  const packageJob = workflow.jobs.package;
+  assert.equal(
+    packageJob.env.BITFUN_RELEASE_CHANNEL,
+    '${{ needs.prepare.outputs.release_channel }}',
+  );
+  assert.equal(packageJob.env.TAURI_UPDATER_ENDPOINT, undefined);
+  const patchIndex = packageJob.steps.findIndex(
+    (step) => step.name === 'Project beta build version',
+  );
+  const verifyIndex = packageJob.steps.findIndex(
+    (step) => step.name === 'Verify release version metadata',
+  );
+  assert.ok(patchIndex >= 0 && patchIndex < verifyIndex);
+  assert.equal(
+    packageJob.steps[patchIndex].if,
+    "needs.prepare.outputs.release_channel == 'beta'",
+  );
+
+  const uploadSteps = workflow.jobs['upload-release-assets'].steps;
+  const release = uploadSteps.find((step) => step.name === 'Upload to release');
+  assert.equal(
+    release.with.prerelease,
+    "${{ needs.prepare.outputs.release_channel == 'beta' }}",
+  );
+  const verifyIndexPublished = uploadSteps.findIndex(
+    (step) => step.name === 'Verify published updater manifest',
+  );
+  const promoteIndex = uploadSteps.findIndex(
+    (step) => step.name === 'Publish beta channel manifest',
+  );
+  assert.ok(verifyIndexPublished >= 0 && verifyIndexPublished < promoteIndex);
+});
+
+test('beta publishing cannot advance the Relay latest image tag', () => {
+  const workflow = yaml.parse(
+    readFileSync(
+      path.join(repoRoot, '.github/workflows/desktop-package.yml'),
+      'utf8',
+    ),
+  );
+  const imageTags = workflow.jobs['publish-relay-image'].steps.find(
+    (step) => step.name === 'Resolve image tags',
+  );
+  assert.equal(
+    imageTags.env.RELEASE_CHANNEL,
+    '${{ needs.prepare.outputs.release_channel }}',
+  );
+  assert.match(imageTags.run, /RELEASE_CHANNEL.*stable/);
+  assert.doesNotMatch(imageTags.run, /RELEASE_PRERELEASE/);
+});
+
+test('nightly and beta use the shared build-version projection', () => {
+  const nightly = yaml.parse(
+    readFileSync(path.join(repoRoot, '.github/workflows/nightly.yml'), 'utf8'),
+  );
+  const patch = nightly.jobs.package.steps.find(
+    (step) => step.name === 'Patch nightly version',
+  );
+  assert.match(patch.run, /node scripts\/set-build-version\.mjs/);
+  assert.equal(nightly.jobs.package.env.BITFUN_RELEASE_CHANNEL, 'nightly');
+});

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -460,6 +460,25 @@ test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
     uploadSteps.find((step) => step.name === 'Generate updater manifest').run,
     /github\.repository/,
   );
+  const signingStep = uploadSteps.find(
+    (step) => step.name === 'Sign installer packages',
+  );
+  assert.match(signingStep.run, /write-minisign-public-key\.mjs/);
+  assert.doesNotMatch(signingStep.run, /BITFUN_SIGNING_PUBKEY.*base64 -d/);
+  const promotionStep = uploadSteps.find(
+    (step) => step.name === 'Resolve beta channel promotion',
+  );
+  assert.doesNotMatch(promotionStep.run, /current\.beta\.json \|\| true/);
+  assert.match(promotionStep.run, /case "\$\{channel_status\}" in/);
+  assert.match(promotionStep.run, /404\)/);
+  assert.match(promotionStep.run, /GitHub API returned/);
+  const publishStep = uploadSteps.find(
+    (step) => step.name === 'Publish beta channel manifest',
+  );
+  assert.equal(
+    publishStep.env.CHANNEL_EXISTS,
+    '${{ steps.beta-channel.outputs.channel_exists }}',
+  );
 });
 
 test('beta publishing cannot advance the Relay latest image tag', () => {
@@ -489,4 +508,8 @@ test('nightly and beta use the shared build-version projection', () => {
   );
   assert.match(patch.run, /node scripts\/set-build-version\.mjs/);
   assert.equal(nightly.jobs.package.env.BITFUN_RELEASE_CHANNEL, 'nightly');
+  const signingStep = nightly.jobs['publish-nightly'].steps.find(
+    (step) => step.name === 'Sign installer packages',
+  );
+  assert.match(signingStep.run, /write-minisign-public-key\.mjs/);
 });

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -508,6 +508,15 @@ test('nightly and beta use the shared build-version projection', () => {
   );
   assert.match(patch.run, /node scripts\/set-build-version\.mjs/);
   assert.equal(nightly.jobs.package.env.BITFUN_RELEASE_CHANNEL, 'nightly');
+  assert.equal(
+    nightly.jobs.package.env.TAURI_UPDATER_ENDPOINT,
+    'https://github.com/GCWing/BitFun/releases/latest/download/latest.json',
+  );
+  assert.equal(
+    nightly.jobs.package.env.TAURI_UPDATER_FALLBACK_ENDPOINT,
+    'https://openbitfun.com/release/latest.json',
+  );
+  assert.equal(nightly.jobs.package.env.BITFUN_ENABLE_UPDATER_ARTIFACTS, undefined);
   const signingStep = nightly.jobs['publish-nightly'].steps.find(
     (step) => step.name === 'Sign installer packages',
   );

--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -15,6 +15,7 @@ import { ensureFlashgrepBinary } from './prepare-flashgrep-resource.mjs';
 import { extractProductConfigArg } from './product-customization/cli.mjs';
 import { productBuildEnvironment } from './product-customization/projections.mjs';
 import { resolveProductDefinition } from './product-customization/resolver.mjs';
+import { resolveReleaseChannel } from './release-channel.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -40,6 +41,8 @@ async function main() {
   const resolution = resolveProductDefinition({ rootDir: ROOT, productConfig, member: 'desktop' });
   Object.assign(process.env, productBuildEnvironment(resolution));
   console.log(`[product] ${resolution.assembly.member} ${resolution.assembly.assemblyDigest}`);
+  const releaseChannel = resolveReleaseChannel(process.env.BITFUN_RELEASE_CHANNEL);
+  console.log(`[release] channel=${releaseChannel.channel}`);
 
   const flashgrepBinary = ensureFlashgrepBinary();
   process.env.FLASHGREP_DAEMON_BIN = flashgrepBinary;
@@ -52,6 +55,7 @@ async function main() {
     desktopDir,
     flashgrepBinary,
     resolution,
+    releaseChannel,
   });
   const tauriBin = join(ROOT, 'node_modules', '.bin', 'tauri');
   const tauriArgs = ['build', '--config', tauriConfig, ...forward];
@@ -168,7 +172,7 @@ function optionValue(args, option) {
 
 export function prepareTauriConfig(
   baseConfigPath,
-  { desktopDir, flashgrepBinary, resolution }
+  { desktopDir, flashgrepBinary, resolution, releaseChannel }
 ) {
   const config = JSON.parse(readFileSync(baseConfigPath, 'utf8'));
   if (resolution) {
@@ -180,6 +184,16 @@ export function prepareTauriConfig(
     config.identifier = resolution.assembly.bundleId;
   }
   injectTargetFlashgrepResource(config, desktopDir, flashgrepBinary);
+
+  const release = releaseChannel
+    ?? resolveReleaseChannel(process.env.BITFUN_RELEASE_CHANNEL);
+  const primaryEndpoint =
+    process.env.TAURI_UPDATER_ENDPOINT || release.primaryUpdaterEndpoint;
+  const fallbackEndpoint =
+    process.env.TAURI_UPDATER_FALLBACK_ENDPOINT || release.fallbackUpdaterEndpoint;
+  process.env.BITFUN_RELEASE_CHANNEL = release.channel;
+  process.env.BITFUN_UPDATER_PRIMARY_ENDPOINT = primaryEndpoint;
+  process.env.BITFUN_UPDATER_FALLBACK_ENDPOINT = fallbackEndpoint;
 
   const enabled = ['1', 'true', 'yes'].includes(
     String(process.env.BITFUN_ENABLE_UPDATER_ARTIFACTS || '').toLowerCase()
@@ -196,16 +210,9 @@ export function prepareTauriConfig(
       process.exit(1);
     }
 
-    const primaryEndpoint =
-      process.env.TAURI_UPDATER_ENDPOINT ||
-      'https://github.com/GCWing/BitFun/releases/latest/download/latest.json';
     // Fallback endpoint used when GitHub is unreachable (not when no update is found).
     // Tauri updater iterates endpoints and only falls through on network/HTTP errors;
     // a 204 (no update) or a successfully parsed manifest stops the loop.
-    const fallbackEndpoint =
-      process.env.TAURI_UPDATER_FALLBACK_ENDPOINT ||
-      'https://openbitfun.com/release/latest.json';
-
     config.bundle = {
       ...(config.bundle || {}),
       createUpdaterArtifacts: true,
@@ -221,7 +228,7 @@ export function prepareTauriConfig(
       },
     };
     console.log(
-      `[tauri-build] Updater artifacts enabled: ${primaryEndpoint} (fallback: ${fallbackEndpoint})`
+      `[tauri-build] Updater artifacts enabled for ${release.channel}: ${primaryEndpoint} (fallback: ${fallbackEndpoint})`
     );
   }
 

--- a/scripts/desktop-tauri-build.test.mjs
+++ b/scripts/desktop-tauri-build.test.mjs
@@ -130,7 +130,12 @@ test('Windows updater installs NSIS packages without showing its progress window
   const baseConfig = join(fixture, 'tauri.conf.json');
   const updaterEnv = {
     BITFUN_ENABLE_UPDATER_ARTIFACTS: process.env.BITFUN_ENABLE_UPDATER_ARTIFACTS,
+    BITFUN_RELEASE_CHANNEL: process.env.BITFUN_RELEASE_CHANNEL,
+    BITFUN_UPDATER_FALLBACK_ENDPOINT: process.env.BITFUN_UPDATER_FALLBACK_ENDPOINT,
+    BITFUN_UPDATER_PRIMARY_ENDPOINT: process.env.BITFUN_UPDATER_PRIMARY_ENDPOINT,
     TAURI_SIGNING_PRIVATE_KEY: process.env.TAURI_SIGNING_PRIVATE_KEY,
+    TAURI_UPDATER_ENDPOINT: process.env.TAURI_UPDATER_ENDPOINT,
+    TAURI_UPDATER_FALLBACK_ENDPOINT: process.env.TAURI_UPDATER_FALLBACK_ENDPOINT,
     TAURI_UPDATER_PUBKEY: process.env.TAURI_UPDATER_PUBKEY,
   };
   mkdirSync(fixture, { recursive: true });
@@ -146,6 +151,7 @@ test('Windows updater installs NSIS packages without showing its progress window
     });
     const config = JSON.parse(readFileSync(generated, 'utf8'));
     assert.equal(config.plugins.updater.windows.installMode, 'quiet');
+    assert.match(config.plugins.updater.endpoints[0], /releases\/latest\/download/);
   } finally {
     for (const [name, value] of Object.entries(updaterEnv)) {
       if (value === undefined) {
@@ -153,6 +159,60 @@ test('Windows updater installs NSIS packages without showing its progress window
       } else {
         process.env[name] = value;
       }
+    }
+    rmSync(fixture, { force: true, recursive: true });
+  }
+});
+
+test('beta Desktop artifacts compile and bundle only beta updater endpoints', () => {
+  const fixture = join(tmpdir(), `bitfun-tauri-beta-${process.pid}-${Date.now()}`);
+  const baseConfig = join(fixture, 'tauri.conf.json');
+  const names = [
+    'BITFUN_ENABLE_UPDATER_ARTIFACTS',
+    'BITFUN_RELEASE_CHANNEL',
+    'BITFUN_UPDATER_FALLBACK_ENDPOINT',
+    'BITFUN_UPDATER_PRIMARY_ENDPOINT',
+    'TAURI_SIGNING_PRIVATE_KEY',
+    'TAURI_UPDATER_ENDPOINT',
+    'TAURI_UPDATER_FALLBACK_ENDPOINT',
+    'TAURI_UPDATER_PUBKEY',
+  ];
+  const previous = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+  mkdirSync(fixture, { recursive: true });
+  writeFileSync(baseConfig, JSON.stringify({ bundle: { resources: {} } }));
+  process.env.BITFUN_ENABLE_UPDATER_ARTIFACTS = 'true';
+  process.env.BITFUN_RELEASE_CHANNEL = 'beta';
+  process.env.TAURI_SIGNING_PRIVATE_KEY = 'test-private-key';
+  process.env.TAURI_UPDATER_PUBKEY = 'test-public-key';
+  delete process.env.TAURI_UPDATER_ENDPOINT;
+  delete process.env.TAURI_UPDATER_FALLBACK_ENDPOINT;
+
+  try {
+    const generated = prepareTauriConfig(baseConfig, {
+      desktopDir: fixture,
+      flashgrepBinary: join(fixture, 'flashgrep'),
+    });
+    const config = JSON.parse(readFileSync(generated, 'utf8'));
+    assert.equal(
+      config.plugins.updater.endpoints[0],
+      'https://github.com/GCWing/BitFun/releases/download/channel-beta/latest.json',
+    );
+    assert.equal(
+      config.plugins.updater.endpoints[1],
+      'https://openbitfun.com/release/beta/latest.json',
+    );
+    assert.equal(
+      process.env.BITFUN_UPDATER_PRIMARY_ENDPOINT,
+      config.plugins.updater.endpoints[0],
+    );
+    assert.equal(
+      process.env.BITFUN_UPDATER_FALLBACK_ENDPOINT,
+      config.plugins.updater.endpoints[1],
+    );
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
     }
     rmSync(fixture, { force: true, recursive: true });
   }

--- a/scripts/generate-version.cjs
+++ b/scripts/generate-version.cjs
@@ -59,6 +59,10 @@ function generateVersionInfo(buildEnv) {
   const buildDate = new Date().toISOString();
   const buildTimestamp = Date.now();
   const isDev = buildEnv === 'development';
+  const releaseChannel = process.env.BITFUN_RELEASE_CHANNEL || 'stable';
+  if (!['stable', 'beta', 'nightly'].includes(releaseChannel)) {
+    throw new Error(`Unsupported BITFUN_RELEASE_CHANNEL: ${releaseChannel}`);
+  }
   
   const versionInfo = {
     name: packageJson.name === 'BitFun' ? 'BitFun' : packageJson.name,
@@ -66,6 +70,7 @@ function generateVersionInfo(buildEnv) {
     buildDate,
     buildTimestamp,
     buildEnv,
+    releaseChannel,
     isDev,
     ...gitInfo
   };
@@ -145,5 +150,4 @@ try {
   printWarning('Version info generation failed: ' + (err.message || err));
   process.exit(1);
 }
-
 

--- a/scripts/linux-binaries-manifest.test.mjs
+++ b/scripts/linux-binaries-manifest.test.mjs
@@ -374,15 +374,17 @@ test('website download manifest uses installer while updater manifest keeps setu
   );
 });
 
-test('Linux archives are mirrored before the much larger Desktop packages', () => {
+test('stable Linux archives are mirrored before the much larger Desktop packages', () => {
   const syncScript = fs.readFileSync(
     path.join(repoRoot, 'scripts/openbitfun-release-sync.sh'),
     'utf8'
   );
 
-  const linuxCall = syncScript.indexOf('\n  mirror_linux_binaries\n');
+  const stableBranch = syncScript.indexOf('if [ "$RELEASE_CHANNEL" = "stable" ]; then');
+  const linuxCall = syncScript.indexOf('\n    mirror_linux_binaries\n', stableBranch);
   const desktopLoop = syncScript.indexOf('Mirroring Desktop asset');
-  assert.ok(linuxCall > 0, 'mirror_linux_binaries must be called from main');
+  assert.ok(stableBranch > 0, 'stable channel branch must exist');
+  assert.ok(linuxCall > stableBranch, 'stable main path must call mirror_linux_binaries');
   assert.ok(desktopLoop > 0, 'Desktop asset mirroring must still exist');
   assert.ok(
     linuxCall < desktopLoop,

--- a/scripts/openbitfun-release-sync.sh
+++ b/scripts/openbitfun-release-sync.sh
@@ -3,7 +3,7 @@
 # sync-release.sh — Mirror BitFun release assets from GitHub to openbitfun.com.
 #
 # Flow:
-#   1. Fetch latest.json from GitHub (follows /releases/latest/download/ redirect)
+#   1. Fetch the selected channel's latest.json from GitHub
 #   2. Mirror the signed Relay image descriptor and Linux binary manifest FIRST
 #      (small trust metadata must not queue behind ~700 MB of Desktop packages)
 #   3. Download every Desktop updater package plus the standalone Windows
@@ -12,7 +12,8 @@
 #   5. Atomically publish versioned and root manifests
 #   6. Remove old version dirs, keeping only the most recent KEEP_VERSIONS
 #
-# The published release/latest.json is the Tauri updater fallback endpoint.
+# The published release/latest.json and release/beta/latest.json files are the
+# stable and beta Tauri updater fallback endpoints.
 # When GitHub is unreachable, the desktop client automatically falls through
 # to https://openbitfun.com/release/latest.json and downloads from this mirror.
 # The published release/downloads.json is for the website. Its Windows URL uses
@@ -31,7 +32,8 @@
 #
 #   while true; do
 #     nc -l -p 8787 -q 1 >/dev/null \
-#       && /root/repos/BitFun-AutoUpdate/openbitfun-release-sync.sh \
+#       && BITFUN_RELEASE_CHANNEL=stable \
+#            /root/repos/BitFun-AutoUpdate/openbitfun-release-sync.sh \
 #            >> /root/repos/BitFun-AutoUpdate/sync.log 2>&1
 #   done
 #
@@ -42,16 +44,32 @@
 set -euo pipefail
 
 # ── Configuration ──────────────────────────────────────────────
-GITHUB_LATEST_JSON_URL="https://github.com/GCWing/BitFun/releases/latest/download/latest.json"
-GITHUB_LINUX_BINARIES_URL="https://github.com/GCWing/BitFun/releases/latest/download/linux-binaries.json"
-GITHUB_RELAY_IMAGE_URL="https://github.com/GCWing/BitFun/releases/latest/download/relay-image.json"
-OPENBITFUN_BASE_URL="https://openbitfun.com/release"
+RELEASE_CHANNEL="${BITFUN_RELEASE_CHANNEL:-stable}"
+case "$RELEASE_CHANNEL" in
+  stable)
+    CHANNEL_PATH=""
+    GITHUB_RELEASE_ROOT="https://github.com/GCWing/BitFun/releases/latest/download"
+    ;;
+  beta)
+    CHANNEL_PATH="/beta"
+    GITHUB_RELEASE_ROOT="https://github.com/GCWing/BitFun/releases/download/channel-beta"
+    ;;
+  *)
+    echo "Unsupported BITFUN_RELEASE_CHANNEL: $RELEASE_CHANNEL" >&2
+    exit 1
+    ;;
+esac
+GITHUB_LATEST_JSON_URL="${GITHUB_RELEASE_ROOT}/latest.json"
+GITHUB_LINUX_BINARIES_URL="${GITHUB_RELEASE_ROOT}/linux-binaries.json"
+GITHUB_RELAY_IMAGE_URL="${GITHUB_RELEASE_ROOT}/relay-image.json"
+OPENBITFUN_BASE_URL="https://openbitfun.com/release${CHANNEL_PATH}"
 # The mirror deliberately lives outside the website checkout. It used to be
 # BitFun-Website/dist/release, but `npm run build` empties dist/, so every
 # website deploy silently deleted the mirrored installers and manifests —
 # breaking downloads and the updater fallback until someone noticed. nginx
 # serves this directory through a `location ^~ /release/` alias instead.
-WEBSITE_RELEASE_DIR="${WEBSITE_RELEASE_DIR:-/srv/bitfun-release}"
+WEBSITE_RELEASE_ROOT="${WEBSITE_RELEASE_DIR:-/srv/bitfun-release}"
+WEBSITE_RELEASE_DIR="${WEBSITE_RELEASE_ROOT}${CHANNEL_PATH}"
 LOCK_FILE="/root/repos/BitFun-AutoUpdate/sync.lock"
 LEGACY_WINDOWS_INSTALLER_FILENAME="bitfun-installer.exe"
 WINDOWS_INSTALLER_FILENAME="$LEGACY_WINDOWS_INSTALLER_FILENAME"
@@ -495,7 +513,7 @@ main() {
     exit 0
   fi
 
-  log "=== BitFun release sync started ==="
+  log "=== BitFun ${RELEASE_CHANNEL} release sync started ==="
 
   mkdir -p "$WEBSITE_RELEASE_DIR"
 
@@ -566,10 +584,15 @@ if entry:
   VERSION_DIR="${WEBSITE_RELEASE_DIR}/${VERSION}"
   mkdir -p "$VERSION_DIR"
 
-  # 4. Mirror small trust metadata and Linux archives first.
-  mirror_relay_image_descriptor
-  mirror_linux_binaries
-  mirror_dispatch_macos_cli_archives
+  # 4. Stable owns the CLI/Relay floating manifests. The first beta slice only
+  # mirrors Desktop updater and installer assets under /release/beta.
+  if [ "$RELEASE_CHANNEL" = "stable" ]; then
+    mirror_relay_image_descriptor
+    mirror_linux_binaries
+    mirror_dispatch_macos_cli_archives
+  else
+    log "Skipping stable-only CLI and Relay metadata for the beta channel"
+  fi
 
   # 5. Download all platform installer packages
   #    Extract "<url>\t<filename>" pairs, then curl each one.
@@ -638,7 +661,7 @@ print(json.dumps(data, indent=2))
     done
   fi
 
-  log "=== Sync complete: version $VERSION ==="
+  log "=== ${RELEASE_CHANNEL} sync complete: version $VERSION ==="
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/plan-channel-promotion.mjs
+++ b/scripts/plan-channel-promotion.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { compareReleaseVersions } from './release-channel.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+const candidatePath = requireArg(args, 'candidate');
+const currentPath = args.current;
+const candidate = readVersion(candidatePath);
+const current = currentPath && existsSync(currentPath) ? readVersion(currentPath) : null;
+const promote = current === null || compareReleaseVersions(candidate, current) >= 0;
+
+console.log(
+  current === null
+    ? `[channel-promotion] Initial channel version: ${candidate}`
+    : `[channel-promotion] current=${current} candidate=${candidate} promote=${promote}`,
+);
+if (args['github-output']) {
+  appendFileSync(args['github-output'], `promote=${promote}\n`, 'utf8');
+  appendFileSync(args['github-output'], `candidate_version=${candidate}\n`, 'utf8');
+}
+
+function readVersion(file) {
+  const data = JSON.parse(readFileSync(file, 'utf8'));
+  if (typeof data.version !== 'string') {
+    throw new Error(`Manifest has no string version: ${file}`);
+  }
+  return data.version;
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const name = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!name?.startsWith('--') || !value) {
+      throw new Error(`Invalid argument near ${name || '<end>'}`);
+    }
+    parsed[name.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function requireArg(parsed, name) {
+  if (!parsed[name]) throw new Error(`Missing required --${name} argument`);
+  return parsed[name];
+}

--- a/scripts/release-channel.mjs
+++ b/scripts/release-channel.mjs
@@ -1,0 +1,82 @@
+const CHANNELS = {
+  stable: {
+    primaryUpdaterEndpoint:
+      'https://github.com/GCWing/BitFun/releases/latest/download/latest.json',
+    fallbackUpdaterEndpoint: 'https://openbitfun.com/release/latest.json',
+    githubChannelTag: null,
+  },
+  beta: {
+    primaryUpdaterEndpoint:
+      'https://github.com/GCWing/BitFun/releases/download/channel-beta/latest.json',
+    fallbackUpdaterEndpoint: 'https://openbitfun.com/release/beta/latest.json',
+    githubChannelTag: 'channel-beta',
+  },
+  nightly: {
+    primaryUpdaterEndpoint:
+      'https://github.com/GCWing/BitFun/releases/download/nightly/latest.json',
+    fallbackUpdaterEndpoint: 'https://openbitfun.com/release/nightly/latest.json',
+    githubChannelTag: 'nightly',
+  },
+};
+
+export function resolveReleaseChannel(value = 'stable') {
+  const channel = String(value || 'stable').trim().toLowerCase();
+  const config = CHANNELS[channel];
+  if (!config) {
+    throw new Error(
+      `Unsupported release channel "${value}". Expected one of: ${Object.keys(CHANNELS).join(', ')}`,
+    );
+  }
+  return { channel, ...config };
+}
+
+export function validateReleaseVersion(channelValue, versionValue) {
+  const { channel } = resolveReleaseChannel(channelValue);
+  const version = String(versionValue || '').trim();
+  const stablePattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+  const betaPattern =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-beta\.([1-9]\d*)$/;
+  const nightlyPattern =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-nightly\.\d{8}$/;
+  const valid = channel === 'stable'
+    ? stablePattern.test(version)
+    : channel === 'beta'
+      ? betaPattern.test(version)
+      : nightlyPattern.test(version);
+  if (!valid) {
+    const example = channel === 'stable'
+      ? '0.2.18'
+      : channel === 'beta'
+        ? '0.2.18-beta.1'
+        : '0.2.18-nightly.20260811';
+    throw new Error(
+      `Version "${versionValue}" is invalid for the ${channel} channel. Expected a version like ${example}`,
+    );
+  }
+  return version;
+}
+
+export function compareReleaseVersions(leftValue, rightValue) {
+  const left = parseComparableVersion(leftValue);
+  const right = parseComparableVersion(rightValue);
+  for (let index = 0; index < 3; index += 1) {
+    if (left.core[index] !== right.core[index]) {
+      return left.core[index] < right.core[index] ? -1 : 1;
+    }
+  }
+  if (left.beta === right.beta) return 0;
+  if (left.beta === null) return 1;
+  if (right.beta === null) return -1;
+  return left.beta < right.beta ? -1 : 1;
+}
+
+function parseComparableVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-beta\.([1-9]\d*))?$/.exec(String(value));
+  if (!match) {
+    throw new Error(`Unsupported channel version: ${value}`);
+  }
+  return {
+    core: match.slice(1, 4).map(Number),
+    beta: match[4] === undefined ? null : Number(match[4]),
+  };
+}

--- a/scripts/release-channel.test.mjs
+++ b/scripts/release-channel.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  compareReleaseVersions,
+  resolveReleaseChannel,
+  validateReleaseVersion,
+} from './release-channel.mjs';
+import { setBuildVersion } from './set-build-version.mjs';
+
+test('stable and beta channels resolve to isolated updater feeds', () => {
+  const stable = resolveReleaseChannel('stable');
+  const beta = resolveReleaseChannel('beta');
+  assert.match(stable.primaryUpdaterEndpoint, /releases\/latest\/download/);
+  assert.match(beta.primaryUpdaterEndpoint, /releases\/download\/channel-beta/);
+  assert.equal(beta.fallbackUpdaterEndpoint, 'https://openbitfun.com/release/beta/latest.json');
+  assert.notEqual(beta.primaryUpdaterEndpoint, stable.primaryUpdaterEndpoint);
+});
+
+test('channel promotion follows SemVer including beta precedence', () => {
+  assert.equal(compareReleaseVersions('0.2.18-beta.2', '0.2.18-beta.1'), 1);
+  assert.equal(compareReleaseVersions('0.2.18', '0.2.18-beta.9'), 1);
+  assert.equal(compareReleaseVersions('0.2.19-beta.1', '0.2.18'), 1);
+  assert.equal(compareReleaseVersions('0.2.18', '0.2.19-beta.1'), -1);
+  assert.equal(compareReleaseVersions('0.2.18-beta.2', '0.2.18-beta.2'), 0);
+});
+
+test('release versions must match their channel', () => {
+  assert.equal(validateReleaseVersion('stable', '0.2.18'), '0.2.18');
+  assert.equal(validateReleaseVersion('beta', '0.2.18-beta.1'), '0.2.18-beta.1');
+  assert.throws(() => validateReleaseVersion('stable', '0.2.18-beta.1'));
+  assert.throws(() => validateReleaseVersion('beta', '0.2.18'));
+  assert.throws(() => validateReleaseVersion('beta', '0.2.18-beta.0'));
+  assert.equal(
+    validateReleaseVersion('nightly', '0.2.18-nightly.20260811'),
+    '0.2.18-nightly.20260811',
+  );
+});
+
+test('build version projection updates every release-owned version file', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'bitfun-build-version-'));
+  const jsonFiles = [
+    'package.json',
+    'package-lock.json',
+    'BitFun-Installer/package.json',
+    'BitFun-Installer/package-lock.json',
+  ];
+  for (const relative of jsonFiles) {
+    const file = path.join(root, relative);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ version: '1.0.0', packages: { '': { version: '1.0.0' } } }));
+  }
+  writeFixture(root, 'Cargo.toml', 'version = "1.0.0" # x-release-please-version\n');
+  writeFixture(
+    root,
+    'src/apps/relay-server/Cargo.toml',
+    'version = "1.0.0" # x-release-please-version\n',
+  );
+  writeFixture(root, 'BitFun-Installer/src-tauri/Cargo.toml', 'version = "1.0.0"\n');
+
+  setBuildVersion(root, '1.1.0-beta.2');
+
+  for (const relative of jsonFiles) {
+    const data = JSON.parse(readFileSync(path.join(root, relative), 'utf8'));
+    assert.equal(data.version, '1.1.0-beta.2');
+    assert.equal(data.packages[''].version, '1.1.0-beta.2');
+  }
+  assert.match(readFileSync(path.join(root, 'Cargo.toml'), 'utf8'), /1\.1\.0-beta\.2/);
+  assert.match(
+    readFileSync(path.join(root, 'src/apps/relay-server/Cargo.toml'), 'utf8'),
+    /1\.1\.0-beta\.2/,
+  );
+});
+
+function writeFixture(root, relative, content) {
+  const file = path.join(root, relative);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}

--- a/scripts/release-channel.test.mjs
+++ b/scripts/release-channel.test.mjs
@@ -9,6 +9,10 @@ import {
   validateReleaseVersion,
 } from './release-channel.mjs';
 import { setBuildVersion } from './set-build-version.mjs';
+import { decodeMinisignPublicKey } from './write-minisign-public-key.mjs';
+
+const RAW_PUBLIC_KEY = `untrusted comment: minisign public key E3E0874CEC1C22C3
+RWTDIhzsTIfg41w2Gwiei0zNDKaLYm9dQVpEWNQ/Ulpyt2mbS2JE1U2M`;
 
 test('stable and beta channels resolve to isolated updater feeds', () => {
   const stable = resolveReleaseChannel('stable');
@@ -37,6 +41,16 @@ test('release versions must match their channel', () => {
     validateReleaseVersion('nightly', '0.2.18-nightly.20260811'),
     '0.2.18-nightly.20260811',
   );
+});
+
+test('release public key export accepts raw and legacy base64 values', () => {
+  const expected = `${RAW_PUBLIC_KEY}\n`;
+  assert.equal(decodeMinisignPublicKey(RAW_PUBLIC_KEY), expected);
+  assert.equal(
+    decodeMinisignPublicKey(Buffer.from(expected).toString('base64')),
+    expected,
+  );
+  assert.throws(() => decodeMinisignPublicKey('not-a-key'));
 });
 
 test('build version projection updates every release-owned version file', () => {

--- a/scripts/set-build-version.mjs
+++ b/scripts/set-build-version.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export function setBuildVersion(root, version) {
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid build version: ${version}`);
+  }
+
+  for (const relative of [
+    'package.json',
+    'package-lock.json',
+    'BitFun-Installer/package.json',
+    'BitFun-Installer/package-lock.json',
+  ]) {
+    const file = path.join(root, relative);
+    const data = JSON.parse(readFileSync(file, 'utf8'));
+    data.version = version;
+    if (data.packages?.['']) {
+      data.packages[''].version = version;
+    }
+    writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+  }
+
+  replaceVersion(
+    path.join(root, 'Cargo.toml'),
+    /^version = "[^"]+" # x-release-please-version$/m,
+    `version = "${version}" # x-release-please-version`,
+  );
+  replaceVersion(
+    path.join(root, 'src/apps/relay-server/Cargo.toml'),
+    /^version = "[^"]+" # x-release-please-version$/m,
+    `version = "${version}" # x-release-please-version`,
+  );
+  replaceVersion(
+    path.join(root, 'BitFun-Installer/src-tauri/Cargo.toml'),
+    /^version = "[^"]+"$/m,
+    `version = "${version}"`,
+  );
+}
+
+function replaceVersion(file, pattern, replacement) {
+  const source = readFileSync(file, 'utf8');
+  if (!pattern.test(source)) {
+    throw new Error(`Version marker was not found in ${file}`);
+  }
+  writeFileSync(file, source.replace(pattern, replacement), 'utf8');
+}
+
+function readArg(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const version = readArg(process.argv.slice(2), '--version');
+    if (!version) {
+      throw new Error('Missing required --version argument');
+    }
+    setBuildVersion(ROOT, version);
+    console.log(`[build-version] Updated release metadata to ${version}`);
+  } catch (error) {
+    console.error(`[build-version] ${error.message || error}`);
+    process.exit(1);
+  }
+}
+

--- a/scripts/set-build-version.mjs
+++ b/scripts/set-build-version.mjs
@@ -68,4 +68,3 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
     process.exit(1);
   }
 }
-

--- a/scripts/sign-release-assets.sh
+++ b/scripts/sign-release-assets.sh
@@ -9,7 +9,8 @@
 #   BITFUN_SIGNING_KEY       minisign secret key, either the raw key file or
 #                            base64 of that file (legacy wrapper format)
 #   BITFUN_SIGNING_PASSWORD  password for that key
-#   BITFUN_SIGNING_PUBKEY    minisign public key, base64; used to self-verify
+#   BITFUN_SIGNING_PUBKEY    minisign public key, either the raw key file or
+#                            base64 of that file; used to self-verify
 #
 # With no signing key configured this is a no-op, so forks keep building.
 #
@@ -100,7 +101,14 @@ case "$BITFUN_SIGNING_KEY" in
     printf '%s' "$BITFUN_SIGNING_KEY" | base64 -d >"$WORK/release.key"
     ;;
 esac
-printf '%s' "${BITFUN_SIGNING_PUBKEY:-}" | base64 -d >"$WORK/release.pub" 2>/dev/null || true
+case "${BITFUN_SIGNING_PUBKEY:-}" in
+  "untrusted comment:"*)
+    printf '%s\n' "$BITFUN_SIGNING_PUBKEY" >"$WORK/release.pub"
+    ;;
+  *)
+    printf '%s' "${BITFUN_SIGNING_PUBKEY:-}" | base64 -d >"$WORK/release.pub" 2>/dev/null || true
+    ;;
+esac
 
 signed=0
 skipped=0

--- a/scripts/sign-release-assets.sh
+++ b/scripts/sign-release-assets.sh
@@ -6,7 +6,8 @@
 # Usage: sign-release-assets.sh <file> [<file>...]
 #
 # Environment:
-#   BITFUN_SIGNING_KEY       minisign secret key, base64 (Tauri's wrapper format)
+#   BITFUN_SIGNING_KEY       minisign secret key, either the raw key file or
+#                            base64 of that file (legacy wrapper format)
 #   BITFUN_SIGNING_PASSWORD  password for that key
 #   BITFUN_SIGNING_PUBKEY    minisign public key, base64; used to self-verify
 #
@@ -88,9 +89,17 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 umask 077
 
-# Tauri stores the minisign secret key base64-wrapped; unwrap it to the on-disk
-# format minisign expects.
-printf '%s' "$BITFUN_SIGNING_KEY" | base64 -d >"$WORK/release.key"
+# New Tauri CLIs accept the raw minisign key file as their environment value;
+# older repository secrets wrap that whole file in base64. Support both so the
+# Tauri bundler and direct minisign asset signing can share one secret.
+case "$BITFUN_SIGNING_KEY" in
+  "untrusted comment:"*)
+    printf '%s\n' "$BITFUN_SIGNING_KEY" >"$WORK/release.key"
+    ;;
+  *)
+    printf '%s' "$BITFUN_SIGNING_KEY" | base64 -d >"$WORK/release.key"
+    ;;
+esac
 printf '%s' "${BITFUN_SIGNING_PUBKEY:-}" | base64 -d >"$WORK/release.pub" 2>/dev/null || true
 
 signed=0

--- a/scripts/version-generation.test.mjs
+++ b/scripts/version-generation.test.mjs
@@ -18,9 +18,23 @@ for (const [buildEnv, isDev] of [['production', false], ['development', true]]) 
     );
     assert.equal(generated.version, expectedVersion);
     assert.equal(generated.buildEnv, buildEnv);
+    assert.equal(generated.releaseChannel, 'stable');
     assert.equal(generated.isDev, isDev);
   });
 }
+
+test('records the immutable release channel in generated metadata', () => {
+  const outputRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-version-beta-'));
+  const result = run(
+    ['--build-env', 'production', '--output-root', outputRoot],
+    { BITFUN_RELEASE_CHANNEL: 'beta' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const generated = JSON.parse(
+    fs.readFileSync(path.join(outputRoot, 'src/web-ui/public/version.json'), 'utf8')
+  );
+  assert.equal(generated.releaseChannel, 'beta');
+});
 
 test('fails instead of reusing stale metadata when build environment is missing', () => {
   const outputRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-version-missing-'));
@@ -29,9 +43,10 @@ test('fails instead of reusing stale metadata when build environment is missing'
   assert.match(`${result.stdout}\n${result.stderr}`, /Expected --build-env/);
 });
 
-function run(args) {
+function run(args, extraEnv = {}) {
   return spawnSync(process.execPath, ['scripts/generate-version.cjs', ...args], {
     cwd: root,
     encoding: 'utf8',
+    env: { ...process.env, ...extraEnv },
   });
 }

--- a/scripts/write-minisign-public-key.mjs
+++ b/scripts/write-minisign-public-key.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function decodeMinisignPublicKey(value) {
+  const input = String(value || '').trim();
+  if (!input) {
+    throw new Error('BITFUN_SIGNING_PUBKEY is required');
+  }
+
+  const raw = input.startsWith('untrusted comment:')
+    ? input
+    : decodeBase64(input);
+  const lines = raw.trim().split(/\r?\n/);
+  if (!lines[0]?.startsWith('untrusted comment:') || lines.length < 2 || !lines[1]) {
+    throw new Error('Public key is not a minisign public key file');
+  }
+  return `${raw.trim()}\n`;
+}
+
+function decodeBase64(value) {
+  const compact = value.replace(/\s/g, '');
+  if (
+    compact.length === 0
+    || compact.length % 4 !== 0
+    || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(compact)
+  ) {
+    throw new Error('Public key is neither raw minisign text nor valid base64');
+  }
+  return Buffer.from(compact, 'base64').toString('utf8');
+}
+
+function readArg(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const output = readArg(process.argv.slice(2), '--out');
+    if (!output) throw new Error('Missing required --out argument');
+    writeFileSync(output, decodeMinisignPublicKey(process.env.BITFUN_SIGNING_PUBKEY), 'utf8');
+  } catch (error) {
+    console.error(`[release-key] ${error.message || error}`);
+    process.exit(1);
+  }
+}

--- a/src/apps/cli/src/self_update.rs
+++ b/src/apps/cli/src/self_update.rs
@@ -1128,13 +1128,17 @@ fn is_newer_version(candidate: &str, current: &str) -> bool {
 
 fn automatic_update_is_eligible() -> bool {
     if std::env::var_os("BITFUN_CLI_DISABLE_AUTO_UPDATE").is_some()
-        || env!("CARGO_PKG_VERSION").contains("-nightly.")
+        || !release_version_allows_automatic_update(env!("CARGO_PKG_VERSION"))
     {
         return false;
     }
     std::env::current_exe()
         .ok()
         .is_some_and(|path| current_platform_key().is_some() && !is_development_binary(&path))
+}
+
+fn release_version_allows_automatic_update(version: &str) -> bool {
+    !version.contains("-nightly.") && !version.contains("-beta.")
 }
 
 /// Share the CLI's own config directory so a relocated profile (E2E storage
@@ -1444,6 +1448,15 @@ mod tests {
         assert!(is_newer_version("0.2.14", "0.2.13"));
         assert!(!is_newer_version("0.2.13", "0.2.13-nightly.1+abc"));
         assert!(!is_newer_version("0.2.12", "0.2.13"));
+    }
+
+    #[test]
+    fn prerelease_cli_builds_do_not_use_the_stable_auto_update_feed() {
+        assert!(release_version_allows_automatic_update("0.2.14"));
+        assert!(!release_version_allows_automatic_update("0.2.14-beta.1"));
+        assert!(!release_version_allows_automatic_update(
+            "0.2.14-nightly.20260811"
+        ));
     }
 
     /// Fixture produced with the real `minisign` CLI, then wrapped the way

--- a/src/apps/cli/src/self_update.rs
+++ b/src/apps/cli/src/self_update.rs
@@ -899,26 +899,33 @@ fn release_pubkey() -> Option<&'static str> {
 }
 
 /// Verify a Tauri-format `.sig` (base64 of a minisign signature file) over the
-/// archive, using the base64-wrapped public key.
+/// archive. The public key accepts both current raw Tauri values and the legacy
+/// base64 wrapper.
 ///
 /// A checksum only proves the transfer was not corrupted: whoever serves the
 /// archive can serve a matching `.sha256`. A signature proves the bytes came
 /// from whoever holds the release key, which is what actually protects the
 /// third-party GitHub proxy and mirror paths.
-fn verify_signature(archive: &[u8], signature_b64: &str, pubkey_b64: &str) -> Result<()> {
+fn verify_signature(archive: &[u8], signature_b64: &str, pubkey: &str) -> Result<()> {
     use base64::Engine as _;
-    let decode = |value: &str, what: &str| -> Result<String> {
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(value.trim().as_bytes())
-            .with_context(|| format!("decode {what}"))?;
-        String::from_utf8(bytes).with_context(|| format!("decode {what} as UTF-8"))
-    };
 
-    let public_key = minisign_verify::PublicKey::decode(&decode(pubkey_b64, "release public key")?)
+    let public_key_text = if pubkey.trim().starts_with("untrusted comment:") {
+        pubkey.trim().to_owned()
+    } else {
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(pubkey.trim().as_bytes())
+            .context("decode release public key")?;
+        String::from_utf8(bytes).context("decode release public key as UTF-8")?
+    };
+    let public_key = minisign_verify::PublicKey::decode(&public_key_text)
         .map_err(|error| anyhow!("invalid release public key: {error}"))?;
-    let signature =
-        minisign_verify::Signature::decode(&decode(signature_b64, "release signature")?)
-            .map_err(|error| anyhow!("invalid release signature: {error}"))?;
+    let signature_bytes = base64::engine::general_purpose::STANDARD
+        .decode(signature_b64.trim().as_bytes())
+        .context("decode release signature")?;
+    let signature_text =
+        String::from_utf8(signature_bytes).context("decode release signature as UTF-8")?;
+    let signature = minisign_verify::Signature::decode(&signature_text)
+        .map_err(|error| anyhow!("invalid release signature: {error}"))?;
     public_key
         .verify(archive, &signature, false)
         .map_err(|error| anyhow!("release signature does not match the archive: {error}"))
@@ -1198,6 +1205,7 @@ fn restart_managed_daemon() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
     use sha2::{Digest, Sha256};
     use std::sync::Arc;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -1470,6 +1478,14 @@ mod tests {
     fn release_signature_accepts_the_tauri_wire_format() {
         verify_signature(FIXTURE_DATA, FIXTURE_SIGNATURE, FIXTURE_PUBKEY)
             .expect("minisign signature in Tauri's base64 wrapper must verify");
+        let raw_pubkey = String::from_utf8(
+            base64::engine::general_purpose::STANDARD
+                .decode(FIXTURE_PUBKEY)
+                .expect("decode fixture public key"),
+        )
+        .expect("fixture public key is UTF-8");
+        verify_signature(FIXTURE_DATA, FIXTURE_SIGNATURE, &raw_pubkey)
+            .expect("raw minisign public key must verify");
     }
 
     #[test]

--- a/src/apps/desktop/build.rs
+++ b/src/apps/desktop/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=BITFUN_RELEASE_CHANNEL");
+    println!("cargo:rerun-if-env-changed=BITFUN_UPDATER_PRIMARY_ENDPOINT");
+    println!("cargo:rerun-if-env-changed=BITFUN_UPDATER_FALLBACK_ENDPOINT");
     // The Windows primary thread keeps the Tauri event loop and native window
     // creation stack. Reserve the same headroom as the Tokio workers so a
     // large debug invoke dispatcher cannot exhaust the default 1 MiB stack.

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -16,9 +16,14 @@ const UPDATE_PROGRESS_EVENT: &str = "bitfun-update-progress";
 
 /// Updater origins, in configured (fallback) order. Kept in step with
 /// `scripts/desktop-tauri-build.mjs`, which bakes the same pair into the bundle.
-const GITHUB_UPDATER_ENDPOINT: &str =
-    "https://github.com/GCWing/BitFun/releases/latest/download/latest.json";
-const OPENBITFUN_UPDATER_ENDPOINT: &str = "https://openbitfun.com/release/latest.json";
+const GITHUB_UPDATER_ENDPOINT: &str = match option_env!("BITFUN_UPDATER_PRIMARY_ENDPOINT") {
+    Some(endpoint) => endpoint,
+    None => "https://github.com/GCWing/BitFun/releases/latest/download/latest.json",
+};
+const OPENBITFUN_UPDATER_ENDPOINT: &str = match option_env!("BITFUN_UPDATER_FALLBACK_ENDPOINT") {
+    Some(endpoint) => endpoint,
+    None => "https://openbitfun.com/release/latest.json",
+};
 
 /// Throughput probe settings, matching the CLI updater and the relay deploy
 /// script (`src/apps/cli/src/self_update.rs`,

--- a/src/crates/services/services-integrations/src/remote_ssh/release_verify.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/release_verify.rs
@@ -67,26 +67,37 @@ pub(crate) fn verify_sha256(data: &[u8], expected: &str, filename: &str) -> Resu
     Ok(())
 }
 
-/// Verify a Tauri-format `.sig` (base64 of a complete minisign signature file)
-/// using the likewise base64-wrapped public key.
-pub(crate) fn verify_minisign(data: &[u8], signature_b64: &str, pubkey_b64: &str) -> Result<()> {
+/// Verify a Tauri-format `.sig` (base64 of a complete minisign signature file).
+/// The public key may be the raw minisign file accepted by current Tauri CLIs
+/// or the legacy base64 wrapper stored by older release configurations.
+pub(crate) fn verify_minisign(data: &[u8], signature_b64: &str, pubkey: &str) -> Result<()> {
     use base64::Engine as _;
 
-    let decode = |value: &str, what: &str| -> Result<String> {
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(value.trim().as_bytes())
-            .with_context(|| format!("decode {what}"))?;
-        String::from_utf8(bytes).with_context(|| format!("decode {what} as UTF-8"))
-    };
-
-    let public_key = minisign_verify::PublicKey::decode(&decode(pubkey_b64, "release public key")?)
+    let public_key = minisign_verify::PublicKey::decode(&decode_public_key(pubkey)?)
         .map_err(|error| anyhow!("invalid release public key: {error}"))?;
-    let signature =
-        minisign_verify::Signature::decode(&decode(signature_b64, "release signature")?)
-            .map_err(|error| anyhow!("invalid release signature: {error}"))?;
+    let signature_bytes = base64::engine::general_purpose::STANDARD
+        .decode(signature_b64.trim().as_bytes())
+        .context("decode release signature")?;
+    let signature_text =
+        String::from_utf8(signature_bytes).context("decode release signature as UTF-8")?;
+    let signature = minisign_verify::Signature::decode(&signature_text)
+        .map_err(|error| anyhow!("invalid release signature: {error}"))?;
     public_key
         .verify(data, &signature, false)
         .map_err(|error| anyhow!("release signature does not match the signed data: {error}"))
+}
+
+fn decode_public_key(value: &str) -> Result<String> {
+    use base64::Engine as _;
+
+    let value = value.trim();
+    if value.starts_with("untrusted comment:") {
+        return Ok(value.to_owned());
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value.as_bytes())
+        .context("decode release public key")?;
+    String::from_utf8(bytes).context("decode release public key as UTF-8")
 }
 
 /// Verify the minisign signature over a checksum sidecar, then return its
@@ -114,13 +125,8 @@ mod tests {
 
     #[test]
     fn embedded_trust_root_is_always_available_and_well_formed() {
-        use base64::Engine as _;
-
         let pubkey = require_release_pubkey().expect("every build carries a trust root");
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(pubkey.trim().as_bytes())
-            .expect("trust root is base64");
-        let text = String::from_utf8(decoded).expect("trust root decodes as UTF-8");
+        let text = decode_public_key(pubkey).expect("trust root has a supported key format");
         minisign_verify::PublicKey::decode(&text).expect("trust root is a minisign public key");
     }
 
@@ -128,6 +134,9 @@ mod tests {
     fn minisign_wire_format_accepts_authentic_data_and_rejects_tampering() {
         verify_minisign(FIXTURE_DATA, FIXTURE_SIGNATURE, FIXTURE_PUBKEY)
             .expect("fixture signature must verify");
+        let raw_pubkey = decode_public_key(FIXTURE_PUBKEY).expect("decode fixture public key");
+        verify_minisign(FIXTURE_DATA, FIXTURE_SIGNATURE, &raw_pubkey)
+            .expect("raw minisign public key must verify");
         assert!(verify_minisign(b"tampered\n", FIXTURE_SIGNATURE, FIXTURE_PUBKEY).is_err());
         assert!(verify_minisign(FIXTURE_DATA, "bm90LWEtc2ln", FIXTURE_PUBKEY).is_err());
     }

--- a/src/web-ui/src/shared/types/version.ts
+++ b/src/web-ui/src/shared/types/version.ts
@@ -20,6 +20,8 @@ export interface VersionInfo {
   isDev: boolean;
    
   buildEnv: 'development' | 'production' | 'preview';
+
+  releaseChannel?: 'stable' | 'beta' | 'nightly';
 }
 
  
@@ -47,4 +49,3 @@ export interface AboutInfo {
     issues?: string;
   };
 }
-

--- a/src/web-ui/src/shared/utils/version.test.ts
+++ b/src/web-ui/src/shared/utils/version.test.ts
@@ -8,6 +8,7 @@ const productionInfo: VersionInfo = {
   buildDate: '2026-08-06T00:00:00Z',
   buildTimestamp: 0,
   buildEnv: 'production',
+  releaseChannel: 'stable',
   isDev: false,
 };
 

--- a/src/web-ui/src/shared/utils/version.ts
+++ b/src/web-ui/src/shared/utils/version.ts
@@ -10,7 +10,8 @@ const DEFAULT_VERSION_INFO: VersionInfo = {
   buildDate: new Date(0).toISOString(),
   buildTimestamp: 0,
   isDev: import.meta.env.DEV,
-  buildEnv: import.meta.env.MODE as VersionInfo['buildEnv']
+  buildEnv: import.meta.env.MODE as VersionInfo['buildEnv'],
+  releaseChannel: 'stable'
 };
 
 


### PR DESCRIPTION
## Summary

- add stable, beta, and nightly release-channel resolution and version projection
- publish public beta desktop packages as GitHub prereleases with a mutable `channel-beta` updater feed
- support fork-owned beta downloads and updater endpoints while keeping stable release mirrors canonical
- keep public beta scope to Desktop and Installer packages; skip CLI and Relay publishing
- accept raw Tauri signing key wrappers in release signing helpers
- add release-channel tests, workflow coverage, and releasing documentation

## Validation

- `pnpm run check:github-config`
- `pnpm run test:release-packaging`
- `bash -n scripts/sign-release-assets.sh`
- public beta workflow run on fork succeeded: https://github.com/wgqqqqq/BitFun/actions/runs/31491075322
- published prerelease: https://github.com/wgqqqqq/BitFun/releases/tag/v0.2.18-beta.1

## Notes

The beta workflow was exercised on the fork and verified across macOS arm64/x64, Windows x64, and Linux arm64/x64. The upstream PR contains the reusable packaging/channel changes; repository secrets remain fork-specific.
