### PR TITLE
fix(goal): keep the resume prompt inside its own session

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -583,6 +583,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const threadGoalController = useThreadGoalController(effectiveTargetSession, {
     isBtwSession,
     disabled: !caps.threadGoal,
+    sceneActive: isSceneActive,
   });
   const currentSessionTitle = currentSession?.title?.trim() || t('session.untitled');
   const activeBtwSession = activeBtwSessionId

--- a/src/web-ui/src/flow_chat/hooks/useThreadGoalController.ts
+++ b/src/web-ui/src/flow_chat/hooks/useThreadGoalController.ts
@@ -6,9 +6,9 @@ import type { Session } from '../types/flow-chat';
 import { flowChatStore } from '../store/FlowChatStore';
 import {
   dismissResumePrompt,
-  isResumePromptDismissed,
+  resumePromptKey,
+  shouldOpenResumePrompt,
   threadGoalActionsForStatus,
-  threadGoalStatusNeedsResumePrompt,
   type ThreadGoalUiAction,
 } from '../services/threadGoalActions';
 import { parseGoalCommand } from '../services/goalCommandParser';
@@ -105,12 +105,13 @@ function useStableThreadGoalSnapshot(sessionId: string | undefined): ThreadGoalS
 
 export function useThreadGoalController(
   session: Session | undefined,
-  options?: { isBtwSession?: boolean; disabled?: boolean }
+  options?: { isBtwSession?: boolean; disabled?: boolean; sceneActive?: boolean }
 ): ThreadGoalController {
   const { t } = useTranslation('flow-chat');
   const sessionId = session?.sessionId;
   const isBtwSession = Boolean(options?.isBtwSession);
   const disabled = isBtwSession || Boolean(options?.disabled);
+  const sceneActive = options?.sceneActive ?? true;
 
   const storeGoal = useStableThreadGoalSnapshot(sessionId);
 
@@ -161,30 +162,36 @@ export function useThreadGoalController(
     void refreshGoal();
   }, [session?.isHistorical, sessionId, disabled, refreshGoal]);
 
-  const goalId = goal?.goalId;
-  const goalStatus = goal?.status;
-  const goalUpdatedAt = goal?.updatedAt;
+  /** Which session the user is actually looking at through this controller. */
+  const visitKey = sceneActive && sessionId ? sessionId : null;
+
+  /**
+   * Every scene stays mounted, so a paused goal must not raise its modal over
+   * whatever scene is in front. Leaving this session — or opening another one —
+   * retracts the prompt and re-arms the gate, which brings the prompt back when
+   * the user opens the paused session again. Declared before the effect below
+   * so a new visit re-arms first and can then re-open in the same commit.
+   */
+  useEffect(() => {
+    lastResumePromptKey.current = null;
+    setResumeOpen(false);
+  }, [visitKey]);
 
   useEffect(() => {
     if (
-      disabled
-      || !sessionId
-      || !goalId
-      || !goalStatus
-      || !threadGoalStatusNeedsResumePrompt(goalStatus)
+      !shouldOpenResumePrompt({
+        sessionId,
+        goal,
+        sceneActive,
+        disabled,
+        lastPromptedKey: lastResumePromptKey.current,
+      })
     ) {
       return;
     }
-    if (!goal || isResumePromptDismissed(sessionId, goal)) {
-      return;
-    }
-    const key = `${goalId}:${goalUpdatedAt ?? 0}:${goalStatus}`;
-    if (lastResumePromptKey.current === key) {
-      return;
-    }
-    lastResumePromptKey.current = key;
+    lastResumePromptKey.current = resumePromptKey(goal);
     setResumeOpen(true);
-  }, [disabled, goal, goalId, goalStatus, goalUpdatedAt, sessionId]);
+  }, [disabled, goal, sceneActive, sessionId]);
 
   const openMenu = useCallback(() => {
     setMenuOpen(true);

--- a/src/web-ui/src/flow_chat/services/threadGoalActions.test.ts
+++ b/src/web-ui/src/flow_chat/services/threadGoalActions.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { threadGoalActionsForStatus } from './threadGoalActions';
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  dismissResumePrompt,
+  resumePromptKey,
+  shouldOpenResumePrompt,
+  threadGoalActionsForStatus,
+} from './threadGoalActions';
+import type { ThreadGoalSnapshot } from './goalService';
 
 describe('threadGoalActionsForStatus', () => {
   it('offers resume for paused goals after user stop', () => {
@@ -8,5 +15,66 @@ describe('threadGoalActionsForStatus', () => {
 
   it('does not offer resume while goal is still active', () => {
     expect(threadGoalActionsForStatus('active')).toEqual(['edit', 'pause', 'clear']);
+  });
+});
+
+const pausedGoal: ThreadGoalSnapshot = {
+  goalId: 'goal-1',
+  objective: 'ship the thing',
+  status: 'paused',
+  updatedAt: 42,
+};
+
+function gate(overrides: Partial<Parameters<typeof shouldOpenResumePrompt>[0]> = {}) {
+  return shouldOpenResumePrompt({
+    sessionId: 'session-1',
+    goal: pausedGoal,
+    sceneActive: true,
+    disabled: false,
+    lastPromptedKey: null,
+    ...overrides,
+  });
+}
+
+describe('resumePromptKey', () => {
+  it('keys the prompt by goal, revision and status', () => {
+    expect(resumePromptKey(pausedGoal)).toBe('goal-1:42:paused');
+  });
+
+  it('has no key for statuses that never prompt', () => {
+    expect(resumePromptKey({ ...pausedGoal, status: 'active' })).toBeNull();
+    expect(resumePromptKey(null)).toBeNull();
+  });
+});
+
+describe('shouldOpenResumePrompt', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('prompts while the user is looking at the session that owns the goal', () => {
+    expect(gate()).toBe(true);
+  });
+
+  it('stays closed while the session sits in a background scene', () => {
+    expect(gate({ sceneActive: false })).toBe(false);
+  });
+
+  it('prompts again once the user opens that session, after the gate is re-armed', () => {
+    const key = resumePromptKey(pausedGoal);
+    expect(gate({ lastPromptedKey: key })).toBe(false);
+    expect(gate({ lastPromptedKey: null })).toBe(true);
+  });
+
+  it('respects an explicit leave-paused dismissal', () => {
+    dismissResumePrompt('session-1', pausedGoal);
+    expect(gate()).toBe(false);
+  });
+
+  it('does not prompt for goals that are not paused, or when goals are disabled', () => {
+    expect(gate({ goal: { ...pausedGoal, status: 'active' } })).toBe(false);
+    expect(gate({ goal: null })).toBe(false);
+    expect(gate({ disabled: true })).toBe(false);
+    expect(gate({ sessionId: undefined })).toBe(false);
   });
 });

--- a/src/web-ui/src/flow_chat/services/threadGoalActions.ts
+++ b/src/web-ui/src/flow_chat/services/threadGoalActions.ts
@@ -43,3 +43,40 @@ export function dismissResumePrompt(sessionId: string, goal: ThreadGoalSnapshot)
     // ignore storage failures
   }
 }
+
+/**
+ * Identifies one paused-goal state, so the resume prompt opens once per visit to
+ * the session instead of on every effect run. Null when the goal cannot prompt.
+ */
+export function resumePromptKey(goal: ThreadGoalSnapshot | null | undefined): string | null {
+  if (!goal?.goalId || !threadGoalStatusNeedsResumePrompt(goal.status)) return null;
+  return `${goal.goalId}:${goal.updatedAt ?? 0}:${goal.status}`;
+}
+
+export interface ResumePromptGate {
+  sessionId: string | undefined;
+  goal: ThreadGoalSnapshot | null;
+  /** False while the session sits in a scene the user is not looking at. */
+  sceneActive: boolean;
+  disabled: boolean;
+  /** State this controller already prompted for during the current visit. */
+  lastPromptedKey: string | null;
+}
+
+/**
+ * The prompt belongs to the session the user opened. Every scene stays mounted,
+ * so without the `sceneActive` gate a paused goal would raise its modal on top
+ * of whatever unrelated scene happens to be in front.
+ */
+export function shouldOpenResumePrompt({
+  sessionId,
+  goal,
+  sceneActive,
+  disabled,
+  lastPromptedKey,
+}: ResumePromptGate): boolean {
+  if (disabled || !sceneActive || !sessionId || !goal) return false;
+  const key = resumePromptKey(goal);
+  if (!key || key === lastPromptedKey) return false;
+  return !isResumePromptDismissed(sessionId, goal);
+}


### PR DESCRIPTION
## Summary

A paused `/goal` raised its "resume the paused goal?" modal from a background scene: after pausing, clicking into the MiniApp gallery — or any other scene — popped the dialog on top of that scene, unrelated to the session that owns the goal.

`SceneViewport` keeps every scene mounted and only marks one active, so the `SessionScene` → `ChatPane` → `ChatInput` chain (and with it `useThreadGoalController`) keeps running while the user is somewhere else. The auto-open effect had no notion of whether the user was actually looking at that session, so a goal refresh or a remount re-fired the prompt wherever the user happened to be.

The prompt is now gated on the owning session being the one in front, and a change of visit — leaving the session, or opening a different one — retracts it and re-arms the gate, so it comes back when the user opens the paused session again.

## Type and Areas

Type: bug fix

Areas: web UI (`src/web-ui/src/flow_chat`)

## Motivation / Impact

Before: pause a goal, then click anywhere in the app → the resume dialog interrupts on top of the current scene.

After:

- The prompt only opens while the session that owns the paused goal is the visible one.
- Switching away retracts it instead of leaving it stacked over the next scene.
- Opening that session again re-prompts.
- An explicit "保持暂停" / close still suppresses the prompt for that goal, unchanged.

## Verification

```
pnpm run type-check:web
pnpm --dir src/web-ui run test:run src/flow_chat/services/threadGoalActions.test.ts src/app/startup/startupPerformanceContract.test.ts   # 56 passed
npx eslint src/flow_chat/hooks/useThreadGoalController.ts src/flow_chat/services/threadGoalActions.ts src/flow_chat/components/ChatInput.tsx   # clean
pnpm --dir src/web-ui run test:run src/flow_chat   # 1526 passed, 2 pre-existing failures in modelResolution.test.ts (also fail on main, unrelated)
```

Seven new cases cover the gate: prompts while the session is in front, stays closed from a background scene, re-prompts once re-armed, respects the leave-paused dismissal, and ignores non-paused / disabled / session-less states.

Remote scenarios: this is client-side presentation of an already-fetched goal snapshot, with no transport, protocol, or persisted-shape change, so remote workspace, remote control, peer device, and detached dispatch behave as before.

## Reviewer Notes

The gate decision moved into `shouldOpenResumePrompt` / `resumePromptKey` in `threadGoalActions.ts` so it can be unit-tested without a React renderer (`web-ui` has no `@testing-library/react`).

Effect order matters and is intentional: the visit-change effect is declared before the auto-open effect, so a new visit re-arms first and can re-open in the same commit.

`ChatInput` gets the signal from the `isSceneActive` prop it already receives; the option defaults to `true`, so the `FloatingMiniChat` surface (mounted only while its bubble is open) is unaffected.
