### PR TITLE
fix(git): recover untrusted repository operations with a confirmation flow

### DIFF
--- a/docs/features/remote-workspaces.md
+++ b/docs/features/remote-workspaces.md
@@ -91,6 +91,23 @@ The configured Docker CLI remains the security boundary. BitFun does not expose
 the Docker daemon over the network or bypass the current user's Docker
 permissions.
 
+## Git ownership trust
+
+Git refuses a repository whose directory is owned by another user until the
+path is listed in the protected `safe.directory` configuration — a common shape
+for shared SSH hosts, bind-mounted trees, and containers that run as a
+different uid. BitFun classifies that refusal as its own state instead of
+reporting "not a repository", so Git-backed surfaces can explain the wall and
+the Review launch fails with a specific reason.
+
+The decision itself belongs to the machine that owns the repository. For a
+remote workspace BitFun reports the state and hands over the exact command
+(`git config --global --add safe.directory "<path>"`) to run on the remote
+host; it never writes the remote user's global Git configuration, and it never
+grants trust implicitly as a fallback of a failed read. The same rule applies
+in Peer Device Mode: the read-only probe answers for a controller, granting is
+refused on the peer host.
+
 ## Upgrade compatibility
 
 Existing SSH profiles remain plain SSH targets because the new `proxyJump` and

--- a/src/apps/cli/src/dispatch/mod.rs
+++ b/src/apps/cli/src/dispatch/mod.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 use anyhow::{anyhow, bail, Context, Result};
 use bitfun_core::infrastructure::ai::AIClientFactory;
 use bitfun_core::service::config::{AuthConfig, GlobalConfig};
+use bitfun_core::service::git::trust;
 use serde::de::DeserializeOwned;
 
 use protocol::{
@@ -758,18 +759,23 @@ fn inspect_workspace(workspace_path: &str) -> Result<DispatchWorkspaceProbe> {
     } else {
         path
     };
-    let is_git_repository = is_directory
-        && git_output(&canonical, &["rev-parse", "--is-inside-work-tree"])
-            .is_some_and(|output| output.trim() == "true");
+    let RepositoryProbe {
+        is_git_repository,
+        trust_required,
+    } = is_directory
+        .then(|| classify_repository_probe(git_probe(&canonical, REV_PARSE_INSIDE_WORK_TREE)))
+        .unwrap_or_default();
     let branch = is_git_repository
         .then(|| git_output(&canonical, &["branch", "--show-current"]))
         .flatten()
         .map(|branch| branch.trim().to_string())
         .filter(|branch| !branch.is_empty());
-    let dirty = is_git_repository.then(|| {
-        git_output(&canonical, &["status", "--porcelain"])
-            .is_some_and(|output| !output.trim().is_empty())
-    });
+    // `None`, not `Some(false)`, when the read never landed: a repository we
+    // were not allowed to inspect is not a clean one.
+    let dirty = is_git_repository
+        .then(|| git_output(&canonical, &["status", "--porcelain"]))
+        .flatten()
+        .map(|output| !output.trim().is_empty());
     let (ahead, behind) = if is_git_repository {
         git_output(
             &canonical,
@@ -786,6 +792,7 @@ fn inspect_workspace(workspace_path: &str) -> Result<DispatchWorkspaceProbe> {
         exists,
         is_directory,
         is_git_repository,
+        trust_required: trust_required.then_some(true),
         branch,
         dirty,
         ahead,
@@ -801,16 +808,72 @@ fn parse_ahead_behind(counts: &str) -> Option<(u64, u64)> {
 }
 
 fn git_output(workspace: &Path, args: &[&str]) -> Option<String> {
+    git_probe(workspace, args).ok().map(|probe| probe.stdout)
+}
+
+struct GitProbeOutput {
+    stdout: String,
+    diagnostic: String,
+}
+
+const REV_PARSE_INSIDE_WORK_TREE: &[&str] = &["rev-parse", "--is-inside-work-tree"];
+
+#[derive(Default)]
+struct RepositoryProbe {
+    is_git_repository: bool,
+    trust_required: bool,
+}
+
+/// Reads what a `rev-parse --is-inside-work-tree` probe actually established.
+///
+/// A repository Git refuses on ownership grounds still *is* one. Reporting
+/// `false` — which is what discarding the exit status did — tells a detached
+/// controller there is nothing to review here, and hides the one thing that
+/// would fix it. Same reading as the local and remote probes
+/// (`is_git_repository`, `remote_probe_found_repository`).
+fn classify_repository_probe(result: Result<GitProbeOutput, GitProbeOutput>) -> RepositoryProbe {
+    match result {
+        Ok(output) => RepositoryProbe {
+            is_git_repository: output.stdout.trim() == "true",
+            trust_required: false,
+        },
+        Err(failure) => {
+            let trust_required = trust::is_untrusted_repository_message(&failure.diagnostic);
+            RepositoryProbe {
+                is_git_repository: trust_required,
+                trust_required,
+            }
+        }
+    }
+}
+
+/// Runs one probe command, keeping the diagnostic a failure came with.
+///
+/// `LC_ALL=C` for the same reason every other executor pins it: the classifier
+/// below matches Git's English prose, and a localized host would otherwise make
+/// an ownership rejection unrecognizable.
+fn git_probe(workspace: &Path, args: &[&str]) -> Result<GitProbeOutput, GitProbeOutput> {
     let output = Command::new("git")
+        .env("LC_ALL", "C")
         .arg("-C")
         .arg(workspace)
         .args(args)
-        .output()
-        .ok()?;
-    output
-        .status
-        .success()
-        .then(|| String::from_utf8_lossy(&output.stdout).to_string())
+        .output();
+    let Ok(output) = output else {
+        return Err(GitProbeOutput {
+            stdout: String::new(),
+            diagnostic: String::new(),
+        });
+    };
+    let probe = GitProbeOutput {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        diagnostic: String::from_utf8_lossy(&output.stderr).to_string(),
+    };
+    if output.status.success() {
+        Ok(probe)
+    } else {
+        Err(probe)
+    }
 }
 
 fn canonical_workspace(workspace_path: &str) -> Result<PathBuf> {
@@ -894,6 +957,53 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
     use crate::dispatch::protocol::{DispatchApprovalPolicy, DispatchSubmitRequest};
+
+    fn probe_failure(diagnostic: &str) -> Result<GitProbeOutput, GitProbeOutput> {
+        Err(GitProbeOutput {
+            stdout: String::new(),
+            diagnostic: diagnostic.to_string(),
+        })
+    }
+
+    /// A shared host where the workspace belongs to another account is the
+    /// ordinary case for detached dispatch. Answering "not a Git repository"
+    /// there sends the controller looking for a repository that is right where
+    /// it said it was.
+    #[test]
+    fn an_ownership_rejection_still_reports_a_repository() {
+        let probe = classify_repository_probe(probe_failure(
+            "fatal: detected dubious ownership in repository at '/srv/shared/repo'",
+        ));
+
+        assert!(probe.is_git_repository);
+        assert!(probe.trust_required);
+    }
+
+    #[test]
+    fn a_missing_repository_stays_absent_and_needs_no_trust() {
+        let probe = classify_repository_probe(probe_failure(
+            "fatal: not a git repository (or any of the parent directories): .git",
+        ));
+
+        assert!(!probe.is_git_repository);
+        assert!(!probe.trust_required);
+    }
+
+    #[test]
+    fn a_successful_probe_reads_its_answer() {
+        let yes = classify_repository_probe(Ok(GitProbeOutput {
+            stdout: "true\n".to_string(),
+            diagnostic: String::new(),
+        }));
+        assert!(yes.is_git_repository);
+        assert!(!yes.trust_required);
+
+        let no = classify_repository_probe(Ok(GitProbeOutput {
+            stdout: "false\n".to_string(),
+            diagnostic: String::new(),
+        }));
+        assert!(!no.is_git_repository);
+    }
 
     fn test_request(job_id: &str) -> DispatchSubmitRequest {
         DispatchSubmitRequest {

--- a/src/apps/cli/src/dispatch/protocol.rs
+++ b/src/apps/cli/src/dispatch/protocol.rs
@@ -25,6 +25,11 @@ pub(crate) struct DispatchWorkspaceProbe {
     pub(crate) exists: bool,
     pub(crate) is_directory: bool,
     pub(crate) is_git_repository: bool,
+    /// Git found the repository but refuses to read it until the current user
+    /// trusts the path. Present only when that is the case, so a controller can
+    /// say why `branch` and `dirty` are missing instead of showing a blank.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) trust_required: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) branch: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/apps/cli/src/peer_host/commands/git.rs
+++ b/src/apps/cli/src/peer_host/commands/git.rs
@@ -17,3 +17,22 @@ pub(crate) async fn git_is_repository(args: &Value) -> Result<Value, String> {
         })?;
     Ok(json!(is_repo))
 }
+
+/// Read-only ownership-trust probe.
+///
+/// Granting trust writes to the host user's global Git configuration, so that
+/// decision stays on surfaces where the user is at the machine; a controller
+/// only gets the diagnosis and the manual command.
+pub(crate) async fn git_get_repository_trust(args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let repository_path = get_string(request, "repositoryPath")?;
+    let report = GitService::inspect_trust(&repository_path)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to inspect Git repository trust: path={repository_path}, error={e}"
+            );
+            format!("Failed to inspect Git repository trust: {e}")
+        })?;
+    serde_json::to_value(report).map_err(|e| format!("Failed to serialize trust report: {e}"))
+}

--- a/src/apps/cli/src/peer_host/commands/mod.rs
+++ b/src/apps/cli/src/peer_host/commands/mod.rs
@@ -119,6 +119,7 @@ pub(crate) async fn dispatch(
 
         // Git (local workspace only)
         "git_is_repository" => git::git_is_repository(args).await,
+        "git_get_repository_trust" => git::git_get_repository_trust(args).await,
 
         // Soft empty / no-op for Desktop-only subsystems
         "notify_cron_host_ready" => soft::notify_cron_host_ready().await,

--- a/src/apps/cli/src/peer_host/deny.rs
+++ b/src/apps/cli/src/peer_host/deny.rs
@@ -108,14 +108,21 @@ static LOCAL_ONLY_COMMANDS: &[&str] = &[
     "speech_append_audio_chunk",
     "speech_finish_input_session",
     "speech_cancel_input_session",
+    // Granting Git ownership trust writes this user's global Git configuration
+    // and tells Git to run hooks from a tree they do not own. That decision
+    // belongs to the person at this machine, so refuse it explicitly rather
+    // than relying on the command being unimplemented here.
+    "git_trust_repository",
 ];
 
 /// Desktop IDE surfaces that CLI Peer Host does not implement.
 /// Prefix match is applied for `lsp_`, `canvas_`, `editor_`, `ssh_`,
 /// `terminal_`, `search_` unless the command is explicitly allowlisted.
 ///
-/// `git_*` is intentionally not prefix-denied: `git_is_repository` is
-/// implemented; other git commands fall through to the registry miss path.
+/// `git_*` is intentionally not prefix-denied: `git_is_repository` and the
+/// read-only `git_get_repository_trust` are implemented; `git_trust_repository`
+/// is refused as local-only above, and other git commands fall through to the
+/// registry miss path.
 static CLI_UNSUPPORTED_EXACT: &[&str] = &[
     "open_remote_workspace",
     "remote_get_workspace_info",
@@ -193,5 +200,15 @@ mod tests {
         ] {
             assert!(is_local_only_command(command), "{command}");
         }
+    }
+
+    /// Reading why Git refuses a repository is safe to answer for a controller
+    /// and is implemented here; granting the exception writes this user's
+    /// global Git configuration and must be decided at this machine. Being
+    /// unimplemented is not a boundary — say no explicitly.
+    #[test]
+    fn granting_git_ownership_trust_is_refused_on_the_peer() {
+        assert!(is_local_only_command("git_trust_repository"));
+        assert!(!is_local_only_command("git_get_repository_trust"));
     }
 }

--- a/src/apps/desktop/src/api/git_api.rs
+++ b/src/apps/desktop/src/api/git_api.rs
@@ -9,17 +9,39 @@ use bitfun_core::service::git::{
     GitLogParams, GitPullParams, GitPushParams, GitService,
 };
 use bitfun_core::service::git::{
-    GitBranch, GitCommit, GitOperationResult, GitRepository, GitStatus,
+    trust, GitBranch, GitCommit, GitError, GitOperationResult, GitRepository, GitStatus,
+    GitTrustOutcome, GitTrustReport, GitTrustState,
 };
 use bitfun_core::service::remote_ssh::{
-    build_remote_git_command as build_remote_git_command_shared, lookup_remote_connection,
-    normalize_remote_workspace_path,
+    build_remote_git_command as build_remote_git_command_shared, is_remote_path,
+    lookup_remote_connection, normalize_remote_workspace_path,
 };
 use bitfun_core::service::workspace::WorktreeTopologyFreshness;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use tauri::State;
+
+/// Flattens a Git service failure into the desktop error string, keeping
+/// ownership rejections machine-recognizable across the command boundary. The
+/// wire form is produced by `trust`, shared with the app-server surface.
+fn git_error_message(context: &str, error: &GitError) -> String {
+    match error.untrusted_repository_path() {
+        Some(repository_path) => trust::untrusted_repository_error_message(repository_path),
+        None => format!("{context}: {error}"),
+    }
+}
+
+/// Same classification for repositories reached over a remote connection, where
+/// only the remote diagnostic text is available.
+fn remote_git_error_message(fallback_path: &str, message: String) -> String {
+    if trust::is_untrusted_repository_message(&message) {
+        let repository_path = trust::untrusted_repository_path_from_message(&message)
+            .unwrap_or_else(|| fallback_path.to_string());
+        return trust::untrusted_repository_error_message(&repository_path);
+    }
+    message
+}
 
 #[derive(Debug, Clone)]
 struct RemoteGitTarget {
@@ -34,12 +56,36 @@ struct RemoteGitOutput {
     exit_code: i32,
 }
 
-async fn resolve_remote_git_target(repository_path: &str) -> Option<RemoteGitTarget> {
-    let entry = lookup_remote_connection(repository_path).await?;
-    Some(RemoteGitTarget {
-        connection_id: entry.connection_id,
-        repository_path: normalize_remote_workspace_path(repository_path),
-    })
+/// Resolves the remote workspace a Git request belongs to, if any.
+///
+/// `Ok(None)` means "this path is on this machine". It must not also mean "this
+/// path belongs to another machine but I could not say which": overlapping
+/// registered roots with no usable connection hint make `lookup_remote_connection`
+/// answer `None` for a path that plainly is remote (`is_remote_path` still says
+/// so), and treating that as local hands the request to the local `GitService`.
+/// For a read that reports a stranger's repository; for `git_trust_repository`
+/// it writes *this* user's global `safe.directory` for a path that lives
+/// somewhere else — a real, wrong, host operation whenever a same-named path
+/// happens to exist here. Remote workspace search already refuses the identical
+/// ambiguity out loud (`search_api::workspace_search_unavailable_message`).
+async fn resolve_remote_git_target(
+    repository_path: &str,
+) -> Result<Option<RemoteGitTarget>, String> {
+    if let Some(entry) = lookup_remote_connection(repository_path).await {
+        return Ok(Some(RemoteGitTarget {
+            connection_id: entry.connection_id,
+            repository_path: normalize_remote_workspace_path(repository_path),
+        }));
+    }
+
+    if is_remote_path(repository_path).await {
+        return Err(format!(
+            "Remote workspace is not registered with BitFun SSH state: no single SSH connection \
+             matches {repository_path}"
+        ));
+    }
+
+    Ok(None)
 }
 
 fn build_remote_git_command(repository_path: &str, args: &[String]) -> String {
@@ -82,7 +128,10 @@ async fn execute_remote_git_success(
         } else {
             output.stderr
         };
-        Err(error.trim().to_string())
+        Err(remote_git_error_message(
+            &target.repository_path,
+            error.trim().to_string(),
+        ))
     }
 }
 
@@ -93,13 +142,7 @@ async fn execute_remote_git_operation(
 ) -> Result<GitOperationResult, String> {
     let output = execute_remote_git_command(state, target, args).await?;
     let success = output.exit_code == 0;
-    let error = (!success).then(|| {
-        if output.stderr.trim().is_empty() {
-            output.stdout.trim().to_string()
-        } else {
-            output.stderr.trim().to_string()
-        }
-    });
+    let error = remote_operation_error(&target.repository_path, &output);
 
     Ok(GitOperationResult {
         success,
@@ -111,6 +154,24 @@ async fn execute_remote_git_operation(
         output: Some(output.stdout),
         duration: None,
     })
+}
+
+/// The failure a remote mutation reports, `None` when it succeeded.
+///
+/// A mutation refused on ownership grounds hits the same wall a read hits, and
+/// has to reach the frontend the same way — through the stable code the trust
+/// recovery flow branches on. Reporting the raw remote diagnostic instead put
+/// `fatal: detected dubious ownership` in front of the user with nothing to do
+/// about it, while the same rejection on a read offered the way out.
+fn remote_operation_error(fallback_path: &str, output: &RemoteGitOutput) -> Option<String> {
+    if output.exit_code == 0 {
+        return None;
+    }
+
+    Some(remote_git_error_message(
+        fallback_path,
+        remote_git_diagnostic(output),
+    ))
 }
 
 fn parse_remote_status_line(
@@ -484,6 +545,169 @@ pub struct GitRemoveWorktreeRequest {
     pub force: Option<bool>,
 }
 
+/// Read-only ownership-trust probe for a repository.
+///
+/// Git refuses to operate on a repository owned by another user until the path
+/// is listed in the protected `safe.directory` configuration. Surfaces call
+/// this to tell that state apart from "not a repository" before offering the
+/// trust decision.
+#[tauri::command]
+pub async fn git_get_repository_trust(
+    state: State<'_, AppState>,
+    request: GitRepositoryRequest,
+) -> Result<GitTrustReport, String> {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
+        return inspect_remote_repository_trust(&state, &target).await;
+    }
+
+    GitService::inspect_trust(&request.repository_path)
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to inspect Git repository trust: path={}, error={}",
+                request.repository_path, e
+            );
+            git_error_message("Failed to inspect Git repository trust", &e)
+        })
+}
+
+/// Grants ownership trust for a repository after the user confirmed it.
+///
+/// Writes the `safe.directory` exception Git asks for, then re-probes the
+/// repository. A decision that could not be applied here (remote workspace,
+/// read-only configuration) is reported with `state != trusted` and the manual
+/// command, never silently swallowed.
+#[tauri::command]
+pub async fn git_trust_repository(
+    state: State<'_, AppState>,
+    request: GitRepositoryRequest,
+) -> Result<GitTrustOutcome, String> {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
+        let report = inspect_remote_repository_trust(&state, &target).await?;
+        info!(
+            "Git repository trust must be granted on the remote host: path={}",
+            target.repository_path
+        );
+        return Ok(GitTrustOutcome {
+            already_trusted: report.state == GitTrustState::Trusted,
+            state: report.state,
+            repository_path: report.repository_path,
+            added_entries: Vec::new(),
+            detail: report.detail,
+            manual_command: report.manual_command,
+        });
+    }
+
+    let outcome = GitService::trust_repository(&request.repository_path)
+        .await
+        .map_err(|e| {
+            error!(
+                "Failed to trust Git repository: path={}, error={}",
+                request.repository_path, e
+            );
+            git_error_message("Failed to trust Git repository", &e)
+        })?;
+    info!(
+        "Git repository trust decision applied: path={}, state={:?}, added={}",
+        request.repository_path,
+        outcome.state,
+        outcome.added_entries.len()
+    );
+    Ok(outcome)
+}
+
+async fn inspect_remote_repository_trust(
+    state: &AppState,
+    target: &RemoteGitTarget,
+) -> Result<GitTrustReport, String> {
+    let output = execute_remote_git_command(
+        state,
+        target,
+        &["rev-parse".to_string(), "--show-toplevel".to_string()],
+    )
+    .await?;
+
+    if output.exit_code == 0 {
+        // A successful `--show-toplevel` always names the worktree. Empty
+        // output means the transport, not Git, produced this result; calling it
+        // "trusted" would report a repository we never actually saw.
+        // Normalized like every local path, so a remote report and a local one
+        // are comparable and a `safe.directory` entry derived from either has
+        // the same spelling.
+        let Some(repository_path) = trust::normalize_trust_path(&output.stdout) else {
+            return Err(
+                "Failed to inspect Git repository trust on the remote host: git reported success without a repository path"
+                    .to_string(),
+            );
+        };
+        return Ok(GitTrustReport {
+            state: GitTrustState::Trusted,
+            repository_path: Some(repository_path),
+            detail: None,
+            manual_command: None,
+        });
+    }
+
+    let diagnostic = remote_git_diagnostic(&output);
+    if trust::is_untrusted_repository_message(&diagnostic) {
+        let repository_path = trust::untrusted_repository_path_from_message(&diagnostic)
+            .or_else(|| trust::normalize_trust_path(&target.repository_path))
+            .unwrap_or_else(|| target.repository_path.clone());
+        let manual_command = trust::manual_trust_command(&repository_path);
+        return Ok(GitTrustReport {
+            state: GitTrustState::TrustRequired,
+            repository_path: Some(repository_path),
+            detail: Some(diagnostic),
+            manual_command: Some(manual_command),
+        });
+    }
+
+    if trust::is_missing_repository_message(&diagnostic) {
+        return Ok(GitTrustReport {
+            state: GitTrustState::NotARepository,
+            repository_path: trust::normalize_trust_path(&target.repository_path)
+                .or_else(|| Some(target.repository_path.clone())),
+            detail: Some(diagnostic),
+            manual_command: None,
+        });
+    }
+
+    // Anything else — a denied path, a broken `.git`, an SSH wrapper that died
+    // — means the probe could not reach an answer. The local inspection returns
+    // an error there, and so must this one: reporting "not a repository" would
+    // send the user to initialize one over a repository that is already there.
+    Err(format!(
+        "Failed to inspect Git repository trust on the remote host: {}",
+        if diagnostic.is_empty() {
+            format!("git exited with code {}", output.exit_code)
+        } else {
+            diagnostic
+        }
+    ))
+}
+
+/// The remote diagnostic to classify: stderr when Git wrote one, stdout
+/// otherwise (some SSH wrappers merge the streams).
+fn remote_git_diagnostic(output: &RemoteGitOutput) -> String {
+    if output.stderr.trim().is_empty() {
+        output.stdout.trim().to_string()
+    } else {
+        output.stderr.trim().to_string()
+    }
+}
+
+/// Whether a remote `rev-parse --is-inside-work-tree` found a repository.
+///
+/// Mirrors the local [`bitfun_core::service::git::utils::is_git_repository`]:
+/// a repository Git refuses on ownership grounds still *is* one, and answering
+/// `false` there hides the recovery affordance behind "not a repository".
+fn remote_probe_found_repository(output: &RemoteGitOutput) -> bool {
+    if output.exit_code == 0 {
+        return output.stdout.trim() == "true";
+    }
+    trust::is_untrusted_repository_message(&remote_git_diagnostic(output))
+}
+
 #[tauri::command]
 pub async fn git_is_repository(
     state: State<'_, AppState>,
@@ -491,14 +715,14 @@ pub async fn git_is_repository(
     request: GitRepositoryRequest,
 ) -> Result<bool, String> {
     let trace_started = Instant::now();
-    let result = if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    let result = if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         execute_remote_git_command(
             &state,
             &target,
             &["rev-parse".to_string(), "--is-inside-work-tree".to_string()],
         )
         .await
-        .map(|output| output.exit_code == 0 && output.stdout.trim() == "true")
+        .map(|output| remote_probe_found_repository(&output))
     } else {
         GitService::is_repository(&request.repository_path)
             .await
@@ -507,7 +731,7 @@ pub async fn git_is_repository(
                     "Failed to check Git repository: path={}, error={}",
                     request.repository_path, e
                 );
-                format!("Failed to check Git repository: {}", e)
+                git_error_message("Failed to check Git repository", &e)
             })
     };
 
@@ -520,7 +744,7 @@ pub async fn git_get_repository(
     state: State<'_, AppState>,
     request: GitRepositoryRequest,
 ) -> Result<GitRepository, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let current_branch = execute_remote_git_success(
             &state,
             &target,
@@ -573,7 +797,7 @@ pub async fn git_get_repository(
                 "Failed to get Git repository info: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to get Git repository info: {}", e)
+            git_error_message("Failed to get Git repository info", &e)
         })
 }
 
@@ -585,7 +809,7 @@ pub async fn git_get_repository_basic(
 ) -> Result<GitRepository, String> {
     let trace_started = Instant::now();
     let result = async {
-        if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+        if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
             let current_branch = execute_remote_git_success(
                 &state,
                 &target,
@@ -624,7 +848,7 @@ pub async fn git_get_repository_basic(
                         "Failed to get basic Git repository info: path={}, error={}",
                         request.repository_path, e
                     );
-                    format!("Failed to get basic Git repository info: {}", e)
+                    git_error_message("Failed to get basic Git repository info", &e)
                 })
         }
     }
@@ -644,7 +868,7 @@ pub async fn git_resolve_revision(
         return Err("Revision cannot be empty".to_string());
     }
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         return execute_remote_git_success(
             &state,
             &target,
@@ -660,7 +884,7 @@ pub async fn git_resolve_revision(
 
     GitService::resolve_revision(&request.repository_path, revision)
         .await
-        .map_err(|e| format!("Failed to resolve Git revision: {}", e))
+        .map_err(|e| git_error_message("Failed to resolve Git revision", &e))
 }
 
 #[tauri::command]
@@ -668,7 +892,7 @@ pub async fn git_get_status(
     state: State<'_, AppState>,
     request: GitRepositoryRequest,
 ) -> Result<GitStatus, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let output = execute_remote_git_success(
             &state,
             &target,
@@ -690,7 +914,7 @@ pub async fn git_get_status(
                 "Failed to get Git status: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to get Git status: {}", e)
+            git_error_message("Failed to get Git status", &e)
         })
 }
 
@@ -700,7 +924,7 @@ pub async fn git_get_branches(
     request: GitBranchesRequest,
 ) -> Result<Vec<GitBranch>, String> {
     let include_remote = request.include_remote.unwrap_or(false);
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec![
             "for-each-ref".to_string(),
             "--format=%(if)%(HEAD)%(then)*%(else) %(end)%09%(refname)%09%(refname:short)%09%(upstream:short)%09%(objectname)%09%(committerdate:iso-strict)".to_string(),
@@ -720,7 +944,7 @@ pub async fn git_get_branches(
                 "Failed to get Git branches: path={}, include_remote={}, error={}",
                 request.repository_path, include_remote, e
             );
-            format!("Failed to get Git branches: {}", e)
+            git_error_message("Failed to get Git branches", &e)
         })
 }
 
@@ -730,7 +954,7 @@ pub async fn git_get_enhanced_branches(
     request: GitBranchesRequest,
 ) -> Result<Vec<GitBranch>, String> {
     let include_remote = request.include_remote.unwrap_or(false);
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec![
             "for-each-ref".to_string(),
             "--format=%(if)%(HEAD)%(then)*%(else) %(end)%09%(refname)%09%(refname:short)%09%(upstream:short)%09%(objectname)%09%(committerdate:iso-strict)".to_string(),
@@ -750,7 +974,7 @@ pub async fn git_get_enhanced_branches(
                 "Failed to get enhanced Git branches: path={}, include_remote={}, error={}",
                 request.repository_path, include_remote, e
             );
-            format!("Failed to get enhanced Git branches: {}", e)
+            git_error_message("Failed to get enhanced Git branches", &e)
         })
 }
 
@@ -760,7 +984,7 @@ pub async fn git_get_commits(
     request: GitCommitsRequest,
 ) -> Result<Vec<GitCommit>, String> {
     let params = request.params.unwrap_or_default();
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let output = execute_remote_git_success(&state, &target, &git_log_args(&params)).await?;
         return Ok(parse_remote_commits(&output));
     }
@@ -772,7 +996,7 @@ pub async fn git_get_commits(
                 "Failed to get Git commits: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to get Git commits: {}", e)
+            git_error_message("Failed to get Git commits", &e)
         })
 }
 
@@ -781,7 +1005,7 @@ pub async fn git_add_files(
     state: State<'_, AppState>,
     request: GitAddFilesRequest,
 ) -> Result<GitOperationResult, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec!["add".to_string()];
         if request.params.all.unwrap_or(false) {
             args.push("-A".to_string());
@@ -800,7 +1024,7 @@ pub async fn git_add_files(
                 "Failed to add files: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to add files: {}", e)
+            git_error_message("Failed to add files", &e)
         })
 }
 
@@ -809,7 +1033,7 @@ pub async fn git_commit(
     state: State<'_, AppState>,
     request: GitCommitRequest,
 ) -> Result<GitOperationResult, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec![
             "commit".to_string(),
             "-m".to_string(),
@@ -838,7 +1062,7 @@ pub async fn git_commit(
                 "Failed to commit: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to commit: {}", e)
+            git_error_message("Failed to commit", &e)
         })
 }
 
@@ -847,7 +1071,7 @@ pub async fn git_push(
     state: State<'_, AppState>,
     request: GitPushRequest,
 ) -> Result<GitOperationResult, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec!["push".to_string()];
         if request.params.force.unwrap_or(false) {
             args.push("--force".to_string());
@@ -871,7 +1095,7 @@ pub async fn git_push(
                 "Failed to push: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to push: {}", e)
+            git_error_message("Failed to push", &e)
         })
 }
 
@@ -880,7 +1104,7 @@ pub async fn git_pull(
     state: State<'_, AppState>,
     request: GitPullRequest,
 ) -> Result<GitOperationResult, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec!["pull".to_string()];
         if request.params.rebase.unwrap_or(false) {
             args.push("--rebase".to_string());
@@ -901,7 +1125,7 @@ pub async fn git_pull(
                 "Failed to pull: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to pull: {}", e)
+            git_error_message("Failed to pull", &e)
         })
 }
 
@@ -910,7 +1134,7 @@ pub async fn git_checkout_branch(
     state: State<'_, AppState>,
     request: GitCheckoutBranchRequest,
 ) -> Result<GitOperationResult, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         return execute_remote_git_operation(
             &state,
             &target,
@@ -926,7 +1150,7 @@ pub async fn git_checkout_branch(
                 "Failed to checkout branch: path={}, branch={}, error={}",
                 request.repository_path, request.branch_name, e
             );
-            format!("Failed to checkout branch: {}", e)
+            git_error_message("Failed to checkout branch", &e)
         })
 }
 
@@ -935,7 +1159,7 @@ pub async fn git_create_branch(
     state: State<'_, AppState>,
     request: GitCreateBranchRequest,
 ) -> Result<GitOperationResult, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec![
             "checkout".to_string(),
             "-b".to_string(),
@@ -958,7 +1182,7 @@ pub async fn git_create_branch(
             "Failed to create branch: path={}, branch={}, error={}",
             request.repository_path, request.branch_name, e
         );
-        format!("Failed to create branch: {}", e)
+        git_error_message("Failed to create branch", &e)
     })
 }
 
@@ -968,7 +1192,7 @@ pub async fn git_delete_branch(
     request: GitDeleteBranchRequest,
 ) -> Result<GitOperationResult, String> {
     let force = request.force.unwrap_or(false);
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         return execute_remote_git_operation(
             &state,
             &target,
@@ -988,7 +1212,7 @@ pub async fn git_delete_branch(
                 "Failed to delete branch: path={}, branch={}, force={}, error={}",
                 request.repository_path, request.branch_name, force, e
             );
-            format!("Failed to delete branch: {}", e)
+            git_error_message("Failed to delete branch", &e)
         })
 }
 
@@ -997,7 +1221,7 @@ pub async fn git_get_diff(
     state: State<'_, AppState>,
     request: GitDiffRequest,
 ) -> Result<String, String> {
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         return execute_remote_git_success(&state, &target, &build_git_diff_args(&request.params))
             .await;
     }
@@ -1009,7 +1233,7 @@ pub async fn git_get_diff(
                 "Failed to get Git diff: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to get Git diff: {}", e)
+            git_error_message("Failed to get Git diff", &e)
         })
 }
 
@@ -1023,7 +1247,7 @@ pub async fn git_get_changed_files(
         request.repository_path
     );
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let output = execute_remote_git_success(
             &state,
             &target,
@@ -1037,7 +1261,7 @@ pub async fn git_get_changed_files(
         .await
         .map_err(|e| {
             error!("Failed to get changed Git files: {}", e);
-            e.to_string()
+            git_error_message("Failed to get changed Git files", &e)
         })
 }
 
@@ -1053,7 +1277,7 @@ pub async fn git_reset_files(
         request.repository_path, staged, request.files
     );
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec!["restore".to_string()];
         if staged {
             args.push("--staged".to_string());
@@ -1071,7 +1295,7 @@ pub async fn git_reset_files(
             output: Some(output),
             duration: None,
         })
-        .map_err(|e| e.to_string())
+        .map_err(|e| git_error_message("Failed to reset files", &e))
 }
 
 #[tauri::command]
@@ -1084,7 +1308,7 @@ pub async fn git_get_file_content(
         request.file_path, request.commit, request.repository_path
     );
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let object_spec = format!(
             "{}:{}",
             request.commit.as_deref().unwrap_or("HEAD"),
@@ -1100,7 +1324,7 @@ pub async fn git_get_file_content(
         request.commit.as_deref(),
     )
     .await
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| git_error_message("Failed to get file content", &e))?;
 
     Ok(content)
 }
@@ -1115,7 +1339,7 @@ pub async fn git_reset_to_commit(
         request.commit_hash, request.mode, request.repository_path
     );
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mode_flag = match request.mode.as_str() {
             "soft" => "--soft",
             "mixed" => "--mixed",
@@ -1145,7 +1369,7 @@ pub async fn git_reset_to_commit(
             "Failed to reset to commit: path={}, commit={}, mode={}, error={}",
             request.repository_path, request.commit_hash, request.mode, e
         );
-        format!("Failed to reset: {}", e)
+        git_error_message("Failed to reset", &e)
     })
 }
 
@@ -1161,13 +1385,13 @@ pub async fn git_get_graph(
         repository_path, max_count, branch_name
     );
 
-    if resolve_remote_git_target(&repository_path).await.is_some() {
+    if resolve_remote_git_target(&repository_path).await?.is_some() {
         return Err("Git graph is not supported for remote SSH workspaces yet".to_string());
     }
 
     GitService::get_git_graph_for_branch(&repository_path, max_count, branch_name)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| git_error_message("Failed to get Git graph", &e))
 }
 
 #[tauri::command]
@@ -1182,7 +1406,7 @@ pub async fn git_cherry_pick(
         request.commit_hash, request.repository_path, no_commit
     );
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         let mut args = vec!["cherry-pick".to_string()];
         if no_commit {
             args.push("-n".to_string());
@@ -1198,7 +1422,7 @@ pub async fn git_cherry_pick(
                 "Failed to cherry-pick: path={}, commit={}, no_commit={}, error={}",
                 request.repository_path, request.commit_hash, no_commit, e
             );
-            format!("Failed to cherry-pick: {}", e)
+            git_error_message("Failed to cherry-pick", &e)
         })
 }
 
@@ -1209,7 +1433,7 @@ pub async fn git_cherry_pick_abort(
 ) -> Result<GitOperationResult, String> {
     info!("Aborting cherry-pick in repo '{}'", request.repository_path);
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         return execute_remote_git_operation(
             &state,
             &target,
@@ -1225,7 +1449,7 @@ pub async fn git_cherry_pick_abort(
                 "Failed to abort cherry-pick: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to abort cherry-pick: {}", e)
+            git_error_message("Failed to abort cherry-pick", &e)
         })
 }
 
@@ -1239,7 +1463,7 @@ pub async fn git_cherry_pick_continue(
         request.repository_path
     );
 
-    if let Some(target) = resolve_remote_git_target(&request.repository_path).await {
+    if let Some(target) = resolve_remote_git_target(&request.repository_path).await? {
         return execute_remote_git_operation(
             &state,
             &target,
@@ -1255,7 +1479,7 @@ pub async fn git_cherry_pick_continue(
                 "Failed to continue cherry-pick: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to continue cherry-pick: {}", e)
+            git_error_message("Failed to continue cherry-pick", &e)
         })
 }
 
@@ -1267,7 +1491,7 @@ pub async fn git_list_worktrees(
     info!("Listing worktrees for '{}'", request.repository_path);
 
     if resolve_remote_git_target(&request.repository_path)
-        .await
+        .await?
         .is_some()
     {
         return Err("Git worktrees are not supported for remote SSH workspaces yet".to_string());
@@ -1285,7 +1509,7 @@ pub async fn git_list_worktrees(
                 "Failed to list worktrees: path={}, error={}",
                 request.repository_path, e
             );
-            format!("Failed to list worktrees: {}", e)
+            git_error_message("Failed to list worktrees", &e)
         })
 }
 
@@ -1301,7 +1525,7 @@ pub async fn git_add_worktree(
     );
 
     if resolve_remote_git_target(&request.repository_path)
-        .await
+        .await?
         .is_some()
     {
         return Err("Git worktrees are not supported for remote SSH workspaces yet".to_string());
@@ -1315,7 +1539,7 @@ pub async fn git_add_worktree(
                     "Failed to add worktree: path={}, branch={}, create_branch={}, error={}",
                     request.repository_path, request.branch, create_branch, e
                 );
-                format!("Failed to add worktree: {}", e)
+                git_error_message("Failed to add worktree", &e)
             })?;
     state
         .workspace_service
@@ -1336,7 +1560,7 @@ pub async fn git_remove_worktree(
     );
 
     if resolve_remote_git_target(&request.repository_path)
-        .await
+        .await?
         .is_some()
     {
         return Err("Git worktrees are not supported for remote SSH workspaces yet".to_string());
@@ -1350,7 +1574,7 @@ pub async fn git_remove_worktree(
                     "Failed to remove worktree: path={}, worktree_path={}, force={}, error={}",
                     request.repository_path, request.worktree_path, force, e
                 );
-                format!("Failed to remove worktree: {}", e)
+                git_error_message("Failed to remove worktree", &e)
             })?;
     state
         .workspace_service
@@ -1421,5 +1645,97 @@ pub async fn load_git_repo_history(
     match data {
         Some(data) => Ok(data.repos),
         None => Ok(Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn remote_output(stdout: &str, stderr: &str, exit_code: i32) -> RemoteGitOutput {
+        RemoteGitOutput {
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+            exit_code,
+        }
+    }
+
+    #[test]
+    fn a_remote_repository_git_refuses_on_ownership_is_still_a_repository() {
+        // Answering `false` here is what sent shared SSH hosts and containers
+        // running under a different uid to the "initialize a repository" page.
+        let output = remote_output(
+            "",
+            "fatal: detected dubious ownership in repository at '/srv/shared/repo'",
+            128,
+        );
+
+        assert!(remote_probe_found_repository(&output));
+    }
+
+    #[test]
+    fn a_remote_path_without_a_repository_is_reported_as_none() {
+        let output = remote_output(
+            "",
+            "fatal: not a git repository (or any parent up to /)",
+            128,
+        );
+
+        assert!(!remote_probe_found_repository(&output));
+    }
+
+    #[test]
+    fn a_remote_worktree_answers_the_probe() {
+        assert!(remote_probe_found_repository(&remote_output(
+            "true\n", "", 0
+        )));
+        assert!(!remote_probe_found_repository(&remote_output(
+            "false\n", "", 0
+        )));
+    }
+
+    #[test]
+    fn a_merged_stream_still_carries_the_ownership_rejection() {
+        // Some SSH wrappers fold stderr into stdout; the diagnostic must be
+        // read from whichever stream carried it.
+        let output = remote_output(
+            "fatal: detected dubious ownership in repository at '/srv/shared/repo'",
+            "",
+            128,
+        );
+
+        assert!(remote_probe_found_repository(&output));
+    }
+
+    #[test]
+    fn a_remote_mutation_refused_on_ownership_carries_the_stable_code() {
+        // Commit, push, checkout and the rest went through a path that reported
+        // the raw diagnostic, so the frontend could not tell this failure from
+        // any other and the user saw Git's prose with no way out — while the
+        // same rejection on a read offered one.
+        let output = remote_output(
+            "",
+            "fatal: detected dubious ownership in repository at '/srv/shared/repo'",
+            128,
+        );
+
+        assert_eq!(
+            remote_operation_error("/srv/shared/other", &output).as_deref(),
+            Some("git_repository_untrusted: /srv/shared/repo")
+        );
+    }
+
+    #[test]
+    fn an_ordinary_remote_mutation_failure_is_reported_as_is() {
+        let output = remote_output("", "error: failed to push some refs", 1);
+
+        assert_eq!(
+            remote_operation_error("/srv/shared/repo", &output).as_deref(),
+            Some("error: failed to push some refs")
+        );
+        assert_eq!(
+            remote_operation_error("/srv/shared/repo", &remote_output("ok\n", "", 0)),
+            None
+        );
     }
 }

--- a/src/apps/desktop/src/api/peer_host_invoke.rs
+++ b/src/apps/desktop/src/api/peer_host_invoke.rs
@@ -140,6 +140,11 @@ static LOCAL_ONLY_COMMANDS: &[&str] = &[
     "speech_append_audio_chunk",
     "speech_finish_input_session",
     "speech_cancel_input_session",
+    // Granting Git ownership trust writes to the peer user's global Git
+    // configuration and tells Git to run hooks from a tree they do not own.
+    // That decision stays with the person at that machine; a controller can
+    // still read `git_get_repository_trust` and relay the manual command.
+    "git_trust_repository",
 ];
 
 static PENDING: OnceLock<Mutex<HashMap<String, oneshot::Sender<HostInvokeBridgeResult>>>> =
@@ -516,6 +521,15 @@ mod tests {
         ] {
             assert!(is_local_only_command(command), "{command}");
         }
+    }
+
+    /// Reading why Git refuses a repository is safe to answer for a
+    /// controller; granting the exception writes this user's global Git
+    /// configuration and must be decided at this machine.
+    #[test]
+    fn granting_git_ownership_trust_is_refused_on_the_peer() {
+        assert!(is_local_only_command("git_trust_repository"));
+        assert!(!is_local_only_command("git_get_repository_trust"));
     }
 
     #[test]

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -799,6 +799,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         "git_get_repository_basic",
         RemoteWorkspacePolicy::RemoteRouted,
     ),
+    (
+        "git_get_repository_trust",
+        RemoteWorkspacePolicy::RemoteRouted,
+    ),
     ("git_get_status", RemoteWorkspacePolicy::RemoteRouted),
     ("git_is_repository", RemoteWorkspacePolicy::RemoteRouted),
     (
@@ -814,6 +818,7 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
     ("git_reset_files", RemoteWorkspacePolicy::RemoteRouted),
     ("git_reset_to_commit", RemoteWorkspacePolicy::RemoteRouted),
     ("git_resolve_revision", RemoteWorkspacePolicy::RemoteRouted),
+    ("git_trust_repository", RemoteWorkspacePolicy::RemoteRouted),
     ("grant_miniapp_path", RemoteWorkspacePolicy::LegacyUnaudited),
     (
         "grant_miniapp_workspace",

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1439,6 +1439,8 @@ pub async fn run() {
             add_skill,
             delete_skill,
             git_is_repository,
+            git_get_repository_trust,
+            git_trust_repository,
             git_get_repository_basic,
             git_resolve_revision,
             git_get_repository,

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json
@@ -1,9 +1,9 @@
 {
   "schema": "bitfun.appearance.registry",
   "schemaVersion": 1,
-  "generatedFrom": "71fbdbb26757c930eedfef5cfda55ca12e008ae1",
-  "generatedAt": "2026-08-06T15:48:31.702263+00:00",
-  "sourceRevision": "71fbdbb26757c930eedfef5cfda55ca12e008ae1",
+  "generatedFrom": "bc77e2c28c7b847abc175b6307ac18f84a89265a",
+  "generatedAt": "2026-08-16T16:09:40.016459+00:00",
+  "sourceRevision": "bc77e2c28c7b847abc175b6307ac18f84a89265a",
   "sourceDirty": false,
   "sourceTreeHash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
   "components": [
@@ -2177,6 +2177,23 @@
       "states": []
     },
     {
+      "id": "view-transition-boundary",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "layout",
+          "visualRole": "continuous-surface"
+        },
+        {
+          "id": "view",
+          "propertyProfile": "container",
+          "visualRole": "content"
+        }
+      ],
+      "facets": [],
+      "states": []
+    },
+    {
       "id": "chat-input",
       "parts": [
         {
@@ -2257,6 +2274,10 @@
         },
         {
           "id": "commandCurrent",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "commandStatus",
           "propertyProfile": "container"
         },
         {
@@ -2398,6 +2419,7 @@
           "attribute": "data-bf-action",
           "values": [
             "cancel",
+            "continue-interrupted",
             "retry",
             "send",
             "split"
@@ -3754,10 +3776,6 @@
         },
         {
           "id": "error",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "notice",
           "propertyProfile": "container"
         },
         {
@@ -5208,6 +5226,17 @@
       ]
     },
     {
+      "id": "session-usage-modal",
+      "parts": [
+        {
+          "id": "content",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": []
+    },
+    {
       "id": "ask-user-question-card",
       "parts": [
         {
@@ -5545,6 +5574,14 @@
           "propertyProfile": "container"
         },
         {
+          "id": "marketBrowse",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "marketResults",
+          "propertyProfile": "container"
+        },
+        {
           "id": "marketGrid",
           "propertyProfile": "container"
         },
@@ -5667,6 +5704,13 @@
           "selector": {
             "kind": "self",
             "suffix": "[data-bf-state~=\"disabled\"]"
+          }
+        },
+        {
+          "id": "loading",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"loading\"]"
           }
         }
       ]
@@ -6075,19 +6119,31 @@
           "propertyProfile": "container"
         },
         {
-          "id": "badge",
+          "id": "switcher",
           "propertyProfile": "container"
         },
         {
-          "id": "badgeIcon",
+          "id": "switcherLabel",
           "propertyProfile": "container"
         },
         {
-          "id": "badgeLabel",
+          "id": "switcherElsewhere",
           "propertyProfile": "container"
         },
         {
-          "id": "disconnectButton",
+          "id": "switcherMenu",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "switcherItem",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "switcherStatusDot",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "switcherDisconnect",
           "propertyProfile": "container"
         }
       ],
@@ -6126,6 +6182,34 @@
           "selector": {
             "kind": "self",
             "suffix": ":disabled"
+          }
+        },
+        {
+          "id": "remote",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"remote\"]"
+          }
+        },
+        {
+          "id": "local",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"local\"]"
+          }
+        },
+        {
+          "id": "busy",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"busy\"]"
+          }
+        },
+        {
+          "id": "offline",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"offline\"]"
           }
         }
       ]
@@ -6698,6 +6782,10 @@
           "propertyProfile": "container"
         },
         {
+          "id": "progressIcon",
+          "propertyProfile": "container"
+        },
+        {
           "id": "progressBar",
           "propertyProfile": "container"
         },
@@ -6901,6 +6989,10 @@
         },
         {
           "id": "meditorPreview",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "meditorFrontmatter",
           "propertyProfile": "container"
         },
         {
@@ -8583,6 +8675,7 @@
             "code",
             "cowork",
             "assistant",
+            "todos",
             "extensions",
             "agents",
             "skills"
@@ -9505,6 +9598,67 @@
       ]
     },
     {
+      "id": "localized-datetime-field",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": [
+        {
+          "id": "error",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"error\"]"
+          }
+        }
+      ]
+    },
+    {
+      "id": "datetime-picker",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "head",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "grid",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "day",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "foot",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": [
+        {
+          "id": "selected",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"selected\"]"
+          }
+        },
+        {
+          "id": "today",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"today\"]"
+          }
+        }
+      ]
+    },
+    {
       "id": "flexible-panel",
       "parts": [
         {
@@ -9686,6 +9840,13 @@
             "kind": "self",
             "suffix": "[data-bf-state~=\"minimized\"]"
           }
+        },
+        {
+          "id": "hidden",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"hidden\"]"
+          }
         }
       ]
     },
@@ -9748,11 +9909,7 @@
           "propertyProfile": "container"
         },
         {
-          "id": "handoffOverlay",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "handoffContent",
+          "id": "tailSpacer",
           "propertyProfile": "container"
         }
       ],
@@ -10024,6 +10181,10 @@
           "propertyProfile": "container"
         },
         {
+          "id": "unavailableWarning",
+          "propertyProfile": "container"
+        },
+        {
           "id": "generated",
           "propertyProfile": "container"
         },
@@ -10197,6 +10358,26 @@
         {
           "id": "ecosystemState",
           "propertyProfile": "container"
+        },
+        {
+          "id": "application",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "appAttention",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "applicationToggle",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "hooksSection",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "hooksSummary",
+          "propertyProfile": "container"
         }
       ],
       "facets": [],
@@ -10259,6 +10440,14 @@
         },
         {
           "id": "remoteList",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "hiddenRemoteList",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "hiddenRemoteRow",
           "propertyProfile": "container"
         },
         {
@@ -10593,6 +10782,13 @@
           "selector": {
             "kind": "self",
             "suffix": "[data-bf-state~=\"muted\"]"
+          }
+        },
+        {
+          "id": "stale",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"stale\"]"
           }
         }
       ]
@@ -11217,6 +11413,11 @@
           "visualRole": "control"
         },
         {
+          "id": "itemUnseen",
+          "propertyProfile": "paint",
+          "visualRole": "decoration"
+        },
+        {
           "id": "highlight",
           "propertyProfile": "paint",
           "visualRole": "decoration"
@@ -11436,6 +11637,14 @@
           "propertyProfile": "container"
         },
         {
+          "id": "currentDirectoryName",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "parentDirectoryPath",
+          "propertyProfile": "container"
+        },
+        {
           "id": "footer",
           "propertyProfile": "container"
         }
@@ -11454,6 +11663,13 @@
           "selector": {
             "kind": "self",
             "suffix": "[data-bf-state~=\"loading\"]"
+          }
+        },
+        {
+          "id": "error",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"error\"]"
           }
         }
       ]
@@ -12024,6 +12240,10 @@
         },
         {
           "id": "content",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "notice",
           "propertyProfile": "container"
         },
         {
@@ -12969,7 +13189,19 @@
           "propertyProfile": "container"
         },
         {
+          "id": "permissionOptionRow",
+          "propertyProfile": "container"
+        },
+        {
           "id": "permissionOption",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "permissionOptionTrailing",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "permissionOptionNextTurn",
           "propertyProfile": "container"
         },
         {
@@ -12991,6 +13223,13 @@
           "selector": {
             "kind": "self",
             "suffix": "[data-bf-state~=\"selected\"]"
+          }
+        },
+        {
+          "id": "armed",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"armed\"]"
           }
         }
       ]
@@ -14695,52 +14934,6 @@
       ]
     },
     {
-      "id": "user-message",
-      "parts": [
-        {
-          "id": "root",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "content",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "inlineContent",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "footer",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "timestamp",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "snapshotAction",
-          "propertyProfile": "container"
-        }
-      ],
-      "facets": [],
-      "states": [
-        {
-          "id": "expanded",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"expanded\"]"
-          }
-        },
-        {
-          "id": "collapsed",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"collapsed\"]"
-          }
-        }
-      ]
-    },
-    {
       "id": "tool-card",
       "parts": [
         {
@@ -15733,6 +15926,52 @@
       ]
     },
     {
+      "id": "run-code-tool-card",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "expanded",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "section",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "label",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "output",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "error",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": [
+        {
+          "id": "expanded",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"expanded\"]"
+          }
+        },
+        {
+          "id": "failed",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"failed\"]"
+          }
+        }
+      ]
+    },
+    {
       "id": "acp-plan-panel",
       "parts": [
         {
@@ -16236,40 +16475,6 @@
       "states": []
     },
     {
-      "id": "snapshot-rollback-button",
-      "parts": [
-        {
-          "id": "root",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "label",
-          "propertyProfile": "container"
-        }
-      ],
-      "facets": [
-        {
-          "id": "outcome",
-          "attribute": "data-bf-outcome",
-          "values": [
-            "idle",
-            "current",
-            "success",
-            "error"
-          ]
-        }
-      ],
-      "states": [
-        {
-          "id": "loading",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"loading\"]"
-          }
-        }
-      ]
-    },
-    {
       "id": "smart-recommendations",
       "parts": [
         {
@@ -16306,136 +16511,6 @@
         }
       ],
       "facets": [],
-      "states": [
-        {
-          "id": "loading",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"loading\"]"
-          }
-        }
-      ]
-    },
-    {
-      "id": "sticky-task-indicator",
-      "parts": [
-        {
-          "id": "root",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "gradient",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "content",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "button",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "icon",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "label",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "arrow",
-          "propertyProfile": "container"
-        }
-      ],
-      "facets": [],
-      "states": [
-        {
-          "id": "visible",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"visible\"]"
-          }
-        }
-      ]
-    },
-    {
-      "id": "turn-history-panel",
-      "parts": [
-        {
-          "id": "root",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "loading",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "empty",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "header",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "count",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "list",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "item",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "itemHeader",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "files",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "filesList",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "time",
-          "propertyProfile": "container"
-        }
-      ],
-      "facets": [],
-      "states": [
-        {
-          "id": "current",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"current\"]"
-          }
-        }
-      ]
-    },
-    {
-      "id": "turn-rollback-button",
-      "parts": [
-        {
-          "id": "root",
-          "propertyProfile": "container"
-        }
-      ],
-      "facets": [
-        {
-          "id": "mode",
-          "attribute": "data-bf-mode",
-          "values": [
-            "current",
-            "action"
-          ]
-        }
-      ],
       "states": [
         {
           "id": "loading",
@@ -17201,6 +17276,7 @@
             "hidden",
             "repository",
             "not-repository",
+            "trust-required",
             "loading"
           ]
         }
@@ -17875,6 +17951,157 @@
           "selector": {
             "kind": "self",
             "suffix": "[data-bf-state~=\"inactive\"]"
+          }
+        }
+      ]
+    },
+    {
+      "id": "todos",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "header",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "headerActions",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "panes",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "listPane",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "rows",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "row",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "rowTime",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "rowBody",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "rowBadge",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "rowError",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "rowActions",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "inactive",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "empty",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "calendarPane",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "calendar",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "calendarHead",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "calendarNav",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "calendarGrid",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "calendarCell",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "dayDetail",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "editor",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "editorHead",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "editorGrid",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "editorActions",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "field",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "warning",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": [
+        {
+          "id": "selected",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"selected\"]"
+          }
+        },
+        {
+          "id": "today",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"today\"]"
+          }
+        },
+        {
+          "id": "outside",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"outside\"]"
+          }
+        },
+        {
+          "id": "overdue",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"overdue\"]"
+          }
+        },
+        {
+          "id": "disabled",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"disabled\"]"
           }
         }
       ]

--- a/src/crates/assembly/core/src/service/dispatch/controller.rs
+++ b/src/crates/assembly/core/src/service/dispatch/controller.rs
@@ -7,6 +7,7 @@ use bitfun_services_integrations::remote_ssh::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::service::git::trust;
 use crate::service::worktree::WorktreeService;
 
 use super::baseline::{
@@ -1580,6 +1581,28 @@ pub(super) fn validate_submission_preflight(
     {
         anyhow::bail!("Dispatch workspace is not a Git worktree on the target");
     }
+    // A repository the target's Git refuses on ownership grounds still *is* one,
+    // so the probe answers `isGitRepository: true` and the check above passes.
+    // Submitting anyway creates the record, ships the job, and fails on the
+    // target at the worker's first Git read — far from the person who could act
+    // on it. Nothing here can fix it either: the trust decision belongs to the
+    // machine holding the repository, and this controller cannot write that
+    // host's configuration. Refusing now, by name, is the only honest outcome.
+    if workspace.get("trustRequired").and_then(Value::as_bool) == Some(true) {
+        // The path the *target* reported, not the one this controller asked
+        // about: the probe canonicalizes it, and the command below has to be run
+        // over there.
+        let path = workspace.get("path").and_then(Value::as_str);
+        let remedy = path.map_or_else(
+            || "Add the workspace to that host's `safe.directory` configuration".to_string(),
+            |path| format!("Run `{}` on that host", trust::manual_trust_command(path)),
+        );
+        anyhow::bail!(
+            "Git on the dispatch target refuses '{}': the repository is owned by another user \
+             there. {remedy} and submit again",
+            path.unwrap_or("the dispatch workspace")
+        );
+    }
     let selected_model = if let Some(requested_model) = requested_model
         .map(str::trim)
         .filter(|model| !model.is_empty())
@@ -1715,6 +1738,46 @@ mod tests {
             "availableModels": []
         });
         assert!(validate_submission_preflight(&missing_model, None, None).is_err());
+    }
+
+    /// The target's Git refuses the workspace on ownership grounds. It is still
+    /// a repository, so every readiness field says yes — and the job would be
+    /// submitted only to die at the worker's first Git read on a host nobody is
+    /// watching.
+    #[test]
+    fn submission_preflight_refuses_a_workspace_the_target_does_not_trust() {
+        let untrusted = json!({
+            "workspace": {
+                "path": "/srv/shared/repo",
+                "exists": true,
+                "isDirectory": true,
+                "isGitRepository": true,
+                "trustRequired": true
+            },
+            "modelConfigured": true,
+            "availableModels": ["target-model"],
+            "defaultModel": "target-model"
+        });
+        let error = validate_submission_preflight(&untrusted, None, None)
+            .expect_err("an untrusted target workspace cannot be dispatched to");
+        let message = error.to_string();
+        assert!(message.contains("/srv/shared/repo"), "{message}");
+        // The exact command, shell-quoted by the same helper every other surface
+        // uses — the user has to paste this into a shell on the target.
+        assert!(
+            message.contains("git config --global --add safe.directory /srv/shared/repo"),
+            "{message}"
+        );
+
+        // A target that never reports the field (an older CLI) is unchanged.
+        let legacy = json!({
+            "workspace": { "exists": true, "isDirectory": true, "isGitRepository": true },
+            "modelConfigured": true,
+            "availableModels": ["target-model"],
+            "defaultModel": "target-model"
+        });
+        validate_submission_preflight(&legacy, None, None)
+            .expect("legacy target stays dispatchable");
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/git/git_types.rs
+++ b/src/crates/assembly/core/src/service/git/git_types.rs
@@ -1,2 +1,3 @@
 pub use bitfun_services_integrations::git::types::*;
 pub use bitfun_services_integrations::git::GitError;
+pub use bitfun_services_integrations::git::{GitTrustOutcome, GitTrustReport, GitTrustState};

--- a/src/crates/assembly/core/src/service/git/mod.rs
+++ b/src/crates/assembly/core/src/service/git/mod.rs
@@ -6,6 +6,7 @@ pub mod git_types;
 pub mod git_utils;
 pub mod graph;
 
+pub use bitfun_services_integrations::git::trust;
 pub use git_service::GitService;
 pub use git_types::*;
 pub use git_utils::*;

--- a/src/crates/assembly/core/src/service/worktree/mod.rs
+++ b/src/crates/assembly/core/src/service/worktree/mod.rs
@@ -1952,6 +1952,13 @@ fn validate_automatic_removal(summary: &WorktreeSummary) -> Result<(), WorktreeE
 }
 
 fn map_base_ref_error(git_error: GitError, base_ref: &str) -> WorktreeError {
+    // A walled repository fails revision resolution the same way a typo does,
+    // and blaming the base ref sends the user hunting for a branch that is
+    // perfectly fine.
+    if matches!(git_error, GitError::RepositoryUntrusted { .. }) {
+        return map_git_error(git_error);
+    }
+
     let text = git_error.to_string();
     if text.to_ascii_lowercase().contains("unborn")
         || text.contains("reference 'HEAD' not found")
@@ -1987,6 +1994,22 @@ fn map_git_error(git_error: GitError) -> WorktreeError {
         GitError::RepositoryNotFound(message) => {
             error(WorktreeErrorCode::NotGitRepository, message)
         }
+        // An ownership rejection is the one Git failure the user can clear
+        // themselves, so it must not disappear into `GitFailed`: a session bound
+        // to a managed worktree would report "Git command failed" for a
+        // repository that is present, intact, and one command away from working.
+        GitError::RepositoryUntrusted {
+            repository_path, ..
+        } => {
+            let remedy = crate::service::git::trust::manual_trust_command(&repository_path);
+            error(
+                WorktreeErrorCode::RepositoryUntrusted,
+                format!(
+                    "Git refuses '{repository_path}': the repository is owned by another user. \
+                     Run `{remedy}` and try again"
+                ),
+            )
+        }
         GitError::InvalidPath(message) => error(WorktreeErrorCode::InvalidPath, message),
         GitError::IoError(io_error) => error(WorktreeErrorCode::IoFailed, io_error.to_string()),
         other => {
@@ -2005,11 +2028,13 @@ fn map_git_error(git_error: GitError) -> WorktreeError {
 mod tests {
     use super::{
         automatic_delete_candidate_ids, managed_target_path, managed_worktree_directory_name,
-        path_is_within_root, repository_id, resolve_managed_root, sanitize_worktree_project_label,
-        validate_automatic_removal, validate_removal, RegisteredWorktree, RepositoryContext,
-        WorktreeOperationReceipt, WorktreeRegistry, WorktreeService, AUTO_DELETE_MIN_AGE_MS,
+        map_base_ref_error, map_branch_error, map_git_error, path_is_within_root, repository_id,
+        resolve_managed_root, sanitize_worktree_project_label, validate_automatic_removal,
+        validate_removal, RegisteredWorktree, RepositoryContext, WorktreeOperationReceipt,
+        WorktreeRegistry, WorktreeService, AUTO_DELETE_MIN_AGE_MS,
     };
     use crate::infrastructure::PathManager;
+    use crate::service::git::GitError;
     use bitfun_core_types::{
         WorktreeErrorCode, WorktreeLifecycle, WorktreeSettings, WorktreeSummary,
     };
@@ -2032,6 +2057,44 @@ mod tests {
             running_session_count: 0,
             sessions: Vec::new(),
         }
+    }
+
+    /// A worktree is how a Review session gets its own checkout, so this is the
+    /// first place the ownership wall is met on that path. Folded into
+    /// `GitFailed` it reads as "Git command failed" — a dead end for a
+    /// repository the user can trust in one command.
+    #[test]
+    fn an_ownership_rejection_keeps_its_own_code_and_the_command_that_clears_it() {
+        let mapped = map_git_error(GitError::RepositoryUntrusted {
+            repository_path: "/srv/shared/repo".to_string(),
+            detail: "detected dubious ownership".to_string(),
+        });
+        assert_eq!(mapped.code, WorktreeErrorCode::RepositoryUntrusted);
+        assert!(
+            mapped
+                .message
+                .contains("git config --global --add safe.directory /srv/shared/repo"),
+            "the remedy has to travel with the refusal: {}",
+            mapped.message
+        );
+
+        // Branch creation and base-ref resolution reach the same wall through
+        // their own mappers. `InvalidBaseRef` would be an accusation against a
+        // branch that is fine.
+        let branch = map_branch_error(GitError::RepositoryUntrusted {
+            repository_path: "/srv/shared/repo".to_string(),
+            detail: "detected dubious ownership".to_string(),
+        });
+        assert_eq!(branch.code, WorktreeErrorCode::RepositoryUntrusted);
+
+        let base_ref = map_base_ref_error(
+            GitError::RepositoryUntrusted {
+                repository_path: "/srv/shared/repo".to_string(),
+                detail: "detected dubious ownership".to_string(),
+            },
+            "main",
+        );
+        assert_eq!(base_ref.code, WorktreeErrorCode::RepositoryUntrusted);
     }
 
     #[test]

--- a/src/crates/contracts/core-types/src/worktree.rs
+++ b/src/crates/contracts/core-types/src/worktree.rs
@@ -139,6 +139,10 @@ pub struct WorktreeSummary {
 pub enum WorktreeErrorCode {
     RemoteUnsupported,
     NotGitRepository,
+    /// The repository is there, but Git refuses to read it because the directory
+    /// belongs to another user. Distinct from `NotGitRepository`: nothing is
+    /// missing and nothing needs initializing — the user has to trust the path.
+    RepositoryUntrusted,
     UnbornRepo,
     InvalidBaseRef,
     WorktreeNotFound,
@@ -160,6 +164,7 @@ impl WorktreeErrorCode {
         match self {
             Self::RemoteUnsupported => "remote_unsupported",
             Self::NotGitRepository => "not_git_repository",
+            Self::RepositoryUntrusted => "repository_untrusted",
             Self::UnbornRepo => "unborn_repo",
             Self::InvalidBaseRef => "invalid_base_ref",
             Self::WorktreeNotFound => "worktree_not_found",

--- a/src/crates/interfaces/app-server-protocol/src/schemas/git.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/git.rs
@@ -17,6 +17,19 @@ pub struct GitGetStatusMessage(pub GitRepositoryPathRequest);
 #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
 pub struct GitGetStatusResponse(pub GitStatus);
 
+/// Read-only ownership-trust probe.
+///
+/// Granting trust is deliberately absent from this surface: it writes the
+/// server user's global Git configuration, and a browser client is not the
+/// machine that owns the repository. The probe is what lets such a client name
+/// the folder and hand over the exact command instead of a dead end.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[request(method = "git/getRepositoryTrust", response = GitGetRepositoryTrustResponse)]
+pub struct GitGetRepositoryTrustMessage(pub GitRepositoryPathRequest);
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+pub struct GitGetRepositoryTrustResponse(pub GitTrustReport);
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
 #[request(method = "git/getBranches", response = GitGetBranchesResponse)]
 pub struct GitGetBranchesMessage(pub GitBranchesRequest);
@@ -40,6 +53,28 @@ pub struct GitBranchesRequest {
     pub repository_path: String,
     #[serde(default)]
     pub include_remote: Option<bool>,
+}
+
+/// Whether Git accepts a repository for the user this host runs as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "snake_case")]
+pub enum GitTrustState {
+    Trusted,
+    TrustRequired,
+    NotARepository,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct GitTrustReport {
+    pub state: GitTrustState,
+    pub repository_path: Option<String>,
+    /// Git's own diagnostic, for surfaces that show manual steps.
+    pub detail: Option<String>,
+    /// Command the user can run on this host to resolve it themselves.
+    pub manual_command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/crates/interfaces/app-server/src/agent.rs
+++ b/src/crates/interfaces/app-server/src/agent.rs
@@ -113,6 +113,16 @@ pub fn runtime_call<T>(result: std::result::Result<T, RuntimeError>) -> Result<T
 /// `data`. Used by the `git/*` schema handlers.
 pub fn git_service_error(error: GitError) -> Error {
     match error {
+        // The repository exists and the request was well formed; Git refuses it
+        // because this user does not own the directory. Carry the same stable
+        // code the desktop boundary uses, so a client can name the folder and
+        // offer remediation instead of rendering "internal error".
+        GitError::RepositoryUntrusted {
+            ref repository_path,
+            ..
+        } => Error::invalid_params().data(serde_json::json!(
+            bitfun_core::service::git::trust::untrusted_repository_error_message(repository_path)
+        )),
         GitError::RepositoryNotFound(_)
         | GitError::InvalidPath(_)
         | GitError::BranchNotFound(_) => {
@@ -162,6 +172,29 @@ pub fn config_get_error(error: bitfun_core::BitFunError) -> Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Web-mode clients read the stable code out of JSON-RPC error `data`. An
+    /// ownership rejection must arrive with the same prefix and path the
+    /// desktop boundary produces; otherwise the Git surface degrades to an
+    /// opaque "internal error" the user cannot act on.
+    #[test]
+    fn untrusted_repository_keeps_its_stable_code_over_json_rpc() {
+        let mapped = git_service_error(GitError::RepositoryUntrusted {
+            repository_path: "/srv/shared/repo".to_string(),
+            detail: "detected dubious ownership".to_string(),
+        });
+
+        let data = mapped
+            .data
+            .as_ref()
+            .and_then(serde_json::Value::as_str)
+            .expect("ownership rejections carry their code in data");
+        assert!(
+            data.starts_with(bitfun_core::service::git::trust::REPOSITORY_UNTRUSTED_ERROR_PREFIX)
+        );
+        assert!(data.contains("/srv/shared/repo"));
+        assert_eq!(mapped.code, Error::invalid_params().code);
+    }
 
     /// The frontend `ConfigAPI.getConfig` swallows the error into `undefined`
     /// only when `error.message` (lowercased) contains `not found:`, `config

--- a/src/crates/interfaces/app-server/src/server/handlers/app.rs
+++ b/src/crates/interfaces/app-server/src/server/handlers/app.rs
@@ -155,7 +155,12 @@ fn registered_capabilities(
         ),
         (
             "git",
-            vec!["git/isRepository", "git/getStatus", "git/getBranches"],
+            vec![
+                "git/isRepository",
+                "git/getStatus",
+                "git/getBranches",
+                "git/getRepositoryTrust",
+            ],
         ),
         (
             "config",

--- a/src/crates/interfaces/app-server/src/server/handlers/git.rs
+++ b/src/crates/interfaces/app-server/src/server/handlers/git.rs
@@ -4,7 +4,8 @@ use bitfun_core::service::git::GitService;
 use crate::agent::git_service_error;
 use crate::role::{AppClient, AppServer};
 use crate::schema::{
-    GitBranchesRequest, GitGetBranchesMessage, GitGetBranchesResponse, GitGetStatusMessage,
+    GitBranchesRequest, GitGetBranchesMessage, GitGetBranchesResponse,
+    GitGetRepositoryTrustMessage, GitGetRepositoryTrustResponse, GitGetStatusMessage,
     GitGetStatusResponse, GitIsRepositoryMessage, GitIsRepositoryResponse,
     GitRepositoryPathRequest,
 };
@@ -33,6 +34,23 @@ pub(in crate::server) fn builder() -> Builder<AppServer, impl HandleDispatchFrom
                     GitService::get_status(&repository_path)
                         .await
                         .map(|status| GitGetStatusResponse(wire::git_status(status)))
+                        .map_err(git_service_error),
+                )
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        // Read-only on purpose. Granting trust writes the server user's global
+        // Git configuration and tells Git to run hooks from a tree they do not
+        // own; that decision belongs to the machine holding the repository, not
+        // to a browser client. The probe still answers, so such a client can
+        // name the folder and show the exact command.
+        .on_receive_request(
+            async move |request: GitGetRepositoryTrustMessage, responder, _cx| {
+                let GitRepositoryPathRequest { repository_path } = request.0;
+                responder.respond_with_result(
+                    GitService::inspect_trust(&repository_path)
+                        .await
+                        .map(|report| GitGetRepositoryTrustResponse(wire::git_trust_report(report)))
                         .map_err(git_service_error),
                 )
             },

--- a/src/crates/interfaces/app-server/src/server/wire.rs
+++ b/src/crates/interfaces/app-server/src/server/wire.rs
@@ -12,7 +12,8 @@ use bitfun_app_server_protocol::agent::{
 use bitfun_app_server_protocol::config::AgentProfileView;
 use bitfun_app_server_protocol::event::ConfigUpdate;
 use bitfun_app_server_protocol::git::{
-    GitBranch, GitBranchStats, GitFileStatus, GitLinesChanged, GitStatus,
+    GitBranch, GitBranchStats, GitFileStatus, GitLinesChanged, GitStatus, GitTrustReport,
+    GitTrustState,
 };
 use bitfun_app_server_protocol::session::{
     RestoreSessionMessage, RestoreSessionResponse, SessionProcessingPhase, SessionRuntimeState,
@@ -149,6 +150,23 @@ pub(super) fn git_status(value: bitfun_core::service::git::GitStatus) -> GitStat
         current_branch: value.current_branch,
         ahead: value.ahead,
         behind: value.behind,
+    }
+}
+
+pub(super) fn git_trust_report(value: bitfun_core::service::git::GitTrustReport) -> GitTrustReport {
+    GitTrustReport {
+        state: git_trust_state(value.state),
+        repository_path: value.repository_path,
+        detail: value.detail,
+        manual_command: value.manual_command,
+    }
+}
+
+fn git_trust_state(value: bitfun_core::service::git::GitTrustState) -> GitTrustState {
+    match value {
+        bitfun_core::service::git::GitTrustState::Trusted => GitTrustState::Trusted,
+        bitfun_core::service::git::GitTrustState::TrustRequired => GitTrustState::TrustRequired,
+        bitfun_core::service::git::GitTrustState::NotARepository => GitTrustState::NotARepository,
     }
 }
 

--- a/src/crates/services/services-integrations/src/git/error.rs
+++ b/src/crates/services/services-integrations/src/git/error.rs
@@ -3,6 +3,14 @@ pub enum GitError {
     #[error("Repository not found: {0}")]
     RepositoryNotFound(String),
 
+    /// The repository exists, but Git refuses to operate on it because the
+    /// directory owner differs from the current user (`safe.directory` gate).
+    #[error("Repository ownership is not trusted: {repository_path}")]
+    RepositoryUntrusted {
+        repository_path: String,
+        detail: String,
+    },
+
     #[error("Git command failed: {0}")]
     CommandFailed(String),
 
@@ -29,4 +37,17 @@ pub enum GitError {
 
     #[error("Git2 error: {0}")]
     Git2Error(#[from] git2::Error),
+}
+
+impl GitError {
+    /// Repository path Git validates ownership against, when this failure is an
+    /// ownership rejection.
+    pub fn untrusted_repository_path(&self) -> Option<&str> {
+        match self {
+            Self::RepositoryUntrusted {
+                repository_path, ..
+            } => Some(repository_path.as_str()),
+            _ => None,
+        }
+    }
 }

--- a/src/crates/services/services-integrations/src/git/managed_worktree.rs
+++ b/src/crates/services/services-integrations/src/git/managed_worktree.rs
@@ -1,6 +1,6 @@
 use super::service::GitService;
 use super::types::{GitLocalChangeSummary, GitWorktreeInfo};
-use super::utils::execute_git_command;
+use super::utils::{execute_git_command, open_repository};
 use super::GitError;
 use bitfun_services_core::process_manager;
 use git2::Repository;
@@ -384,8 +384,7 @@ impl GitService {
         worktree_path: P,
     ) -> Result<bool, GitError> {
         let worktree_path = worktree_path.as_ref();
-        let repository = Repository::open(worktree_path)
-            .map_err(|error| GitError::RepositoryNotFound(error.to_string()))?;
+        let repository = open_repository(worktree_path)?;
         if repository.head().ok().is_some_and(|head| head.is_branch()) {
             return Ok(false);
         }

--- a/src/crates/services/services-integrations/src/git/mod.rs
+++ b/src/crates/services/services-integrations/src/git/mod.rs
@@ -11,6 +11,7 @@ pub mod name_status;
 mod runtime_port;
 pub mod service;
 pub mod text;
+pub mod trust;
 pub mod types;
 pub mod utils;
 pub mod worktree;
@@ -22,6 +23,10 @@ pub use name_status::parse_name_status_output;
 pub use runtime_port::GitWorkspaceDiffPort;
 pub use service::GitService;
 pub use text::{parse_branch_line, parse_git_log_line};
+pub use trust::{
+    is_untrusted_repository_message, manual_trust_command, untrusted_repository_path_from_message,
+    GitTrustOutcome, GitTrustReport, GitTrustState,
+};
 pub use types::*;
 pub use utils::*;
 pub use worktree::parse_worktree_list;

--- a/src/crates/services/services-integrations/src/git/runtime_port.rs
+++ b/src/crates/services/services-integrations/src/git/runtime_port.rs
@@ -11,6 +11,7 @@ use git2::{
     Delta, DiffFindOptions, DiffFlags, DiffOptions, Patch, Repository, Status, StatusOptions,
 };
 
+use super::utils::discover_repository;
 use super::GitError;
 
 const MAX_WORKSPACE_DIFF_FILES: usize = 256;
@@ -48,8 +49,7 @@ impl GitPort for GitWorkspaceDiffPort {
 }
 
 fn collect_workspace_diff(workspace_root: &Path) -> Result<WorkspaceDiffSnapshot, GitError> {
-    let repository = Repository::discover(workspace_root)
-        .map_err(|error| GitError::RepositoryNotFound(error.to_string()))?;
+    let repository = discover_repository(workspace_root)?;
     let repository_root = repository
         .workdir()
         .ok_or_else(|| GitError::InvalidPath("Repository has no working directory".to_string()))?
@@ -322,6 +322,9 @@ fn unstaged_statuses() -> Status {
 fn map_git_error(error: GitError) -> PortError {
     let kind = match &error {
         GitError::RepositoryNotFound(_) => PortErrorKind::NotFound,
+        // The repository is reachable; Git refuses it until the user grants
+        // ownership trust, so this is a permission decision, not a lookup miss.
+        GitError::RepositoryUntrusted { .. } => PortErrorKind::PermissionDenied,
         GitError::InvalidPath(_) => PortErrorKind::InvalidRequest,
         GitError::CommandFailed(message) if message.contains("timed out") => PortErrorKind::Timeout,
         _ => PortErrorKind::Backend,

--- a/src/crates/services/services-integrations/src/git/service.rs
+++ b/src/crates/services/services-integrations/src/git/service.rs
@@ -97,6 +97,18 @@ impl GitService {
             .map_err(|e| GitError::CommandFailed(format!("spawn_blocking join: {e}")))?
     }
 
+    /// Reports whether Git accepts the repository's ownership for the current
+    /// user. Read-only: nothing is configured.
+    pub async fn inspect_trust<P: AsRef<Path>>(path: P) -> Result<GitTrustReport, GitError> {
+        trust::inspect_repository_trust(&path.as_ref().to_string_lossy()).await
+    }
+
+    /// Grants ownership trust for the repository after the caller obtained an
+    /// explicit user confirmation. See [`trust::trust_repository`].
+    pub async fn trust_repository<P: AsRef<Path>>(path: P) -> Result<GitTrustOutcome, GitError> {
+        trust::trust_repository(&path.as_ref().to_string_lossy()).await
+    }
+
     /// Resolves the stable repository identity shared by all worktrees without
     /// spawning the Git CLI.
     pub async fn resolve_worktree_repository<P: AsRef<Path>>(
@@ -104,8 +116,7 @@ impl GitService {
     ) -> Result<GitWorktreeRepositoryInfo, GitError> {
         let requested_path = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repository = Repository::discover(&requested_path)
-                .map_err(|error| GitError::RepositoryNotFound(error.to_string()))?;
+            let repository = discover_repository(&requested_path)?;
             let query_path = repository
                 .workdir()
                 .map(Path::to_path_buf)
@@ -148,8 +159,7 @@ impl GitService {
         }
 
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
             let object = repo
                 .revparse_single(&revision)
                 .map_err(|e| GitError::CommandFailed(format!("Failed to resolve revision: {e}")))?;
@@ -216,8 +226,7 @@ impl GitService {
     pub async fn get_repository<P: AsRef<Path>>(path: P) -> Result<GitRepository, GitError> {
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
 
             let current_branch = get_current_branch(&repo)?;
             let is_bare = repo.is_bare();
@@ -254,8 +263,7 @@ impl GitService {
     pub async fn get_repository_basic<P: AsRef<Path>>(path: P) -> Result<GitRepository, GitError> {
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
 
             let current_branch = get_current_branch(&repo)?;
             let is_bare = repo.is_bare();
@@ -286,8 +294,7 @@ impl GitService {
         timeout(
             Duration::from_secs(10),
             task::spawn_blocking(move || {
-                let repo = Repository::open(&path_buf)
-                    .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+                let repo = open_repository(&path_buf)?;
 
                 let current_branch = get_current_branch(&repo)?;
                 let file_statuses = get_file_statuses(&repo)?;
@@ -340,8 +347,7 @@ impl GitService {
     ) -> Result<Vec<GitBranch>, GitError> {
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
 
             let mut branches = Vec::new();
             let current_branch = get_current_branch(&repo)?;
@@ -476,8 +482,7 @@ impl GitService {
 
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
             let current_branch = get_current_branch(&repo)?;
 
             for branch in &mut branches {
@@ -667,8 +672,7 @@ impl GitService {
     ) -> Result<Vec<GitCommit>, GitError> {
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
             let since_timestamp = params
                 .since
                 .as_deref()
@@ -1228,8 +1232,7 @@ impl GitService {
     ) -> Result<GitGraph, GitError> {
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
             build_git_graph(&repo, max_count).map_err(|e| GitError::CommandFailed(e.to_string()))
         })
         .await
@@ -1244,8 +1247,7 @@ impl GitService {
     ) -> Result<GitGraph, GitError> {
         let path_buf = path.as_ref().to_path_buf();
         task::spawn_blocking(move || {
-            let repo = Repository::open(&path_buf)
-                .map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+            let repo = open_repository(&path_buf)?;
             build_git_graph_for_branch(&repo, max_count, branch_name.as_deref())
                 .map_err(|e| GitError::CommandFailed(e.to_string()))
         })
@@ -1380,8 +1382,7 @@ impl GitService {
         let repository_info = Self::resolve_worktree_repository(path.as_ref()).await?;
 
         task::spawn_blocking(move || {
-            let repository = Repository::discover(&repository_path)
-                .map_err(|error| GitError::RepositoryNotFound(error.to_string()))?;
+            let repository = discover_repository(&repository_path)?;
             match repository.head() {
                 Ok(head) if head.target().is_some() => {}
                 Err(error) if error.code() == ErrorCode::UnbornBranch => {

--- a/src/crates/services/services-integrations/src/git/trust.rs
+++ b/src/crates/services/services-integrations/src/git/trust.rs
@@ -1,0 +1,1095 @@
+//! Repository ownership trust.
+//!
+//! Git (since 2.35.2) and libgit2 refuse to operate on a repository whose
+//! directory owner differs from the current user unless the path is listed in
+//! the protected `safe.directory` configuration. That guard is correct, but it
+//! surfaces as an opaque command failure: read-only product flows such as
+//! Review then look indistinguishable from "this is not a repository".
+//!
+//! This module keeps the ownership decision explicit and platform-neutral:
+//!
+//! - classify Git/libgit2 ownership rejections into
+//!   [`GitError::RepositoryUntrusted`] so every surface can branch on the code
+//!   instead of parsing prose,
+//! - report the current trust state without mutating anything, and
+//! - apply the trust decision (write `safe.directory`) only when a caller has
+//!   an explicit user confirmation, then verify that Git actually accepts the
+//!   repository afterwards.
+//!
+//! Trust is never granted implicitly: nothing in this module is invoked as a
+//! fallback of a failed operation.
+
+use super::utils::execute_git_hardened_command_with_env;
+use super::GitError;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Ownership rejection wordings emitted by the Git CLI and by libgit2.
+const OWNERSHIP_REJECTION_MARKERS: [&str; 5] = [
+    "dubious ownership",
+    "is owned by someone else",
+    "is not owned by current user",
+    "not owned by current user",
+    "owned by a different user",
+];
+
+// Repository-level phrasings only. A bare "does not exist" also matches Git
+// talking about an object, a ref or a pathspec inside a repository that is
+// plainly there ("path 'x' does not exist in 'HEAD'"), which would turn a
+// corrupt or unusual failure into "no repository here". A path that genuinely
+// is not there is established by looking, not by prose.
+const MISSING_REPOSITORY_MARKERS: [&str; 3] = [
+    "not a git repository",
+    "could not find repository",
+    "repository does not exist",
+];
+
+/// Whether the given repository path is usable by Git for the current user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitTrustState {
+    /// Git accepts the repository as-is.
+    Trusted,
+    /// The repository exists but Git rejects it on ownership grounds.
+    TrustRequired,
+    /// No repository was found at the path.
+    NotARepository,
+}
+
+/// Read-only trust probe result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitTrustReport {
+    pub state: GitTrustState,
+    /// Path Git validates ownership against, when it is known.
+    pub repository_path: Option<String>,
+    /// Git's own diagnostic, preserved for surfaces that show manual steps.
+    pub detail: Option<String>,
+    /// Command the user can run to resolve this outside the product.
+    pub manual_command: Option<String>,
+}
+
+/// Result of an explicitly confirmed trust decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitTrustOutcome {
+    /// Trust state observed after the decision was applied and verified.
+    pub state: GitTrustState,
+    pub repository_path: Option<String>,
+    /// Whether Git already accepted the repository before this call.
+    pub already_trusted: bool,
+    /// `safe.directory` entries this call added, in the order they were tried.
+    pub added_entries: Vec<String>,
+    pub detail: Option<String>,
+    pub manual_command: Option<String>,
+}
+
+fn contains_any(message: &str, markers: &[&str]) -> bool {
+    let lowered = message.to_lowercase();
+    markers.iter().any(|marker| lowered.contains(marker))
+}
+
+/// Whether a Git/libgit2 diagnostic is an ownership rejection.
+pub fn is_untrusted_repository_message(message: &str) -> bool {
+    contains_any(message, &OWNERSHIP_REJECTION_MARKERS)
+}
+
+/// Whether a Git/libgit2 diagnostic says no repository is there.
+///
+/// What is neither this nor [`is_untrusted_repository_message`] is a probe that
+/// failed (an unreadable `.git`, a denied path, a broken remote wrapper).
+/// Callers must not fold that remainder into "not a repository": that reports a
+/// failure to look as an answer, and sends the user to "initialize a
+/// repository" for a problem initializing cannot fix.
+pub fn is_missing_repository_message(message: &str) -> bool {
+    contains_any(message, &MISSING_REPOSITORY_MARKERS)
+}
+
+/// True when the value carries a shape only Windows produces: a `\\server\share`
+/// or `\\?\...` prefix, or a `C:\` / `C:/` drive root.
+///
+/// This is a shape test on purpose, not `cfg!(windows)`: a Windows desktop
+/// driving a remote Linux workspace normalizes that host's paths, and a POSIX
+/// host can be handed a Windows path by a peer.
+fn looks_like_windows_path(value: &str) -> bool {
+    if value.starts_with('\\') {
+        return true;
+    }
+    let mut chars = value.chars();
+    matches!(
+        (chars.next(), chars.next(), chars.next()),
+        (Some(drive), Some(':'), Some('\\' | '/')) if drive.is_ascii_alphabetic()
+    )
+}
+
+/// Normalizes a repository path into the shape Git compares `safe.directory`
+/// entries against: forward slashes, no extended-length prefix, no trailing
+/// separator.
+pub fn normalize_trust_path(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_matches('\'').trim_matches('"').trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Only a Windows-shaped path may have its backslashes rewritten. Backslash
+    // is an ordinary filename character on POSIX, and rewriting it would turn
+    // `/srv/we\ird/repo` into a `safe.directory` entry that can never match and
+    // a manual command naming a directory that does not exist.
+    let mut value = if looks_like_windows_path(trimmed) {
+        trimmed.replace('\\', "/")
+    } else {
+        trimmed.to_string()
+    };
+    // `\\?\UNC\server\share` is the extended-length spelling of the UNC path
+    // `\\server\share`. Dropping the whole prefix would leave
+    // `UNC/server/share`, which Git never matches — and the manual command we
+    // hand the user would name a path that does not exist.
+    let unc_prefix = value
+        .get(..8)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("//?/UNC/"));
+    if unc_prefix.is_some() {
+        value = format!("//{}", &value[8..]);
+    } else if let Some(stripped) = value.strip_prefix("//?/") {
+        value = stripped.to_string();
+    }
+    while value.len() > 1 && value.ends_with('/') && !value.ends_with(":/") {
+        value.pop();
+    }
+
+    (!value.is_empty()).then_some(value)
+}
+
+/// Extracts the repository path Git named in an ownership rejection.
+///
+/// Both wordings quote the path first, before any remediation hint:
+/// `detected dubious ownership in repository at '<path>'` (CLI) and
+/// `repository path '<path>' is not owned by current user` (libgit2).
+///
+/// Only the line carrying the rejection itself is read. The CLI's advice block
+/// repeats the path on later lines, and reading those would make the result
+/// depend on how far the prose was truncated.
+pub fn untrusted_repository_path_from_message(message: &str) -> Option<String> {
+    if !is_untrusted_repository_message(message) {
+        return None;
+    }
+
+    message
+        .lines()
+        .filter(|line| contains_any(line, &OWNERSHIP_REJECTION_MARKERS))
+        .find_map(quoted_path_on_line)
+        // A wording we have not seen may put the path on its own line. Falling
+        // back to any quoted span still beats losing the path entirely.
+        .or_else(|| message.lines().find_map(quoted_path_on_line))
+}
+
+/// Takes the widest quoted span on a line: first quote to last quote of the same
+/// kind.
+///
+/// Git does not escape quotes inside the path it prints, so stopping at the
+/// first closing quote truncates `/srv/a'b/repo` to `/srv/a` — and that
+/// truncated path outranks the caller's in `classify_command_failure`, so it is
+/// what would be written into the user's global `safe.directory`, never
+/// reclaimed, and still not resolve the rejection.
+fn quoted_path_on_line(line: &str) -> Option<String> {
+    for quote in ['\'', '"'] {
+        let Some(open) = line.find(quote) else {
+            continue;
+        };
+        let start = open + quote.len_utf8();
+        let Some(end) = line.rfind(quote) else {
+            continue;
+        };
+        if end < start {
+            continue;
+        }
+        if let Some(path) = normalize_trust_path(&line[start..end]) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// The command a user can run themselves when the product cannot apply the
+/// decision (remote workspace, peer host, restricted configuration).
+///
+/// This string exists to be copied into a shell verbatim, so the path cannot go
+/// in bare: it can come from another machine, and any `$(...)`, backtick, quote
+/// or backslash in it would be the shell's to interpret. It also cannot go in
+/// quoted unconditionally — the user's shell is not knowable from here, and
+/// single quotes are not quoting characters in `cmd.exe`, which would take them
+/// as part of the path and write a `safe.directory` value that never matches.
+///
+/// So it follows Git's own rule (`sq_quote_buf_pretty` in `quote.c`) for the
+/// common case and then goes one step further, because Git only ever quotes for
+/// a POSIX shell and this string is most often pasted into a Windows one.
+///
+/// A path made only of characters no shell can read as syntax is emitted bare —
+/// the ordinary Windows and POSIX path, and why Git's own dubious ownership
+/// advice prints unquoted. A path that merely needs *grouping* — a space, an
+/// apostrophe, a comma, `^` — is double quoted, which `sh`, PowerShell and
+/// `cmd.exe` all read the same way, and which is the answer for
+/// `C:/Users/John Doe/repo`. Only a path carrying a character that stays live
+/// inside double quotes falls back to POSIX single quoting with the `'\''`
+/// break-out; that form is correct in POSIX shells alone, but such a path is one
+/// we must not hand over unquoted, and a `cmd.exe` user who has one has to
+/// re-quote it themselves.
+///
+/// Two deliberate differences from Git's bare set. `^` and `,` come out: `^` is
+/// `cmd.exe`'s escape character, and `,` is PowerShell's array operator, which
+/// turns a bare `/srv/a,b` into two arguments rejoined with a space — a
+/// `safe.directory` entry that silently never matches. Non-ASCII goes in: Git
+/// walks bytes under the C locale, so it quotes every path with a Chinese or
+/// Japanese folder name in it, and no shell's syntax lives outside ASCII.
+pub fn manual_trust_command(repository_path: &str) -> String {
+    format!(
+        "git config --global --add safe.directory {}",
+        shell_quote_pretty(repository_path)
+    )
+}
+
+/// ASCII punctuation Git treats as needing no quoting, minus `^` and `,` (see
+/// above). None of the rest is syntax in `sh`, PowerShell or `cmd.exe`.
+const SHELL_SAFE_PUNCTUATION: &str = "+-./:=@_";
+
+/// Characters that keep their meaning *inside* double quotes in at least one of
+/// the three shells: `"` ends the string, `$` and `` ` `` expand in `sh` and
+/// PowerShell, `\` escapes in `sh`, `%` and `!` expand in `cmd.exe`.
+const DOUBLE_QUOTE_UNSAFE: &[char] = &['"', '$', '`', '\\', '%', '!'];
+
+fn shell_quote_pretty(value: &str) -> String {
+    // The non-ASCII allowance is for letters, not for everything outside ASCII:
+    // U+00A0, U+2028 and U+3000 are whitespace or line breaks that a shell would
+    // split the argument on, and Unicode control characters are invisible in the
+    // string we ask the user to paste. Those take the quoted path.
+    let bare = !value.is_empty()
+        && value.chars().all(|c| {
+            (!c.is_ascii() && !c.is_control() && !c.is_whitespace())
+                || c.is_ascii_alphanumeric()
+                || SHELL_SAFE_PUNCTUATION.contains(c)
+        });
+    if bare {
+        return value.to_string();
+    }
+    if !value.contains(DOUBLE_QUOTE_UNSAFE) && !value.chars().any(char::is_control) {
+        return format!("\"{value}\"");
+    }
+    shell_single_quote(value)
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// Stable prefix every interface uses to carry an ownership rejection across a
+/// command boundary that only transports strings (Tauri `Result<T, String>`,
+/// JSON-RPC error `data`). Frontends branch on this instead of on prose, which
+/// is localized by Git itself and differs between the CLI and libgit2.
+pub const REPOSITORY_UNTRUSTED_ERROR_PREFIX: &str = "git_repository_untrusted:";
+
+/// Boundary error string for an ownership rejection. One producer so the
+/// desktop and app-server surfaces cannot drift apart on the wire.
+pub fn untrusted_repository_error_message(repository_path: &str) -> String {
+    format!("{REPOSITORY_UNTRUSTED_ERROR_PREFIX} {repository_path}")
+}
+
+fn untrusted_error(repository_path: Option<String>, detail: impl Into<String>) -> GitError {
+    GitError::RepositoryUntrusted {
+        repository_path: repository_path.unwrap_or_default(),
+        detail: detail.into(),
+    }
+}
+
+/// Classifies a failed Git CLI invocation, keeping ownership rejections typed.
+pub fn classify_command_failure(repo_path: &str, message: String) -> GitError {
+    if is_untrusted_repository_message(&message) {
+        let repository_path = untrusted_repository_path_from_message(&message)
+            .or_else(|| normalize_trust_path(repo_path));
+        return untrusted_error(repository_path, message);
+    }
+
+    GitError::CommandFailed(message)
+}
+
+/// Classifies a failed `libgit2` repository open/discover.
+///
+/// The remainder — a corrupt object store, an unreadable `.git`, a denied path
+/// — is a probe that failed, not an answer. Reporting it as
+/// [`GitError::RepositoryNotFound`] is what turns it into "not a Git
+/// repository" downstream (`map_git_error` in the worktree service, `NotFound`
+/// on the runtime port), which offers the user an initialization that cannot
+/// fix any of those. Only a diagnostic that says so, or a path that plainly is
+/// not there, gets that verdict.
+pub fn classify_repository_open_error(path: &Path, error: &git2::Error) -> GitError {
+    let message = error.message().to_string();
+    if is_untrusted_repository_message(&message) {
+        let repository_path = untrusted_repository_path_from_message(&message)
+            .or_else(|| normalize_trust_path(&path.to_string_lossy()));
+        return untrusted_error(repository_path, message);
+    }
+
+    // `try_exists` rather than `exists`: the latter answers `false` when it
+    // could not look (a denied parent directory), which is the very case that
+    // must not be called "no repository".
+    let definitely_absent = matches!(path.try_exists(), Ok(false));
+    if definitely_absent || is_missing_repository_message(&message) {
+        return GitError::RepositoryNotFound(error.to_string());
+    }
+
+    GitError::CommandFailed(error.to_string())
+}
+
+/// Candidate `safe.directory` values for a rejected repository, most precise
+/// first. Git names the exact path it validated, so that value is authoritative;
+/// the worktree root is only a fallback for the case where the rejection came
+/// from the administrative `.git` directory.
+fn trust_candidates(repository_path: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(primary) = normalize_trust_path(repository_path) {
+        if let Some(worktree) = primary.strip_suffix("/.git") {
+            if let Some(parent) = normalize_trust_path(worktree) {
+                candidates.push(primary.clone());
+                candidates.push(parent);
+                return candidates;
+            }
+        }
+        candidates.push(primary);
+    }
+    candidates
+}
+
+/// Runs a Git command that must not depend on the repository under inspection.
+async fn run_global_git_command(args: &[&str], env: GitTrustEnv<'_>) -> Result<String, GitError> {
+    let working_directory = std::env::temp_dir();
+    let working_directory = working_directory.to_string_lossy().to_string();
+    execute_git_hardened_command_with_env(&working_directory, args, env).await
+}
+
+async fn configured_safe_directories(env: GitTrustEnv<'_>) -> Vec<String> {
+    // A missing key exits non-zero; that is "no entries", not a failure.
+    let raw = run_global_git_command(&["config", "--global", "--get-all", "safe.directory"], env)
+        .await
+        .unwrap_or_default();
+
+    raw.lines()
+        .filter_map(normalize_trust_path)
+        .collect::<Vec<_>>()
+}
+
+/// Environment overrides applied to every Git invocation of a trust probe.
+/// Production callers pass none; in-crate tests use it to exercise the real Git
+/// ownership gate against a throwaway global configuration.
+type GitTrustEnv<'a> = &'a [(&'a str, &'a str)];
+
+/// Reports whether Git accepts the repository at `path`, without changing any
+/// configuration.
+pub async fn inspect_repository_trust(path: &str) -> Result<GitTrustReport, GitError> {
+    inspect_repository_trust_with_env(path, &[]).await
+}
+
+async fn inspect_repository_trust_with_env(
+    path: &str,
+    env: GitTrustEnv<'_>,
+) -> Result<GitTrustReport, GitError> {
+    if path.trim().is_empty() {
+        return Err(GitError::InvalidPath(
+            "Repository path cannot be empty".to_string(),
+        ));
+    }
+    // `try_exists`, not `exists`: the latter also answers `false` when it could
+    // not look — a denied parent directory — and this probe's `false` becomes
+    // "not a Git repository" for the caller, offering an initialization that
+    // cannot fix a permission problem. Same rule as
+    // `classify_repository_open_error`. A path we cannot stat falls through to
+    // Git, whose diagnostic is worth more than our guess.
+    if matches!(Path::new(path).try_exists(), Ok(false)) {
+        return Ok(GitTrustReport {
+            state: GitTrustState::NotARepository,
+            repository_path: normalize_trust_path(path),
+            detail: Some("Path does not exist".to_string()),
+            manual_command: None,
+        });
+    }
+
+    let probe =
+        execute_git_hardened_command_with_env(path, &["rev-parse", "--show-toplevel"], env).await;
+    classify_toplevel_probe(path, probe)
+}
+
+/// Turns one `rev-parse --show-toplevel` outcome into a trust report.
+///
+/// Split out from the invocation so every branch — including the ones a real
+/// local Git will not produce on demand — is reachable from a test. The remote
+/// probe in the desktop app classifies the same four shapes; the two must not
+/// drift apart.
+fn classify_toplevel_probe(
+    path: &str,
+    probe: Result<String, GitError>,
+) -> Result<GitTrustReport, GitError> {
+    match probe {
+        // A `--show-toplevel` that exits zero with nothing to say did not
+        // answer. Calling that "trusted" manufactures a pass out of a broken
+        // transport or a wrapper that swallowed the output; the remote probe
+        // already refuses to, and the local one must not disagree.
+        Ok(output) if output.trim().is_empty() => Err(GitError::CommandFailed(
+            "git rev-parse --show-toplevel reported success without naming a repository"
+                .to_string(),
+        )),
+        Ok(output) => Ok(GitTrustReport {
+            state: GitTrustState::Trusted,
+            repository_path: normalize_trust_path(&output).or_else(|| normalize_trust_path(path)),
+            detail: None,
+            manual_command: None,
+        }),
+        Err(error) => {
+            // Two shapes of the same wall: the typed ownership rejection every
+            // in-crate executor produces, and — defensively — a raw command
+            // failure whose prose still carries the markers. Both resolve to
+            // the same report.
+            let (repository_path, detail) = match error {
+                GitError::RepositoryUntrusted {
+                    repository_path,
+                    detail,
+                } => (
+                    normalize_trust_path(&repository_path)
+                        .or_else(|| untrusted_repository_path_from_message(&detail))
+                        .or_else(|| normalize_trust_path(path)),
+                    detail,
+                ),
+                GitError::CommandFailed(message) if is_untrusted_repository_message(&message) => (
+                    untrusted_repository_path_from_message(&message)
+                        .or_else(|| normalize_trust_path(path)),
+                    message,
+                ),
+                GitError::CommandFailed(message) if is_missing_repository_message(&message) => {
+                    return Ok(GitTrustReport {
+                        state: GitTrustState::NotARepository,
+                        repository_path: normalize_trust_path(path),
+                        detail: Some(message),
+                        manual_command: None,
+                    })
+                }
+                other => return Err(other),
+            };
+            let manual_command = repository_path.as_deref().map(manual_trust_command);
+            Ok(GitTrustReport {
+                state: GitTrustState::TrustRequired,
+                repository_path,
+                detail: Some(detail),
+                manual_command,
+            })
+        }
+    }
+}
+
+/// Whether a configured `safe.directory` entry already covers the candidate.
+/// Git compares entries case-insensitively on Windows, so the dedupe check
+/// must too — otherwise a grant appends a duplicate that differs only by
+/// drive-letter casing.
+fn safe_directory_entry_matches(existing: &str, candidate: &str) -> bool {
+    if cfg!(windows) {
+        existing.eq_ignore_ascii_case(candidate)
+    } else {
+        existing == candidate
+    }
+}
+
+/// Applies an explicitly confirmed trust decision for `path`.
+///
+/// Callers must obtain user confirmation first: this writes to the user's
+/// global Git configuration, which is exactly the exception Git asks the user
+/// to make deliberately. The write is idempotent, is skipped when the entry is
+/// already present, and is always verified by re-probing the repository, so a
+/// decision that does not actually resolve the rejection is reported instead of
+/// silently assumed.
+pub async fn trust_repository(path: &str) -> Result<GitTrustOutcome, GitError> {
+    trust_repository_with_env(path, &[]).await
+}
+
+async fn trust_repository_with_env(
+    path: &str,
+    env: GitTrustEnv<'_>,
+) -> Result<GitTrustOutcome, GitError> {
+    let report = inspect_repository_trust_with_env(path, env).await?;
+    match report.state {
+        GitTrustState::Trusted => {
+            return Ok(GitTrustOutcome {
+                state: GitTrustState::Trusted,
+                repository_path: report.repository_path,
+                already_trusted: true,
+                added_entries: Vec::new(),
+                detail: None,
+                manual_command: None,
+            })
+        }
+        GitTrustState::NotARepository => {
+            return Err(GitError::RepositoryNotFound(
+                report
+                    .detail
+                    .unwrap_or_else(|| format!("No Git repository at {path}")),
+            ))
+        }
+        GitTrustState::TrustRequired => {}
+    }
+
+    let rejected_path = report
+        .repository_path
+        .clone()
+        .or_else(|| normalize_trust_path(path))
+        .ok_or_else(|| GitError::InvalidPath("Repository path cannot be empty".to_string()))?;
+    let existing = configured_safe_directories(env).await;
+    let mut added_entries = Vec::new();
+    let mut last_report = report;
+    let mut skipped_pattern = false;
+    let mut attempted = false;
+
+    for candidate in trust_candidates(&rejected_path) {
+        // Never write a value Git reads as a pattern: the user consented to one
+        // directory, and the entry would grant a whole tree.
+        if is_pattern_safe_directory(&candidate) {
+            skipped_pattern = true;
+            continue;
+        }
+        attempted = true;
+        if !existing
+            .iter()
+            .any(|entry| safe_directory_entry_matches(entry, &candidate))
+        {
+            run_global_git_command(
+                &["config", "--global", "--add", "safe.directory", &candidate],
+                env,
+            )
+            .await?;
+            added_entries.push(candidate.clone());
+        }
+
+        last_report = inspect_repository_trust_with_env(path, env).await?;
+        if last_report.state == GitTrustState::Trusted {
+            return Ok(GitTrustOutcome {
+                state: GitTrustState::Trusted,
+                repository_path: last_report.repository_path,
+                already_trusted: false,
+                added_entries,
+                detail: None,
+                manual_command: None,
+            });
+        }
+    }
+
+    // Trust could not be established (for example a read-only global config or
+    // a rejection Git reports against a path we cannot express). Report it
+    // loudly with the exact manual step instead of pretending it worked.
+    //
+    // A path Git can only read as a pattern still gets the manual step — that is
+    // the command Git's own advice prints, and the probe would report it anyway.
+    // What it also gets is a `detail` saying what the entry would actually do,
+    // because there is no escaping in `safe.directory`: the value cannot name
+    // this repository alone, and applying it silently is what this refuses.
+    let unexpressible = skipped_pattern && !attempted;
+    Ok(GitTrustOutcome {
+        state: last_report.state,
+        repository_path: last_report.repository_path.clone(),
+        already_trusted: false,
+        added_entries,
+        detail: if unexpressible {
+            Some(format!(
+                "Git reads '{rejected_path}' as a safe.directory pattern, not as a literal path, \
+                 so no entry can trust this repository alone — the value below would trust every \
+                 repository the pattern covers. Rename or move the directory instead."
+            ))
+        } else {
+            last_report.detail
+        },
+        manual_command: last_report
+            .repository_path
+            .as_deref()
+            .or(Some(rejected_path.as_str()))
+            .map(manual_trust_command),
+    })
+}
+
+/// True when Git would read the value as a pattern rather than as the literal
+/// directory it names.
+///
+/// `safe.directory = *` disables the ownership check for every repository, and a
+/// value ending in `/*` trusts everything beneath that prefix. Both are legal
+/// directory names on POSIX, so a repository at `/tmp/*` would silently turn one
+/// "trust this folder" into a blanket grant over `/tmp`. `%(prefix)/` is Git's
+/// runtime-prefix interpolation, which resolves to a different path than the one
+/// probed.
+fn is_pattern_safe_directory(candidate: &str) -> bool {
+    candidate == "*" || candidate.ends_with("/*") || candidate.starts_with("%(prefix)/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLI_REJECTION: &str = "fatal: detected dubious ownership in repository at 'C:/work/repo'\n'C:/work/repo' is owned by:\n\t'S-1-5-21-1'\nbut the current user is:\n\t'S-1-5-21-2'\nTo add an exception for this directory, call:\n\n\tgit config --global --add safe.directory 'C:/work/repo'";
+    const LIBGIT2_REJECTION: &str =
+        "repository path '/srv/shared/repo/.git/' is not owned by current user";
+    const POSIX_CLI_REJECTION: &str =
+        "fatal: detected dubious ownership in repository at '/srv/shared/repo'";
+
+    /// Every interface builds this string from the same producer, and each one
+    /// carries the rejected path so a frontend can name the folder without a
+    /// second round trip.
+    #[test]
+    fn the_boundary_error_string_carries_the_rejected_path() {
+        let message = untrusted_repository_error_message("/srv/shared/repo");
+
+        assert!(message.starts_with(REPOSITORY_UNTRUSTED_ERROR_PREFIX));
+        assert_eq!(
+            message[REPOSITORY_UNTRUSTED_ERROR_PREFIX.len()..].trim(),
+            "/srv/shared/repo"
+        );
+    }
+
+    #[test]
+    fn recognizes_cli_and_libgit2_ownership_rejections() {
+        assert!(is_untrusted_repository_message(CLI_REJECTION));
+        assert!(is_untrusted_repository_message(LIBGIT2_REJECTION));
+        assert!(is_untrusted_repository_message(POSIX_CLI_REJECTION));
+        assert!(!is_untrusted_repository_message(
+            "fatal: not a git repository (or any of the parent directories): .git"
+        ));
+    }
+
+    #[test]
+    fn extracts_the_repository_path_git_rejected() {
+        assert_eq!(
+            untrusted_repository_path_from_message(CLI_REJECTION).as_deref(),
+            Some("C:/work/repo")
+        );
+        assert_eq!(
+            untrusted_repository_path_from_message(POSIX_CLI_REJECTION).as_deref(),
+            Some("/srv/shared/repo")
+        );
+        assert_eq!(
+            untrusted_repository_path_from_message(LIBGIT2_REJECTION).as_deref(),
+            Some("/srv/shared/repo/.git")
+        );
+        assert_eq!(
+            untrusted_repository_path_from_message("fatal: not a git repository"),
+            None
+        );
+    }
+
+    /// Git does not escape the quote characters inside the path it prints, so a
+    /// reader that stops at the first closing quote invents a shorter path —
+    /// and that path outranks the caller's, gets written to the user's global
+    /// config, and never resolves the rejection it was written for.
+    #[test]
+    fn keeps_a_quote_that_belongs_to_the_directory_name() {
+        assert_eq!(
+            untrusted_repository_path_from_message(
+                "fatal: detected dubious ownership in repository at '/srv/o'brien/repo'"
+            )
+            .as_deref(),
+            Some("/srv/o'brien/repo")
+        );
+        assert_eq!(
+            untrusted_repository_path_from_message(
+                "repository path '/srv/a'b/repo/' is not owned by current user"
+            )
+            .as_deref(),
+            Some("/srv/a'b/repo")
+        );
+    }
+
+    /// The CLI repeats the path in its advice block. Reading the whole message
+    /// instead of the rejection line makes the result depend on how much of
+    /// that block survived, and the advice line ends with a quoted path of its
+    /// own.
+    #[test]
+    fn reads_the_path_from_the_rejection_line_not_the_advice_block() {
+        let message = concat!(
+            "fatal: detected dubious ownership in repository at '/srv/shared/repo'\n",
+            "'/srv/shared/repo' is owned by:\n",
+            "    uid 0\n",
+            "but the current user is:\n",
+            "    uid 1000\n",
+            "To add an exception for this directory, call:\n\n",
+            "    git config --global --add safe.directory '/srv/shared/repo'\n",
+        );
+        assert_eq!(
+            untrusted_repository_path_from_message(message).as_deref(),
+            Some("/srv/shared/repo")
+        );
+    }
+
+    #[test]
+    fn normalizes_paths_into_the_shape_git_compares() {
+        assert_eq!(
+            normalize_trust_path("\\\\?\\C:\\work\\repo\\").as_deref(),
+            Some("C:/work/repo")
+        );
+        assert_eq!(normalize_trust_path("C:/").as_deref(), Some("C:/"));
+        assert_eq!(normalize_trust_path("   ").as_deref(), None);
+    }
+
+    /// Backslash is an ordinary filename character on POSIX. Rewriting it there
+    /// produces a `safe.directory` entry that can never match and a manual
+    /// command naming a directory that does not exist — so the rewrite is gated
+    /// on the path shapes only Windows produces, not on the host we run on.
+    #[test]
+    fn leaves_a_posix_backslash_inside_the_directory_name() {
+        assert_eq!(
+            normalize_trust_path("/srv/we\\ird/repo").as_deref(),
+            Some("/srv/we\\ird/repo")
+        );
+        assert_eq!(
+            normalize_trust_path("/srv/trailing\\").as_deref(),
+            Some("/srv/trailing\\")
+        );
+        assert_eq!(
+            normalize_trust_path("C:\\work\\repo").as_deref(),
+            Some("C:/work/repo")
+        );
+    }
+
+    /// `safe.directory` has no escaping: `*` disables the ownership check
+    /// everywhere and a trailing `/*` trusts the whole tree beneath it. A
+    /// directory may legally be named `*` on POSIX, so writing the entry the
+    /// dialog implies would grant far more than the user approved.
+    #[test]
+    fn refuses_to_write_a_safe_directory_value_git_reads_as_a_pattern() {
+        assert!(is_pattern_safe_directory("*"));
+        assert!(is_pattern_safe_directory("/tmp/*"));
+        assert!(is_pattern_safe_directory("%(prefix)/srv/repo"));
+        assert!(!is_pattern_safe_directory("/tmp/*/repo"));
+        assert!(!is_pattern_safe_directory("/tmp/*/.git"));
+        assert!(!is_pattern_safe_directory("/srv/shared/repo"));
+        // The gitdir of a repository named `*` still names one repository, so
+        // the recovery is not lost — only the blanket entry is.
+        assert_eq!(
+            trust_candidates("/tmp/*"),
+            vec!["/tmp/*".to_string()],
+            "the candidate list itself is unchanged; the grant loop is what skips it"
+        );
+    }
+
+    /// `\\?\UNC\server\share` is the extended-length spelling of
+    /// `\\server\share`. Dropping the whole prefix leaves `UNC/server/share`,
+    /// a path that exists nowhere — so both the grant and the manual command
+    /// we print would name the wrong folder.
+    #[test]
+    fn rewrites_the_extended_length_spelling_of_a_unc_path() {
+        assert_eq!(
+            normalize_trust_path("\\\\?\\UNC\\build01\\shared\\repo").as_deref(),
+            Some("//build01/shared/repo")
+        );
+        assert_eq!(
+            normalize_trust_path("\\\\?\\unc\\build01\\shared\\repo\\").as_deref(),
+            Some("//build01/shared/repo")
+        );
+        assert_eq!(
+            normalize_trust_path("\\\\build01\\shared\\repo").as_deref(),
+            Some("//build01/shared/repo")
+        );
+    }
+
+    /// A probe that failed is not an answer. Calling a corrupt object store or
+    /// a denied path "not a Git repository" is what offers the user an
+    /// initialization that cannot fix either.
+    #[test]
+    fn keeps_an_inconclusive_open_failure_out_of_not_a_repository() {
+        let existing = std::env::temp_dir();
+        let corrupt = git2::Error::from_str("failed to parse object header");
+        assert!(matches!(
+            classify_repository_open_error(&existing, &corrupt),
+            GitError::CommandFailed(_)
+        ));
+
+        let missing = existing.join("bitfun-trust-test-absent-directory");
+        assert!(matches!(
+            classify_repository_open_error(&missing, &corrupt),
+            GitError::RepositoryNotFound(_)
+        ));
+
+        let diagnosed = git2::Error::from_str(
+            "could not find repository at '/srv/shared/repo'; class=Repository",
+        );
+        assert!(matches!(
+            classify_repository_open_error(&existing, &diagnosed),
+            GitError::RepositoryNotFound(_)
+        ));
+
+        let rejected = git2::Error::from_str(LIBGIT2_REJECTION);
+        assert!(matches!(
+            classify_repository_open_error(&existing, &rejected),
+            GitError::RepositoryUntrusted { .. }
+        ));
+    }
+
+    #[test]
+    fn falls_back_to_the_worktree_root_for_a_rejected_git_directory() {
+        assert_eq!(
+            trust_candidates("/srv/shared/repo/.git"),
+            vec![
+                "/srv/shared/repo/.git".to_string(),
+                "/srv/shared/repo".to_string()
+            ]
+        );
+        assert_eq!(
+            trust_candidates("/srv/shared/repo"),
+            vec!["/srv/shared/repo".to_string()]
+        );
+    }
+
+    #[test]
+    fn classifies_command_failures_without_losing_the_diagnostic() {
+        let error = classify_command_failure("C:/work/repo", CLI_REJECTION.to_string());
+        assert!(matches!(&error, GitError::RepositoryUntrusted { .. }));
+        assert_eq!(error.untrusted_repository_path(), Some("C:/work/repo"));
+
+        let other = classify_command_failure("C:/work/repo", "fatal: bad revision".to_string());
+        assert!(matches!(&other, GitError::CommandFailed(_)));
+        assert_eq!(other.untrusted_repository_path(), None);
+    }
+
+    /// The manual command exists to be pasted into a shell, so a path is data
+    /// there, never syntax. A repository path can arrive from another machine.
+    #[test]
+    fn quotes_the_path_in_the_manual_command_so_a_shell_cannot_read_it_as_syntax() {
+        // An ordinary path is syntax in no shell, so it goes in bare — the
+        // spelling Git's own advice prints, and the only one `cmd.exe` reads
+        // correctly, since it does not strip single quotes.
+        assert_eq!(
+            manual_trust_command("/srv/shared/repo"),
+            "git config --global --add safe.directory /srv/shared/repo"
+        );
+        assert_eq!(
+            manual_trust_command("C:/work/repo"),
+            "git config --global --add safe.directory C:/work/repo"
+        );
+
+        // Command substitution, a backtick, a double quote and a backslash are
+        // all literal inside single quotes — nothing here may execute or vanish.
+        let hostile = manual_trust_command(r#"/srv/$(id)/`whoami`/a"b\c"#);
+        assert_eq!(
+            hostile,
+            r#"git config --global --add safe.directory '/srv/$(id)/`whoami`/a"b\c'"#
+        );
+
+        // A space is the everyday reason to quote, and `C:/Users/John Doe/repo`
+        // is an everyday Windows path — so it gets the one quoting all three
+        // shells strip. Single quotes would have become part of the value on
+        // `cmd.exe`: a command that succeeds and grants nothing.
+        assert_eq!(
+            manual_trust_command("C:/Users/a b/repo"),
+            r#"git config --global --add safe.directory "C:/Users/a b/repo""#
+        );
+
+        // An apostrophe is literal inside double quotes everywhere, so this no
+        // longer needs the POSIX-only `'\''` break-out.
+        assert_eq!(
+            manual_trust_command("/srv/o'brien/repo"),
+            r#"git config --global --add safe.directory "/srv/o'brien/repo""#
+        );
+
+        // `^` is `cmd.exe`'s escape character and `,` is PowerShell's array
+        // operator — bare, either one silently rewrites the path. Both are inert
+        // once quoted.
+        assert_eq!(
+            manual_trust_command("/srv/a^b"),
+            r#"git config --global --add safe.directory "/srv/a^b""#
+        );
+        assert_eq!(
+            manual_trust_command("D:/Reports, 2024/repo"),
+            r#"git config --global --add safe.directory "D:/Reports, 2024/repo""#
+        );
+
+        // Nothing at all must not collapse into a bare, invisible argument.
+        assert_eq!(
+            manual_trust_command(""),
+            r#"git config --global --add safe.directory """#
+        );
+
+        // The everyday Windows path here: Git would quote it, and the quotes
+        // would then be part of the value on `cmd.exe`. Nothing outside ASCII
+        // is syntax in any shell, so it stays bare.
+        assert_eq!(
+            manual_trust_command("D:/工作区/仓库"),
+            "git config --global --add safe.directory D:/工作区/仓库"
+        );
+
+        // The non-ASCII allowance is for letters. An ideographic space is a
+        // space: bare, the shell would split the argument on it and grant a
+        // path that stops short. A no-break space is worse — it is invisible.
+        assert_eq!(
+            manual_trust_command("D:/工作\u{3000}区/仓库"),
+            "git config --global --add safe.directory \"D:/工作\u{3000}区/仓库\""
+        );
+        assert_eq!(
+            manual_trust_command("/srv/a\u{00a0}b/repo"),
+            "git config --global --add safe.directory \"/srv/a\u{00a0}b/repo\""
+        );
+        // A Unicode control character cannot be shown at all, so it takes the
+        // strictest form we have rather than riding along inside double quotes.
+        assert_eq!(
+            manual_trust_command("/srv/a\u{0085}b/repo"),
+            "git config --global --add safe.directory '/srv/a\u{0085}b/repo'"
+        );
+    }
+
+    /// "does not exist" on its own is Git talking about an object, a ref or a
+    /// pathspec just as often as about a repository. Matching it turns a
+    /// perfectly present repository into an offer to initialize one.
+    #[test]
+    fn reads_only_repository_level_prose_as_a_missing_repository() {
+        assert!(is_missing_repository_message(
+            "fatal: not a git repository (or any of the parent directories): .git"
+        ));
+        assert!(is_missing_repository_message(
+            "could not find repository at '/srv/shared/repo'"
+        ));
+        assert!(is_missing_repository_message(
+            "fatal: repository does not exist"
+        ));
+
+        assert!(!is_missing_repository_message(
+            "fatal: path 'src/main.rs' does not exist in 'HEAD'"
+        ));
+        assert!(!is_missing_repository_message(
+            "fatal: Not a valid object name: 'refs/heads/main' does not exist"
+        ));
+        assert!(!is_missing_repository_message(
+            "error: object file .git/objects/ab/cdef is empty"
+        ));
+    }
+
+    #[test]
+    fn classifies_every_shape_a_toplevel_probe_can_return() {
+        let trusted = classify_toplevel_probe("/srv/shared/repo", Ok("/srv/shared/repo\n".into()))
+            .expect("trust report");
+        assert_eq!(trusted.state, GitTrustState::Trusted);
+        assert_eq!(trusted.repository_path.as_deref(), Some("/srv/shared/repo"));
+
+        // An exit-zero that names no repository did not answer. Calling it
+        // "trusted" manufactures a pass out of a broken transport or a wrapper
+        // that swallowed the output; the remote probe already refuses to.
+        assert!(matches!(
+            classify_toplevel_probe("/srv/shared/repo", Ok("   \n".into())),
+            Err(GitError::CommandFailed(_))
+        ));
+
+        let rejected = classify_toplevel_probe(
+            "C:/work/repo",
+            Err(GitError::CommandFailed(CLI_REJECTION.to_string())),
+        )
+        .expect("trust report");
+        assert_eq!(rejected.state, GitTrustState::TrustRequired);
+        assert_eq!(rejected.repository_path.as_deref(), Some("C:/work/repo"));
+        assert_eq!(
+            rejected.manual_command.as_deref(),
+            Some("git config --global --add safe.directory C:/work/repo")
+        );
+
+        let absent = classify_toplevel_probe(
+            "/srv/shared/nowhere",
+            Err(GitError::CommandFailed(
+                "fatal: not a git repository (or any of the parent directories): .git".into(),
+            )),
+        )
+        .expect("trust report");
+        assert_eq!(absent.state, GitTrustState::NotARepository);
+
+        // Anything else is a probe that failed, not a verdict about the
+        // repository — it must stay an error rather than become "no repository
+        // here" and offer an initialization that cannot fix it.
+        assert!(matches!(
+            classify_toplevel_probe(
+                "/srv/shared/repo",
+                Err(GitError::CommandFailed(
+                    "error: object file .git/objects/ab/cdef is empty".into()
+                ))
+            ),
+            Err(GitError::CommandFailed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn reports_a_normal_repository_as_trusted() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        git2::Repository::init(temp.path()).expect("repository");
+
+        let report = inspect_repository_trust(&temp.path().to_string_lossy())
+            .await
+            .expect("trust report");
+        assert_eq!(report.state, GitTrustState::Trusted);
+        assert!(report.repository_path.is_some());
+        assert!(report.manual_command.is_none());
+    }
+
+    #[tokio::test]
+    async fn reports_a_plain_directory_as_not_a_repository() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let report = inspect_repository_trust(&temp.path().to_string_lossy())
+            .await
+            .expect("trust report");
+        assert_eq!(report.state, GitTrustState::NotARepository);
+    }
+
+    /// Drives the real Git ownership gate: `GIT_TEST_ASSUME_DIFFERENT_OWNER`
+    /// makes Git reject the repository exactly as it does for a foreign owner,
+    /// and `GIT_CONFIG_GLOBAL` keeps the granted exception inside the test.
+    #[tokio::test]
+    async fn grants_and_verifies_trust_against_the_real_ownership_gate() {
+        let repository = tempfile::tempdir().expect("repository tempdir");
+        let config_home = tempfile::tempdir().expect("config tempdir");
+        let global_config = config_home.path().join("gitconfig");
+        let global_config = global_config.to_string_lossy().to_string();
+        git2::Repository::init(repository.path()).expect("repository");
+        let path = repository.path().to_string_lossy().to_string();
+        let env = [
+            ("GIT_TEST_ASSUME_DIFFERENT_OWNER", "1"),
+            ("GIT_CONFIG_GLOBAL", global_config.as_str()),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+        ];
+
+        let report = inspect_repository_trust_with_env(&path, &env)
+            .await
+            .expect("trust report");
+        if report.state != GitTrustState::TrustRequired {
+            eprintln!(
+                "skipping: installed Git does not honor GIT_TEST_ASSUME_DIFFERENT_OWNER (state={:?})",
+                report.state
+            );
+            return;
+        }
+        assert!(report.manual_command.is_some());
+
+        let outcome = trust_repository_with_env(&path, &env)
+            .await
+            .expect("trust outcome");
+        assert_eq!(outcome.state, GitTrustState::Trusted);
+        assert!(!outcome.already_trusted);
+        assert_eq!(outcome.added_entries.len(), 1);
+        assert!(outcome.manual_command.is_none());
+
+        // The exception is written to the throwaway global config only.
+        let written = std::fs::read_to_string(&global_config).expect("global config");
+        assert!(written.contains("[safe]"));
+        assert!(written.contains(&outcome.added_entries[0]));
+
+        let repeated = trust_repository_with_env(&path, &env)
+            .await
+            .expect("repeat trust outcome");
+        assert!(repeated.already_trusted);
+        assert!(repeated.added_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn trusting_an_already_trusted_repository_changes_nothing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        git2::Repository::init(temp.path()).expect("repository");
+
+        let outcome = trust_repository(&temp.path().to_string_lossy())
+            .await
+            .expect("trust outcome");
+        assert_eq!(outcome.state, GitTrustState::Trusted);
+        assert!(outcome.already_trusted);
+        assert!(outcome.added_entries.is_empty());
+    }
+}

--- a/src/crates/services/services-integrations/src/git/utils.rs
+++ b/src/crates/services/services-integrations/src/git/utils.rs
@@ -1,9 +1,10 @@
-pub use super::{
-    build_git_changed_files_args, build_git_diff_args, parse_branch_line, parse_git_log_line,
-};
 /**
  * Git utility functions
  */
+use super::trust;
+pub use super::{
+    build_git_changed_files_args, build_git_diff_args, parse_branch_line, parse_git_log_line,
+};
 use super::{GitCommandOutput, GitError, GitFileStatus};
 use bitfun_services_core::process_manager;
 use git2::{Repository, Status, StatusOptions};
@@ -34,9 +35,30 @@ where
     Ok(bytes)
 }
 
+/// Opens a repository, keeping an ownership rejection distinguishable from a
+/// missing repository.
+pub fn open_repository<P: AsRef<Path>>(path: P) -> Result<Repository, GitError> {
+    let path = path.as_ref();
+    Repository::open(path).map_err(|error| trust::classify_repository_open_error(path, &error))
+}
+
+/// Discovers the repository containing `path`, keeping an ownership rejection
+/// distinguishable from a missing repository.
+pub fn discover_repository<P: AsRef<Path>>(path: P) -> Result<Repository, GitError> {
+    let path = path.as_ref();
+    Repository::discover(path).map_err(|error| trust::classify_repository_open_error(path, &error))
+}
+
 /// Returns whether the given path is a Git repository.
+///
+/// A repository whose owner differs from the current user still is one: Git
+/// only refuses to operate on it. Reporting `false` there would hide the real
+/// reason behind "not a repository" and strip every recovery affordance.
 pub fn is_git_repository<P: AsRef<Path>>(path: P) -> bool {
-    Repository::open(path).is_ok()
+    match open_repository(path) {
+        Ok(_) => true,
+        Err(error) => error.untrusted_repository_path().is_some(),
+    }
 }
 
 /// Returns the repository root directory.
@@ -51,13 +73,18 @@ pub fn get_repository_root<P: AsRef<Path>>(path: P) -> Result<String, GitError> 
         .ancestors()
         .filter(|ancestor| ancestor.join(".git").exists())
     {
-        if Repository::open(root).is_ok() {
-            return Ok(root.to_string_lossy().to_string());
+        // An ownership rejection still identifies a real repository root; the
+        // operation that needs it will fail with the actionable trust error.
+        match open_repository(root) {
+            Ok(_) => return Ok(root.to_string_lossy().to_string()),
+            Err(error) if error.untrusted_repository_path().is_some() => {
+                return Ok(root.to_string_lossy().to_string())
+            }
+            Err(_) => {}
         }
     }
 
-    let repo =
-        Repository::discover(requested).map_err(|e| GitError::RepositoryNotFound(e.to_string()))?;
+    let repo = discover_repository(requested)?;
 
     let workdir = repo
         .workdir()
@@ -254,8 +281,12 @@ pub async fn execute_git_command_raw(
     repo_path: &str,
     args: &[&str],
 ) -> Result<GitCommandOutput, GitError> {
+    // Ownership-trust classification matches Git's English diagnostics, so
+    // every in-product Git call pins the locale instead of inheriting the
+    // user's (possibly localized) one.
     let output = process_manager::create_tokio_command("git")
         .current_dir(repo_path)
+        .env("LC_ALL", "C")
         .args(args)
         .output()
         .await
@@ -284,7 +315,7 @@ pub async fn execute_git_command(repo_path: &str, args: &[&str]) -> Result<Strin
         } else {
             result.stderr
         };
-        Err(GitError::CommandFailed(error))
+        Err(trust::classify_command_failure(repo_path, error))
     }
 }
 
@@ -295,9 +326,25 @@ pub async fn execute_git_readonly_command(
     repo_path: &str,
     args: &[&str],
 ) -> Result<String, GitError> {
+    execute_git_hardened_command_with_env(repo_path, args, &[]).await
+}
+
+/// Runs a Git command under the hardened, non-interactive environment every
+/// in-product probe shares: no optional locks, no terminal prompts, no lazy
+/// fetches, and English diagnostics (`LC_ALL=C`) so [`trust`] can classify the
+/// output regardless of the user's locale. Despite the read-only callers, the
+/// environment itself makes no such promise: the trust module deliberately
+/// reuses it for the confirmed `safe.directory` config write, which needs the
+/// same prompt-free, bounded execution.
+pub(crate) async fn execute_git_hardened_command_with_env(
+    repo_path: &str,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> Result<String, GitError> {
     let mut command = process_manager::create_tokio_command("git");
     command
         .current_dir(repo_path)
+        .env("LC_ALL", "C")
         .env("GIT_OPTIONAL_LOCKS", "0")
         .env("GIT_NO_LAZY_FETCH", "1")
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -308,6 +355,9 @@ pub async fn execute_git_readonly_command(
         .kill_on_drop(true)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    for (key, value) in env {
+        command.env(key, value);
+    }
     let mut child = command.spawn().map_err(|error| {
         GitError::CommandFailed(format!("Failed to execute Git inspection: {error}"))
     })?;
@@ -350,11 +400,10 @@ pub async fn execute_git_readonly_command(
     } else {
         let stderr = String::from_utf8_lossy(&stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&stdout).trim().to_string();
-        Err(GitError::CommandFailed(if stderr.is_empty() {
-            stdout
-        } else {
-            stderr
-        }))
+        Err(trust::classify_command_failure(
+            repo_path,
+            if stderr.is_empty() { stdout } else { stderr },
+        ))
     }
 }
 
@@ -363,8 +412,10 @@ pub fn execute_git_command_sync_raw(
     repo_path: &str,
     args: &[&str],
 ) -> Result<GitCommandOutput, GitError> {
+    // English diagnostics, see execute_git_command_raw.
     let output = process_manager::create_command("git")
         .current_dir(repo_path)
+        .env("LC_ALL", "C")
         .args(args)
         .output()
         .map_err(|e| GitError::CommandFailed(format!("Failed to execute git command: {}", e)))?;
@@ -393,6 +444,8 @@ pub fn execute_git_command_sync_with_timeout(
 
     let mut child = process_manager::create_command("git")
         .current_dir(repo_path)
+        // English diagnostics, see execute_git_command_raw.
+        .env("LC_ALL", "C")
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -432,11 +485,10 @@ pub fn execute_git_command_sync_with_timeout(
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Err(GitError::CommandFailed(if stderr.is_empty() {
-        stdout
-    } else {
-        stderr
-    }))
+    Err(trust::classify_command_failure(
+        repo_path,
+        if stderr.is_empty() { stdout } else { stderr },
+    ))
 }
 
 /// Executes a Git command synchronously.
@@ -451,7 +503,7 @@ pub fn execute_git_command_sync(repo_path: &str, args: &[&str]) -> Result<String
         } else {
             result.stderr
         };
-        Err(GitError::CommandFailed(error))
+        Err(trust::classify_command_failure(repo_path, error))
     }
 }
 

--- a/src/crates/services/services-integrations/src/remote_ssh/remote_git.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/remote_git.rs
@@ -18,14 +18,19 @@ pub fn shell_quote_posix(value: &str) -> String {
     }
 }
 
-/// Builds a `git -C <repository_path> --no-pager <args...>` command line for
-/// execution through an SSH channel.
+/// Builds a `LC_ALL=C git -C <repository_path> --no-pager <args...>` command
+/// line for execution through an SSH channel.
+///
+/// The locale pin keeps diagnostics in English: ownership-trust
+/// classification matches Git's wording, and the remote user's locale is
+/// outside the host's control.
 pub fn build_remote_git_command<I, S>(repository_path: &str, args: I) -> String
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
     let mut parts = vec![
+        "LC_ALL=C".to_string(),
         "git".to_string(),
         "-C".to_string(),
         shell_quote_posix(repository_path),
@@ -56,7 +61,7 @@ mod tests {
     fn builds_git_command_with_no_pager() {
         assert_eq!(
             build_remote_git_command("/srv/my repo", ["remote", "-v"]),
-            "git -C '/srv/my repo' --no-pager remote -v"
+            "LC_ALL=C git -C '/srv/my repo' --no-pager remote -v"
         );
     }
 }

--- a/src/web-ui/scripts/gen-api-barrel.mjs
+++ b/src/web-ui/scripts/gen-api-barrel.mjs
@@ -36,6 +36,7 @@ const requiredTypes = [
   'ForkSessionResponse',
   'GitBranch',
   'GitRepositoryPathRequest',
+  'GitTrustReport',
   'ListSessionsResponse',
   'PermissionGrant',
   'PermissionReply',

--- a/src/web-ui/src/app/scenes/git/GitScene.tsx
+++ b/src/web-ui/src/app/scenes/git/GitScene.tsx
@@ -5,13 +5,14 @@
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { GitBranch, Plus, RefreshCw } from 'lucide-react';
+import { GitBranch, Plus, RefreshCw, ShieldAlert } from 'lucide-react';
 import { useGitSceneStore } from './gitSceneStore';
 import { WorkingCopyView, BranchesView, GraphView } from './views';
 import { useGitState } from '@/tools/git/hooks';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { IconButton, CubeLoading } from '@/component-library';
 import { globalEventBus } from '@/infrastructure/event-bus';
+import { requestGitRepositoryTrust } from '@/shared/services/gitTrustService';
 import './GitScene.scss';
 
 interface GitSceneProps {
@@ -33,6 +34,7 @@ const GitScene: React.FC<GitSceneProps> = ({
 
   const {
     isRepository,
+    repositoryTrustRequired,
     isLoading: statusLoading,
     refresh,
   } = useGitState({
@@ -41,6 +43,8 @@ const GitScene: React.FC<GitSceneProps> = ({
     refreshOnMount: true,
     layers: ['basic', 'status'],
   });
+
+  const [isTrusting, setIsTrusting] = useState(false);
 
   const repoLoading = statusLoading && !isRepository;
   const handleRefresh = useCallback(
@@ -72,6 +76,21 @@ const GitScene: React.FC<GitSceneProps> = ({
     globalEventBus.emit('fill-chat-input', { content: t('init.chatPrompt') });
   }, [t]);
 
+  // The service owns the confirmation, the grant, and every failure
+  // notification; a granted decision only needs the repository state rebuilt.
+  const handleTrustRepository = useCallback(async () => {
+    if (!workspacePath || isTrusting) return;
+    setIsTrusting(true);
+    try {
+      const trusted = await requestGitRepositoryTrust(workspacePath, { userInitiated: true });
+      if (trusted) {
+        await refresh({ force: true, layers: ['basic', 'status'], reason: 'manual' });
+      }
+    } finally {
+      setIsTrusting(false);
+    }
+  }, [workspacePath, isTrusting, refresh]);
+
   const renderView = useCallback(() => {
     switch (activeView) {
       case 'branches':
@@ -86,6 +105,33 @@ const GitScene: React.FC<GitSceneProps> = ({
 
   if (!isActive) {
     return <div className="bitfun-git-scene" aria-hidden="true" data-bf-scene="git" data-bf-part="root" data-bf-view="hidden" />;
+  }
+
+  // Ownership trust outranks `isRepository`. A repository Git refuses on
+  // ownership grounds still *is* one, so the probe reports it as such; gating
+  // this view on `!isRepository` made it unreachable exactly where it matters.
+  if (!repoLoading && repositoryTrustRequired) {
+    return (
+      <div className="bitfun-git-scene bitfun-git-scene--not-repository" data-bf-scene="git" data-bf-part="root" data-bf-view="trust-required">
+        <div className="bitfun-git-scene__content" data-bf-scene="git" data-bf-part="content">
+          <div className="bitfun-git-scene__init-container" data-bf-scene="git" data-bf-part="empty">
+            <div className="bitfun-git-scene__init-card">
+              <div className="bitfun-git-scene__init-icon">
+                <ShieldAlert size={24} />
+              </div>
+              <div className="bitfun-git-scene__init-text">
+                <h3>{t('trust.title')}</h3>
+                <p>{t('trust.required', { path: workspacePath })}</p>
+              </div>
+              <button type="button" className="bitfun-git-scene__init-button" onClick={handleTrustRepository} disabled={isTrusting}>
+                <ShieldAlert size={14} />
+                <span>{t('trust.confirm')}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   if (!repoLoading && !isRepository) {

--- a/src/web-ui/src/app/scenes/git/appearance.ts
+++ b/src/web-ui/src/app/scenes/git/appearance.ts
@@ -3,5 +3,5 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance/ty
 export const gitAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'git',
   parts: [{ id: 'root' }, { id: 'content' }, { id: 'empty' }, { id: 'loading' }],
-  facets: [{ id: 'view', attribute: 'data-bf-view', values: ['hidden', 'repository', 'not-repository', 'loading'] }],
+  facets: [{ id: 'view', attribute: 'data-bf-view', values: ['hidden', 'repository', 'not-repository', 'trust-required', 'loading'] }],
 };

--- a/src/web-ui/src/features/dispatch/types.ts
+++ b/src/web-ui/src/features/dispatch/types.ts
@@ -67,6 +67,12 @@ export interface DispatchWorkspaceProbe {
   exists: boolean;
   isDirectory: boolean;
   isGitRepository: boolean;
+  /**
+   * Git found the repository but refuses to read it until the target host's
+   * user trusts the path. Only then is `branch`/`dirty` absence a permission
+   * problem rather than a plain unborn branch or clean tree.
+   */
+  trustRequired?: boolean;
   branch?: string;
   dirty?: boolean;
   ahead?: number;

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -166,7 +166,7 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const trimmedPath = repositoryPath.trim();
   const label = workspaceLabel.trim();
 
-  const { currentBranch, isRepository, refreshBasic } = useGitState({
+  const { currentBranch, isRepository, repositoryTrustRequired, refreshBasic } = useGitState({
     repositoryPath: trimmedPath,
     layers: ['basic'],
     isActive: !deferPassiveGitRefresh,
@@ -198,7 +198,11 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   // Dispatch delivers work as a Git worktree of the controller's repository, so
   // it is only meaningful where a worktree itself is — the same condition the
   // isolation toggle uses, evaluated from the same Git probe.
-  const isGitWorkspace = isRepository || isWorktree || worktreeEnabled;
+  // A repository Git refuses to read for ownership reasons is still a
+  // repository: `isRepository` only turns true after a status call the
+  // ownership gate blocks, so leaving it out would hide the Git controls on
+  // exactly the workspace whose problem the user has to act on.
+  const isGitWorkspace = isRepository || repositoryTrustRequired || isWorktree || worktreeEnabled;
   const showWorktreeToggle = !!worktreeControl && isGitWorkspace;
   const showDispatchPicker = !!dispatchControl && isGitWorkspace;
   const showRightActions =
@@ -261,8 +265,13 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
       dispatchBranch
         || (isRepository && currentBranch?.trim()
         ? currentBranch.trim()
+        // "Not a Git repository" is the wrong answer for a repository Git
+        // refused to read: the branch is unknown because the directory is owned
+        // by someone else, and that is a state the user can clear.
+        : repositoryTrustRequired
+        ? t('workspaceStrip.branchTooltipUntrusted')
         : t('workspaceStrip.branchTooltipUnavailable')),
-    [currentBranch, dispatchBranch, isRepository, t],
+    [currentBranch, dispatchBranch, isRepository, repositoryTrustRequired, t],
   );
 
   if (!label && !showRightActions) {

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
@@ -53,9 +53,12 @@ describe('ChatInputWorkspaceStrip layout styles', () => {
     );
     expect(component).toContain('<DispatchTargetPicker');
     // One Git probe decides both controls, so they can never disagree about
-    // whether the workspace is a repository.
+    // whether the workspace is a repository. A repository Git refuses to read
+    // for ownership reasons counts: `isRepository` only turns true after a
+    // status call that rejection blocks, and hiding the controls there would
+    // hide the very state the user has to act on.
     expect(component).toContain(
-      'const isGitWorkspace = isRepository || isWorktree || worktreeEnabled;',
+      'const isGitWorkspace = isRepository || repositoryTrustRequired || isWorktree || worktreeEnabled;',
     );
     expect(component).toContain('const showWorktreeToggle = !!worktreeControl && isGitWorkspace;');
     expect(component).toContain('const showDispatchPicker = !!dispatchControl && isGitWorkspace;');

--- a/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.test.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.test.ts
@@ -6,6 +6,7 @@ import {
   resolveSlashCommandReviewTarget,
 } from './targetResolver';
 import { classifyReviewTargetFromFiles } from '@/shared/services/reviewTargetClassifier';
+import { TauriCommandError } from '@/infrastructure/api/errors/TauriCommandError';
 
 const mockGitGetStatus = vi.fn();
 const mockGitGetChangedFiles = vi.fn();
@@ -574,5 +575,31 @@ describe('Deep Review target resolver', () => {
     expect(result.target.files.map((file) => file.normalizedPath)).toContain(
       'src/crates/assembly/core/src/agentic/auth.rs',
     );
+  });
+
+  it('lets an ownership rejection out instead of degrading it to unknown evidence', async () => {
+    const untrusted = new TauriCommandError('Command failed', {
+      command: 'git_get_status',
+      originalError: 'git_repository_untrusted: /workspace',
+    });
+    mockGitGetStatus.mockRejectedValue(untrusted);
+
+    await expect(
+      resolveSlashCommandReviewTarget('review the workspace', '/workspace'),
+    ).rejects.toBe(untrusted);
+
+    const target = classifyReviewTargetFromFiles(['src/lib.rs'], 'session_files');
+    await expect(
+      resolveCurrentFileReviewSnapshot('/workspace', target),
+    ).rejects.toBe(untrusted);
+  });
+
+  it('still degrades an ordinary Git failure into unknown evidence', async () => {
+    mockGitGetStatus.mockRejectedValue(new Error('fatal: not a git repository'));
+
+    const target = classifyReviewTargetFromFiles(['src/lib.rs'], 'session_files');
+    const snapshot = await resolveCurrentFileReviewSnapshot('/workspace', target);
+
+    expect(snapshot.targetEvidence.limitations).toContain('file_scope_target_evidence_failed');
   });
 });

--- a/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.ts
@@ -1,4 +1,5 @@
 import { gitAPI, workspaceAPI } from '@/infrastructure/api';
+import { isGitRepositoryUntrustedError } from '@/infrastructure/api/errors/TauriCommandError';
 import type {
   GitChangedFile,
   GitDiffParams,
@@ -39,6 +40,20 @@ export interface ResolvedDeepReviewTarget {
   targetEvidence: ReviewTargetEvidence;
 }
 
+/**
+ * Lets an ownership rejection out of an evidence-gathering catch.
+ *
+ * Every other Git failure here degrades into "evidence unavailable", which is
+ * the right answer for a repository we genuinely cannot read. An untrusted
+ * repository is different: it is readable the moment the user says so, and
+ * collapsing it into "unknown" would hide both the reason and the remedy.
+ */
+function rethrowIfRepositoryUntrusted(error: unknown): void {
+  if (isGitRepositoryUntrustedError(error)) {
+    throw error;
+  }
+}
+
 async function resolveRevision(
   workspacePath: string,
   revision: string,
@@ -46,6 +61,7 @@ async function resolveRevision(
   try {
     return await gitAPI.resolveRevision(workspacePath, revision);
   } catch (error) {
+    rethrowIfRepositoryUntrusted(error);
     log.warn('Failed to resolve Git revision for Review target evidence', {
       workspacePath,
       revision,
@@ -62,6 +78,7 @@ async function resolveDiff(
   try {
     return await gitAPI.getDiff(workspacePath, { ...params, reviewSafe: true });
   } catch (error) {
+    rethrowIfRepositoryUntrusted(error);
     log.warn('Failed to resolve Git diff for Review target evidence', {
       workspacePath,
       params,
@@ -511,6 +528,7 @@ export async function resolveCurrentFileReviewSnapshot(
       targetEvidence,
     };
   } catch (error) {
+    rethrowIfRepositoryUntrusted(error);
     log.warn('Failed to resolve file-scoped Review snapshot', {
       workspacePath,
       targetFiles,
@@ -684,6 +702,7 @@ export async function resolveSlashCommandReviewTarget(
         status,
       );
     } catch (error) {
+      rethrowIfRepositoryUntrusted(error);
       log.warn('Failed to resolve explicit Review file scope', {
         workspacePath,
         explicitFilePaths,
@@ -754,6 +773,7 @@ export async function resolveSlashCommandReviewTarget(
           resolveDiff(workspacePath, immutableTarget),
           resolveRevision(workspacePath, 'HEAD'),
           gitAPI.getStatus(workspacePath, 'deep_review_git_range_binding').catch((error) => {
+            rethrowIfRepositoryUntrusted(error);
             log.warn('Failed to resolve workspace binding for Git range Review', {
               workspacePath,
               error,
@@ -787,6 +807,7 @@ export async function resolveSlashCommandReviewTarget(
         }),
       };
     } catch (error) {
+      rethrowIfRepositoryUntrusted(error);
       log.warn('Failed to resolve Git target for Deep Review target', {
         workspacePath,
         gitTarget,
@@ -835,6 +856,7 @@ export async function resolveSlashCommandReviewTarget(
         targetEvidence: snapshot.targetEvidence,
       };
     } catch (error) {
+      rethrowIfRepositoryUntrusted(error);
       log.warn('Failed to resolve workspace diff for Deep Review target', {
         workspacePath,
         error,

--- a/src/web-ui/src/flow_chat/services/ReviewService.test.ts
+++ b/src/web-ui/src/flow_chat/services/ReviewService.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TauriCommandError } from '@/infrastructure/api/errors/TauriCommandError';
+import { resetGitTrustDecisions } from '@/shared/services/gitTrustService';
 import type { ReviewTeamRunManifest } from '@/shared/services/reviewTeamService';
 import {
   launchPreparedReviewSession,
@@ -21,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   closeBtwSessionInAuxPane: vi.fn(),
   deleteSession: vi.fn(),
   discardLocalSession: vi.fn(),
+  trustRepository: vi.fn(),
+  confirmWarning: vi.fn(),
   sessions: new Map<string, unknown>(),
 }));
 
@@ -28,6 +32,18 @@ vi.mock('@/infrastructure/api', () => ({
   agentAPI: {
     deleteSession: (...args: unknown[]) => mocks.deleteSession(...args),
   },
+  gitAPI: {
+    trustRepository: (...args: unknown[]) => mocks.trustRepository(...args),
+  },
+}));
+
+// Review drives the real trust recovery; only its user-facing edges are stubbed.
+vi.mock('@/component-library/components/ConfirmDialog/confirmService', () => ({
+  confirmWarning: (...args: unknown[]) => mocks.confirmWarning(...args),
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: { warning: vi.fn(), success: vi.fn() },
 }));
 
 vi.mock('./DeepReviewService', () => ({
@@ -131,6 +147,7 @@ function targetEvidence() {
 describe('ReviewService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetGitTrustDecisions();
     mocks.sessions.clear();
     mocks.createBtwChildSession.mockResolvedValue({
       childSessionId: 'review-child',
@@ -376,6 +393,48 @@ describe('ReviewService', () => {
       requiresConsent: false,
       runManifest: manifest,
     });
+  });
+
+  it('prepares Review after the user grants ownership trust', async () => {
+    const untrusted = new TauriCommandError('Command failed', {
+      command: 'git_get_status',
+      originalError: 'git_repository_untrusted: D:/workspace/project',
+    });
+    mocks.resolveCurrentFileReviewSnapshot.mockRejectedValueOnce(untrusted);
+    mocks.confirmWarning.mockResolvedValue(true);
+    mocks.trustRepository.mockResolvedValue({
+      state: 'trusted',
+      repositoryPath: 'D:/workspace/project',
+      alreadyTrusted: false,
+      addedEntries: ['D:/workspace/project'],
+      detail: null,
+      manualCommand: null,
+    });
+
+    const prepared = await prepareReviewLaunchFromSessionFiles(['src/small.ts'], {
+      workspacePath: 'D:/workspace/project',
+    });
+
+    expect(prepared.mode).toBe('standard');
+    expect(mocks.trustRepository).toHaveBeenCalledWith('D:/workspace/project');
+    expect(mocks.resolveCurrentFileReviewSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('names the ownership wall when the user does not grant trust', async () => {
+    mocks.resolveCurrentFileReviewSnapshot.mockRejectedValue(
+      new TauriCommandError('Command failed', {
+        command: 'git_get_status',
+        originalError: 'git_repository_untrusted: D:/workspace/project',
+      }),
+    );
+    mocks.confirmWarning.mockResolvedValue(false);
+
+    await expect(prepareReviewLaunchFromSessionFiles(['src/small.ts'], {
+      workspacePath: 'D:/workspace/project',
+    })).rejects.toMatchObject({
+      launchErrorMessageKey: 'deepReviewActionBar.launchError.repositoryUntrusted',
+    });
+    expect(mocks.trustRepository).not.toHaveBeenCalled();
   });
 
   it('blocks remote Git ranges before spending reviewer capacity', async () => {

--- a/src/web-ui/src/flow_chat/services/ReviewService.ts
+++ b/src/web-ui/src/flow_chat/services/ReviewService.ts
@@ -1,8 +1,13 @@
+import {
+  gitRepositoryUntrustedPath,
+  isGitRepositoryUntrustedError,
+} from '@/infrastructure/api/errors/TauriCommandError';
 import type {
   ReviewPlatformPullRequestReviewTarget,
   ReviewPlatformRemote,
   ReviewPlatformRepositoryRef,
 } from '@/infrastructure/api/service-api/ReviewPlatformAPI';
+import { withGitRepositoryTrustRecovery } from '@/shared/services/gitTrustService';
 import {
   buildAdaptiveStandardReviewManifest,
   buildPullRequestReviewTargetEvidence,
@@ -44,6 +49,38 @@ function reviewTargetError(
     launchErrorMessageKey: messageKey,
     originalMessage: message,
   });
+}
+
+/**
+ * Prepares a Review target, recovering once from a repository Git refuses to
+ * read because it is owned by another user.
+ *
+ * Preparation is read-only, so replaying it after the user grants trust is
+ * safe. A repository that stays untrusted surfaces as its own launch error
+ * rather than as a generic "target could not be prepared": the user needs to
+ * know a decision is waiting, not that Review is broken.
+ */
+async function prepareWithRepositoryTrust(
+  prepare: () => Promise<PreparedReviewLaunch>,
+): Promise<PreparedReviewLaunch> {
+  try {
+    // Launching Review is one deliberate action, not a call inside a refresh
+    // burst, so it is always worth a prompt — including right after a decline.
+    return await withGitRepositoryTrustRecovery(prepare, { userInitiated: true });
+  } catch (error) {
+    if (!isGitRepositoryUntrustedError(error)) {
+      throw error;
+    }
+    const repositoryPath = gitRepositoryUntrustedPath(error) ?? 'this repository';
+    log.warn('Review target preparation stopped on an untrusted repository', {
+      repositoryPath,
+    });
+    throw reviewTargetError(
+      `Git will not read "${repositoryPath}" because the folder is owned by another user. ` +
+        'Trust the folder when prompted, or add it to safe.directory, then start Review again.',
+      'deepReviewActionBar.launchError.repositoryUntrusted',
+    );
+  }
 }
 
 interface PreparedReviewBase {
@@ -381,23 +418,25 @@ export async function prepareReviewLaunchFromSessionFiles(
   filePaths: string[],
   options: PrepareReviewLaunchOptions = {},
 ): Promise<PreparedReviewLaunch> {
-  const target = classifyReviewTargetFromFiles(filePaths, 'session_files');
-  const snapshot = await resolveCurrentFileReviewSnapshot(
-    options.workspacePath,
-    target,
-    options.remoteConnectionId,
-  );
-  const resolvedTarget = snapshot.target;
-  const changeStats = options.changeStats ?? snapshot.changeStats;
-  const targetEvidence = snapshot.targetEvidence;
-  return prepareFromResolvedTarget({
-    target: resolvedTarget,
-    changeStats,
-    targetEvidence,
-    requestedFiles: includedTargetFiles(resolvedTarget),
-    workspacePath: options.workspacePath,
-    extraContext: options.extraContext,
-    intent: options.intent === 'strict' ? 'strict' : 'review',
+  return prepareWithRepositoryTrust(async () => {
+    const target = classifyReviewTargetFromFiles(filePaths, 'session_files');
+    const snapshot = await resolveCurrentFileReviewSnapshot(
+      options.workspacePath,
+      target,
+      options.remoteConnectionId,
+    );
+    const resolvedTarget = snapshot.target;
+    const changeStats = options.changeStats ?? snapshot.changeStats;
+    const targetEvidence = snapshot.targetEvidence;
+    return prepareFromResolvedTarget({
+      target: resolvedTarget,
+      changeStats,
+      targetEvidence,
+      requestedFiles: includedTargetFiles(resolvedTarget),
+      workspacePath: options.workspacePath,
+      extraContext: options.extraContext,
+      intent: options.intent === 'strict' ? 'strict' : 'review',
+    });
   });
 }
 
@@ -406,21 +445,23 @@ export async function prepareReviewLaunchFromSlashCommand(
   workspacePath?: string,
   remoteConnectionId?: string,
 ): Promise<PreparedReviewLaunch> {
-  const extraContext = getDeepReviewCommandFocus(commandText);
-  const { target, changeStats, targetEvidence } = await resolveSlashCommandReviewTarget(
-    extraContext,
-    workspacePath,
-    remoteConnectionId,
-  );
-  return prepareFromResolvedTarget({
-    target,
-    changeStats,
-    targetEvidence,
-    requestedFiles: includedTargetFiles(target),
-    workspacePath,
-    extraContext,
-    commandText,
-    intent: getReviewSlashCommandIntent(commandText) === 'strict' ? 'strict' : 'review',
+  return prepareWithRepositoryTrust(async () => {
+    const extraContext = getDeepReviewCommandFocus(commandText);
+    const { target, changeStats, targetEvidence } = await resolveSlashCommandReviewTarget(
+      extraContext,
+      workspacePath,
+      remoteConnectionId,
+    );
+    return prepareFromResolvedTarget({
+      target,
+      changeStats,
+      targetEvidence,
+      requestedFiles: includedTargetFiles(target),
+      workspacePath,
+      extraContext,
+      commandText,
+      intent: getReviewSlashCommandIntent(commandText) === 'strict' ? 'strict' : 'review',
+    });
   });
 }
 
@@ -469,7 +510,9 @@ export async function prepareReviewLaunchFromPullRequest(params: {
     (total, file) => total + Math.max(0, file.additions) + Math.max(0, file.deletions),
     0,
   );
-  return prepareFromResolvedTarget({
+  // The provider supplied the evidence, but the manifest build still reads the
+  // local workspace, so the same trust wall can appear here.
+  return prepareWithRepositoryTrust(() => prepareFromResolvedTarget({
     target,
     changeStats: {
       fileCount: params.reviewTarget.files.length,
@@ -480,7 +523,7 @@ export async function prepareReviewLaunchFromPullRequest(params: {
     requestedFiles: includedTargetFiles(target),
     workspacePath: params.workspacePath,
     intent: 'review',
-  });
+  }));
 }
 
 export async function launchPreparedReviewSession(params: {

--- a/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.test.ts
@@ -143,10 +143,11 @@ describe('resolveWsMethod', () => {
     // because the table is a plain object). Track B Batch 1 added config write +
     // i18n and the P0 Session/Config control plane. Atomic cloud-speech save
     // config validation, and live reasoning projection raise the count to 34.
+    // The read-only Git ownership-trust probe makes 35.
     expect(AGENT_COMMAND_SCHEMA.start_dialog_turn.method).toBe(
       'agent/submitDialogTurn'
     );
-    expect(Object.keys(AGENT_COMMAND_SCHEMA).length).toBe(34);
+    expect(Object.keys(AGENT_COMMAND_SCHEMA).length).toBe(35);
 
     // Touch the locals so noUnusedLocals does not flag them under vitest's
     // transformed build (tsc --noEmit is the real gate; this is belt-and-suspenders).

--- a/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.ts
@@ -18,6 +18,7 @@ import type {
   ForkSessionResponse,
   GitBranch,
   GitRepositoryPathRequest,
+  GitTrustReport,
   ListSessionsResponse,
   PermissionGrant,
   PermissionReply,
@@ -153,6 +154,15 @@ export const AGENT_COMMAND_SCHEMA = {
     method: 'git/getBranches',
     request: null as unknown as GitRepositoryPathRequest,
     response: null as unknown as { branches: GitBranch[] },
+  },
+  // Read-only. `git_trust_repository` is deliberately absent: granting writes
+  // the Server Host user's global Git configuration, which is not a decision a
+  // browser client gets to make. The probe is what lets this transport still
+  // name the repository and hand over the manual command.
+  git_get_repository_trust: {
+    method: 'git/getRepositoryTrust',
+    request: null as unknown as GitRepositoryPathRequest,
+    response: null as unknown as GitTrustReport,
   },
   // Config service surface. The agent-profile and
   // model-config reads reach the global config singletons the Desktop host

--- a/src/web-ui/src/infrastructure/api/errors/TauriCommandError.test.ts
+++ b/src/web-ui/src/infrastructure/api/errors/TauriCommandError.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  gitRepositoryUntrustedPath,
+  isGitRepositoryUntrustedError,
   isOutcomeUnknownError,
   isSessionInUseError,
   TauriCommandError,
@@ -58,5 +60,58 @@ describe('isOutcomeUnknownError', () => {
 
   it('does not infer unknown outcomes from human prose', () => {
     expect(isOutcomeUnknownError(new Error('The rename might have worked'))).toBe(false);
+  });
+});
+
+describe('isGitRepositoryUntrustedError', () => {
+  it('recognizes the ownership rejection through Tauri and Peer wrappers', () => {
+    expect(
+      isGitRepositoryUntrustedError(
+        new TauriCommandError('Command failed', {
+          command: 'git_get_status',
+          originalError: 'git_repository_untrusted: D:/workspace/project/BitFun',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isGitRepositoryUntrustedError({
+        message: 'Host command failed',
+        details: { originalError: 'git_repository_untrusted: /srv/repo' },
+      }),
+    ).toBe(true);
+  });
+
+  it('recognizes the JSON-RPC shape web mode receives over the WebSocket transport', () => {
+    // `webSocketResponseError` builds this: the protocol phrase is the message
+    // and the host's stable code rides in `data`.
+    const error = Object.assign(new Error('Invalid params'), {
+      code: -32602,
+      data: 'git_repository_untrusted: /srv/shared/repo',
+    });
+
+    expect(isGitRepositoryUntrustedError(error)).toBe(true);
+    expect(gitRepositoryUntrustedPath(error)).toBe('/srv/shared/repo');
+  });
+
+  it('does not classify an ordinary Git failure as an ownership rejection', () => {
+    expect(
+      isGitRepositoryUntrustedError(new Error('Failed to get status: not a git repository')),
+    ).toBe(false);
+  });
+
+  it('carries the repository path Git rejected', () => {
+    const error = new TauriCommandError('Command failed', {
+      command: 'git_get_status',
+      originalError: 'git_repository_untrusted: D:/workspace/project/BitFun',
+    });
+
+    expect(gitRepositoryUntrustedPath(error)).toBe('D:/workspace/project/BitFun');
+    expect(gitRepositoryUntrustedPath(new Error('unrelated'))).toBeUndefined();
+  });
+
+  it('reports no path when the backend sent the prefix without one', () => {
+    expect(
+      gitRepositoryUntrustedPath(new Error('git_repository_untrusted:   ')),
+    ).toBeUndefined();
   });
 });

--- a/src/web-ui/src/infrastructure/api/errors/TauriCommandError.ts
+++ b/src/web-ui/src/infrastructure/api/errors/TauriCommandError.ts
@@ -102,15 +102,22 @@ export function isTauriCommandError(error: any): error is TauriCommandError {
 
 const SESSION_IN_USE_PREFIX = 'session_in_use:';
 const OUTCOME_UNKNOWN_PREFIX = 'outcome_unknown:';
+const GIT_REPOSITORY_UNTRUSTED_PREFIX = 'git_repository_untrusted:';
 
-function hasStableErrorPrefix(error: unknown, prefix: string): boolean {
+/** Returns the payload carried after a stable error prefix, if present. */
+function stableErrorPayload(error: unknown, prefix: string): string | undefined {
   const pending: unknown[] = [error];
   const seen = new Set<object>();
 
-  for (let inspected = 0; pending.length > 0 && inspected < 12; inspected += 1) {
+  // The budget bounds a hostile or deeply nested payload. It counts only nodes
+  // that could carry the code — absent fields are never queued, so a wrapper
+  // that fills two of its five slots does not spend the budget on the other
+  // three and truncate the walk before the code is reached.
+  for (let inspected = 0; pending.length > 0 && inspected < 24; inspected += 1) {
     const current = pending.shift();
     if (typeof current === 'string') {
-      if (current.trimStart().startsWith(prefix)) return true;
+      const trimmed = current.trimStart();
+      if (trimmed.startsWith(prefix)) return trimmed.slice(prefix.length).trim();
       continue;
     }
     if (!current || typeof current !== 'object' || seen.has(current)) continue;
@@ -118,19 +125,29 @@ function hasStableErrorPrefix(error: unknown, prefix: string): boolean {
 
     const candidate = current as {
       message?: unknown;
+      data?: unknown;
       originalError?: unknown;
       context?: { originalError?: unknown };
       details?: { originalError?: unknown };
     };
-    pending.push(
+    for (const next of [
       candidate.message,
+      // Web mode reaches the host over JSON-RPC, where the code rides in the
+      // error `data` and `message` is the generic protocol phrase.
+      candidate.data,
       candidate.originalError,
       candidate.context?.originalError,
       candidate.details?.originalError,
-    );
+    ]) {
+      if (next !== undefined && next !== null) pending.push(next);
+    }
   }
 
-  return false;
+  return undefined;
+}
+
+function hasStableErrorPrefix(error: unknown, prefix: string): boolean {
+  return stableErrorPayload(error, prefix) !== undefined;
 }
 
 /** Recognizes the stable Desktop/Peer error code without parsing localized prose. */
@@ -141,4 +158,18 @@ export function isSessionInUseError(error: unknown): boolean {
 /** Identifies a mutation that must be read back before the user retries it. */
 export function isOutcomeUnknownError(error: unknown): boolean {
   return hasStableErrorPrefix(error, OUTCOME_UNKNOWN_PREFIX);
+}
+
+/**
+ * Identifies a repository Git refuses to read because it is owned by another
+ * user. The repository still exists: the user can grant ownership trust.
+ */
+export function isGitRepositoryUntrustedError(error: unknown): boolean {
+  return hasStableErrorPrefix(error, GIT_REPOSITORY_UNTRUSTED_PREFIX);
+}
+
+/** Repository path Git rejected, as reported by the backend. */
+export function gitRepositoryUntrustedPath(error: unknown): string | undefined {
+  const payload = stableErrorPayload(error, GIT_REPOSITORY_UNTRUSTED_PREFIX);
+  return payload ? payload : undefined;
 }

--- a/src/web-ui/src/infrastructure/api/service-api/GitAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GitAPI.test.ts
@@ -51,4 +51,100 @@ describe('GitAPI repository probe cache', () => {
 
     expect(invokeMock).toHaveBeenCalledTimes(1);
   });
+
+  it('drops a cached probe result once ownership trust is granted', async () => {
+    invokeMock.mockResolvedValueOnce(false);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+
+    invokeMock.mockResolvedValueOnce({
+      state: 'trusted',
+      repositoryPath: 'D:/workspace/BitFun',
+      alreadyTrusted: false,
+      addedEntries: ['D:/workspace/BitFun'],
+      detail: null,
+      manualCommand: null,
+    });
+    await gitAPI.trustRepository('D:/workspace/BitFun');
+
+    invokeMock.mockResolvedValueOnce(true);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(true);
+  });
+
+  // One folder reaches this API under several spellings — a tree node hands in
+  // `D:\workspace\BitFun`, the backend hands back `D:/workspace/BitFun`. The
+  // backend treats them as one repository, so a cache keyed on the raw string
+  // probes twice and, worse, leaves a stale entry a granted decision misses.
+  it('treats the spellings of one repository as one cache entry', async () => {
+    invokeMock.mockResolvedValueOnce(false);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+    await expect(gitAPI.isGitRepository('d:\\workspace\\bitfun\\')).resolves.toBe(false);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    invokeMock.mockResolvedValueOnce({
+      state: 'trusted',
+      repositoryPath: 'D:/workspace/BitFun',
+      alreadyTrusted: false,
+      addedEntries: ['D:/workspace/BitFun'],
+      detail: null,
+      manualCommand: null,
+    });
+    await gitAPI.trustRepository('d:\\workspace\\bitfun');
+
+    invokeMock.mockResolvedValueOnce(true);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(true);
+  });
+
+  // The user runs the manual command in a terminal, or the repository's owner
+  // fixes ownership. Nothing in this process granted anything, so the read-only
+  // probe is the only place that learns — and the stale `false` it leaves behind
+  // fails the very retry the recovery just decided was worth making.
+  it('drops a cached probe result once the read-only probe reports trust', async () => {
+    invokeMock.mockResolvedValueOnce(false);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+
+    invokeMock.mockResolvedValueOnce({
+      state: 'trusted',
+      repositoryPath: 'D:/workspace/BitFun',
+      detail: null,
+      manualCommand: null,
+    });
+    await gitAPI.getRepositoryTrust('d:\\workspace\\bitfun');
+
+    invokeMock.mockResolvedValueOnce(true);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(true);
+  });
+
+  it('keeps the cached probe result while the probe still reports the wall', async () => {
+    invokeMock.mockResolvedValueOnce(false);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+
+    invokeMock.mockResolvedValueOnce({
+      state: 'trust_required',
+      repositoryPath: 'D:/workspace/BitFun',
+      detail: 'detected dubious ownership',
+      manualCommand: "git config --global --add safe.directory 'D:/workspace/BitFun'",
+    });
+    await gitAPI.getRepositoryTrust('D:/workspace/BitFun');
+
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the cached probe result when trust was not granted', async () => {
+    invokeMock.mockResolvedValueOnce(false);
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+
+    invokeMock.mockResolvedValueOnce({
+      state: 'trust_required',
+      repositoryPath: 'D:/workspace/BitFun',
+      alreadyTrusted: false,
+      addedEntries: [],
+      detail: 'detected dubious ownership',
+      manualCommand: 'git config --global --add safe.directory "D:/workspace/BitFun"',
+    });
+    await gitAPI.trustRepository('D:/workspace/BitFun');
+
+    await expect(gitAPI.isGitRepository('D:/workspace/BitFun')).resolves.toBe(false);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/web-ui/src/infrastructure/api/service-api/GitAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/GitAPI.ts
@@ -3,6 +3,7 @@
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
 import { createLogger } from '@/shared/utils/logger';
+import { repositoryPathKey } from '@/shared/utils/pathUtils';
 import { startupTrace } from '@/shared/utils/startupTrace';
 
 const log = createLogger('GitAPI');
@@ -183,6 +184,34 @@ export interface GitWorktreeInfo {
   isPrunable: boolean;
 }
 
+/**
+ * Whether Git will operate on a repository, and why not when it refuses.
+ *
+ * `trust_required` means the repository exists but its directory is owned by
+ * another user, so Git blocks it until the path is listed in `safe.directory`.
+ */
+export type GitTrustState = 'trusted' | 'trust_required' | 'not_a_repository';
+
+export interface GitTrustReport {
+  state: GitTrustState;
+  /** Path Git reported, normalized to the shape it compares against. */
+  repositoryPath: string | null;
+  /** Git's own diagnostic, kept for support and for the manual path. */
+  detail: string | null;
+  /** Command the user can run themselves when we cannot apply the change. */
+  manualCommand: string | null;
+}
+
+export interface GitTrustOutcome {
+  state: GitTrustState;
+  repositoryPath: string | null;
+  alreadyTrusted: boolean;
+  /** `safe.directory` entries added by this call; empty when nothing changed. */
+  addedEntries: string[];
+  detail: string | null;
+  manualCommand: string | null;
+}
+
 export class GitAPI {
   private repositoryProbeCache = new Map<string, {
     value: boolean;
@@ -190,15 +219,19 @@ export class GitAPI {
   }>();
   private repositoryProbeInFlight = new Map<string, Promise<boolean>>();
 
-   
+
   async isGitRepository(repositoryPath: string): Promise<boolean> {
+    // Keyed on the canonical spelling, not the caller's: `C:/repo`, `c:\repo`
+    // and `C:/repo/` are one repository to the backend, so a shared probe and a
+    // granted decision must reach all three here too.
+    const key = repositoryPathKey(repositoryPath);
     const now = Date.now();
-    const cached = this.repositoryProbeCache.get(repositoryPath);
+    const cached = this.repositoryProbeCache.get(key);
     if (cached && cached.expiresAt > now) {
       return cached.value;
     }
 
-    const inFlight = this.repositoryProbeInFlight.get(repositoryPath);
+    const inFlight = this.repositoryProbeInFlight.get(key);
     if (inFlight) {
       return inFlight;
     }
@@ -206,7 +239,7 @@ export class GitAPI {
     const request = { repositoryPath };
     const probe = api.invoke<boolean>('git_is_repository', { request })
       .then((value) => {
-        this.repositoryProbeCache.set(repositoryPath, {
+        this.repositoryProbeCache.set(key, {
           value,
           expiresAt: Date.now() + REPOSITORY_PROBE_CACHE_TTL_MS,
         });
@@ -216,14 +249,68 @@ export class GitAPI {
         throw createTauriCommandError('git_is_repository', error, { repositoryPath });
       })
       .finally(() => {
-        this.repositoryProbeInFlight.delete(repositoryPath);
+        this.repositoryProbeInFlight.delete(key);
       });
 
-    this.repositoryProbeInFlight.set(repositoryPath, probe);
+    this.repositoryProbeInFlight.set(key, probe);
     return probe;
   }
 
-   
+  /** Reads whether Git trusts the repository's ownership. Never writes. */
+  async getRepositoryTrust(repositoryPath: string): Promise<GitTrustReport> {
+    try {
+      const report: GitTrustReport = await api.invoke('git_get_repository_trust', {
+        request: { repositoryPath },
+      });
+      // Trust can be granted outside this product — the user runs the manual
+      // command in a terminal, or the repository's owner fixes it. Whoever
+      // learns that first has to drop the `false` the probe cached while the
+      // repository was still refused, or the caller replays against it.
+      if (report.state === 'trusted') {
+        this.dropRepositoryProbe(repositoryPath, report.repositoryPath);
+      }
+      return report;
+    } catch (error) {
+      throw createTauriCommandError('git_get_repository_trust', error, { repositoryPath });
+    }
+  }
+
+  /** Forgets a cached repository probe under every spelling of its path. */
+  private dropRepositoryProbe(repositoryPath: string, reportedPath?: string | null): void {
+    this.repositoryProbeCache.delete(repositoryPathKey(repositoryPath));
+    if (reportedPath) {
+      this.repositoryProbeCache.delete(repositoryPathKey(reportedPath));
+    }
+  }
+
+  /**
+   * Grants ownership trust for a repository. Call this only after the user
+   * confirmed it: it writes a `safe.directory` exception to their global Git
+   * configuration.
+   *
+   * Consent is enforced by the frontend only: this method is reached solely
+   * from the interactive confirmation flow, and the backend carries no
+   * separate consent token. That single-location guard matches the project's
+   * existing convention for write-gated operations, so no backend mechanism
+   * is introduced here.
+   */
+  async trustRepository(repositoryPath: string): Promise<GitTrustOutcome> {
+    try {
+      const outcome = await api.invoke<GitTrustOutcome>('git_trust_repository', {
+        request: { repositoryPath },
+      });
+      // The probe cache may hold the `false` this repository returned while it
+      // was still refused; a granted decision must not wait it out.
+      if (outcome.state === 'trusted') {
+        this.dropRepositoryProbe(repositoryPath, outcome.repositoryPath);
+      }
+      return outcome;
+    } catch (error) {
+      throw createTauriCommandError('git_trust_repository', error, { repositoryPath });
+    }
+  }
+
+
   async getRepository(repositoryPath: string): Promise<GitRepository> {
     try {
       return await api.invoke('git_get_repository', { 

--- a/src/web-ui/src/infrastructure/api/service-api/WorktreeAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/WorktreeAPI.ts
@@ -57,6 +57,7 @@ export interface WorktreeProjectSummary {
 export type WorktreeErrorCode =
   | 'remote_unsupported'
   | 'not_git_repository'
+  | 'repository_untrusted'
   | 'unborn_repo'
   | 'invalid_base_ref'
   | 'worktree_not_found'
@@ -124,6 +125,7 @@ export interface WorktreeSessionBindingResult {
 const WORKTREE_ERROR_CODES = new Set<WorktreeErrorCode>([
   'remote_unsupported',
   'not_git_repository',
+  'repository_untrusted',
   'unborn_repo',
   'invalid_base_ref',
   'worktree_not_found',

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -212,6 +212,15 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     back to a controller-local or numeric rollback path. Never include catalog
     preview text in Peer request/response logs.
 
+15. **Git ownership trust is read on the peer, granted at the machine.**
+    `git_get_repository_trust` is a read-only probe and routes to the peer
+    host. `git_trust_repository` writes the peer user's global Git
+    configuration (`safe.directory`) and tells Git to run hooks from a tree
+    they do not own, so it is denied on both the desktop and CLI peer hosts.
+    Keep it out of the FE `LOCAL_ONLY` set: running it on the controller would
+    write an exception for a path that only exists on the peer. A controller
+    surfaces the probe's `manualCommand` instead.
+
 ## Related account-login guards
 
 Incomplete login (cloud vs local settings choice) must not persist a session

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -574,7 +574,8 @@
     }
   },
   "workspaceStrip": {
-    "branchTooltipUnavailable": "Not a git repository or no current branch"
+    "branchTooltipUnavailable": "Not a git repository or no current branch",
+    "branchTooltipUntrusted": "Git will not read this repository because the folder is owned by another user. Trust the folder to see the branch."
   },
   "context": {
     "title": "Context",
@@ -1188,6 +1189,7 @@
       "emptyWorkspace": "There are no workspace changes to review.",
       "emptyExplicitScope": "The requested files or directories contain no workspace changes.",
       "unresolvedTarget": "The Review target could not be prepared as bounded evidence. Open its workspace or narrow the target and try again.",
+      "repositoryUntrusted": "Git will not read this repository because the folder is owned by another user. Trust the folder when prompted, then start Review again.",
       "uncertain": "The Review request may already be running. Its session was preserved so you can inspect or retry it safely.",
       "unknown": "Review launch failed. Please retry."
     }

--- a/src/web-ui/src/locales/en-US/panels/git.json
+++ b/src/web-ui/src/locales/en-US/panels/git.json
@@ -424,5 +424,16 @@
     "discardAllChanges": "Warning: This will:\n\n1. Discard all staged changes\n2. Discard all unstaged changes\n3. Delete all untracked files\n\nThis action cannot be undone! Are you sure?",
     "resetToCommit": "Are you sure you want to reset to commit {{hash}}?\n\nThis will move the current branch pointer to this commit.",
     "deleteBranch": "Are you sure you want to delete branch \"{{branch}}\"?"
+  },
+  "trust": {
+    "title": "Trust this repository?",
+    "message": "Git will not read \"{{path}}\" because the folder is owned by another user.\n\nTrusting it adds the folder to your global safe.directory list, so Git will run its configuration and hooks from a tree you do not own. Only continue if you know where this folder came from.",
+    "confirm": "Trust folder",
+    "cancel": "Cancel",
+    "granted": "Git now trusts \"{{path}}\".",
+    "alreadyTrusted": "Git already accepts \"{{path}}\" — nothing left to grant.",
+    "unavailable": "Git ownership trust for \"{{path}}\" could not be granted from here. Grant it on the machine that owns the repository.",
+    "unavailableWithCommand": "Git ownership trust for \"{{path}}\" could not be granted from here. Run this command on the machine that holds the repository:\n\n{{command}}",
+    "required": "Git will not read \"{{path}}\" until you trust its ownership."
   }
 }

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -574,7 +574,8 @@
     }
   },
   "workspaceStrip": {
-    "branchTooltipUnavailable": "非 Git 仓库或当前无分支"
+    "branchTooltipUnavailable": "非 Git 仓库或当前无分支",
+    "branchTooltipUntrusted": "该目录属于其他用户，Git 拒绝读取此仓库。信任该目录后即可看到分支。"
   },
   "context": {
     "title": "上下文",
@@ -1188,6 +1189,7 @@
       "emptyWorkspace": "当前工作区没有可审核的变更",
       "emptyExplicitScope": "请求的文件或目录没有工作区变更",
       "unresolvedTarget": "无法将审核目标准备为有界证据，请打开对应工作区或缩小目标后重试",
+      "repositoryUntrusted": "该目录属于其他用户，Git 拒绝读取此仓库。请在提示中信任该目录后重新启动审核",
       "uncertain": "审核请求可能已经在运行。会话已保留，可安全检查或重试",
       "unknown": "审核启动失败，请重试"
     }

--- a/src/web-ui/src/locales/zh-CN/panels/git.json
+++ b/src/web-ui/src/locales/zh-CN/panels/git.json
@@ -424,5 +424,16 @@
     "discardAllChanges": "警告：此操作将会：\n\n1. 回退所有暂存区的更改\n2. 回退所有工作区的更改\n3. 删除所有未跟踪的文件\n\n此操作不可恢复！确定要继续吗？",
     "resetToCommit": "确定要重置到提交 {{hash}} 吗？\n\n这将移动当前分支指针到此提交。",
     "deleteBranch": "确定要删除分支 \"{{branch}}\" 吗？"
+  },
+  "trust": {
+    "title": "信任此仓库？",
+    "message": "Git 拒绝读取 \"{{path}}\"，因为该目录属于其他用户。\n\n信任后会把该目录加入全局 safe.directory 列表，Git 将从你并不拥有的目录中读取配置并执行钩子。请仅在确认该目录来源可靠时继续。",
+    "confirm": "信任该目录",
+    "cancel": "取消",
+    "granted": "Git 已信任 \"{{path}}\"。",
+    "alreadyTrusted": "Git 现在已经接受 \"{{path}}\"，无需再次授权。",
+    "unavailable": "无法在此处为 \"{{path}}\" 授予 Git 所有权信任，请在持有该仓库的机器上授予。",
+    "unavailableWithCommand": "无法在此处为 \"{{path}}\" 授予 Git 所有权信任。请在持有该仓库的机器上执行：\n\n{{command}}",
+    "required": "在你信任其所有权之前，Git 不会读取 \"{{path}}\"。"
   }
 }

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -574,7 +574,8 @@
     }
   },
   "workspaceStrip": {
-    "branchTooltipUnavailable": "非 Git 存放庫或目前無分支"
+    "branchTooltipUnavailable": "非 Git 存放庫或目前無分支",
+    "branchTooltipUntrusted": "該目錄屬於其他使用者，Git 拒絕讀取此存放庫。信任該目錄後即可看到分支。"
   },
   "context": {
     "title": "上下文",
@@ -1188,6 +1189,7 @@
       "emptyWorkspace": "目前工作區沒有可審核的變更",
       "emptyExplicitScope": "要求的檔案或目錄沒有工作區變更",
       "unresolvedTarget": "無法將審核目標準備為有界證據，請開啟對應工作區或縮小目標後重試",
+      "repositoryUntrusted": "該目錄屬於其他使用者，Git 拒絕讀取此儲存庫。請在提示中信任該目錄後重新啟動審核",
       "uncertain": "審核要求可能已在執行。工作階段已保留，可安全檢查或重試",
       "unknown": "審核啟動失敗，請重試"
     }

--- a/src/web-ui/src/locales/zh-TW/panels/git.json
+++ b/src/web-ui/src/locales/zh-TW/panels/git.json
@@ -424,5 +424,16 @@
     "discardAllChanges": "警告：此操作將會：\n\n1. 回退所有暫存區的更改\n2. 回退所有工作區的更改\n3. 刪除所有未跟蹤的檔案\n\n此操作不可恢復！確定要繼續嗎？",
     "resetToCommit": "確定要重設到提交 {{hash}} 嗎？\n\n這將移動目前分支指針到此提交。",
     "deleteBranch": "確定要刪除分支 \"{{branch}}\" 嗎？"
+  },
+  "trust": {
+    "title": "信任此儲存庫？",
+    "message": "Git 拒絕讀取 \"{{path}}\"，因為該目錄屬於其他使用者。\n\n信任後會把該目錄加入全域 safe.directory 清單，Git 將從你並不擁有的目錄中讀取設定並執行掛鉤。請僅在確認該目錄來源可靠時繼續。",
+    "confirm": "信任該目錄",
+    "cancel": "取消",
+    "granted": "Git 已信任 \"{{path}}\"。",
+    "alreadyTrusted": "Git 現在已經接受 \"{{path}}\"，無需再次授權。",
+    "unavailable": "無法在此處為 \"{{path}}\" 授予 Git 所有權信任，請在持有該儲存庫的機器上授予。",
+    "unavailableWithCommand": "無法在此處為 \"{{path}}\" 授予 Git 所有權信任。請在持有該儲存庫的機器上執行：\n\n{{command}}",
+    "required": "在你信任其所有權之前，Git 不會讀取 \"{{path}}\"。"
   }
 }

--- a/src/web-ui/src/shared/services/gitTrustService.test.ts
+++ b/src/web-ui/src/shared/services/gitTrustService.test.ts
@@ -1,0 +1,423 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TauriCommandError } from '@/infrastructure/api/errors/TauriCommandError';
+import {
+  requestGitRepositoryTrust,
+  resetGitTrustDecisions,
+  withGitRepositoryTrustRecovery,
+} from './gitTrustService';
+
+const confirmWarningMock = vi.hoisted(() => vi.fn());
+const trustRepositoryMock = vi.hoisted(() => vi.fn());
+const getRepositoryTrustMock = vi.hoisted(() => vi.fn());
+const warningMock = vi.hoisted(() => vi.fn());
+const successMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/component-library/components/ConfirmDialog/confirmService', () => ({
+  confirmWarning: confirmWarningMock,
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  gitAPI: {
+    trustRepository: trustRepositoryMock,
+    getRepositoryTrust: getRepositoryTrustMock,
+  },
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: (key: string, options?: Record<string, unknown>) =>
+      options ? `${key}|${JSON.stringify(options)}` : key,
+  },
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    warning: warningMock,
+    success: successMock,
+  },
+}));
+
+const REPOSITORY_PATH = 'D:/workspace/project/BitFun';
+
+function untrustedError(repositoryPath = REPOSITORY_PATH): TauriCommandError {
+  return new TauriCommandError('Command failed', {
+    command: 'git_get_status',
+    originalError: `git_repository_untrusted: ${repositoryPath}`,
+  });
+}
+
+function grantedOutcome() {
+  return {
+    state: 'trusted',
+    repositoryPath: REPOSITORY_PATH,
+    alreadyTrusted: false,
+    addedEntries: [REPOSITORY_PATH],
+    detail: null,
+    manualCommand: null,
+  };
+}
+
+beforeEach(() => {
+  resetGitTrustDecisions();
+  confirmWarningMock.mockReset();
+  trustRepositoryMock.mockReset();
+  getRepositoryTrustMock.mockReset();
+  getRepositoryTrustMock.mockRejectedValue(new Error('probe not stubbed'));
+  warningMock.mockReset();
+  successMock.mockReset();
+});
+
+describe('requestGitRepositoryTrust', () => {
+  it('grants trust only after the user confirms', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(true);
+    expect(trustRepositoryMock).toHaveBeenCalledWith(REPOSITORY_PATH);
+  });
+
+  it('writes nothing when the user declines', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+    expect(trustRepositoryMock).not.toHaveBeenCalled();
+  });
+
+  it('asks once for a burst of callers on the same repository', async () => {
+    let resolveConfirm!: (value: boolean) => void;
+    confirmWarningMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveConfirm = resolve;
+      }),
+    );
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+
+    const first = requestGitRepositoryTrust(REPOSITORY_PATH);
+    const second = requestGitRepositoryTrust(REPOSITORY_PATH);
+    resolveConfirm(true);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+    expect(trustRepositoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not ask again in the quiet period after a decline', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+
+    await requestGitRepositoryTrust(REPOSITORY_PATH);
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not ask again in the quiet period after a failed grant', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValue(new Error('config is read-only'));
+
+    await requestGitRepositoryTrust(REPOSITORY_PATH);
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+    expect(trustRepositoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The Trust button is visible and enabled after a failure. Returning false
+  // without a dialog would read as a dead button, and would strand a user who
+  // just fixed safe.directory in a terminal or reconnected a remote host.
+  it('answers an explicit user request during the quiet period', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValueOnce(new Error('config is read-only'));
+
+    await requestGitRepositoryTrust(REPOSITORY_PATH);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+
+    trustRepositoryMock.mockResolvedValueOnce(grantedOutcome());
+    await expect(
+      requestGitRepositoryTrust(REPOSITORY_PATH, { userInitiated: true }),
+    ).resolves.toBe(true);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still absorbs the automatic burst that follows a user request', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+
+    await requestGitRepositoryTrust(REPOSITORY_PATH, { userInitiated: true });
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes a burst across Windows spellings of one repository', async () => {
+    let resolveConfirm!: (value: boolean) => void;
+    confirmWarningMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveConfirm = resolve;
+      }),
+    );
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+
+    const first = requestGitRepositoryTrust('D:/workspace/project/BitFun');
+    const second = requestGitRepositoryTrust('d:\\workspace\\project\\BitFun');
+    resolveConfirm(true);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+    expect(trustRepositoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The backend folds the whole path on Windows (`safe_directory_entry_matches`),
+  // so a key that folded only the drive letter prompted twice for one entry.
+  it('dedupes a burst across the case of a Windows path', async () => {
+    let resolveConfirm!: (value: boolean) => void;
+    confirmWarningMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveConfirm = resolve;
+      }),
+    );
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+
+    const first = requestGitRepositoryTrust('D:/Workspace/Project/BitFun');
+    const second = requestGitRepositoryTrust('d:/workspace/project/bitfun');
+    resolveConfirm(true);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A share mounted from another machine is the classic way a Windows folder
+  // ends up owned by someone else, so UNC is a likely spelling here, not a rare one.
+  it('dedupes a burst across the case of a UNC path', async () => {
+    let resolveConfirm!: (value: boolean) => void;
+    confirmWarningMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveConfirm = resolve;
+      }),
+    );
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+
+    const first = requestGitRepositoryTrust('\\\\Build01\\Shared\\BitFun');
+    const second = requestGitRepositoryTrust('//build01/shared/bitfun');
+    resolveConfirm(true);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The backend drops the trailing separator before comparing, so a key that
+  // kept it made one repository two and prompted a second time in one burst.
+  it('dedupes a burst across a trailing separator', async () => {
+    let resolveConfirm!: (value: boolean) => void;
+    confirmWarningMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveConfirm = resolve;
+      }),
+    );
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+
+    const first = requestGitRepositoryTrust('/srv/shared/repo');
+    const second = requestGitRepositoryTrust('/srv/shared/repo/');
+    resolveConfirm(true);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps case-sensitive POSIX paths apart', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+
+    await requestGitRepositoryTrust('/srv/Repo');
+    await requestGitRepositoryTrust('/srv/repo');
+
+    expect(confirmWarningMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('hands over the manual command when trust could not be applied', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockResolvedValue({
+      state: 'trust_required',
+      repositoryPath: REPOSITORY_PATH,
+      alreadyTrusted: false,
+      addedEntries: [],
+      detail: 'detected dubious ownership',
+      manualCommand: `git config --global --add safe.directory "${REPOSITORY_PATH}"`,
+    });
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+    expect(warningMock).toHaveBeenCalledTimes(1);
+    expect(warningMock.mock.calls[0][0]).toContain('trust.unavailableWithCommand');
+    expect(warningMock.mock.calls[0][0]).toContain('safe.directory');
+  });
+
+  it('reports a failed trust command instead of claiming success', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValue(new Error('config is read-only'));
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+    expect(warningMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A peer host denies granting on purpose. The read-only probe still answers
+  // there, so the controller must end up showing the command instead of a
+  // dead end.
+  it('falls back to the read-only probe for the command when granting is refused', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValue(
+      new Error("command 'git_trust_repository' is local-only and cannot run on peer"),
+    );
+    getRepositoryTrustMock.mockResolvedValue({
+      state: 'trust_required',
+      repositoryPath: REPOSITORY_PATH,
+      detail: 'detected dubious ownership',
+      manualCommand: `git config --global --add safe.directory "${REPOSITORY_PATH}"`,
+    });
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+    expect(getRepositoryTrustMock).toHaveBeenCalledWith(REPOSITORY_PATH);
+    expect(warningMock.mock.calls[0][0]).toContain('trust.unavailableWithCommand');
+    expect(warningMock.mock.calls[0][0]).toContain('safe.directory');
+  });
+
+  // The manual command exists to be run. Once the user (or the owner of the
+  // repository) has run it, the wall is down — reporting "could not be granted"
+  // and answering `false` would strand a repository that already works.
+  it('treats a repository fixed outside the product as recovered', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValue(
+      new Error("command 'git_trust_repository' is local-only and cannot run on peer"),
+    );
+    getRepositoryTrustMock.mockResolvedValue({
+      state: 'trusted',
+      repositoryPath: REPOSITORY_PATH,
+      detail: null,
+      manualCommand: null,
+    });
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(true);
+    expect(warningMock).not.toHaveBeenCalled();
+    expect(successMock).toHaveBeenCalledTimes(1);
+    expect(successMock.mock.calls[0][0]).toContain('trust.alreadyTrusted');
+  });
+
+  // ...and the recovery it reports must be a real one: the next automatic call
+  // gets a fresh prompt rather than the quiet period a failure would have set.
+  it('does not silence the next caller after recovering outside the product', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValueOnce(new Error('config is read-only'));
+    getRepositoryTrustMock.mockResolvedValue({
+      state: 'trusted',
+      repositoryPath: REPOSITORY_PATH,
+      detail: null,
+      manualCommand: null,
+    });
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(true);
+
+    trustRepositoryMock.mockResolvedValueOnce(grantedOutcome());
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(true);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still reports the wall when the host is too old to answer the probe', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValue(new Error('unknown command'));
+    getRepositoryTrustMock.mockRejectedValue(new Error('unknown command'));
+
+    await expect(requestGitRepositoryTrust(REPOSITORY_PATH)).resolves.toBe(false);
+    expect(warningMock).toHaveBeenCalledTimes(1);
+    expect(warningMock.mock.calls[0][0]).toContain('trust.unavailable');
+  });
+});
+
+describe('withGitRepositoryTrustRecovery', () => {
+  it('replays the operation once after trust is granted', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(untrustedError())
+      .mockResolvedValueOnce('status');
+
+    await expect(withGitRepositoryTrustRecovery(operation)).resolves.toBe('status');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the original error when the user declines', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+    const error = untrustedError();
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(withGitRepositoryTrustRecovery(operation)).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not loop when the repository stays untrusted after a grant', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+    const error = untrustedError();
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(withGitRepositoryTrustRecovery(operation)).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  // The quiet period absorbs a burst of automatic Git reads. It must not answer
+  // a deliberate launch with a silent refusal plus an error telling the user to
+  // trust the folder "when prompted".
+  it('still prompts a user-initiated recovery during the quiet period', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+    await requestGitRepositoryTrust(REPOSITORY_PATH);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockResolvedValue(grantedOutcome());
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(untrustedError())
+      .mockResolvedValueOnce('status');
+
+    await expect(
+      withGitRepositoryTrustRecovery(operation, { userInitiated: true }),
+    ).resolves.toBe('status');
+    expect(confirmWarningMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stays quiet for an automatic recovery during the quiet period', async () => {
+    confirmWarningMock.mockResolvedValue(false);
+    await requestGitRepositoryTrust(REPOSITORY_PATH);
+
+    const error = untrustedError();
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(withGitRepositoryTrustRecovery(operation)).rejects.toBe(error);
+    expect(confirmWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole point of handing over a manual command on a host that cannot
+  // grant: the user runs it, comes back, and the operation goes through.
+  it('replays after the user fixed trust in a terminal', async () => {
+    confirmWarningMock.mockResolvedValue(true);
+    trustRepositoryMock.mockRejectedValue(new Error('config is read-only'));
+    getRepositoryTrustMock.mockResolvedValue({
+      state: 'trusted',
+      repositoryPath: REPOSITORY_PATH,
+      detail: null,
+      manualCommand: null,
+    });
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(untrustedError())
+      .mockResolvedValueOnce('status');
+
+    await expect(withGitRepositoryTrustRecovery(operation)).resolves.toBe('status');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves every other failure untouched', async () => {
+    const error = new Error('not a git repository');
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(withGitRepositoryTrustRecovery(operation)).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(confirmWarningMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/shared/services/gitTrustService.ts
+++ b/src/web-ui/src/shared/services/gitTrustService.ts
@@ -1,0 +1,258 @@
+/**
+ * Ownership-trust recovery for Git-backed surfaces.
+ *
+ * Git refuses to read a repository whose directory is owned by another user
+ * until the path is listed in the protected `safe.directory` configuration.
+ * Callers that hit that wall hand the failure here: the service explains the
+ * state, asks the user once, and — only after they agree — grants trust and
+ * replays the operation.
+ *
+ * Trust is never granted implicitly. Listing a directory in `safe.directory`
+ * tells Git to run hooks and config from a tree the current user does not own,
+ * so the decision belongs to the user, not to the surface that tripped over it.
+ */
+
+import { confirmWarning } from '@/component-library/components/ConfirmDialog/confirmService';
+import { gitAPI } from '@/infrastructure/api';
+import type { GitTrustReport } from '@/infrastructure/api/service-api/GitAPI';
+import {
+  gitRepositoryUntrustedPath,
+  isGitRepositoryUntrustedError,
+} from '@/infrastructure/api/errors/TauriCommandError';
+import { i18nService } from '@/infrastructure/i18n';
+import { notificationService } from '@/shared/notification-system';
+import { createLogger } from '@/shared/utils/logger';
+import { repositoryPathKey } from '@/shared/utils/pathUtils';
+
+const log = createLogger('GitTrustService');
+
+/**
+ * How long a settled decision keeps later prompts quiet.
+ *
+ * One user action (launching Review, refreshing a panel) fans out into many
+ * Git reads. Without this, every remaining call in the same burst would ask
+ * again — after a decline, and just as much after a grant that failed (a
+ * read-only configuration, a refusing peer host): confirming into the same
+ * wall is not a fresh decision. The window is deliberately short: a fresh
+ * attempt later is a fresh decision.
+ */
+const PROMPT_QUIET_PERIOD_MS = 30_000;
+
+const inFlightRequests = new Map<string, Promise<boolean>>();
+const promptQuietUntil = new Map<string, number>();
+
+/**
+ * Dedupe keys collapse the spellings one repository arrives under: Windows
+ * callers hand the same folder in as `C:\work\repo`, `c:/work/repo`, or the
+ * backend-normalized `C:/work/repo`. Shared with `GitAPI`'s probe cache so one
+ * folder is one entry on both sides of the boundary.
+ */
+const promptKey = repositoryPathKey;
+
+/** Test seam: forgets in-flight prompts and remembered decisions. */
+export function resetGitTrustDecisions(): void {
+  inFlightRequests.clear();
+  promptQuietUntil.clear();
+}
+
+/**
+ * Re-reads trust from the host that owns the repository.
+ *
+ * That host is the only one that can phrase the manual command, and in Peer
+ * Device Mode it is also the only one allowed to grant: the peer refuses
+ * `git_trust_repository` on purpose, so this read-only probe is how a
+ * controller still ends up with something actionable. A host too old to answer
+ * it returns `null`, which degrades to the generic message loudly rather than
+ * silently.
+ */
+async function readTrustReport(repositoryPath: string): Promise<GitTrustReport | null> {
+  try {
+    return await gitAPI.getRepositoryTrust(repositoryPath);
+  } catch (error) {
+    log.warn('Could not read Git repository trust for manual guidance', {
+      repositoryPath,
+      error,
+    });
+    return null;
+  }
+}
+
+/**
+ * Settles a grant that did not take, and reports whether the wall is still up.
+ *
+ * The re-read is not bookkeeping. The manual command exists to be run, and the
+ * whole point of the paths that cannot grant — a remote workspace, a peer host,
+ * a read-only configuration — is that the user (or the repository's owner)
+ * fixes it elsewhere and comes back. By then Git accepts the repository, and
+ * announcing "could not be granted" while answering the caller `false` strands
+ * a repository that works: no refresh, no replay, and a warning about a wall
+ * that is no longer there. Only a probe that still says `trustRequired`, or one
+ * that could not answer at all, hands over the manual command.
+ */
+async function settleUngrantedTrust(
+  repositoryPath: string,
+  reportedPath: string,
+  manualCommand: string | null,
+): Promise<boolean> {
+  // Probe the path the caller will retry, not the one Git named: a rejection
+  // raised against the administrative `.git` directory reports that directory,
+  // and it is the worktree the caller is going to read again.
+  const report = await readTrustReport(repositoryPath);
+  if (report?.state === 'trusted') {
+    promptQuietUntil.delete(promptKey(repositoryPath));
+    log.info('Git repository trust was resolved outside the product', { repositoryPath });
+    notificationService.success(
+      i18nService.t('panels/git:trust.alreadyTrusted', { path: repositoryPath }),
+    );
+    return true;
+  }
+
+  // Like a decline, an unresolved failure settles the current burst: confirming
+  // into the same wall is not a fresh decision, so no re-prompt until the quiet
+  // period ends. Keyed on the caller's path — the key the next call arrives
+  // under — while the message names the path Git actually rejected.
+  promptQuietUntil.set(promptKey(repositoryPath), Date.now() + PROMPT_QUIET_PERIOD_MS);
+  reportManualPath(reportedPath, manualCommand ?? report?.manualCommand ?? null);
+  return false;
+}
+
+function reportManualPath(repositoryPath: string, manualCommand: string | null): void {
+  const message = manualCommand
+    ? i18nService.t('panels/git:trust.unavailableWithCommand', {
+        path: repositoryPath,
+        command: manualCommand,
+      })
+    : i18nService.t('panels/git:trust.unavailable', { path: repositoryPath });
+  notificationService.warning(message, {
+    title: i18nService.t('panels/git:trust.title'),
+    duration: 0,
+  });
+}
+
+async function promptAndTrust(repositoryPath: string): Promise<boolean> {
+  const confirmed = await confirmWarning(
+    i18nService.t('panels/git:trust.title'),
+    i18nService.t('panels/git:trust.message', { path: repositoryPath }),
+    {
+      confirmText: i18nService.t('panels/git:trust.confirm'),
+      cancelText: i18nService.t('panels/git:trust.cancel'),
+    },
+  );
+
+  if (!confirmed) {
+    promptQuietUntil.set(promptKey(repositoryPath), Date.now() + PROMPT_QUIET_PERIOD_MS);
+    log.info('Git repository trust declined by user', { repositoryPath });
+    return false;
+  }
+
+  try {
+    const outcome = await gitAPI.trustRepository(repositoryPath);
+    if (outcome.state === 'trusted') {
+      promptQuietUntil.delete(promptKey(repositoryPath));
+      notificationService.success(
+        i18nService.t('panels/git:trust.granted', { path: repositoryPath }),
+      );
+      return true;
+    }
+
+    // The backend reached the repository but could not make Git accept it —
+    // a remote workspace, a read-only configuration, an unexpected path shape.
+    // Re-read before deciding: the user may have run the command themselves.
+    log.warn('Git repository trust could not be applied', {
+      repositoryPath,
+      state: outcome.state,
+      detail: outcome.detail,
+    });
+    const reportedPath = outcome.repositoryPath ?? repositoryPath;
+    return await settleUngrantedTrust(repositoryPath, reportedPath, outcome.manualCommand);
+  } catch (error) {
+    // Includes the hosts that refuse to grant at all: a peer host denies
+    // `git_trust_repository` on purpose, and an older host does not know it.
+    log.error('Failed to grant Git repository trust', { repositoryPath, error });
+    return await settleUngrantedTrust(repositoryPath, repositoryPath, null);
+  }
+}
+
+export interface GitRepositoryTrustRequestOptions {
+  /**
+   * The user asked for this directly (the Trust button), rather than a Git read
+   * tripping over the wall.
+   *
+   * A direct ask is always answered: the quiet period exists to keep one user
+   * action from prompting once per Git call in the burst, not to make a visible
+   * button do nothing. Silently returning `false` to a click reads as a broken
+   * button, and it strands the user who just fixed `safe.directory` in a
+   * terminal or reconnected a remote host.
+   */
+  userInitiated?: boolean;
+}
+
+/**
+ * Asks the user to trust a repository Git rejected, and grants it on approval.
+ *
+ * Concurrent callers for the same path share one prompt. Returns whether Git
+ * now accepts the repository.
+ */
+export function requestGitRepositoryTrust(
+  repositoryPath: string,
+  options: GitRepositoryTrustRequestOptions = {},
+): Promise<boolean> {
+  const key = promptKey(repositoryPath);
+  const pending = inFlightRequests.get(key);
+  if (pending) {
+    return pending;
+  }
+
+  const quietUntil = promptQuietUntil.get(key);
+  if (quietUntil !== undefined) {
+    if (quietUntil > Date.now() && !options.userInitiated) {
+      return Promise.resolve(false);
+    }
+    promptQuietUntil.delete(key);
+  }
+
+  const request = promptAndTrust(repositoryPath).finally(() => {
+    inFlightRequests.delete(key);
+  });
+  inFlightRequests.set(key, request);
+  return request;
+}
+
+/**
+ * Runs a read-only Git operation, recovering once from an ownership rejection.
+ *
+ * Anything other than an ownership rejection propagates untouched, and the
+ * replay happens at most once — so a repository that stays untrusted fails with
+ * its original error instead of looping.
+ *
+ * Only for operations that are safe to run twice. Do not wrap mutations.
+ *
+ * Pass `userInitiated` when the operation is one discrete thing the user asked
+ * for (launching Review), rather than one call inside an automatic burst: the
+ * quiet period would otherwise answer a deliberate action with a silent `false`
+ * and an error telling them to trust the folder "when prompted".
+ */
+export async function withGitRepositoryTrustRecovery<T>(
+  operation: () => Promise<T>,
+  options: GitRepositoryTrustRequestOptions = {},
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isGitRepositoryUntrustedError(error)) {
+      throw error;
+    }
+
+    const repositoryPath = gitRepositoryUntrustedPath(error);
+    if (!repositoryPath) {
+      throw error;
+    }
+
+    const trusted = await requestGitRepositoryTrust(repositoryPath, options);
+    if (!trusted) {
+      throw error;
+    }
+
+    return await operation();
+  }
+}

--- a/src/web-ui/src/shared/utils/pathUtils.test.ts
+++ b/src/web-ui/src/shared/utils/pathUtils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { repositoryPathKey } from './pathUtils';
+
+describe('repositoryPathKey', () => {
+  it('collapses the spellings one Windows repository arrives under', () => {
+    const expected = 'c:/work/repo';
+    expect(repositoryPathKey('C:\\work\\repo')).toBe(expected);
+    expect(repositoryPathKey('c:/work/repo')).toBe(expected);
+    expect(repositoryPathKey('C:/work/repo/')).toBe(expected);
+  });
+
+  it('keys a UNC share the same way whichever separator it arrives with', () => {
+    expect(repositoryPathKey('\\\\build01\\shared\\repo')).toBe('//build01/shared/repo');
+    expect(repositoryPathKey('//Build01/Shared/repo/')).toBe('//build01/shared/repo');
+  });
+
+  // Backslash is an ordinary filename character on POSIX, so rewriting it would
+  // collapse two different repositories onto one key — and this key gates the
+  // trust prompt and the probe cache, so one dismissal would answer for both.
+  it('keeps a POSIX backslash distinct from a separator', () => {
+    expect(repositoryPathKey('/srv/we\\ird/repo')).toBe('/srv/we\\ird/repo');
+    expect(repositoryPathKey('/srv/we\\ird/repo')).not.toBe(repositoryPathKey('/srv/we/ird/repo'));
+  });
+
+  it('leaves POSIX case alone and drops only a trailing separator', () => {
+    expect(repositoryPathKey('/srv/Shared/Repo/')).toBe('/srv/Shared/Repo');
+    expect(repositoryPathKey('/')).toBe('/');
+  });
+});

--- a/src/web-ui/src/shared/utils/pathUtils.ts
+++ b/src/web-ui/src/shared/utils/pathUtils.ts
@@ -152,6 +152,32 @@ export function pathsEquivalentFs(a: string, b: string): boolean {
   return false;
 }
 
+/**
+ * Canonical map key for one repository, collapsing the spellings it arrives
+ * under: `C:\work\repo`, `c:/work/repo`, `C:/work/repo/`.
+ *
+ * Mirrors the backend's `normalize_trust_path` (forward slashes, no trailing
+ * separator) and `safe_directory_entry_matches` (whole-path case folding on
+ * Windows, where Git itself compares that way). Callers that key caches or
+ * in-flight requests by repository must share this, or the same folder becomes
+ * two entries here while the backend treats it as one. UNC paths count: a share
+ * mounted from another machine is one of the commonest ways to own nothing in
+ * your own workspace. POSIX paths are case-sensitive and stay untouched.
+ */
+export function repositoryPathKey(repositoryPath: string): string {
+  // Backslash is only a separator on a Windows-shaped path; on POSIX it is an
+  // ordinary filename character, and rewriting it would collapse the distinct
+  // directories `/srv/we\ird` and `/srv/we/ird` onto one key — one prompt
+  // dismissal, or one cached probe, answering for both. The backend gates the
+  // same rewrite the same way.
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(repositoryPath) || /^[\\/]{2}/.test(repositoryPath);
+  let normalized = isWindowsPath ? repositoryPath.replace(/\\/g, '/') : repositoryPath;
+  while (normalized.length > 1 && normalized.endsWith('/') && !normalized.endsWith(':/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return isWindowsPath ? normalized.toLowerCase() : normalized;
+}
+
 /** Whether `path` is expanded when the set may mix separators or drive letter case (Windows). */
 export function expandedFoldersContains(expandedFolders: Set<string>, path: string): boolean {
   if (expandedFolders.has(path)) return true;

--- a/src/web-ui/src/tools/git/components/GitBranchHistoryView/GitBranchHistoryView.tsx
+++ b/src/web-ui/src/tools/git/components/GitBranchHistoryView/GitBranchHistoryView.tsx
@@ -11,6 +11,7 @@ import { gitAPI } from '@/infrastructure/api';
 import { useNotification } from '@/shared/notification-system';
 import type { GitGraphNode } from '@/infrastructure/api/service-api/GitAPI';
 import { i18nService } from '@/infrastructure/i18n';
+import { describeGitTrustFailure } from '../../services/GitService';
 import { createLogger } from '@/shared/utils/logger';
 import './GitBranchHistoryView.scss';
 
@@ -121,7 +122,9 @@ export const GitBranchHistoryView: React.FC<GitBranchHistoryViewProps> = ({
       setCommits(parsedCommits);
     } catch (err) {
       log.error('Failed to load commit history', { repositoryPath, branchName, error: err });
-      setError(err instanceof Error ? err.message : String(err));
+      setError(
+        describeGitTrustFailure(err) ?? (err instanceof Error ? err.message : String(err))
+      );
     } finally {
       setLoading(false);
     }
@@ -236,12 +239,21 @@ export const GitBranchHistoryView: React.FC<GitBranchHistoryViewProps> = ({
         if (result.success) {
           successHashes.push(hash);
         } else {
-          failedHashes.push({ hash, error: result.error || t('branchHistory.cherryPickFailed') });
+          // This panel reaches the backend directly, so it owns the same
+          // translation the service layer does: the ownership rejection arrives
+          // as a stable code, and showing it verbatim tells the user nothing.
+          const error =
+            describeGitTrustFailure(result.error) ??
+            result.error ??
+            t('branchHistory.cherryPickFailed');
+          failedHashes.push({ hash, error });
 
           break;
         }
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : t('branchHistory.cherryPickOperationFailed');
+        const errorMsg =
+          describeGitTrustFailure(err) ??
+          (err instanceof Error ? err.message : t('branchHistory.cherryPickOperationFailed'));
         failedHashes.push({ hash, error: errorMsg });
         break;
       }

--- a/src/web-ui/src/tools/git/components/GitGraphView/GitGraphView.tsx
+++ b/src/web-ui/src/tools/git/components/GitGraphView/GitGraphView.tsx
@@ -16,6 +16,7 @@ import {
 import { i18nService } from '@/infrastructure/i18n';
 import { useAppearance } from '@/infrastructure/appearance';
 import { createLogger } from '@/shared/utils/logger';
+import { describeGitTrustFailure } from '../../services/GitService';
 import './GitGraphView.scss';
 
 const log = createLogger('GitGraphView');
@@ -68,7 +69,11 @@ export const GitGraphView: React.FC<GitGraphViewProps> = ({
       setGraphData(data);
     } catch (err) {
       log.error('Failed to load graph data', { repositoryPath, maxCount, error: err });
-      setError(err instanceof Error ? err.message : String(err));
+      // The wall reaches this panel as a stable code. Shown raw it reads as
+      // machine noise, and this view has no Trust button of its own.
+      setError(
+        describeGitTrustFailure(err) ?? (err instanceof Error ? err.message : String(err))
+      );
     } finally {
       setLoading(false);
     }

--- a/src/web-ui/src/tools/git/hooks/useGitState.ts
+++ b/src/web-ui/src/tools/git/hooks/useGitState.ts
@@ -240,6 +240,7 @@ export function useGitState(options: UseGitStateOptions): UseGitStateReturn {
     refreshDetailed,
 
     isRepository: state?.isRepository ?? false,
+    repositoryTrustRequired: state?.repositoryTrustRequired ?? false,
     currentBranch: state?.currentBranch ?? null,
     ahead: state?.ahead ?? 0,
     behind: state?.behind ?? 0,

--- a/src/web-ui/src/tools/git/services/GitService.test.ts
+++ b/src/web-ui/src/tools/git/services/GitService.test.ts
@@ -5,6 +5,9 @@ const gitApiMocks = vi.hoisted(() => ({
   commit: vi.fn(),
   push: vi.fn(),
   resetFiles: vi.fn(),
+  isGitRepository: vi.fn(),
+  getRepository: vi.fn(),
+  getStatus: vi.fn(),
 }));
 
 const gitStateManagerMock = vi.hoisted(() => ({
@@ -64,5 +67,103 @@ describe('GitService dangerous operation refresh guard', () => {
     expect(gitStateManagerMock.refresh).toHaveBeenCalledTimes(2);
     expect(gitApiMocks.push).toHaveBeenCalledTimes(1);
     expect(gitApiMocks.resetFiles).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The negative cache is consulted before the call is even attempted, so what
+// lands in it decides whether a repository can ever be read again this window.
+describe('GitService non-repository cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('remembers a path that really is not a repository', async () => {
+    const path = 'D:/workspace/not-a-repo';
+    gitApiMocks.getStatus.mockRejectedValue(new Error('not a git repository'));
+
+    await expect(gitService.getStatus(path)).resolves.toBeNull();
+    await expect(gitService.getStatus(path)).resolves.toBeNull();
+
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not remember an ownership rejection as "not a repository"', async () => {
+    // Caching it would outlive the trust decision the user is about to make,
+    // and would hide the error the recovery flow keys off.
+    const path = 'D:/workspace/untrusted-repo';
+    gitApiMocks.getStatus.mockRejectedValue(
+      new Error(`git_repository_untrusted: ${path}`),
+    );
+
+    await expect(gitService.getStatus(path)).resolves.toBeNull();
+    await expect(gitService.getStatus(path)).resolves.toBeNull();
+
+    expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps reprobing a repository the ownership gate blocked', async () => {
+    const path = 'D:/workspace/untrusted-probe';
+    gitApiMocks.isGitRepository.mockRejectedValue(
+      new Error(`git_repository_untrusted: ${path}`),
+    );
+
+    await expect(gitService.isGitRepository(path)).resolves.toBe(false);
+    await expect(gitService.isGitRepository(path)).resolves.toBe(false);
+
+    expect(gitApiMocks.isGitRepository).toHaveBeenCalledTimes(2);
+  });
+});
+
+// A mutation's error string is rendered in the panel as-is. The stable code is
+// for code to branch on, not for a person to read.
+describe('GitService mutation ownership rejections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitStateManagerMock.refresh.mockResolvedValue(undefined);
+  });
+
+  it('names the wall when a local mutation throws the stable code', async () => {
+    gitApiMocks.commit.mockRejectedValue(
+      new Error(`git_repository_untrusted: ${repositoryPath}`),
+    );
+
+    await expect(gitService.commit(repositoryPath, { message: 'test' })).resolves.toEqual({
+      success: false,
+      error: 'panels/git:trust.required',
+    });
+  });
+
+  // The remote executor returns the failure rather than throwing it, so the
+  // returned result needs the same translation as the thrown error.
+  it('names the wall when a remote mutation returns the stable code', async () => {
+    gitApiMocks.push.mockResolvedValue({
+      success: false,
+      error: `git_repository_untrusted: /srv/shared/repo`,
+      data: { remoteExecution: true, exitCode: 128 },
+    });
+
+    await expect(gitService.push(repositoryPath)).resolves.toMatchObject({
+      success: false,
+      error: 'panels/git:trust.required',
+      data: { remoteExecution: true, exitCode: 128 },
+    });
+  });
+
+  it('leaves an ordinary mutation failure exactly as it came', async () => {
+    gitApiMocks.push.mockResolvedValue({
+      success: false,
+      error: 'error: failed to push some refs',
+    });
+
+    await expect(gitService.push(repositoryPath)).resolves.toEqual({
+      success: false,
+      error: 'error: failed to push some refs',
+    });
+
+    gitApiMocks.resetFiles.mockRejectedValue(new Error('unable to write index'));
+    await expect(gitService.resetFiles(repositoryPath, ['src/app.ts'])).resolves.toEqual({
+      success: false,
+      error: 'unable to write index',
+    });
   });
 });

--- a/src/web-ui/src/tools/git/services/GitService.ts
+++ b/src/web-ui/src/tools/git/services/GitService.ts
@@ -3,6 +3,10 @@
  */
 
 import { gitAPI } from '@/infrastructure/api';
+import {
+  gitRepositoryUntrustedPath,
+  isGitRepositoryUntrustedError,
+} from '@/infrastructure/api/errors/TauriCommandError';
 import { createLogger } from '@/shared/utils/logger';
 import { measureAsync } from '@/shared/utils/timing';
 import { i18nService } from '@/infrastructure/i18n';
@@ -39,6 +43,24 @@ import {
   GitDiffParams,
   GitLogParams
 } from '../types';
+
+/**
+ * Names the ownership wall behind a failed Git operation, or `undefined` when
+ * that is not what went wrong.
+ *
+ * The rejection reaches a caller as a stable code from two directions: a local
+ * executor throws it, and a remote one returns it in `result.error`. Neither is
+ * a sentence. Passing it through puts `git_repository_untrusted:
+ * /srv/shared/repo` in the panel next to a commit that did not happen, while
+ * the very same wall on a status read names the repository and points at the
+ * way out.
+ */
+export function describeGitTrustFailure(failure: unknown): string | undefined {
+  const repositoryPath = gitRepositoryUntrustedPath(failure);
+  return repositoryPath
+    ? i18nService.t('panels/git:trust.required', { path: repositoryPath })
+    : undefined;
+}
 
 export class GitService {
   private static instance: GitService;
@@ -89,6 +111,45 @@ export class GitService {
   private addToNonGitCache(path: string): void {
     this.nonGitRepositoryCache.add(path);
     this.cacheTimestamps.set(path, Date.now());
+  }
+
+  /**
+   * Records a failed read as "not a repository" — unless Git refused it on
+   * ownership grounds.
+   *
+   * That refusal says the repository is there, and the negative cache is
+   * consulted before the call is even attempted: caching it would keep
+   * returning `null` for minutes, outliving a trust decision the user just
+   * made and hiding the error the recovery flow needs to see.
+   */
+  private cacheFailureAsNonGit(path: string, error: unknown): void {
+    if (isGitRepositoryUntrustedError(error)) {
+      return;
+    }
+    this.addToNonGitCache(path);
+  }
+
+  /** Turns whatever a mutation failed with into something the user can act on. */
+  private describeOperationFailure(failure: unknown, fallbackKey: string): string {
+    const trustFailure = describeGitTrustFailure(failure);
+    if (trustFailure) {
+      return trustFailure;
+    }
+    if (typeof failure === 'string' && failure.trim().length > 0) {
+      return failure;
+    }
+    return failure instanceof Error ? failure.message : i18nService.t(fallbackKey);
+  }
+
+  /** Same translation for a failure the backend returned rather than threw. */
+  private explainOperationResult(
+    result: GitOperationResult,
+    fallbackKey: string
+  ): GitOperationResult {
+    if (result.success || !isGitRepositoryUntrustedError(result.error)) {
+      return result;
+    }
+    return { ...result, error: this.describeOperationFailure(result.error, fallbackKey) };
   }
 
   private removeFromNonGitCache(path: string): void {
@@ -187,7 +248,7 @@ export class GitService {
       return result;
     } catch (error) {
       log.error('Failed to check git repository', error);
-      this.addToNonGitCache(path);
+      this.cacheFailureAsNonGit(path, error);
       return false;
     }
   }
@@ -214,7 +275,7 @@ export class GitService {
       return this.adaptRepository(result.value);
     } catch (error) {
       log.error('Failed to get repository info', error);
-      this.addToNonGitCache(path);
+      this.cacheFailureAsNonGit(path, error);
       return null;
     }
   }
@@ -239,7 +300,7 @@ export class GitService {
       return this.adaptStatus(result);
     } catch (error) {
       log.error('Failed to get git status', error);
-      this.addToNonGitCache(repositoryPath);
+      this.cacheFailureAsNonGit(repositoryPath, error);
       return null;
     }
   }
@@ -270,12 +331,12 @@ export class GitService {
   async addFiles(repositoryPath: string, params: GitAddParams): Promise<GitOperationResult> {
     try {
       const result = await gitAPI.addFiles(repositoryPath, params);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.addFailed');
     } catch (error) {
       log.error('Failed to add files', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.addFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.addFailed')
       };
     }
   }
@@ -287,12 +348,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.commit(repositoryPath, params);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.commitFailed');
     } catch (error) {
       log.error('Failed to commit', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.commitFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.commitFailed')
       };
     }
   }
@@ -304,12 +365,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.push(repositoryPath, params);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.pushFailed');
     } catch (error) {
       log.error('Failed to push', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.pushFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.pushFailed')
       };
     }
   }
@@ -321,12 +382,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.pull(repositoryPath, params);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.pullFailed');
     } catch (error) {
       log.error('Failed to pull', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.pullFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.pullFailed')
       };
     }
   }
@@ -338,12 +399,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.checkoutBranch(repositoryPath, branchName);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.checkoutFailed');
     } catch (error) {
       log.error('Failed to checkout branch', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.checkoutFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.checkoutFailed')
       };
     }
   }
@@ -355,12 +416,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.createBranch(repositoryPath, branchName, startPoint);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.createBranchFailed');
     } catch (error) {
       log.error('Failed to create branch', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.createBranchFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.createBranchFailed')
       };
     }
   }
@@ -372,12 +433,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.deleteBranch(repositoryPath, branchName, force);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.deleteBranchFailed');
     } catch (error) {
       log.error('Failed to delete branch', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.deleteBranchFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.deleteBranchFailed')
       };
     }
   }
@@ -402,12 +463,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.resetFiles(repositoryPath, files, staged);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.resetFilesFailed');
     } catch (error) {
       log.error('Failed to reset files', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.resetFilesFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.resetFilesFailed')
       };
     }
   }
@@ -419,12 +480,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.resetToCommit(repositoryPath, commitHash, mode);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.resetCommitFailed');
     } catch (error) {
       log.error('Failed to reset to commit', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.resetCommitFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.resetCommitFailed')
       };
     }
   }
@@ -463,12 +524,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.cherryPick(repositoryPath, commitHash, noCommit);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.cherryPickFailed');
     } catch (error) {
       log.error('Failed to cherry-pick', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.cherryPickFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.cherryPickFailed')
       };
     }
   }
@@ -480,12 +541,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.cherryPickAbort(repositoryPath);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.cherryPickAbortFailed');
     } catch (error) {
       log.error('Failed to abort cherry-pick', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.cherryPickAbortFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.cherryPickAbortFailed')
       };
     }
   }
@@ -497,12 +558,12 @@ export class GitService {
     try {
       await this.ensureFreshOperationState(repositoryPath);
       const result = await gitAPI.cherryPickContinue(repositoryPath);
-      return result;
+      return this.explainOperationResult(result, 'panels/git:errors.cherryPickContinueFailed');
     } catch (error) {
       log.error('Failed to continue cherry-pick', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : i18nService.t('panels/git:errors.cherryPickContinueFailed')
+        error: this.describeOperationFailure(error, 'panels/git:errors.cherryPickContinueFailed')
       };
     }
   }

--- a/src/web-ui/src/tools/git/state/GitStateManager.test.ts
+++ b/src/web-ui/src/tools/git/state/GitStateManager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitStateManager } from './GitStateManager';
+import type { GitStateLayer } from './types';
 
 const gitApiMocks = vi.hoisted(() => ({
   isGitRepository: vi.fn(),
@@ -8,6 +9,7 @@ const gitApiMocks = vi.hoisted(() => ({
   getStatus: vi.fn(),
   getBranches: vi.fn(),
   getCommits: vi.fn(),
+  getRepositoryTrust: vi.fn(),
 }));
 
 const gitEventServiceMock = vi.hoisted(() => ({
@@ -230,5 +232,236 @@ describe('GitStateManager refresh performance guards', () => {
     await expect(first).rejects.toThrow('status failed');
     await expect(second).rejects.toThrow('status failed');
     expect(gitApiMocks.getStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GitStateManager ownership trust', () => {
+  let manager: GitStateManager;
+
+  const untrustedError = () =>
+    new Error(`git_repository_untrusted: ${repositoryPath}`);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    GitStateManager.resetInstance();
+    manager = GitStateManager.getInstance();
+    manager.setCacheConfig({ basic: 0, status: 0, detailed: 0 });
+
+    // The probe answers `true` for a repository Git refuses on ownership
+    // grounds: it exists, Git just will not operate on it.
+    gitApiMocks.isGitRepository.mockResolvedValue(true);
+    gitApiMocks.getStatus.mockResolvedValue({
+      staged: [],
+      unstaged: [],
+      untracked: [],
+      conflicts: [],
+      current_branch: 'main',
+      ahead: 0,
+      behind: 0,
+    });
+    gitApiMocks.getBranches.mockResolvedValue([]);
+    gitApiMocks.getCommits.mockResolvedValue([]);
+    // A host too old to answer the read-only probe is the default here; the
+    // tests that rely on it opt in.
+    gitApiMocks.getRepositoryTrust.mockRejectedValue(new Error('unknown command'));
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    GitStateManager.resetInstance();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Drives one refresh to completion. The outcome is captured before the fake
+   * timers advance: the refresh settles inside that window, and a rejection
+   * with no handler attached yet surfaces as an unhandled rejection.
+   */
+  async function runRefresh(layers: GitStateLayer[]): Promise<void> {
+    const settled = manager
+      .refresh(repositoryPath, { layers, force: true, reason: 'manual' })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+    await vi.advanceTimersByTimeAsync(100);
+    const failure = await settled;
+    if (failure) {
+      throw failure;
+    }
+  }
+
+  const refreshBasicAndStatus = () => runRefresh(['basic', 'status']);
+
+  it('records the ownership wall when a status read hits it', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(untrustedError());
+
+    await expect(refreshBasicAndStatus()).rejects.toThrow('git_repository_untrusted');
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: true,
+    });
+  });
+
+  // The state a host or device switch leaves behind: a successful refresh set
+  // `isRepository`, and the ownership rejection that follows does not clear it.
+  // The panel must key its trust view off the flag, not off `!isRepository`.
+  it('keeps the wall visible after the repository already loaded once', async () => {
+    await refreshBasicAndStatus();
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      isRepository: true,
+      repositoryTrustRequired: false,
+    });
+
+    gitApiMocks.getStatus.mockRejectedValueOnce(untrustedError());
+    await expect(refreshBasicAndStatus()).rejects.toThrow('git_repository_untrusted');
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      isRepository: true,
+      repositoryTrustRequired: true,
+    });
+  });
+
+  // A detailed-only refresh never reaches the ownership gate — it swallows its
+  // own failures into empty arrays — so its success is not evidence that trust
+  // is no longer required.
+  it('does not let a detailed-only refresh clear the wall', async () => {
+    await refreshBasicAndStatus();
+    gitApiMocks.getStatus.mockRejectedValueOnce(untrustedError());
+    await expect(refreshBasicAndStatus()).rejects.toThrow('git_repository_untrusted');
+
+    gitApiMocks.getBranches.mockRejectedValueOnce(untrustedError());
+    gitApiMocks.getCommits.mockRejectedValueOnce(untrustedError());
+    await runRefresh(['detailed']);
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: true,
+    });
+  });
+
+  // A dropped SSH connection is the realistic case: the wall is up, the next
+  // automatic refresh fails on transport, and clearing the flag would leave
+  // `isRepository: false` behind — the "initialize a repository" screen over a
+  // repository that exists and is merely blocked.
+  it('keeps the wall through an unrelated failure', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(untrustedError());
+    await expect(refreshBasicAndStatus()).rejects.toThrow('git_repository_untrusted');
+
+    gitApiMocks.isGitRepository.mockRejectedValueOnce(new Error('ssh: connection closed'));
+    await expect(refreshBasicAndStatus()).rejects.toThrow('ssh: connection closed');
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: true,
+    });
+  });
+
+  // Not every execution domain classifies the rejection. The CLI peer answers
+  // the trust probe but has no `git_get_status`, so its refresh fails with
+  // ordinary prose — and without the probe the wall would stay invisible and
+  // the Trust button would never appear on a controller talking to that peer.
+  it('consults the trust probe when the failure cannot classify itself', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(new Error('unsupported command: git_get_status'));
+    gitApiMocks.getRepositoryTrust.mockResolvedValueOnce({
+      state: 'trust_required',
+      repositoryPath,
+      detail: 'detected dubious ownership',
+      manualCommand: `git config --global --add safe.directory '${repositoryPath}'`,
+    });
+
+    await expect(refreshBasicAndStatus()).rejects.toThrow('unsupported command');
+
+    expect(gitApiMocks.getRepositoryTrust).toHaveBeenCalledWith(repositoryPath);
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: true,
+      error: 'panels/git:trust.required',
+    });
+  });
+
+  // A failure we cannot explain must not be dressed up as an ownership wall:
+  // that shows a Trust button whose grant cannot fix anything, and hides the
+  // real error behind it.
+  it('leaves an unrelated failure unexplained when the probe says trust is fine', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(new Error('ssh: connection closed'));
+    gitApiMocks.getRepositoryTrust.mockResolvedValueOnce({
+      state: 'trusted',
+      repositoryPath,
+      detail: null,
+      manualCommand: null,
+    });
+
+    await expect(refreshBasicAndStatus()).rejects.toThrow('ssh: connection closed');
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: false,
+      error: 'ssh: connection closed',
+    });
+  });
+
+  // The way out for an execution domain whose status read can never succeed.
+  // The CLI peer has no `git_get_status`, so "refresh until it works" is not a
+  // path back: the user fixes ownership over there, and the only thing that can
+  // learn it is the probe. Without this the panel stays on the Trust screen for
+  // a repository Git already accepts.
+  it('drops the wall when the probe reports trust after it was raised', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(new Error('unsupported command: git_get_status'));
+    gitApiMocks.getRepositoryTrust.mockResolvedValueOnce({
+      state: 'trust_required',
+      repositoryPath,
+      detail: 'detected dubious ownership',
+      manualCommand: `git config --global --add safe.directory ${repositoryPath}`,
+    });
+    await expect(refreshBasicAndStatus()).rejects.toThrow('unsupported command');
+    expect(manager.getState(repositoryPath)).toMatchObject({ repositoryTrustRequired: true });
+
+    // Same unsupported status read as before — nothing about this domain has
+    // changed except Git's answer over on the peer.
+    gitApiMocks.getStatus.mockRejectedValueOnce(new Error('unsupported command: git_get_status'));
+    gitApiMocks.getRepositoryTrust.mockResolvedValueOnce({
+      state: 'trusted',
+      repositoryPath,
+      detail: null,
+      manualCommand: null,
+    });
+
+    await expect(refreshBasicAndStatus()).rejects.toThrow('unsupported command');
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: false,
+      error: 'unsupported command: git_get_status',
+    });
+  });
+
+  // The other half: a probe that could not answer says nothing about trust, so
+  // a wall raised earlier stays up rather than collapsing on a transport error.
+  it('keeps the wall when the probe itself cannot answer', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(new Error('unsupported command: git_get_status'));
+    gitApiMocks.getRepositoryTrust.mockResolvedValueOnce({
+      state: 'trust_required',
+      repositoryPath,
+      detail: 'detected dubious ownership',
+      manualCommand: `git config --global --add safe.directory ${repositoryPath}`,
+    });
+    await expect(refreshBasicAndStatus()).rejects.toThrow('unsupported command');
+
+    // Default mock: the probe rejects, as it would on a dropped connection.
+    gitApiMocks.getStatus.mockRejectedValueOnce(new Error('unsupported command: git_get_status'));
+    await expect(refreshBasicAndStatus()).rejects.toThrow('unsupported command');
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      repositoryTrustRequired: true,
+    });
+  });
+
+  it('clears the wall once a status read succeeds again', async () => {
+    gitApiMocks.getStatus.mockRejectedValueOnce(untrustedError());
+    await expect(refreshBasicAndStatus()).rejects.toThrow('git_repository_untrusted');
+
+    await refreshBasicAndStatus();
+
+    expect(manager.getState(repositoryPath)).toMatchObject({
+      isRepository: true,
+      repositoryTrustRequired: false,
+    });
   });
 });

--- a/src/web-ui/src/tools/git/state/GitStateManager.ts
+++ b/src/web-ui/src/tools/git/state/GitStateManager.ts
@@ -16,6 +16,7 @@
  */
 
 import { gitAPI } from '@/infrastructure/api';
+import { gitRepositoryUntrustedPath } from '@/infrastructure/api/errors/TauriCommandError';
 import { gitEventService } from '../services/GitEventService';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
@@ -446,7 +447,13 @@ export class GitStateManager {
         }
 
 
-        if (layersToRefresh.includes('basic') || layersToRefresh.includes('status')) {
+        // Only basic/status reaches Git in a way that can observe the ownership
+        // gate. A detailed-only refresh swallows its own failures (branches and
+        // commits fall back to empty arrays), so treating its success as proof
+        // that trust is no longer required would clear a wall nobody retested.
+        const probedTrust =
+          layersToRefresh.includes('basic') || layersToRefresh.includes('status');
+        if (probedTrust) {
           await this.refreshBasicAndStatus(repositoryPath, layersToRefresh);
         }
 
@@ -465,6 +472,7 @@ export class GitStateManager {
           lastRefreshTime: newLastRefreshTime,
           isRefreshing: false,
           refreshingLayers: new Set(),
+          ...(probedTrust ? { repositoryTrustRequired: false } : {}),
         });
 
 
@@ -480,13 +488,50 @@ export class GitStateManager {
       } catch (error) {
         probeOutcome = 'error';
         probeError = error instanceof Error ? error.message : String(error);
-        const errorMessage = error instanceof Error ? error.message : i18nService.t('panels/git:errors.refreshFailed');
+        // The ownership wall reaches here as a stable code, not as prose. Say
+        // what happened instead of showing the raw code to the user.
+        //
+        // The code is produced by whichever executor classified the rejection.
+        // An execution domain that cannot classify still answers the read-only
+        // trust probe, so ask it once before concluding that ownership has
+        // nothing to do with this failure — see `probeRepositoryTrust`.
+        const stablePath = gitRepositoryUntrustedPath(error);
+        const probed = stablePath === undefined
+          ? await this.probeRepositoryTrust(repositoryPath)
+          : undefined;
+        const untrustedPath = stablePath ?? probed?.path;
+        const errorMessage = untrustedPath
+          ? i18nService.t('panels/git:trust.required', { path: untrustedPath })
+          : error instanceof Error
+            ? error.message
+            : i18nService.t('panels/git:errors.refreshFailed');
         log.error('Refresh failed', { repositoryPath, layersToRefresh, error });
 
+        // The flag follows whoever actually reached Git's answer, in both
+        // directions. A probe that answered raises the wall on `trust_required`
+        // and lowers it on anything else: without the lowering half, an
+        // execution domain whose status read can never succeed — the CLI peer
+        // has no `git_get_status` — has no way back out. The user fixes
+        // ownership on the peer, the probe starts reporting `trusted`, and the
+        // panel stays on the Trust screen forever, because the only other thing
+        // that clears the flag is a successful basic/status refresh that will
+        // never come.
+        //
+        // A failure nobody could explain leaves the wall exactly as it was: the
+        // probe threw (a host too old to answer, a dropped SSH connection) and
+        // never reached Git, so it has nothing to say about trust. Clearing on
+        // that would drop a blocked repository back to "not a repository" — the
+        // status read throws before `isRepository` is ever set — and send the
+        // user to initialize one over a repository that is already there.
         this.updateState(repositoryPath, {
           isRefreshing: false,
           refreshingLayers: new Set(),
           error: errorMessage,
+          ...(untrustedPath !== undefined
+            ? { repositoryTrustRequired: true }
+            : probed
+              ? { repositoryTrustRequired: false }
+              : {}),
         });
 
         throw error;
@@ -528,6 +573,38 @@ export class GitStateManager {
   }
 
   /**
+   * Asks the host that owns the repository whether Git is refusing it on
+   * ownership grounds, for a failure that could not say so itself.
+   *
+   * Not every execution domain classifies. The CLI peer implements
+   * `git_get_repository_trust` but not `git_get_status`, so its status refresh
+   * fails with an ordinary "unsupported command" — no stable code, no flag, no
+   * Trust button, and the authorization entry point this feature adds is
+   * unreachable from a controller talking to that peer. One read-only probe
+   * makes it reachable.
+   *
+   * Returns the probe's verdict, or `undefined` when it could not produce one —
+   * a host too old to answer, a transport that failed. Only a verdict may move
+   * the trust flag; a failure we cannot explain must neither be dressed up as
+   * an ownership wall nor be taken as proof that one has come down. The
+   * original error is never replaced by the probe's own.
+   */
+  private async probeRepositoryTrust(
+    repositoryPath: string
+  ): Promise<{ trustRequired: boolean; path?: string } | undefined> {
+    try {
+      const report = await gitAPI.getRepositoryTrust(repositoryPath);
+      if (report.state !== 'trust_required') {
+        return { trustRequired: false };
+      }
+      return { trustRequired: true, path: report.repositoryPath ?? repositoryPath };
+    } catch (error) {
+      log.debug('Git trust probe unavailable after a failed refresh', { repositoryPath, error });
+      return undefined;
+    }
+  }
+
+  /**
    * Refresh basic + status layers.
    */
   private async refreshBasicAndStatus(
@@ -537,9 +614,15 @@ export class GitStateManager {
     try {
       const isRepo = await gitAPI.isGitRepository(repositoryPath);
 
+      // The probe answers `true` for a repository Git refuses on ownership
+      // grounds — local and remote alike — so `false` here really is "no
+      // repository", and clearing the trust flag states a fact rather than
+      // hiding one. The ownership case falls through to the status read below,
+      // whose stable error sets the flag in the caller's catch.
       if (!isRepo) {
         this.updateState(repositoryPath, {
           isRepository: false,
+          repositoryTrustRequired: false,
           currentBranch: null,
           ahead: 0,
           behind: 0,

--- a/src/web-ui/src/tools/git/state/types.ts
+++ b/src/web-ui/src/tools/git/state/types.ts
@@ -13,6 +13,12 @@ export type GitStateLayer = 'basic' | 'status' | 'detailed';
 
 export interface GitState {
   isRepository: boolean;
+  /**
+   * The repository exists but Git refuses to read it because the directory is
+   * owned by another user. Distinct from `error` so surfaces can offer the
+   * trust action instead of rendering a localized message.
+   */
+  repositoryTrustRequired: boolean;
   currentBranch: string | null;
   ahead: number;
   behind: number;
@@ -40,6 +46,7 @@ export interface GitState {
 export function createInitialGitState(): GitState {
   return {
     isRepository: false,
+    repositoryTrustRequired: false,
     currentBranch: null,
     ahead: 0,
     behind: 0,
@@ -155,6 +162,8 @@ export interface UseGitStateReturn {
   refreshDetailed: () => Promise<void>;
   
   isRepository: boolean;
+  /** Git refuses this repository on ownership grounds; offer the trust action. */
+  repositoryTrustRequired: boolean;
   currentBranch: string | null;
   ahead: number;
   behind: number;
@@ -207,7 +216,7 @@ export function compareStates(
   const changedFields: (keyof GitState)[] = [];
 
   const basicFields: (keyof GitState)[] = [
-    'isRepository', 'currentBranch', 'ahead', 'behind', 'hasChanges'
+    'isRepository', 'repositoryTrustRequired', 'currentBranch', 'ahead', 'behind', 'hasChanges'
   ];
   for (const field of basicFields) {
     if (prevState[field] !== newState[field]) {


### PR DESCRIPTION
## Summary

Recover Git operations blocked by dubious-ownership rejection. BitFun now classifies the owner guard as a typed, recoverable error and gives the user one explicit consent flow that writes `safe.directory` and completes the blocked command across local, remote, and peer surfaces.

- Detect libgit2 / Git CLI ownership rejections at the service boundary and raise a typed error instead of an opaque failure.
- Confirm the repository root through a unified consent flow that writes `safe.directory` and replays the blocked operation once.
- Keep probes read-only and non-interactive paths prompt-free; never replay side-effecting commands without consent.
- Apply trust on the machine the user is on: remote and peer surfaces route the diagnosis and the manual command to the controller, while the write stays in the execution domain.
- Provide an authorization entry on the Git scene trust-required state, and manual-resolution guidance for uncertain or unsupported outcomes.
- Serialize Deep Review target Git reads around a single trust decision, and normalize prompt dedupe keys per platform.

## Problem

On Windows, handing a repository folder to another account (e.g. `system`) makes Git refuse to open it with "detected dubious ownership" unless the root is listed in `safe.directory`. BitFun surfaced that as an opaque command failure: the Git scene showed a static "not a repository" state with no recovery path, and read-only flows such as Review looked indistinguishable from a missing repository.

## Analysis

Git (since 2.35.2) and libgit2 refuse to operate on a repository whose directory owner differs from the current user unless its root is listed in `safe.directory`; the only sanctioned relief is that configuration entry, which BitFun never wrote. Failures came back unstructured, so callers could not tell "needs trust" from a broken repository, and concurrent read-only requests raced on the decision: one request opened the prompt while a sibling completed a probe and failed fast, aborting the whole preparation even after approval.

The fix keeps ownership trust in one platform-neutral module: rejections are classified once, trust state is reported without mutation, and `safe.directory` is written only after explicit consent, then verified. Trust is never granted implicitly as a fallback of a failed operation.

## Verification

- Manual (Windows): a repository handed to `system` reopens after the trust confirmation; the Git scene leaves the trust-required state and the previously greyed-out review entry recovers.
- Frontend git/trust suites pass (GitAPI, GitTrustPromptService, GitTrustOutcomePresenter, GitStateManager, DeepReviewService, GitScene).
- Rust: `services-integrations` git tests and `remote_workspace_policy` contract tests pass; remote and peer trust commands are policy-declared and routed.

## Follow-up

- `resolve_remote_git_target` currently returns `Option` and is called from ~30 sites; switching it to `Result` would change behavior at every call site at once, so it is tracked as a documented follow-up rather than a change inside this PR.
