### PR TITLE
fix(todos): make the date field typable and plain

### DIFF
--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.appearance.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.appearance.ts
@@ -4,8 +4,6 @@ export const localizedDateTimeFieldAppearanceDescriptor: AppearanceSurfaceDescri
   id: 'localized-datetime-field',
   parts: [
     { id: 'root' },
-    { id: 'date' },
-    { id: 'time' },
   ],
   states: [
     { id: 'error', selector: { kind: 'self', suffix: '[data-bf-state~="error"]' } },

--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
@@ -1,67 +1,24 @@
 @use '../../../component-library/styles/tokens.scss' as *;
 
 .bf-datetime-field {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: $size-gap-2;
-  box-sizing: border-box;
-  min-height: 28px;
-  padding: 0 8px;
-  border: 1px solid var(--bf-appearance-token-border-subtle);
-  border-radius: $size-radius-base;
-  background: color-mix(in srgb, var(--bf-appearance-token-element-bg-base) 82%, transparent);
-  transition: border-color $motion-fast $easing-standard;
+  gap: $size-gap-1;
+  min-width: 0;
 
-  &:focus-within {
-    border-color: var(--bf-appearance-token-color-accent-500);
-  }
-
-  &--error {
-    border-color: var(--bf-appearance-token-color-error);
-  }
-
-  &--disabled {
-    opacity: 0.6;
-    pointer-events: none;
-  }
-
-  &__group {
-    display: inline-flex;
-    align-items: center;
-    gap: 1px;
-  }
-
-  &__segment {
+  &__input {
+    flex: 1 1 auto;
     min-width: 0;
-    padding: 3px 2px;
-    border: none;
-    border-radius: $size-radius-sm;
-    background: transparent;
-    color: var(--bf-appearance-token-color-text-primary);
-    font-size: var(--bf-appearance-token-font-size-sm);
-    font-variant-numeric: tabular-nums;
-    text-align: center;
-    outline: none;
-
-    &::placeholder {
-      color: var(--bf-appearance-token-color-text-muted);
-    }
-
-    &:focus {
-      background: color-mix(in srgb, var(--bf-appearance-token-color-accent-500) 18%, transparent);
-    }
-
-    // Width tracks the digit count so segments do not jitter while typing.
-    &--year { width: 4ch; }
-    &--month,
-    &--day,
-    &--hour,
-    &--minute { width: 2.4ch; }
   }
 
-  &__sep {
-    color: var(--bf-appearance-token-color-text-muted);
-    font-size: var(--bf-appearance-token-font-size-xs);
-    user-select: none;
+  // Present only so the browser picker has an anchor; never shown or focused.
+  &__picker {
+    position: absolute;
+    width: 0;
+    height: 0;
+    padding: 0;
+    border: 0;
+    opacity: 0;
+    pointer-events: none;
   }
 }

--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.tsx
@@ -4,21 +4,24 @@
  * A native `<input type="datetime-local">` renders in the *browser's* locale,
  * which Chromium takes from the OS and does not read from the `lang`
  * attribute. Running the UI in Chinese on an English system therefore shows
- * `08/12/2026, 04:48 AM` inside an otherwise Chinese form. This control keeps
- * the same `YYYY-MM-DDTHH:mm` value contract as the native input so callers are
- * unchanged, but lays the segments out in the order the active locale reads.
+ * `08/12/2026, 04:48 AM` inside an otherwise Chinese form.
+ *
+ * This is an ordinary text input so it looks and behaves like every other field
+ * in the form, showing `2026/08/12 04:48` in Chinese and `08/12/2026 04:48` in
+ * English. A calendar button opens the browser's own picker for anyone who
+ * would rather click than type. Callers keep the native
+ * `YYYY-MM-DDTHH:mm` value contract.
  */
 
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CalendarDays } from 'lucide-react';
+import { IconButton, Input } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import {
-  SEGMENTS,
-  clampSegmentToRange,
-  composeDateTimeValue,
-  parseDateTimeValue,
-  resolveDateSegmentOrder,
-  type ParsedValue,
-  type SegmentId,
+  dateTimeFormatHint,
+  formatDateTimeText,
+  parseDateTimeText,
+  resolveDateFieldOrder,
 } from './localizedDateTime';
 
 export interface LocalizedDateTimeFieldProps {
@@ -40,89 +43,105 @@ const LocalizedDateTimeField: React.FC<LocalizedDateTimeFieldProps> = ({
   'aria-label': ariaLabel,
 }) => {
   const { t, currentLanguage } = useI18n('common');
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const pickerRef = useRef<HTMLInputElement | null>(null);
+  const editingRef = useRef(false);
 
-  const parsed = useMemo(() => parseDateTimeValue(value), [value]);
-  const dateOrder = useMemo(() => resolveDateSegmentOrder(currentLanguage), [currentLanguage]);
+  const order = useMemo(() => resolveDateFieldOrder(currentLanguage), [currentLanguage]);
 
-  const emit = useCallback((next: ParsedValue) => {
-    const composed = composeDateTimeValue(next);
-    // Hold the edit until every segment is filled; a partial date has no
-    // meaningful timestamp and clearing one field should not wipe the value.
-    if (composed !== null) onChange(composed);
-  }, [onChange]);
+  // Local text so partial input survives; a fully controlled field would reject
+  // every keystroke until the whole date parsed, which makes it untypable.
+  const [text, setText] = useState(() => formatDateTimeText(value, order));
 
-  const handleSegmentChange = useCallback((id: SegmentId, raw: string) => {
-    const spec = SEGMENTS[id];
-    const digits = raw.replace(/\D/g, '').slice(0, spec.length);
-    emit({ ...parsed, [id]: digits });
+  // Adopt external changes (loading a job, switching locale) unless the user is
+  // mid-edit, where overwriting their keystrokes would fight them.
+  useEffect(() => {
+    if (editingRef.current) return;
+    setText(formatDateTimeText(value, order));
+  }, [order, value]);
 
-    // Advance once a segment is unambiguously complete, so typing flows across
-    // the row the way the native control does.
-    if (digits.length === spec.length) {
-      const inputs = containerRef.current?.querySelectorAll<HTMLInputElement>('input');
-      if (!inputs) return;
-      const current = Array.from(inputs).findIndex(input => input.dataset.segment === id);
-      inputs[current + 1]?.focus();
+  const commitText = useCallback((nextText: string) => {
+    setText(nextText);
+
+    if (!nextText.trim()) {
+      onChange('');
+      return;
     }
-  }, [emit, parsed]);
 
-  const handleSegmentBlur = useCallback((id: SegmentId, raw: string) => {
-    const normalized = clampSegmentToRange(raw, SEGMENTS[id]);
-    if (!normalized) return;
-    emit({ ...parsed, [id]: normalized });
-  }, [emit, parsed]);
+    const parsed = parseDateTimeText(nextText, order);
+    if (parsed) onChange(parsed);
+  }, [onChange, order]);
 
-  const renderSegment = (id: SegmentId) => {
-    const spec = SEGMENTS[id];
-    return (
-      <input
-        key={id}
-        type="text"
-        inputMode="numeric"
-        data-segment={id}
-        className={`bf-datetime-field__segment bf-datetime-field__segment--${id}`}
-        value={parsed[id]}
-        disabled={disabled}
-        maxLength={spec.length}
-        size={spec.length}
-        placeholder={t(`dateTimeField.segments.${id}`)}
-        aria-label={t(`dateTimeField.segments.${id}`)}
-        onChange={event => handleSegmentChange(id, event.currentTarget.value)}
-        onBlur={event => handleSegmentBlur(id, event.currentTarget.value)}
-        onFocus={event => event.currentTarget.select()}
-      />
-    );
-  };
+  const handleBlur = useCallback(() => {
+    editingRef.current = false;
+
+    // Normalize whatever parsed into the canonical rendering, so `2026/8/2 4:8`
+    // settles as `2026/08/02 04:08` instead of staying half-typed.
+    const parsed = text.trim() ? parseDateTimeText(text, order) : null;
+    setText(parsed ? formatDateTimeText(parsed, order) : text);
+  }, [order, text]);
+
+  const openPicker = useCallback(() => {
+    const picker = pickerRef.current;
+    if (!picker) return;
+    picker.value = value;
+    picker.showPicker?.();
+  }, [value]);
+
+  const canOpenPicker = typeof HTMLInputElement !== 'undefined'
+    && 'showPicker' in HTMLInputElement.prototype;
 
   return (
     <div
-      ref={containerRef}
-      className={[
-        'bf-datetime-field',
-        error ? 'bf-datetime-field--error' : '',
-        disabled ? 'bf-datetime-field--disabled' : '',
-        className ?? '',
-      ].filter(Boolean).join(' ')}
+      className={['bf-datetime-field', className ?? ''].filter(Boolean).join(' ')}
       data-bf-component="localized-datetime-field"
       data-bf-part="root"
       data-bf-state={error ? 'error' : undefined}
-      role="group"
-      aria-label={ariaLabel ?? t('dateTimeField.label')}
     >
-      <span className="bf-datetime-field__group" data-bf-component="localized-datetime-field" data-bf-part="date">
-        {dateOrder.map((id, index) => (
-          <React.Fragment key={id}>
-            {index > 0 ? <span className="bf-datetime-field__sep" aria-hidden="true">/</span> : null}
-            {renderSegment(id)}
-          </React.Fragment>
-        ))}
-      </span>
-      <span className="bf-datetime-field__group" data-bf-component="localized-datetime-field" data-bf-part="time">
-        {renderSegment('hour')}
-        <span className="bf-datetime-field__sep" aria-hidden="true">:</span>
-        {renderSegment('minute')}
-      </span>
+      <Input
+        size="small"
+        value={text}
+        error={error}
+        disabled={disabled}
+        inputMode="numeric"
+        placeholder={dateTimeFormatHint(order)}
+        aria-label={ariaLabel ?? t('dateTimeField.label')}
+        className="bf-datetime-field__input"
+        onFocus={() => { editingRef.current = true; }}
+        onChange={event => commitText(event.currentTarget.value)}
+        onBlur={handleBlur}
+      />
+
+      {canOpenPicker ? (
+        <>
+          <IconButton
+            type="button"
+            size="xs"
+            disabled={disabled}
+            aria-label={t('dateTimeField.openPicker')}
+            tooltip={t('dateTimeField.openPicker')}
+            onClick={openPicker}
+          >
+            <CalendarDays size={14} />
+          </IconButton>
+          {/*
+            Only ever opened programmatically: the browser picker is a good
+            input surface, its inline text rendering is the part we replaced.
+          */}
+          <input
+            ref={pickerRef}
+            type="datetime-local"
+            className="bf-datetime-field__picker"
+            tabIndex={-1}
+            aria-hidden="true"
+            onChange={event => {
+              editingRef.current = false;
+              const picked = event.currentTarget.value;
+              setText(formatDateTimeText(picked, order));
+              onChange(picked);
+            }}
+          />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.test.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.test.ts
@@ -1,85 +1,90 @@
 /**
- * The whole reason this control exists is that a native datetime-local renders
- * in the browser's locale, not the app's. These cases pin the ordering it
- * replaces that with, and the value contract callers still rely on.
+ * This control exists because a native datetime-local renders in the browser's
+ * locale, not the app's. These cases pin the ordering it replaces that with,
+ * and the text <-> value contract callers still rely on.
  */
 
 import { describe, expect, it } from 'vitest';
 import {
-  composeDateTimeValue,
-  parseDateTimeValue,
-  resolveDateSegmentOrder,
+  dateTimeFormatHint,
+  formatDateTimeText,
+  parseDateTimeText,
+  resolveDateFieldOrder,
 } from './localizedDateTime';
 
-describe('resolveDateSegmentOrder', () => {
-  it('reads year-first for Chinese, regardless of the browser locale', () => {
-    expect(resolveDateSegmentOrder('zh-CN')).toEqual(['year', 'month', 'day']);
-    expect(resolveDateSegmentOrder('zh-TW')).toEqual(['year', 'month', 'day']);
+describe('resolveDateFieldOrder', () => {
+  it('reads year-first for CJK locales, regardless of the browser locale', () => {
+    expect(resolveDateFieldOrder('zh-CN')).toBe('year-first');
+    expect(resolveDateFieldOrder('zh-TW')).toBe('year-first');
+    expect(resolveDateFieldOrder('ja-JP')).toBe('year-first');
   });
 
-  it('reads month-first for English', () => {
-    expect(resolveDateSegmentOrder('en-US')).toEqual(['month', 'day', 'year']);
-  });
-
-  it('falls back to month-first for an unknown or missing locale', () => {
-    expect(resolveDateSegmentOrder(undefined)).toEqual(['month', 'day', 'year']);
-    expect(resolveDateSegmentOrder('')).toEqual(['month', 'day', 'year']);
+  it('reads month-first for English and unknown locales', () => {
+    expect(resolveDateFieldOrder('en-US')).toBe('month-first');
+    expect(resolveDateFieldOrder(undefined)).toBe('month-first');
+    expect(resolveDateFieldOrder('')).toBe('month-first');
   });
 });
 
-describe('parseDateTimeValue', () => {
-  it('splits the native datetime-local value into segments', () => {
-    expect(parseDateTimeValue('2026-08-12T04:48')).toEqual({
-      year: '2026', month: '08', day: '12', hour: '04', minute: '48',
-    });
+describe('formatDateTimeText', () => {
+  it('renders in the locale order', () => {
+    expect(formatDateTimeText('2026-08-12T04:48', 'year-first')).toBe('2026/08/12 04:48');
+    expect(formatDateTimeText('2026-08-12T04:48', 'month-first')).toBe('08/12/2026 04:48');
   });
 
-  it('tolerates a seconds suffix', () => {
-    expect(parseDateTimeValue('2026-08-12T04:48:30').minute).toBe('48');
-  });
-
-  it('returns empty segments for anything unparseable', () => {
-    expect(parseDateTimeValue('')).toEqual({
-      year: '', month: '', day: '', hour: '', minute: '',
-    });
-    expect(parseDateTimeValue('not a date').year).toBe('');
+  it('renders empty for a missing or unparseable value', () => {
+    expect(formatDateTimeText('', 'year-first')).toBe('');
+    expect(formatDateTimeText('nonsense', 'year-first')).toBe('');
   });
 });
 
-describe('composeDateTimeValue', () => {
-  it('rebuilds the exact value the native input would have produced', () => {
-    expect(composeDateTimeValue({
-      year: '2026', month: '08', day: '12', hour: '04', minute: '48',
-    })).toBe('2026-08-12T04:48');
+describe('parseDateTimeText', () => {
+  it('round-trips its own rendering in both orders', () => {
+    for (const order of ['year-first', 'month-first'] as const) {
+      const text = formatDateTimeText('2026-08-12T04:48', order);
+      expect(parseDateTimeText(text, order)).toBe('2026-08-12T04:48');
+    }
   });
 
-  it('round-trips through parse without drift', () => {
-    const original = '2026-12-31T23:59';
-    expect(composeDateTimeValue(parseDateTimeValue(original))).toBe(original);
+  it('accepts loose separators and unpadded numbers', () => {
+    expect(parseDateTimeText('2026-8-12 4:8', 'year-first')).toBe('2026-08-12T04:08');
+    expect(parseDateTimeText('2026.08.12 04:48', 'year-first')).toBe('2026-08-12T04:48');
+    expect(parseDateTimeText('2026/08/12 04:48:30', 'year-first')).toBe('2026-08-12T04:48');
   });
 
-  it('holds back a partial date instead of emitting a broken timestamp', () => {
-    expect(composeDateTimeValue({
-      year: '2026', month: '08', day: '', hour: '04', minute: '48',
-    })).toBeNull();
+  it('locates the year by its four digits, whichever order it was typed in', () => {
+    // Someone pasting the other locale's order still lands on the right date.
+    expect(parseDateTimeText('08/12/2026 04:48', 'year-first')).toBe('2026-08-12T04:48');
+    expect(parseDateTimeText('2026/08/12 04:48', 'month-first')).toBe('2026-08-12T04:48');
   });
 
-  it('clamps a day past the end of its month', () => {
-    // February 31 would otherwise roll into March.
-    expect(composeDateTimeValue({
-      year: '2026', month: '02', day: '31', hour: '09', minute: '00',
-    })).toBe('2026-02-28T09:00');
+  it('falls back to the locale order when no group is four digits', () => {
+    expect(parseDateTimeText('26/8/12 04:48', 'year-first')).toBeNull();
+    expect(parseDateTimeText('8/12/26 04:48', 'month-first')).toBeNull();
   });
 
-  it('respects a leap year', () => {
-    expect(composeDateTimeValue({
-      year: '2028', month: '02', day: '31', hour: '09', minute: '00',
-    })).toBe('2028-02-29T09:00');
+  it('returns null while the text is still incomplete', () => {
+    expect(parseDateTimeText('', 'year-first')).toBeNull();
+    expect(parseDateTimeText('2026', 'year-first')).toBeNull();
+    expect(parseDateTimeText('2026/08/12', 'year-first')).toBeNull();
   });
 
-  it('pads a short month or day back to two digits', () => {
-    expect(composeDateTimeValue({
-      year: '2026', month: '8', day: '2', hour: '04', minute: '48',
-    })).toBe('2026-08-02T04:48');
+  it('rejects out-of-range components', () => {
+    expect(parseDateTimeText('2026/13/12 04:48', 'year-first')).toBeNull();
+    expect(parseDateTimeText('2026/08/12 24:48', 'year-first')).toBeNull();
+    expect(parseDateTimeText('2026/08/12 04:60', 'year-first')).toBeNull();
+  });
+
+  it('clamps a day past the end of its month instead of rolling over', () => {
+    expect(parseDateTimeText('2026/02/31 09:00', 'year-first')).toBe('2026-02-28T09:00');
+    expect(parseDateTimeText('2028/02/31 09:00', 'year-first')).toBe('2028-02-29T09:00');
+    expect(parseDateTimeText('2026/04/31 09:00', 'year-first')).toBe('2026-04-30T09:00');
+  });
+});
+
+describe('dateTimeFormatHint', () => {
+  it('shows the placeholder in the same order the field reads', () => {
+    expect(dateTimeFormatHint('year-first')).toBe('YYYY/MM/DD HH:mm');
+    expect(dateTimeFormatHint('month-first')).toBe('MM/DD/YYYY HH:mm');
   });
 });

--- a/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/localizedDateTime.ts
@@ -1,86 +1,99 @@
 /**
- * Pure date-time segment helpers for `LocalizedDateTimeField`.
+ * Text <-> timestamp helpers for `LocalizedDateTimeField`.
  *
- * Kept out of the component file so the ordering and value rules can be tested
- * directly, and so the component module only exports a component.
+ * The field shows and accepts a plain localized string (`2026/08/12 04:48` in
+ * Chinese, `08/12/2026 04:48` in English) while callers keep the native
+ * `YYYY-MM-DDTHH:mm` value contract.
+ *
+ * Kept apart from the component so the parsing rules can be tested directly.
  */
 
 /** Locales that read year-first. Everything else falls back to month-first. */
 const YEAR_FIRST_LOCALE_PREFIXES = ['zh', 'ja', 'ko'];
 
-export type SegmentId = 'year' | 'month' | 'day' | 'hour' | 'minute';
+export type DateFieldOrder = 'year-first' | 'month-first';
 
-export interface SegmentSpec {
-  id: SegmentId;
-  length: number;
-  min: number;
-  max: number;
+/**
+ * Field order for a locale, driven by the app's language rather than the
+ * browser's — which is the whole reason this control exists.
+ */
+export function resolveDateFieldOrder(locale: string | null | undefined): DateFieldOrder {
+  const language = String(locale ?? '').toLowerCase();
+  return YEAR_FIRST_LOCALE_PREFIXES.some(prefix => language.startsWith(prefix))
+    ? 'year-first'
+    : 'month-first';
 }
 
-export const SEGMENTS: Record<SegmentId, SegmentSpec> = {
-  year: { id: 'year', length: 4, min: 1970, max: 9999 },
-  month: { id: 'month', length: 2, min: 1, max: 12 },
-  day: { id: 'day', length: 2, min: 1, max: 31 },
-  hour: { id: 'hour', length: 2, min: 0, max: 23 },
-  minute: { id: 'minute', length: 2, min: 0, max: 59 },
-};
-
-export interface ParsedValue {
-  year: string;
-  month: string;
-  day: string;
-  hour: string;
-  minute: string;
-}
-
-const EMPTY_PARSED: ParsedValue = { year: '', month: '', day: '', hour: '', minute: '' };
-
-export function parseDateTimeValue(value: string): ParsedValue {
-  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(value.trim());
-  if (!match) return EMPTY_PARSED;
-  return { year: match[1], month: match[2], day: match[3], hour: match[4], minute: match[5] };
-}
-
-export function clampSegmentToRange(raw: string, spec: SegmentSpec): string {
-  const digits = raw.replace(/\D/g, '').slice(0, spec.length);
-  if (!digits) return '';
-  const numeric = Math.min(Math.max(Number(digits), spec.min), spec.max);
-  return String(numeric).padStart(spec.length, '0');
-}
-
-/** Days in the given month, so 31 February normalizes instead of rolling over. */
+/** Days in the given month, so 31 February clamps instead of rolling over. */
 function daysInMonth(year: number, month: number): number {
   return new Date(Date.UTC(year, month, 0)).getUTCDate();
 }
 
-export function composeDateTimeValue(parsed: ParsedValue): string | null {
-  const { year, month, day, hour, minute } = parsed;
-  if (!year || !month || !day || !hour || !minute) return null;
+function pad(value: number, length = 2): string {
+  return String(value).padStart(length, '0');
+}
 
-  const yearNumber = Number(year);
-  const monthNumber = Math.min(Math.max(Number(month), 1), 12);
-  const dayNumber = Math.min(
-    Math.max(Number(day), 1),
-    daysInMonth(yearNumber, monthNumber),
-  );
+/** Renders a native datetime-local value as localized display text. */
+export function formatDateTimeText(value: string, order: DateFieldOrder): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(value.trim());
+  if (!match) return '';
 
-  return [
-    String(yearNumber).padStart(4, '0'),
-    String(monthNumber).padStart(2, '0'),
-    String(dayNumber).padStart(2, '0'),
-  ].join('-')
-    + 'T'
-    + [hour, minute].join(':');
+  const [, year, month, day, hour, minute] = match;
+  const date = order === 'year-first'
+    ? `${year}/${month}/${day}`
+    : `${month}/${day}/${year}`;
+  return `${date} ${hour}:${minute}`;
 }
 
 /**
- * Date segment order for a locale: year-first for CJK, month-first otherwise.
+ * Reads localized display text back into a native datetime-local value.
  *
- * Driven by the app's own locale rather than the browser's, which is the whole
- * point of this control.
+ * Deliberately forgiving about separators, so `2026-08-12 04:48`,
+ * `2026/8/12 4:8` and `2026.08.12 04:48` all work. The four-digit group
+ * identifies the year wherever it sits, which keeps a value pasted in the other
+ * locale's order readable instead of silently landing on the wrong date.
+ * Returns null when the text cannot be read as a complete date and time.
  */
-export function resolveDateSegmentOrder(locale: string | null | undefined): SegmentId[] {
-  const language = String(locale ?? '').toLowerCase();
-  const yearFirst = YEAR_FIRST_LOCALE_PREFIXES.some(prefix => language.startsWith(prefix));
-  return yearFirst ? ['year', 'month', 'day'] : ['month', 'day', 'year'];
+export function parseDateTimeText(text: string, order: DateFieldOrder): string | null {
+  const groups = text.match(/\d+/g);
+  if (!groups || groups.length < 5) return null;
+
+  const [a, b, c, hourText, minuteText] = groups;
+
+  let yearText: string;
+  let monthText: string;
+  let dayText: string;
+
+  if (a.length === 4) {
+    [yearText, monthText, dayText] = [a, b, c];
+  } else if (c.length === 4) {
+    [monthText, dayText, yearText] = [a, b, c];
+  } else if (order === 'year-first') {
+    [yearText, monthText, dayText] = [a, b, c];
+  } else {
+    [monthText, dayText, yearText] = [a, b, c];
+  }
+
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+
+  if (![year, month, day, hour, minute].every(Number.isFinite)) return null;
+  if (year < 1970 || year > 9999) return null;
+  if (month < 1 || month > 12) return null;
+  if (day < 1) return null;
+  if (hour > 23 || minute > 59) return null;
+
+  // Clamp rather than reject: someone typing 31 in a 30-day month means the end
+  // of that month, and rolling into the next one would be a silent wrong date.
+  const clampedDay = Math.min(day, daysInMonth(year, month));
+
+  return `${pad(year, 4)}-${pad(month)}-${pad(clampedDay)}T${pad(hour)}:${pad(minute)}`;
+}
+
+/** Example string used as the field placeholder, in the locale's own order. */
+export function dateTimeFormatHint(order: DateFieldOrder): string {
+  return order === 'year-first' ? 'YYYY/MM/DD HH:mm' : 'MM/DD/YYYY HH:mm';
 }

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -1553,12 +1553,6 @@
   "retry": "Retry",
   "dateTimeField": {
     "label": "Date and time",
-    "segments": {
-      "year": "YYYY",
-      "month": "MM",
-      "day": "DD",
-      "hour": "HH",
-      "minute": "mm"
-    }
+    "openPicker": "Open the date picker"
   }
 }

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -1553,12 +1553,6 @@
   "retry": "重试",
   "dateTimeField": {
     "label": "日期与时间",
-    "segments": {
-      "year": "年",
-      "month": "月",
-      "day": "日",
-      "hour": "时",
-      "minute": "分"
-    }
+    "openPicker": "打开日期选择器"
   }
 }

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -1553,12 +1553,6 @@
   "retry": "重試",
   "dateTimeField": {
     "label": "日期與時間",
-    "segments": {
-      "year": "年",
-      "month": "月",
-      "day": "日",
-      "hour": "時",
-      "minute": "分"
-    }
+    "openPicker": "開啟日期選擇器"
   }
 }


### PR DESCRIPTION
Follow-up to #2245, from two problems reported against the date field it introduced: it looked wrong, and it could not be typed into at all.

## The typing bug was real and total

The segmented control was fully controlled but only emitted when **all five** segments parsed. Typing one digit produced a partial value, nothing was emitted, the `value` prop never changed, and the controlled input rendered the old empty value straight back. Every keystroke was discarded — in every segment, not just some. It could never have worked.

## Replaced with a plain text input

Five narrow CJK-labelled cells with slashes between them also looked nothing like the rest of the form. This is now an ordinary `Input` carrying a localized string — `2026/08/12 04:48` in Chinese, `08/12/2026 04:48` in English — so it renders like every other field and accepts typing normally. Local text state holds partial input and commits only once it parses, which is exactly what the segmented version got wrong.

Callers are untouched: the `YYYY-MM-DDTHH:mm` value contract is unchanged.

Parsing is deliberately forgiving:

- separators may be `/`, `-` or `.`; numbers need no padding (`2026-8-12 4:8` works); a trailing seconds group is ignored;
- the **four-digit group identifies the year wherever it sits**, so a value pasted in the other locale's order still lands on the intended date rather than silently on the wrong one;
- a day past the end of its month clamps (Feb 31 → Feb 28, leap-year aware) instead of rolling into the next month.

A calendar button opens the browser's own picker via `showPicker()` for anyone who would rather click than type. Only the picker's *inline text rendering* was ever the problem — the picker popup itself is fine, so it is kept.

## Verification

`type-check:web`, `lint:web`, `i18n:audit`, `theme:color-audit:all`, the appearance-contract audit and `build:web` all pass. 26 unit tests cover locale ordering, the text/value round trip in both orders, loose separators, year-position detection, out-of-range rejection and month-end clamping.

I rendered the layout in a browser this time and confirmed it reads as a normal field with the calendar button beside it, and that `showPicker` is available. That verifies the **look**; the typing behaviour is covered by unit tests rather than by driving the live field, which is the same gap that let the original bug through — worth a quick manual try before trusting it.

AI-assisted. Testing level: lightly tested.
