### PR TITLE
fix(ci): isolate sherpa native cache lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,20 +197,44 @@ jobs:
 
       - uses: swatinem/rust-cache@v2
         with:
-          shared-key: "ci-check-v4-${{ runner.os }}-no-cargo-bin-v1-sherpa-native-v1"
+          shared-key: "ci-check-v5-${{ runner.os }}-no-cargo-bin-v1"
           cache-bin: false
-          # sherpa-onnx-sys stores downloaded native archives beside Cargo's
-          # normal artifacts. Preserve that directory with the build-script
-          # fingerprints that reference it, or restored test builds cannot link.
-          cache-directories: |
-            target/sherpa-onnx-prebuilt
           # PR caches are scoped to merge refs; trusted main pushes own shared
           # refreshes and retain completed dependency builds after late test failures.
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           cache-on-failure: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
+      # rust-cache prunes the workspace target directory before saving it, so
+      # native libraries stored under target need an independent cache lifecycle.
+      - name: Restore Sherpa native libraries
+        id: sherpa-native-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: target/sherpa-onnx-prebuilt
+          key: sherpa-onnx-v1-${{ runner.os }}-${{ runner.arch }}-1.13.4-static
+
+      - name: Repair missing Sherpa native state
+        shell: bash
+        run: |
+          if ! find target/sherpa-onnx-prebuilt -type f \
+            \( -name 'sherpa-onnx-c-api.lib' -o -name 'libsherpa-onnx-c-api.a' \) \
+            -print -quit 2>/dev/null | grep -q .; then
+            rm -rf target/sherpa-onnx-prebuilt
+            cargo clean -p sherpa-onnx-sys
+          fi
+
       - name: Check compilation
         run: cargo check --locked --workspace
+
+      - name: Save Sherpa native libraries
+        if: >-
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.sherpa-native-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: target/sherpa-onnx-prebuilt
+          key: sherpa-onnx-v1-${{ runner.os }}-${{ runner.arch }}-1.13.4-static
 
       # The installer is intentionally excluded from the root Cargo workspace,
       # so the workspace check above cannot catch drift in its shared Rust APIs.

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -256,8 +256,49 @@ test('keeps Rust CI independent, restore-only on PRs, and target-focused', () =>
   );
   assert.equal(
     rustCache?.with?.['cache-directories'],
-    'target/sherpa-onnx-prebuilt\n',
-    'Rust CI must restore sherpa native libraries with the Cargo fingerprints that reference them',
+    undefined,
+    'Rust cache cleanup must not own native libraries stored under target',
+  );
+
+  const restoreSherpaCache = rustJob.steps.find(
+    (step) => step.name === 'Restore Sherpa native libraries',
+  );
+  const repairSherpaState = rustJob.steps.find(
+    (step) => step.name === 'Repair missing Sherpa native state',
+  );
+  const checkCompilation = rustJob.steps.find(
+    (step) => step.name === 'Check compilation',
+  );
+  const saveSherpaCache = rustJob.steps.find(
+    (step) => step.name === 'Save Sherpa native libraries',
+  );
+  const sherpaCacheKey =
+    'sherpa-onnx-v1-${{ runner.os }}-${{ runner.arch }}-1.13.4-static';
+
+  assert.equal(restoreSherpaCache?.uses, 'actions/cache/restore@v5');
+  assert.equal(restoreSherpaCache?.with?.path, 'target/sherpa-onnx-prebuilt');
+  assert.equal(restoreSherpaCache?.with?.key, sherpaCacheKey);
+  assert.match(
+    repairSherpaState?.run ?? '',
+    /rm -rf target\/sherpa-onnx-prebuilt/,
+  );
+  assert.match(repairSherpaState?.run ?? '', /cargo clean -p sherpa-onnx-sys/);
+  assert.equal(saveSherpaCache?.uses, 'actions/cache/save@v5');
+  assert.equal(saveSherpaCache?.with?.path, 'target/sherpa-onnx-prebuilt');
+  assert.equal(saveSherpaCache?.with?.key, sherpaCacheKey);
+  assert.equal(
+    saveSherpaCache?.if,
+    "github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.sherpa-native-cache.outputs.cache-hit != 'true'",
+  );
+  assert.ok(
+    rustJob.steps.indexOf(restoreSherpaCache) <
+      rustJob.steps.indexOf(checkCompilation),
+    'Sherpa native libraries must be restored before cargo check',
+  );
+  assert.ok(
+    rustJob.steps.indexOf(checkCompilation) <
+      rustJob.steps.indexOf(saveSherpaCache),
+    'Sherpa native libraries must be saved before rust-cache post cleanup',
   );
 
   const commandByStep = new Map(


### PR DESCRIPTION
## Summary

- separate sherpa-onnx native archives from `swatinem/rust-cache` target cleanup
- repair stale Cargo build-script state when the native archive is missing or incomplete
- bump the Rust cache generation to avoid restoring the poisoned Windows cache
- protect cache ownership, ordering, and main-only publishing with GitHub config contract tests

## Why

`swatinem/rust-cache` recursively cleans the workspace `target` directory before saving. The existing `cache-directories: target/sherpa-onnx-prebuilt` entry therefore saved Cargo build-script fingerprints without the native libraries they referenced. Windows then failed during `cargo test` linking with `could not find native static library sherpa-onnx-c-api`, while `cargo check` continued to pass.

## Verification

- `pnpm run check:github-config`
- `git diff --check`
- `pnpm run check:repo-hygiene` (blocked by pre-existing untracked `generate_intro_doc.cjs`, which contains a local absolute path and is not part of this PR)

AI-assisted: yes. Testing level: focused local checks; full cross-platform CI pending.