### PR TITLE
fix(todos): correct date order, calendar scope, intervals and run state

### DIFF
--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.appearance.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.appearance.ts
@@ -1,0 +1,13 @@
+import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
+
+export const localizedDateTimeFieldAppearanceDescriptor: AppearanceSurfaceDescriptor = {
+  id: 'localized-datetime-field',
+  parts: [
+    { id: 'root' },
+    { id: 'date' },
+    { id: 'time' },
+  ],
+  states: [
+    { id: 'error', selector: { kind: 'self', suffix: '[data-bf-state~="error"]' } },
+  ],
+};

--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
@@ -1,0 +1,67 @@
+@use '../../../component-library/styles/tokens.scss' as *;
+
+.bf-datetime-field {
+  display: inline-flex;
+  align-items: center;
+  gap: $size-gap-2;
+  box-sizing: border-box;
+  min-height: 28px;
+  padding: 0 8px;
+  border: 1px solid var(--bf-appearance-token-border-subtle);
+  border-radius: $size-radius-base;
+  background: color-mix(in srgb, var(--bf-appearance-token-element-bg-base) 82%, transparent);
+  transition: border-color $motion-fast $easing-standard;
+
+  &:focus-within {
+    border-color: var(--bf-appearance-token-color-accent-500);
+  }
+
+  &--error {
+    border-color: var(--bf-appearance-token-color-error);
+  }
+
+  &--disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  &__group {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+  }
+
+  &__segment {
+    min-width: 0;
+    padding: 3px 2px;
+    border: none;
+    border-radius: $size-radius-sm;
+    background: transparent;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-size: var(--bf-appearance-token-font-size-sm);
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    outline: none;
+
+    &::placeholder {
+      color: var(--bf-appearance-token-color-text-muted);
+    }
+
+    &:focus {
+      background: color-mix(in srgb, var(--bf-appearance-token-color-accent-500) 18%, transparent);
+    }
+
+    // Width tracks the digit count so segments do not jitter while typing.
+    &--year { width: 4ch; }
+    &--month,
+    &--day,
+    &--hour,
+    &--minute { width: 2.4ch; }
+  }
+
+  &__sep {
+    color: var(--bf-appearance-token-color-text-muted);
+    font-size: var(--bf-appearance-token-font-size-xs);
+    user-select: none;
+  }
+}

--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.tsx
@@ -1,0 +1,130 @@
+/**
+ * Date-time entry whose field order follows the app locale.
+ *
+ * A native `<input type="datetime-local">` renders in the *browser's* locale,
+ * which Chromium takes from the OS and does not read from the `lang`
+ * attribute. Running the UI in Chinese on an English system therefore shows
+ * `08/12/2026, 04:48 AM` inside an otherwise Chinese form. This control keeps
+ * the same `YYYY-MM-DDTHH:mm` value contract as the native input so callers are
+ * unchanged, but lays the segments out in the order the active locale reads.
+ */
+
+import React, { useCallback, useMemo, useRef } from 'react';
+import { useI18n } from '@/infrastructure/i18n';
+import {
+  SEGMENTS,
+  clampSegmentToRange,
+  composeDateTimeValue,
+  parseDateTimeValue,
+  resolveDateSegmentOrder,
+  type ParsedValue,
+  type SegmentId,
+} from './localizedDateTime';
+
+export interface LocalizedDateTimeFieldProps {
+  /** `YYYY-MM-DDTHH:mm`, matching the native datetime-local value. */
+  value: string;
+  onChange: (value: string) => void;
+  error?: boolean;
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+const LocalizedDateTimeField: React.FC<LocalizedDateTimeFieldProps> = ({
+  value,
+  onChange,
+  error = false,
+  disabled = false,
+  className,
+  'aria-label': ariaLabel,
+}) => {
+  const { t, currentLanguage } = useI18n('common');
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const parsed = useMemo(() => parseDateTimeValue(value), [value]);
+  const dateOrder = useMemo(() => resolveDateSegmentOrder(currentLanguage), [currentLanguage]);
+
+  const emit = useCallback((next: ParsedValue) => {
+    const composed = composeDateTimeValue(next);
+    // Hold the edit until every segment is filled; a partial date has no
+    // meaningful timestamp and clearing one field should not wipe the value.
+    if (composed !== null) onChange(composed);
+  }, [onChange]);
+
+  const handleSegmentChange = useCallback((id: SegmentId, raw: string) => {
+    const spec = SEGMENTS[id];
+    const digits = raw.replace(/\D/g, '').slice(0, spec.length);
+    emit({ ...parsed, [id]: digits });
+
+    // Advance once a segment is unambiguously complete, so typing flows across
+    // the row the way the native control does.
+    if (digits.length === spec.length) {
+      const inputs = containerRef.current?.querySelectorAll<HTMLInputElement>('input');
+      if (!inputs) return;
+      const current = Array.from(inputs).findIndex(input => input.dataset.segment === id);
+      inputs[current + 1]?.focus();
+    }
+  }, [emit, parsed]);
+
+  const handleSegmentBlur = useCallback((id: SegmentId, raw: string) => {
+    const normalized = clampSegmentToRange(raw, SEGMENTS[id]);
+    if (!normalized) return;
+    emit({ ...parsed, [id]: normalized });
+  }, [emit, parsed]);
+
+  const renderSegment = (id: SegmentId) => {
+    const spec = SEGMENTS[id];
+    return (
+      <input
+        key={id}
+        type="text"
+        inputMode="numeric"
+        data-segment={id}
+        className={`bf-datetime-field__segment bf-datetime-field__segment--${id}`}
+        value={parsed[id]}
+        disabled={disabled}
+        maxLength={spec.length}
+        size={spec.length}
+        placeholder={t(`dateTimeField.segments.${id}`)}
+        aria-label={t(`dateTimeField.segments.${id}`)}
+        onChange={event => handleSegmentChange(id, event.currentTarget.value)}
+        onBlur={event => handleSegmentBlur(id, event.currentTarget.value)}
+        onFocus={event => event.currentTarget.select()}
+      />
+    );
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={[
+        'bf-datetime-field',
+        error ? 'bf-datetime-field--error' : '',
+        disabled ? 'bf-datetime-field--disabled' : '',
+        className ?? '',
+      ].filter(Boolean).join(' ')}
+      data-bf-component="localized-datetime-field"
+      data-bf-part="root"
+      data-bf-state={error ? 'error' : undefined}
+      role="group"
+      aria-label={ariaLabel ?? t('dateTimeField.label')}
+    >
+      <span className="bf-datetime-field__group" data-bf-component="localized-datetime-field" data-bf-part="date">
+        {dateOrder.map((id, index) => (
+          <React.Fragment key={id}>
+            {index > 0 ? <span className="bf-datetime-field__sep" aria-hidden="true">/</span> : null}
+            {renderSegment(id)}
+          </React.Fragment>
+        ))}
+      </span>
+      <span className="bf-datetime-field__group" data-bf-component="localized-datetime-field" data-bf-part="time">
+        {renderSegment('hour')}
+        <span className="bf-datetime-field__sep" aria-hidden="true">:</span>
+        {renderSegment('minute')}
+      </span>
+    </div>
+  );
+};
+
+export default LocalizedDateTimeField;

--- a/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.scss
+++ b/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.scss
@@ -338,6 +338,11 @@
       grid-template-columns: minmax(0, 1fr) auto;
       align-items: start;
     }
+
+    &--interval {
+      grid-template-columns: minmax(0, 1fr) minmax(84px, auto);
+      align-items: center;
+    }
   }
 
   &__toggle-card {

--- a/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.tsx
@@ -41,12 +41,14 @@ import {
   ASSISTANT_WORKSPACE_AGENT_TYPE,
   DEFAULT_AGENT_TYPE,
   EMPTY_VALIDATION_ERRORS,
+  INTERVAL_UNIT_OPTIONS,
   SCHEDULED_JOBS_CHANGED_EVENT,
   buildScheduleFromDraft,
   buildTargetFromDraft,
   buildWorkspaceRef,
   createEmptyDraft,
-  formatEveryMinutes,
+  formatIntervalValue,
+  splitInterval,
   getCurrentLocalDateTimeInput,
   getNextExecutionAtMs,
   hasValidationErrors,
@@ -54,10 +56,13 @@ import {
   jobToDraft,
   notifyScheduledJobsChanged as emitScheduledJobsChanged,
   validateDraft,
+  type IntervalUnit,
   type JobDraft,
   type JobDraftValidationErrors,
   type ScheduleKind,
 } from './scheduledJobDraft';
+import LocalizedDateTimeField from './LocalizedDateTimeField';
+import './LocalizedDateTimeField.scss';
 import './ScheduledJobsView.scss';
 
 const log = createLogger('ScheduledJobsView');
@@ -97,8 +102,12 @@ function formatScheduleSummary(
   switch (schedule.kind) {
     case 'at':
       return `${t('nav.scheduledJobs.scheduleKinds.at')}: ${formatTimestamp(new Date(schedule.at).getTime(), formatDate, t)}`;
-    case 'every':
-      return t('nav.scheduledJobs.scheduleSummary.every', { everyMinutes: formatEveryMinutes(schedule.everyMs) });
+    case 'every': {
+      const interval = splitInterval(schedule.everyMs);
+      return t(`nav.scheduledJobs.scheduleSummary.everyUnit.${interval.unit}`, {
+        value: formatIntervalValue(interval.value),
+      });
+    }
     case 'cron':
       return schedule.tz
         ? t('nav.scheduledJobs.scheduleSummary.cronWithTz', { expr: schedule.expr, tz: schedule.tz })
@@ -760,7 +769,7 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
                   setValidationErrors(current => ({
                     ...current,
                     at: false,
-                    everyMinutes: false,
+                    everyValue: false,
                     cronExpr: false,
                   }));
                   setDraft(c => ({
@@ -793,13 +802,10 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
               <span className="asv__field-label">{t('nav.scheduledJobs.fields.at')}</span>
             </div>
             <div className="asv__field-control" data-bf-component="scheduled-jobs-view" data-bf-part="fieldControl">
-              <Input
-                size="small"
-                type="datetime-local"
+              <LocalizedDateTimeField
                 value={draft.at}
                 error={validationErrors.at}
-                onChange={e => {
-                  const at = e.currentTarget.value;
+                onChange={at => {
                   setValidationErrors(current => ({ ...current, at: false }));
                   setDraft(c => ({
                     ...c,
@@ -819,18 +825,31 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
                 <span className="asv__field-label">{t('nav.scheduledJobs.fields.everyMs')}</span>
               </div>
               <div className="asv__field-control" data-bf-component="scheduled-jobs-view" data-bf-part="fieldControl">
-                <Input
-                  size="small"
-                  type="number"
-                  value={draft.everyMinutes}
-                  error={validationErrors.everyMinutes}
-                  onChange={e => {
-                    const everyMinutes = e.currentTarget.value;
-                    setValidationErrors(current => ({ ...current, everyMinutes: false }));
-                    setDraft(c => ({ ...c, everyMinutes }));
-                  }}
-                  placeholder="60"
-                />
+                <div className="asv__control-grid asv__control-grid--interval">
+                  <Input
+                    size="small"
+                    type="number"
+                    value={draft.everyValue}
+                    error={validationErrors.everyValue}
+                    onChange={e => {
+                      const everyValue = e.currentTarget.value;
+                      setValidationErrors(current => ({ ...current, everyValue: false }));
+                      setDraft(c => ({ ...c, everyValue }));
+                    }}
+                    placeholder="1"
+                  />
+                  <Select
+                    size="small"
+                    value={draft.everyUnit}
+                    options={INTERVAL_UNIT_OPTIONS.map(unit => ({
+                      value: unit,
+                      label: t(`nav.scheduledJobs.intervalUnits.${unit}`),
+                    }))}
+                    onChange={value => {
+                      setDraft(c => ({ ...c, everyUnit: value as IntervalUnit }));
+                    }}
+                  />
+                </div>
               </div>
             </div>
             <div className="asv__form-row asv__form-row--inline" data-bf-component="scheduled-jobs-view" data-bf-part="field">
@@ -838,15 +857,10 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
                 <span className="asv__field-label">{t('nav.scheduledJobs.fields.anchorMs')}</span>
               </div>
               <div className="asv__field-control" data-bf-component="scheduled-jobs-view" data-bf-part="fieldControl">
-                <Input
-                  size="small"
-                  type="datetime-local"
+                <LocalizedDateTimeField
                   value={draft.anchorMs}
-                  onChange={e => {
-                    const anchorMs = e.currentTarget.value;
-                    setDraft(c => ({ ...c, anchorMs }));
-                  }}
-                  placeholder={t('nav.scheduledJobs.placeholders.anchorMs')}
+                  onChange={anchorMs => setDraft(c => ({ ...c, anchorMs }))}
+                  aria-label={t('nav.scheduledJobs.fields.anchorMs')}
                 />
               </div>
             </div>

--- a/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.test.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The whole reason this control exists is that a native datetime-local renders
+ * in the browser's locale, not the app's. These cases pin the ordering it
+ * replaces that with, and the value contract callers still rely on.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  composeDateTimeValue,
+  parseDateTimeValue,
+  resolveDateSegmentOrder,
+} from './localizedDateTime';
+
+describe('resolveDateSegmentOrder', () => {
+  it('reads year-first for Chinese, regardless of the browser locale', () => {
+    expect(resolveDateSegmentOrder('zh-CN')).toEqual(['year', 'month', 'day']);
+    expect(resolveDateSegmentOrder('zh-TW')).toEqual(['year', 'month', 'day']);
+  });
+
+  it('reads month-first for English', () => {
+    expect(resolveDateSegmentOrder('en-US')).toEqual(['month', 'day', 'year']);
+  });
+
+  it('falls back to month-first for an unknown or missing locale', () => {
+    expect(resolveDateSegmentOrder(undefined)).toEqual(['month', 'day', 'year']);
+    expect(resolveDateSegmentOrder('')).toEqual(['month', 'day', 'year']);
+  });
+});
+
+describe('parseDateTimeValue', () => {
+  it('splits the native datetime-local value into segments', () => {
+    expect(parseDateTimeValue('2026-08-12T04:48')).toEqual({
+      year: '2026', month: '08', day: '12', hour: '04', minute: '48',
+    });
+  });
+
+  it('tolerates a seconds suffix', () => {
+    expect(parseDateTimeValue('2026-08-12T04:48:30').minute).toBe('48');
+  });
+
+  it('returns empty segments for anything unparseable', () => {
+    expect(parseDateTimeValue('')).toEqual({
+      year: '', month: '', day: '', hour: '', minute: '',
+    });
+    expect(parseDateTimeValue('not a date').year).toBe('');
+  });
+});
+
+describe('composeDateTimeValue', () => {
+  it('rebuilds the exact value the native input would have produced', () => {
+    expect(composeDateTimeValue({
+      year: '2026', month: '08', day: '12', hour: '04', minute: '48',
+    })).toBe('2026-08-12T04:48');
+  });
+
+  it('round-trips through parse without drift', () => {
+    const original = '2026-12-31T23:59';
+    expect(composeDateTimeValue(parseDateTimeValue(original))).toBe(original);
+  });
+
+  it('holds back a partial date instead of emitting a broken timestamp', () => {
+    expect(composeDateTimeValue({
+      year: '2026', month: '08', day: '', hour: '04', minute: '48',
+    })).toBeNull();
+  });
+
+  it('clamps a day past the end of its month', () => {
+    // February 31 would otherwise roll into March.
+    expect(composeDateTimeValue({
+      year: '2026', month: '02', day: '31', hour: '09', minute: '00',
+    })).toBe('2026-02-28T09:00');
+  });
+
+  it('respects a leap year', () => {
+    expect(composeDateTimeValue({
+      year: '2028', month: '02', day: '31', hour: '09', minute: '00',
+    })).toBe('2028-02-29T09:00');
+  });
+
+  it('pads a short month or day back to two digits', () => {
+    expect(composeDateTimeValue({
+      year: '2026', month: '8', day: '2', hour: '04', minute: '48',
+    })).toBe('2026-08-02T04:48');
+  });
+});

--- a/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure date-time segment helpers for `LocalizedDateTimeField`.
+ *
+ * Kept out of the component file so the ordering and value rules can be tested
+ * directly, and so the component module only exports a component.
+ */
+
+/** Locales that read year-first. Everything else falls back to month-first. */
+const YEAR_FIRST_LOCALE_PREFIXES = ['zh', 'ja', 'ko'];
+
+export type SegmentId = 'year' | 'month' | 'day' | 'hour' | 'minute';
+
+export interface SegmentSpec {
+  id: SegmentId;
+  length: number;
+  min: number;
+  max: number;
+}
+
+export const SEGMENTS: Record<SegmentId, SegmentSpec> = {
+  year: { id: 'year', length: 4, min: 1970, max: 9999 },
+  month: { id: 'month', length: 2, min: 1, max: 12 },
+  day: { id: 'day', length: 2, min: 1, max: 31 },
+  hour: { id: 'hour', length: 2, min: 0, max: 23 },
+  minute: { id: 'minute', length: 2, min: 0, max: 59 },
+};
+
+export interface ParsedValue {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+}
+
+const EMPTY_PARSED: ParsedValue = { year: '', month: '', day: '', hour: '', minute: '' };
+
+export function parseDateTimeValue(value: string): ParsedValue {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(value.trim());
+  if (!match) return EMPTY_PARSED;
+  return { year: match[1], month: match[2], day: match[3], hour: match[4], minute: match[5] };
+}
+
+export function clampSegmentToRange(raw: string, spec: SegmentSpec): string {
+  const digits = raw.replace(/\D/g, '').slice(0, spec.length);
+  if (!digits) return '';
+  const numeric = Math.min(Math.max(Number(digits), spec.min), spec.max);
+  return String(numeric).padStart(spec.length, '0');
+}
+
+/** Days in the given month, so 31 February normalizes instead of rolling over. */
+function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+export function composeDateTimeValue(parsed: ParsedValue): string | null {
+  const { year, month, day, hour, minute } = parsed;
+  if (!year || !month || !day || !hour || !minute) return null;
+
+  const yearNumber = Number(year);
+  const monthNumber = Math.min(Math.max(Number(month), 1), 12);
+  const dayNumber = Math.min(
+    Math.max(Number(day), 1),
+    daysInMonth(yearNumber, monthNumber),
+  );
+
+  return [
+    String(yearNumber).padStart(4, '0'),
+    String(monthNumber).padStart(2, '0'),
+    String(dayNumber).padStart(2, '0'),
+  ].join('-')
+    + 'T'
+    + [hour, minute].join(':');
+}
+
+/**
+ * Date segment order for a locale: year-first for CJK, month-first otherwise.
+ *
+ * Driven by the app's own locale rather than the browser's, which is the whole
+ * point of this control.
+ */
+export function resolveDateSegmentOrder(locale: string | null | undefined): SegmentId[] {
+  const language = String(locale ?? '').toLowerCase();
+  const yearFirst = YEAR_FIRST_LOCALE_PREFIXES.some(prefix => language.startsWith(prefix));
+  return yearFirst ? ['year', 'month', 'day'] : ['month', 'day', 'year'];
+}

--- a/src/web-ui/src/app/components/scheduled-jobs/scheduledJobDraft.test.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/scheduledJobDraft.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Interval units are entered in one scale and stored in another, so the
+ * round trip is the part worth pinning: what the editor shows must rebuild the
+ * exact millisecond value the scheduler already had.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { CronJob } from '@/infrastructure/api';
+import {
+  DAY_IN_MS,
+  HOUR_IN_MS,
+  MINUTE_IN_MS,
+  buildScheduleFromDraft,
+  createEmptyDraft,
+  formatIntervalValue,
+  jobToDraft,
+  splitInterval,
+} from './scheduledJobDraft';
+
+function jobWithInterval(everyMs: number): CronJob {
+  return {
+    id: 'cron_test',
+    name: 'test',
+    schedule: { kind: 'every', everyMs },
+    payload: { text: 'hello' },
+    enabled: true,
+    target: {
+      kind: 'workspace',
+      workspace: { workspacePath: '/tmp/workspace' },
+      launch: { agentType: 'agentic' },
+    },
+    createdAtMs: 0,
+    configUpdatedAtMs: 0,
+    updatedAtMs: 0,
+    state: { consecutiveFailures: 0, coalescedRunCount: 0 },
+  };
+}
+
+describe('splitInterval', () => {
+  it('reads a daily interval as days rather than 1440 minutes', () => {
+    expect(splitInterval(DAY_IN_MS)).toEqual({ value: 1, unit: 'day' });
+    expect(splitInterval(3 * DAY_IN_MS)).toEqual({ value: 3, unit: 'day' });
+  });
+
+  it('prefers hours when days do not divide evenly', () => {
+    expect(splitInterval(6 * HOUR_IN_MS)).toEqual({ value: 6, unit: 'hour' });
+    expect(splitInterval(36 * HOUR_IN_MS)).toEqual({ value: 36, unit: 'hour' });
+  });
+
+  it('falls back to minutes for anything finer', () => {
+    expect(splitInterval(30 * MINUTE_IN_MS)).toEqual({ value: 30, unit: 'minute' });
+    expect(splitInterval(90 * MINUTE_IN_MS)).toEqual({ value: 90, unit: 'minute' });
+  });
+
+  it('does not claim a unit for a non-positive interval', () => {
+    expect(splitInterval(0).unit).toBe('minute');
+  });
+});
+
+describe('interval round trip', () => {
+  it.each([
+    ['daily', DAY_IN_MS],
+    ['six hourly', 6 * HOUR_IN_MS],
+    ['half hourly', 30 * MINUTE_IN_MS],
+    ['awkward', 90 * MINUTE_IN_MS],
+  ])('rebuilds the exact interval for a %s job', (_label, everyMs) => {
+    const draft = jobToDraft(jobWithInterval(everyMs), 'agentic');
+    const schedule = buildScheduleFromDraft(draft);
+
+    expect(schedule).toMatchObject({ kind: 'every', everyMs });
+  });
+});
+
+describe('formatIntervalValue', () => {
+  it('keeps whole numbers whole and trims trailing zeros', () => {
+    expect(formatIntervalValue(3)).toBe('3');
+    expect(formatIntervalValue(1.5)).toBe('1.5');
+    expect(formatIntervalValue(2.0)).toBe('2');
+  });
+});
+
+describe('createEmptyDraft', () => {
+  it('defaults to a readable hourly interval', () => {
+    const draft = createEmptyDraft();
+    expect(draft.everyValue).toBe('1');
+    expect(draft.everyUnit).toBe('hour');
+    expect(buildScheduleFromDraft({ ...draft, scheduleKind: 'every' }))
+      .toMatchObject({ kind: 'every', everyMs: HOUR_IN_MS });
+  });
+});

--- a/src/web-ui/src/app/components/scheduled-jobs/scheduledJobDraft.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/scheduledJobDraft.ts
@@ -16,8 +16,37 @@ import type {
 import { normalizePath } from '@/shared/utils/pathUtils';
 
 export const MINUTE_IN_MS = 60_000;
+export const HOUR_IN_MS = 60 * MINUTE_IN_MS;
+export const DAY_IN_MS = 24 * HOUR_IN_MS;
 export const DEFAULT_AGENT_TYPE = 'agentic';
 export const ASSISTANT_WORKSPACE_AGENT_TYPE = 'Claw';
+
+/**
+ * Interval units offered by the editors.
+ *
+ * The wire format stays milliseconds; the unit only decides how a value is
+ * entered and read back, so a daily job reads "every 1 day" rather than
+ * "every 1440 minutes".
+ */
+export type IntervalUnit = 'minute' | 'hour' | 'day';
+
+/** Selector order, coarsest-last so the common "every N minutes" stays first. */
+export const INTERVAL_UNIT_OPTIONS: readonly IntervalUnit[] = ['minute', 'hour', 'day'];
+
+export const INTERVAL_UNIT_MS: Record<IntervalUnit, number> = {
+  minute: MINUTE_IN_MS,
+  hour: HOUR_IN_MS,
+  day: DAY_IN_MS,
+};
+
+/** Largest unit that divides the interval evenly, so the value stays whole. */
+export function splitInterval(everyMs: number): { value: number; unit: IntervalUnit } {
+  if (Number.isFinite(everyMs) && everyMs > 0) {
+    if (everyMs % DAY_IN_MS === 0) return { value: everyMs / DAY_IN_MS, unit: 'day' };
+    if (everyMs % HOUR_IN_MS === 0) return { value: everyMs / HOUR_IN_MS, unit: 'hour' };
+  }
+  return { value: everyMs / MINUTE_IN_MS, unit: 'minute' };
+}
 
 /** Emitted after any create/update/delete so other mounted views reload. */
 export const SCHEDULED_JOBS_CHANGED_EVENT = 'bitfun:scheduled-jobs-changed';
@@ -32,7 +61,9 @@ export interface JobDraft {
   agentType: string;
   scheduleKind: ScheduleKind;
   at: string;
-  everyMinutes: string;
+  /** Interval value in `everyUnit`; kept as a string so the input stays free-form. */
+  everyValue: string;
+  everyUnit: IntervalUnit;
   anchorMs: string;
   expr: string;
   tz: string;
@@ -44,7 +75,7 @@ export interface JobDraftValidationErrors {
   agentType: boolean;
   text: boolean;
   at: boolean;
-  everyMinutes: boolean;
+  everyValue: boolean;
   cronExpr: boolean;
 }
 
@@ -55,7 +86,7 @@ export const EMPTY_VALIDATION_ERRORS: JobDraftValidationErrors = Object.freeze({
   agentType: false,
   text: false,
   at: false,
-  everyMinutes: false,
+  everyValue: false,
   cronExpr: false,
 });
 
@@ -79,10 +110,10 @@ export function isFutureLocalDateTimeInput(value: string, nowMs = Date.now()): b
   return Number.isFinite(timestampMs) && timestampMs > nowMs;
 }
 
-export function formatEveryMinutes(everyMs: number): string {
-  const everyMinutes = everyMs / MINUTE_IN_MS;
-  if (Number.isInteger(everyMinutes)) return String(everyMinutes);
-  return everyMinutes.toFixed(2).replace(/\.?0+$/, '');
+/** Trims a possibly fractional interval value to a short display string. */
+export function formatIntervalValue(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(2).replace(/\.?0+$/, '');
 }
 
 export function createEmptyDraft(
@@ -97,7 +128,8 @@ export function createEmptyDraft(
     agentType: defaultAgentType,
     scheduleKind: 'at',
     at: getCurrentLocalDateTimeInput(),
-    everyMinutes: '60',
+    everyValue: '1',
+    everyUnit: 'hour',
     anchorMs: '',
     expr: '0 8 * * *',
     tz: '',
@@ -122,7 +154,9 @@ export function jobToDraft(job: CronJob, defaultAgentType: string): JobDraft {
     draft.at = toLocalDateTimeInput(job.schedule.at);
   } else if (job.schedule.kind === 'every') {
     draft.scheduleKind = 'every';
-    draft.everyMinutes = formatEveryMinutes(job.schedule.everyMs);
+    const interval = splitInterval(job.schedule.everyMs);
+    draft.everyValue = formatIntervalValue(interval.value);
+    draft.everyUnit = interval.unit;
     draft.anchorMs = job.schedule.anchorMs != null
       ? timestampMsToLocalDateTimeInput(job.schedule.anchorMs)
       : '';
@@ -139,9 +173,13 @@ export function buildScheduleFromDraft(draft: JobDraft): CronSchedule {
     return { kind: 'at', at: new Date(draft.at).toISOString() };
   }
   if (draft.scheduleKind === 'every') {
-    const everyMinutes = Number(draft.everyMinutes);
+    const everyValue = Number(draft.everyValue);
     const anchorMs = draft.anchorMs.trim() ? new Date(draft.anchorMs).getTime() : undefined;
-    return { kind: 'every', everyMs: Math.round(everyMinutes * MINUTE_IN_MS), anchorMs };
+    return {
+      kind: 'every',
+      everyMs: Math.round(everyValue * INTERVAL_UNIT_MS[draft.everyUnit]),
+      anchorMs,
+    };
   }
   return { kind: 'cron', expr: draft.expr.trim(), tz: draft.tz.trim() || undefined };
 }
@@ -191,16 +229,16 @@ export function validateDraft(
   targetKind: CronJobTargetKind,
   draft: JobDraft,
 ): JobDraftValidationErrors {
-  const everyMinutes = Number(draft.everyMinutes);
+  const everyValue = Number(draft.everyValue);
   return {
     name: !draft.name.trim(),
     sessionId: targetKind === 'session' && !draft.sessionId.trim(),
     agentType: targetKind === 'workspace' && !draft.agentType.trim(),
     text: !draft.text.trim(),
     at: draft.scheduleKind === 'at' && !draft.at.trim(),
-    everyMinutes:
+    everyValue:
       draft.scheduleKind === 'every'
-      && (!draft.everyMinutes.trim() || !Number.isFinite(everyMinutes) || everyMinutes <= 0),
+      && (!draft.everyValue.trim() || !Number.isFinite(everyValue) || everyValue <= 0),
     cronExpr: draft.scheduleKind === 'cron' && !draft.expr.trim(),
   };
 }
@@ -212,7 +250,7 @@ export function hasValidationErrors(errors: JobDraftValidationErrors): boolean {
     || errors.agentType
     || errors.text
     || errors.at
-    || errors.everyMinutes
+    || errors.everyValue
     || errors.cronExpr
   );
 }

--- a/src/web-ui/src/app/scenes/todos/TodosScene.scss
+++ b/src/web-ui/src/app/scenes/todos/TodosScene.scss
@@ -166,6 +166,10 @@ $todos-stack-breakpoint: 1080px;
       box-shadow: inset 2px 0 0 var(--bf-appearance-token-color-warning);
     }
 
+    &--running {
+      box-shadow: inset 2px 0 0 var(--bf-appearance-token-color-accent-500);
+    }
+
     &--disabled {
       opacity: 0.62;
     }
@@ -232,6 +236,11 @@ $todos-stack-breakpoint: 1080px;
     &--warn {
       background: color-mix(in srgb, var(--bf-appearance-token-color-warning) 16%, transparent);
       color: var(--bf-appearance-token-color-warning);
+    }
+
+    &--running {
+      background: color-mix(in srgb, var(--bf-appearance-token-color-success) 16%, transparent);
+      color: var(--bf-appearance-token-color-success);
     }
   }
 
@@ -526,6 +535,13 @@ $todos-stack-breakpoint: 1080px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  &__interval {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(84px, auto);
+    gap: $size-gap-2;
+    align-items: center;
   }
 
   &__workspace-option {

--- a/src/web-ui/src/app/scenes/todos/TodosScene.tsx
+++ b/src/web-ui/src/app/scenes/todos/TodosScene.tsx
@@ -2,8 +2,9 @@
  * TodosScene — one place for every scheduled task across all workspaces.
  *
  * Two tiers, as the panel's contract:
- *   - anything due within 24 hours is listed, newest deadline first;
- *   - anything further out is placed on a month calendar.
+ *   - anything due within 24 hours is listed, soonest first;
+ *   - the month calendar carries the whole remaining agenda, near-term runs
+ *     included, so a day cell is never mysteriously empty.
  *
  * Todos are scheduled jobs, so this reads and writes the same cron service the
  * agent's own scheduling tool and the per-workspace editors use. Changes here
@@ -147,8 +148,8 @@ const TodosScene: React.FC = () => {
 
   const selectedDayOccurrences = useMemo(() => {
     if (!selectedDayKey) return [];
-    return groupOccurrencesByDay(buckets.later).get(selectedDayKey) ?? [];
-  }, [buckets.later, selectedDayKey]);
+    return groupOccurrencesByDay(buckets.calendar).get(selectedDayKey) ?? [];
+  }, [buckets.calendar, selectedDayKey]);
 
   const resetEditor = useCallback(() => {
     setEditorOpen(false);
@@ -392,6 +393,7 @@ const TodosScene: React.FC = () => {
                   atMs={occurrence.atMs}
                   isOverdue={occurrence.isOverdue}
                   isNextRun={occurrence.isNextRun}
+                  isRunning={occurrence.isRunning}
                   nowMs={nowMs}
                   workspaces={openedWorkspacesList}
                   isSelected={editingJob?.id === occurrence.job.id}
@@ -435,7 +437,7 @@ const TodosScene: React.FC = () => {
           data-bf-part="calendarPane"
         >
           <TodoCalendar
-            occurrences={buckets.later}
+            occurrences={buckets.calendar}
             monthAnchorMs={monthAnchorMs}
             selectedDayKey={selectedDayKey}
             nowMs={nowMs}
@@ -474,6 +476,7 @@ const TodosScene: React.FC = () => {
                       job={occurrence.job}
                       atMs={occurrence.atMs}
                       isNextRun={occurrence.isNextRun}
+                      isRunning={occurrence.isRunning}
                       nowMs={nowMs}
                       workspaces={openedWorkspacesList}
                       isSelected={editingJob?.id === occurrence.job.id}

--- a/src/web-ui/src/app/scenes/todos/components/TodoCalendar.tsx
+++ b/src/web-ui/src/app/scenes/todos/components/TodoCalendar.tsx
@@ -1,9 +1,10 @@
 /**
- * Month calendar for Todos scheduled more than 24 hours out.
+ * Month calendar covering the whole remaining agenda.
  *
- * Near-term runs deliberately do not appear here — they live in the list tier —
- * so the header states the cut-off rather than leaving today's cell looking
- * mysteriously empty.
+ * Near-term runs appear here as well as in the 24-hour list: the list answers
+ * "what is about to happen", the calendar answers "when is everything
+ * happening", and hiding today's runs from it only made day cells look wrong.
+ * Jobs with nothing left to run are the only ones left out.
  */
 
 import React, { useMemo } from 'react';

--- a/src/web-ui/src/app/scenes/todos/components/TodoEditor.tsx
+++ b/src/web-ui/src/app/scenes/todos/components/TodoEditor.tsx
@@ -21,6 +21,12 @@ import {
   type JobDraftValidationErrors,
   type ScheduleKind,
 } from '@/app/components/scheduled-jobs/scheduledJobDraft';
+import {
+  INTERVAL_UNIT_OPTIONS,
+  type IntervalUnit,
+} from '@/app/components/scheduled-jobs/scheduledJobDraft';
+import LocalizedDateTimeField from '@/app/components/scheduled-jobs/LocalizedDateTimeField';
+import '@/app/components/scheduled-jobs/LocalizedDateTimeField.scss';
 import type { TodoWorkspaceOption } from '../todoPresentation';
 
 const log = createLogger('TodoEditor');
@@ -230,7 +236,7 @@ const TodoEditor: React.FC<TodoEditorProps> = ({
               onValidationErrorsChange((current) => ({
                 ...current,
                 at: false,
-                everyMinutes: false,
+                everyValue: false,
                 cronExpr: false,
               }));
               onDraftChange((current) => ({
@@ -248,13 +254,10 @@ const TodoEditor: React.FC<TodoEditorProps> = ({
         {draft.scheduleKind === 'at' ? (
           <label className="bf-todos__field" data-bf-scene="todos" data-bf-part="field">
             <span className="bf-todos__field-label">{t('editor.fields.at')}</span>
-            <Input
-              size="small"
-              type="datetime-local"
+            <LocalizedDateTimeField
               value={draft.at}
               error={validationErrors.at}
-              onChange={(event) => {
-                const at = event.currentTarget.value;
+              onChange={(at) => {
                 clearError('at');
                 // Re-enable a Todo that was left off after its time passed.
                 onDraftChange((current) => ({
@@ -270,28 +273,37 @@ const TodoEditor: React.FC<TodoEditorProps> = ({
         {draft.scheduleKind === 'every' ? (
           <>
             <label className="bf-todos__field" data-bf-scene="todos" data-bf-part="field">
-              <span className="bf-todos__field-label">{t('editor.fields.everyMinutes')}</span>
-              <Input
-                size="small"
-                type="number"
-                value={draft.everyMinutes}
-                error={validationErrors.everyMinutes}
-                placeholder="60"
-                onChange={(event) => {
-                  const everyMinutes = event.currentTarget.value;
-                  clearError('everyMinutes');
-                  updateDraft({ everyMinutes });
-                }}
-              />
+              <span className="bf-todos__field-label">{t('editor.fields.every')}</span>
+              <div className="bf-todos__interval">
+                <Input
+                  size="small"
+                  type="number"
+                  value={draft.everyValue}
+                  error={validationErrors.everyValue}
+                  placeholder="1"
+                  onChange={(event) => {
+                    const everyValue = event.currentTarget.value;
+                    clearError('everyValue');
+                    updateDraft({ everyValue });
+                  }}
+                />
+                <Select
+                  size="small"
+                  value={draft.everyUnit}
+                  options={INTERVAL_UNIT_OPTIONS.map((unit) => ({
+                    value: unit,
+                    label: t(`schedule.intervalUnits.${unit}`),
+                  }))}
+                  onChange={(value) => updateDraft({ everyUnit: value as IntervalUnit })}
+                />
+              </div>
             </label>
             <label className="bf-todos__field" data-bf-scene="todos" data-bf-part="field">
               <span className="bf-todos__field-label">{t('editor.fields.anchor')}</span>
-              <Input
-                size="small"
-                type="datetime-local"
+              <LocalizedDateTimeField
                 value={draft.anchorMs}
-                placeholder={t('editor.placeholders.anchor')}
-                onChange={(event) => updateDraft({ anchorMs: event.currentTarget.value })}
+                aria-label={t('editor.fields.anchor')}
+                onChange={(anchorMs) => updateDraft({ anchorMs })}
               />
             </label>
           </>

--- a/src/web-ui/src/app/scenes/todos/components/TodoItemRow.tsx
+++ b/src/web-ui/src/app/scenes/todos/components/TodoItemRow.tsx
@@ -25,6 +25,8 @@ export interface TodoItemRowProps {
   atMs: number | null;
   isOverdue?: boolean;
   isNextRun?: boolean;
+  /** The scheduler is executing this run right now. */
+  isRunning?: boolean;
   nowMs: number;
   workspaces: WorkspaceInfo[];
   /** Replaces the countdown, used for inactive rows ("Paused", "Done"). */
@@ -40,6 +42,7 @@ const TodoItemRow: React.FC<TodoItemRowProps> = ({
   atMs,
   isOverdue = false,
   isNextRun = false,
+  isRunning = false,
   nowMs,
   workspaces,
   statusLabel,
@@ -48,13 +51,16 @@ const TodoItemRow: React.FC<TodoItemRowProps> = ({
   onDelete,
   onToggleEnabled,
 }) => {
-  const { t, formatDate } = useI18n('scenes/todos');
+  const { t, formatDate } = useI18n(['scenes/todos', 'shared']);
 
   const timeLabel = atMs != null ? formatTimeOfDay(atMs, formatDate) : null;
-  const relativeLabel = statusLabel ?? (atMs != null ? formatCountdown(atMs, nowMs, t) : null);
+  const relativeLabel = statusLabel
+    ?? (isRunning ? t('shared:statuses.running') : null)
+    ?? (atMs != null ? formatCountdown(atMs, nowMs, t) : null);
 
   const rowState = [
     isSelected ? 'selected' : null,
+    isRunning ? 'running' : null,
     isOverdue ? 'overdue' : null,
     job.enabled ? null : 'disabled',
   ].filter(Boolean).join(' ');
@@ -63,6 +69,7 @@ const TodoItemRow: React.FC<TodoItemRowProps> = ({
     <div
       className={[
         'bf-todos__row',
+        isRunning ? 'bf-todos__row--running' : '',
         isOverdue ? 'bf-todos__row--overdue' : '',
         job.enabled ? '' : 'bf-todos__row--disabled',
         isSelected ? 'bf-todos__row--selected' : '',
@@ -92,7 +99,15 @@ const TodoItemRow: React.FC<TodoItemRowProps> = ({
       <div className="bf-todos__row-body" data-bf-scene="todos" data-bf-part="rowBody">
         <div className="bf-todos__row-title-line">
           <span className="bf-todos__row-name">{job.name}</span>
-          {isNextRun ? (
+          {isRunning ? (
+            <span
+              className="bf-todos__row-badge bf-todos__row-badge--running"
+              data-bf-scene="todos"
+              data-bf-part="rowBadge"
+            >
+              {t('shared:statuses.running')}
+            </span>
+          ) : isNextRun ? (
             <span className="bf-todos__row-badge" data-bf-scene="todos" data-bf-part="rowBadge">
               {t('badges.nextRun')}
             </span>

--- a/src/web-ui/src/app/scenes/todos/todoOccurrences.test.ts
+++ b/src/web-ui/src/app/scenes/todos/todoOccurrences.test.ts
@@ -330,6 +330,70 @@ describe('buildTodoBuckets', () => {
     expect(later[0].isNextRun).toBe(true);
   });
 
+  it('puts near-term runs on the calendar as well as in the list', () => {
+    const job = makeJob({
+      schedule: { kind: 'cron', expr: '0 9 * * *' },
+      state: { consecutiveFailures: 0, coalescedRunCount: 0, nextRunAtMs: localMs(2026, 8, 13, 9, 0) },
+    });
+
+    const { upcoming, later, calendar } = buildTodoBuckets([job], { nowMs, rangeEndMs });
+
+    // The list keeps its 24-hour scope, but the calendar carries the whole
+    // agenda so today's and tomorrow's cells are not mysteriously empty.
+    expect(upcoming).toHaveLength(1);
+    expect(calendar).toHaveLength(upcoming.length + later.length);
+    expect(calendar.map((o) => o.atMs)).toContain(localMs(2026, 8, 13, 9, 0));
+    expect(calendar).toEqual([...calendar].sort((a, b) => a.atMs - b.atMs));
+  });
+
+  it('keeps a finished job off the calendar', () => {
+    const firedAtMs = nowMs - 2 * HOUR_IN_MS;
+    const job = makeJob({
+      schedule: { kind: 'at', at: new Date(firedAtMs).toISOString() },
+      state: {
+        consecutiveFailures: 0,
+        coalescedRunCount: 0,
+        lastEnqueuedAtMs: firedAtMs,
+        lastRunStatus: 'ok',
+      },
+    });
+
+    const { calendar, inactive } = buildTodoBuckets([job], { nowMs, rangeEndMs });
+
+    expect(calendar).toHaveLength(0);
+    expect(inactive[0].reason).toBe('completed');
+  });
+
+  it('marks an in-flight run as running rather than overdue', () => {
+    const pendingTriggerAtMs = nowMs - 10 * MINUTE_IN_MS;
+    const job = makeJob({
+      schedule: { kind: 'every', everyMs: DAY_IN_MS, anchorMs: pendingTriggerAtMs },
+      state: {
+        consecutiveFailures: 0,
+        coalescedRunCount: 0,
+        pendingTriggerAtMs,
+        activeTurnId: 'cronjob_test_1',
+        lastRunStatus: 'running',
+      },
+    });
+
+    const { upcoming } = buildTodoBuckets([job], { nowMs, rangeEndMs });
+    const current = upcoming.find((o) => o.atMs === pendingTriggerAtMs);
+
+    expect(current?.isRunning).toBe(true);
+    expect(current?.isOverdue).toBe(false);
+    // A job past its time but not executing is still genuinely overdue.
+    expect(
+      buildTodoBuckets(
+        [makeJob({
+          schedule: { kind: 'at', at: new Date(pendingTriggerAtMs).toISOString() },
+          state: { consecutiveFailures: 0, coalescedRunCount: 0, pendingTriggerAtMs },
+        })],
+        { nowMs, rangeEndMs },
+      ).upcoming[0].isOverdue,
+    ).toBe(true);
+  });
+
   it('reports an unparseable expression as invalid with its error', () => {
     const job = makeJob({ schedule: { kind: 'cron', expr: 'not a cron' } });
 

--- a/src/web-ui/src/app/scenes/todos/todoOccurrences.ts
+++ b/src/web-ui/src/app/scenes/todos/todoOccurrences.ts
@@ -36,8 +36,10 @@ export interface TodoOccurrence {
   atMs: number;
   /** True when the scheduler has this exact run queued as its next action. */
   isNextRun: boolean;
-  /** True when the run time has passed but the scheduler has not cleared it. */
+  /** True when the run time has passed and the job is not currently running. */
   isOverdue: boolean;
+  /** True while the scheduler is executing this run. */
+  isRunning: boolean;
 }
 
 /**
@@ -54,12 +56,32 @@ export interface InactiveTodo {
 }
 
 export interface TodoBuckets {
-  /** Due within 24 hours (including overdue), ascending. */
+  /** Due within 24 hours (including overdue and running), ascending. */
   upcoming: TodoOccurrence[];
   /** More than 24 hours out, ascending. */
   later: TodoOccurrence[];
+  /**
+   * Everything still scheduled, near-term included, for the calendar tier.
+   *
+   * The calendar shows the whole agenda rather than only the far half: a run
+   * happening today is exactly what someone opening a calendar expects to see.
+   * Only jobs with nothing left to run stay out of it.
+   */
+  calendar: TodoOccurrence[];
   /** Jobs with no upcoming run at all. */
   inactive: InactiveTodo[];
+}
+
+/**
+ * Whether the scheduler is executing this job right now.
+ *
+ * A running job keeps its pending trigger timestamp in the past until the turn
+ * finishes, so without this check an in-flight run reads as overdue.
+ */
+export function isJobRunning(job: CronJob): boolean {
+  return job.state.activeTurnId != null
+    || job.state.lastRunStatus === 'running'
+    || job.state.lastRunStatus === 'queued';
 }
 
 export interface BuildTodoBucketsOptions {
@@ -263,12 +285,17 @@ export function buildTodoBuckets(
       occurrenceTimes.sort((a, b) => a - b);
     }
 
+    const running = isJobRunning(job);
+
     for (const atMs of occurrenceTimes) {
       const occurrence: TodoOccurrence = {
         job,
         atMs,
         isNextRun: atMs === scheduledAtMs,
-        isOverdue: atMs < nowMs,
+        // A run that is executing is late only in the clock sense; surfacing it
+        // as overdue misreports healthy work as a problem.
+        isOverdue: atMs < nowMs && !running,
+        isRunning: running && atMs === scheduledAtMs,
       };
       if (atMs <= listBoundaryMs) {
         upcoming.push(occurrence);
@@ -285,7 +312,9 @@ export function buildTodoBuckets(
   later.sort(byTime);
   inactive.sort((a, b) => b.job.configUpdatedAtMs - a.job.configUpdatedAtMs);
 
-  return { upcoming, later, inactive };
+  const calendar = [...upcoming, ...later].sort(byTime);
+
+  return { upcoming, later, calendar, inactive };
 }
 
 /** Local calendar-day key (`YYYY-MM-DD`) used to bucket occurrences into cells. */

--- a/src/web-ui/src/app/scenes/todos/todoPresentation.ts
+++ b/src/web-ui/src/app/scenes/todos/todoPresentation.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CronJob, CronSchedule } from '@/infrastructure/api';
-import { formatEveryMinutes } from '@/app/components/scheduled-jobs/scheduledJobDraft';
+import { formatIntervalValue, splitInterval } from '@/app/components/scheduled-jobs/scheduledJobDraft';
 import { WorkspaceKind, type WorkspaceInfo, isRemoteWorkspace } from '@/shared/types';
 import { normalizePath } from '@/shared/utils/pathUtils';
 
@@ -22,6 +22,15 @@ export function formatDateTime(timestampMs: number, formatDate: FormatDate): str
   });
 }
 
+/**
+ * "Every 30 minutes" / "Every 1 day", using the largest unit that divides the
+ * interval evenly so a daily job does not read as 1440 minutes.
+ */
+export function formatIntervalSummary(everyMs: number, t: Translate): string {
+  const { value, unit } = splitInterval(everyMs);
+  return t(`schedule.everyUnit.${unit}`, { value: formatIntervalValue(value) });
+}
+
 /** Human summary of the recurrence rule, independent of any single run. */
 export function formatScheduleSummary(
   schedule: CronSchedule,
@@ -32,7 +41,7 @@ export function formatScheduleSummary(
     case 'at':
       return t('schedule.once', { at: formatDateTime(new Date(schedule.at).getTime(), formatDate) });
     case 'every':
-      return t('schedule.every', { everyMinutes: formatEveryMinutes(schedule.everyMs) });
+      return formatIntervalSummary(schedule.everyMs, t);
     case 'cron':
       return schedule.tz
         ? t('schedule.cronWithTz', { expr: schedule.expr, tz: schedule.tz })

--- a/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
+++ b/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
@@ -118,6 +118,7 @@ import { filesPanelAppearanceDescriptor } from '@/app/components/panels/FilesPan
 import { reviewPlatformAppearanceDescriptor } from '@/app/components/panels/review-platform/appearance';
 import { remoteAccountPanelAppearanceDescriptor, remoteConnectDialogAppearanceDescriptor } from '@/app/components/RemoteConnectDialog/appearance';
 import { scheduledJobsViewAppearanceDescriptor } from '@/app/components/scheduled-jobs/appearance';
+import { localizedDateTimeFieldAppearanceDescriptor } from '@/app/components/scheduled-jobs/LocalizedDateTimeField.appearance';
 import { todosSceneAppearanceDescriptor } from '@/app/scenes/todos/appearance';
 import { flexiblePanelAppearanceDescriptor } from '@/app/components/panels/base/FlexiblePanel.appearance';
 import { btwSessionPanelAppearanceDescriptor } from '@/flow_chat/components/btw/BtwSessionPanel.appearance';
@@ -410,6 +411,7 @@ export function createDefaultAppearanceRegistry(): AppearanceRegistry {
     .registerComponent(remoteConnectDialogAppearanceDescriptor)
     .registerComponent(remoteAccountPanelAppearanceDescriptor)
     .registerComponent(scheduledJobsViewAppearanceDescriptor)
+    .registerComponent(localizedDateTimeFieldAppearanceDescriptor)
     .registerComponent(flexiblePanelAppearanceDescriptor)
     .registerComponent(btwSessionPanelAppearanceDescriptor)
     .registerComponent(modernFlowChatAppearanceDescriptor)

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -284,7 +284,7 @@
         "enabledHint": "Enable this job",
         "scheduleKind": "Schedule type",
         "at": "Run at",
-        "everyMs": "Interval (minutes)",
+        "everyMs": "Interval",
         "anchorMs": "Anchor time (optional)",
         "cronExpr": "Cron expression",
         "timezone": "Timezone (optional)",
@@ -309,9 +309,13 @@
         "cron": "Cron"
       },
       "scheduleSummary": {
-        "every": "Every {{everyMinutes}} minutes",
         "cron": "Cron: {{expr}}",
-        "cronWithTz": "Cron: {{expr}} · {{tz}}"
+        "cronWithTz": "Cron: {{expr}} · {{tz}}",
+        "everyUnit": {
+          "minute": "Every {{value}} minutes",
+          "hour": "Every {{value}} hours",
+          "day": "Every {{value}} days"
+        }
       },
       "targets": {
         "session": "Session",
@@ -358,6 +362,11 @@
         "promptRequired": "Please enter the job prompt",
         "workspaceRequired": "Please enter a workspace path",
         "sessionRequired": "Please select a session"
+      },
+      "intervalUnits": {
+        "minute": "Minutes",
+        "hour": "Hours",
+        "day": "Days"
       }
     },
     "workspaces": {
@@ -1541,5 +1550,15 @@
   },
   "collapse": "Collapse",
   "expand": "Expand",
-  "retry": "Retry"
+  "retry": "Retry",
+  "dateTimeField": {
+    "label": "Date and time",
+    "segments": {
+      "year": "YYYY",
+      "month": "MM",
+      "day": "DD",
+      "hour": "HH",
+      "minute": "mm"
+    }
+  }
 }

--- a/src/web-ui/src/locales/en-US/scenes/todos.json
+++ b/src/web-ui/src/locales/en-US/scenes/todos.json
@@ -17,7 +17,7 @@
   },
   "calendar": {
     "title": "Later",
-    "hint": "Runs more than 24 hours away.",
+    "hint": "Every scheduled run, including the next 24 hours.",
     "previousMonth": "Previous month",
     "nextMonth": "Next month",
     "today": "Today",
@@ -41,13 +41,22 @@
   },
   "schedule": {
     "once": "Once at {{at}}",
-    "every": "Every {{everyMinutes}} minutes",
     "cron": "Cron: {{expr}}",
     "cronWithTz": "Cron: {{expr}} · {{tz}}",
     "kinds": {
       "at": "One-time",
       "every": "Interval",
       "cron": "Cron"
+    },
+    "everyUnit": {
+      "minute": "Every {{value}} minutes",
+      "hour": "Every {{value}} hours",
+      "day": "Every {{value}} days"
+    },
+    "intervalUnits": {
+      "minute": "Minutes",
+      "hour": "Hours",
+      "day": "Days"
     }
   },
   "target": {
@@ -68,13 +77,13 @@
       "agentType": "Agent type",
       "scheduleKind": "Schedule",
       "at": "Run at",
-      "everyMinutes": "Interval (minutes)",
       "anchor": "Anchor time (optional)",
       "cronExpr": "Cron expression",
       "timezone": "Timezone (optional)",
       "enabled": "Enabled",
       "prompt": "Prompt",
-      "runsIn": "Runs in"
+      "runsIn": "Runs in",
+      "every": "Interval"
     },
     "placeholders": {
       "name": "For example: Daily standup summary",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -284,7 +284,7 @@
         "enabledHint": "启用该任务",
         "scheduleKind": "调度方式",
         "at": "执行时间",
-        "everyMs": "间隔（分钟）",
+        "everyMs": "间隔",
         "anchorMs": "锚点时间（可选）",
         "cronExpr": "Cron 表达式",
         "timezone": "时区（可选）",
@@ -309,9 +309,13 @@
         "cron": "Cron"
       },
       "scheduleSummary": {
-        "every": "每 {{everyMinutes}} 分钟",
         "cron": "Cron: {{expr}}",
-        "cronWithTz": "Cron: {{expr}} · {{tz}}"
+        "cronWithTz": "Cron: {{expr}} · {{tz}}",
+        "everyUnit": {
+          "minute": "每 {{value}} 分钟",
+          "hour": "每 {{value}} 小时",
+          "day": "每 {{value}} 天"
+        }
       },
       "targets": {
         "session": "会话",
@@ -358,6 +362,11 @@
         "promptRequired": "请输入任务内容",
         "workspaceRequired": "请输入工作区路径",
         "sessionRequired": "请选择会话"
+      },
+      "intervalUnits": {
+        "minute": "分钟",
+        "hour": "小时",
+        "day": "天"
       }
     },
     "workspaces": {
@@ -1541,5 +1550,15 @@
   },
   "collapse": "折叠",
   "expand": "展开",
-  "retry": "重试"
+  "retry": "重试",
+  "dateTimeField": {
+    "label": "日期与时间",
+    "segments": {
+      "year": "年",
+      "month": "月",
+      "day": "日",
+      "hour": "时",
+      "minute": "分"
+    }
+  }
 }

--- a/src/web-ui/src/locales/zh-CN/scenes/todos.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/todos.json
@@ -17,7 +17,7 @@
   },
   "calendar": {
     "title": "更晚",
-    "hint": "24 小时之后执行的任务。",
+    "hint": "全部计划执行时间，含 24 小时内的任务。",
     "previousMonth": "上个月",
     "nextMonth": "下个月",
     "today": "今天",
@@ -41,13 +41,22 @@
   },
   "schedule": {
     "once": "单次：{{at}}",
-    "every": "每 {{everyMinutes}} 分钟",
     "cron": "Cron：{{expr}}",
     "cronWithTz": "Cron：{{expr}} · {{tz}}",
     "kinds": {
       "at": "单次",
       "every": "间隔",
       "cron": "Cron"
+    },
+    "everyUnit": {
+      "minute": "每 {{value}} 分钟",
+      "hour": "每 {{value}} 小时",
+      "day": "每 {{value}} 天"
+    },
+    "intervalUnits": {
+      "minute": "分钟",
+      "hour": "小时",
+      "day": "天"
     }
   },
   "target": {
@@ -68,13 +77,13 @@
       "agentType": "Agent 类型",
       "scheduleKind": "计划类型",
       "at": "执行时间",
-      "everyMinutes": "间隔（分钟）",
       "anchor": "起算时间（可选）",
       "cronExpr": "Cron 表达式",
       "timezone": "时区（可选）",
       "enabled": "启用",
       "prompt": "提示词",
-      "runsIn": "运行位置"
+      "runsIn": "运行位置",
+      "every": "间隔"
     },
     "placeholders": {
       "name": "例如：每日站会总结",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -284,7 +284,7 @@
         "enabledHint": "啟用該任務",
         "scheduleKind": "調度方式",
         "at": "執行時間",
-        "everyMs": "間隔（分鐘）",
+        "everyMs": "間隔",
         "anchorMs": "錨點時間（可選）",
         "cronExpr": "Cron 表達式",
         "timezone": "時區（可選）",
@@ -309,9 +309,13 @@
         "cron": "Cron"
       },
       "scheduleSummary": {
-        "every": "每 {{everyMinutes}} 分鐘",
         "cron": "Cron: {{expr}}",
-        "cronWithTz": "Cron: {{expr}} · {{tz}}"
+        "cronWithTz": "Cron: {{expr}} · {{tz}}",
+        "everyUnit": {
+          "minute": "每 {{value}} 分鐘",
+          "hour": "每 {{value}} 小時",
+          "day": "每 {{value}} 天"
+        }
       },
       "targets": {
         "session": "會話",
@@ -358,6 +362,11 @@
         "promptRequired": "請輸入任務內容",
         "workspaceRequired": "請輸入工作區路徑",
         "sessionRequired": "請選擇會話"
+      },
+      "intervalUnits": {
+        "minute": "分鐘",
+        "hour": "小時",
+        "day": "天"
       }
     },
     "workspaces": {
@@ -1541,5 +1550,15 @@
   },
   "collapse": "收合",
   "expand": "展開",
-  "retry": "重試"
+  "retry": "重試",
+  "dateTimeField": {
+    "label": "日期與時間",
+    "segments": {
+      "year": "年",
+      "month": "月",
+      "day": "日",
+      "hour": "時",
+      "minute": "分"
+    }
+  }
 }

--- a/src/web-ui/src/locales/zh-TW/scenes/todos.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/todos.json
@@ -17,7 +17,7 @@
   },
   "calendar": {
     "title": "更晚",
-    "hint": "24 小時之後執行的任務。",
+    "hint": "全部排程執行時間，含 24 小時內的任務。",
     "previousMonth": "上個月",
     "nextMonth": "下個月",
     "today": "今天",
@@ -41,13 +41,22 @@
   },
   "schedule": {
     "once": "單次：{{at}}",
-    "every": "每 {{everyMinutes}} 分鐘",
     "cron": "Cron：{{expr}}",
     "cronWithTz": "Cron：{{expr}} · {{tz}}",
     "kinds": {
       "at": "單次",
       "every": "間隔",
       "cron": "Cron"
+    },
+    "everyUnit": {
+      "minute": "每 {{value}} 分鐘",
+      "hour": "每 {{value}} 小時",
+      "day": "每 {{value}} 天"
+    },
+    "intervalUnits": {
+      "minute": "分鐘",
+      "hour": "小時",
+      "day": "天"
     }
   },
   "target": {
@@ -68,13 +77,13 @@
       "agentType": "Agent 類型",
       "scheduleKind": "排程類型",
       "at": "執行時間",
-      "everyMinutes": "間隔（分鐘）",
       "anchor": "起算時間（選填）",
       "cronExpr": "Cron 運算式",
       "timezone": "時區（選填）",
       "enabled": "啟用",
       "prompt": "提示詞",
-      "runsIn": "執行位置"
+      "runsIn": "執行位置",
+      "every": "間隔"
     },
     "placeholders": {
       "name": "例如：每日站立會議摘要",


### PR DESCRIPTION
Follow-up to #2243, from real usage. Four fixes; three also apply to the per-workspace scheduled-jobs editor.

## 1. Date order was wrong in Chinese

A native `<input type="datetime-local">` renders in the **browser's** locale, which Chromium takes from the OS and does **not** read from the `lang` attribute — I verified this directly (`lang="zh-CN"` and `lang="zh-Hans-CN"` both still rendered `08/12/2026, 04:48 AM`). Running the UI in Chinese on an English system therefore printed a US-ordered date inside a Chinese form.

Replaced with a segmented field ordered by the *app's* locale (year-first for zh/ja/ko, month-first otherwise). It keeps the same `YYYY-MM-DDTHH:mm` value contract, so every caller is unchanged, and it clamps out-of-range input (Feb 31 → Feb 28, leap-year aware) instead of silently rolling over the way a raw `Date` would.

## 2. Near-term runs missing from the calendar

The calendar only held runs more than 24 hours out, so today's cell looked empty while the same run sat in the list next to it. It now carries the whole remaining agenda; only jobs with nothing left to run are excluded. The list keeps its 24-hour scope, so the tiers now answer *"what is about to happen"* and *"when is everything happening"* rather than splitting one timeline in half.

## 3. Intervals only in minutes

A daily job read as "every 1440 minutes". Added a unit selector (minutes / hours / days) and summaries rendered in the largest unit that divides the interval evenly. The wire format stays milliseconds, so existing jobs display better with no migration — a stored 86400000 now reads "every 1 day".

## 4. Running jobs shown as overdue

A job whose turn is still executing keeps its pending trigger timestamp in the past, so an in-flight run was badged 已逾期. Now an active turn reads as running, and overdue is reserved for runs that are genuinely late. Reuses the shared `statuses.running` term rather than defining a second one.

## Two reported items with no code change

**Model selection on create.** Confirmed no change is needed: `CronLaunchSpec.model_id` is optional, and an empty value resolves through `concrete_model_for_session_selection` as `"auto"` → `resolve_model_selection("primary")`, i.e. the primary model. That is the intended default, so I left it alone.

**Jobs created in the Todos panel sometimes not firing.** I could not reproduce this or confirm a cause, and I am not shipping a speculative fix. What I ruled out: the scheduler loop has no workspace gating; `start()` is idempotent and independent of the panel; `create_job` computes `next_run_at_ms` and wakes the loop; and the request the Todos panel sends is byte-for-byte the same shape the workspace editor sends for a workspace-targeted job.

The one real asymmetry I did find: `canonicalize_target` enriches **session** targets with `project_workspace_path` and `execution_target` from the session binding, while **workspace** targets keep only what the client sent. That would explain "editing it under the workspace fixes it" if the edit converted the job to a session target — but both are `None` for a fresh local workspace anyway, so I don't believe it is the cause and didn't want to dress it up as one. To pin it down I need one reproduction left in place (not deleted) so I can read the job's `state.lastError` and `nextRunAtMs` from `~/Library/Application Support/bitfun/data/cron/jobs.json`.

## Verification

`type-check:web`, `lint:web`, `i18n:audit`, `theme:color-audit:all`, appearance-contract audit, and `build:web` all pass. 436 web-ui app tests pass, including 25 new ones covering locale ordering and the date value contract, the interval round trip, the calendar bucket, and running-vs-overdue.

Still **no screenshots** and no manual run-through — same caveat as #2243. AI-assisted. Testing level: lightly tested.
