### PR TITLE
ci: sign and notarize macOS releases

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -280,6 +280,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Configure Apple Developer ID signing and notarization
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          BITFUN_REQUIRE_APPLE_SIGNING: ${{ needs.prepare.outputs.upload_to_release }}
+        run: bash scripts/ci/setup-macos-signing.sh
+
       - name: Project beta build version
         if: needs.prepare.outputs.release_channel == 'beta'
         run: node scripts/set-build-version.mjs --version "${{ needs.prepare.outputs.version }}"
@@ -289,6 +303,11 @@ jobs:
 
       - name: Build desktop app
         run: ${{ matrix.platform.build_command }}
+
+      - name: Verify Apple signature and notarization
+        if: runner.os == 'macOS'
+        shell: bash
+        run: bash scripts/ci/verify-macos-signing.sh "${{ matrix.platform.target }}"
 
       - name: Verify AppImage fcitx5 GTK module
         if: runner.os == 'Linux'

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -426,6 +426,27 @@ test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
   assert.match(packageJob.env.TAURI_UPDATER_ENDPOINT, /github\.repository/);
   assert.match(packageJob.env.TAURI_UPDATER_ENDPOINT, /channel-beta/);
   assert.match(packageJob.env.BITFUN_RELEASE_PUBKEY, /BITFUN_RELEASE_PUBKEY/);
+  const appleSetupIndex = packageJob.steps.findIndex(
+    (step) => step.name === 'Configure Apple Developer ID signing and notarization',
+  );
+  const desktopBuildIndex = packageJob.steps.findIndex(
+    (step) => step.name === 'Build desktop app',
+  );
+  const appleVerifyIndex = packageJob.steps.findIndex(
+    (step) => step.name === 'Verify Apple signature and notarization',
+  );
+  assert.ok(
+    appleSetupIndex >= 0 &&
+      appleSetupIndex < desktopBuildIndex &&
+      desktopBuildIndex < appleVerifyIndex,
+    'Apple credentials must be configured before packaging and verified afterwards',
+  );
+  assert.equal(packageJob.steps[appleSetupIndex].if, "runner.os == 'macOS'");
+  assert.equal(
+    packageJob.steps[appleSetupIndex].env.BITFUN_REQUIRE_APPLE_SIGNING,
+    '${{ needs.prepare.outputs.upload_to_release }}',
+  );
+  assert.equal(packageJob.steps[appleVerifyIndex].if, "runner.os == 'macOS'");
   const patchIndex = packageJob.steps.findIndex(
     (step) => step.name === 'Project beta build version',
   );

--- a/scripts/ci/setup-macos-signing.sh
+++ b/scripts/ci/setup-macos-signing.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required=(
+  APPLE_CERTIFICATE
+  APPLE_CERTIFICATE_PASSWORD
+  APPLE_SIGNING_IDENTITY
+  APPLE_API_ISSUER
+  APPLE_API_KEY
+  APPLE_API_PRIVATE_KEY
+  KEYCHAIN_PASSWORD
+)
+
+missing=()
+for name in "${required[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    missing+=("${name}")
+  fi
+done
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  if [[ "${BITFUN_REQUIRE_APPLE_SIGNING:-false}" == "true" ]]; then
+    printf 'Apple signing is required, but these secrets are missing: %s\n' "${missing[*]}" >&2
+    exit 1
+  fi
+  printf 'Apple signing is not fully configured; leaving this non-release macOS build unsigned. Missing: %s\n' "${missing[*]}"
+  exit 0
+fi
+
+signing_dir="${RUNNER_TEMP}/bitfun-apple-signing"
+certificate_path="${signing_dir}/developer-id.p12"
+api_key_path="${signing_dir}/AuthKey_${APPLE_API_KEY}.p8"
+keychain_path="${RUNNER_TEMP}/bitfun-signing.keychain-db"
+
+mkdir -p "${signing_dir}"
+chmod 700 "${signing_dir}"
+printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode >"${certificate_path}"
+printf '%s' "${APPLE_API_PRIVATE_KEY}" >"${api_key_path}"
+chmod 600 "${certificate_path}" "${api_key_path}"
+
+security create-keychain -p "${KEYCHAIN_PASSWORD}" "${keychain_path}"
+security set-keychain-settings -lut 21600 "${keychain_path}"
+security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${keychain_path}"
+security import "${certificate_path}" \
+  -k "${keychain_path}" \
+  -P "${APPLE_CERTIFICATE_PASSWORD}" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: \
+  -s \
+  -k "${KEYCHAIN_PASSWORD}" \
+  "${keychain_path}"
+
+curl --fail --location --silent --show-error \
+  'https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer' \
+  --output "${signing_dir}/DeveloperIDG2CA.cer"
+security import "${signing_dir}/DeveloperIDG2CA.cer" -k "${keychain_path}"
+
+security list-keychains -d user -s "${keychain_path}" "${HOME}/Library/Keychains/login.keychain-db"
+security default-keychain -d user -s "${keychain_path}"
+security find-identity -v -p codesigning "${keychain_path}"
+
+if ! security find-identity -v -p codesigning "${keychain_path}" | grep -Fq "${APPLE_SIGNING_IDENTITY}"; then
+  echo "The imported certificate does not provide ${APPLE_SIGNING_IDENTITY}." >&2
+  exit 1
+fi
+
+{
+  echo "APPLE_API_ISSUER=${APPLE_API_ISSUER}"
+  echo "APPLE_API_KEY=${APPLE_API_KEY}"
+  echo "APPLE_API_KEY_PATH=${api_key_path}"
+  echo "APPLE_SIGNING_IDENTITY=${APPLE_SIGNING_IDENTITY}"
+  echo "BITFUN_APPLE_SIGNING_CONFIGURED=true"
+} >>"${GITHUB_ENV}"
+
+echo "Apple Developer ID signing and notarization credentials are ready."

--- a/scripts/ci/verify-macos-signing.sh
+++ b/scripts/ci/verify-macos-signing.sh
@@ -20,6 +20,15 @@ fi
 
 for app in "${apps[@]}"; do
   codesign --verify --deep --strict --verbose=2 "${app}"
+  while IFS= read -r -d '' candidate; do
+    if ! file -b "${candidate}" | grep -q 'Mach-O'; then
+      continue
+    fi
+    signature_details="$(codesign -dv --verbose=4 "${candidate}" 2>&1)"
+    grep -Fq 'Authority=Developer ID Application:' <<<"${signature_details}"
+    grep -Eq 'flags=.*\(runtime\)' <<<"${signature_details}"
+    grep -Fq 'Timestamp=' <<<"${signature_details}"
+  done < <(find "${app}" -type f -print0)
   xcrun stapler validate "${app}"
   spctl --assess --type execute --verbose=4 "${app}"
 done

--- a/scripts/ci/verify-macos-signing.sh
+++ b/scripts/ci/verify-macos-signing.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:?usage: verify-macos-signing.sh <target-triple>}"
+if [[ "${BITFUN_APPLE_SIGNING_CONFIGURED:-false}" != "true" ]]; then
+  echo "Apple signing is not configured; skipping macOS signature verification."
+  exit 0
+fi
+
+bundle_dir="target/${target}/release/bundle"
+
+shopt -s nullglob
+apps=("${bundle_dir}/macos/"*.app)
+dmgs=("${bundle_dir}/dmg/"*.dmg)
+
+if [[ "${#apps[@]}" -eq 0 || "${#dmgs[@]}" -eq 0 ]]; then
+  echo "Expected one or more macOS app and DMG bundles under ${bundle_dir}." >&2
+  exit 1
+fi
+
+for app in "${apps[@]}"; do
+  codesign --verify --deep --strict --verbose=2 "${app}"
+  xcrun stapler validate "${app}"
+  spctl --assess --type execute --verbose=4 "${app}"
+done
+
+for dmg in "${dmgs[@]}"; do
+  xcrun notarytool submit "${dmg}" \
+    --issuer "${APPLE_API_ISSUER}" \
+    --key-id "${APPLE_API_KEY}" \
+    --key "${APPLE_API_KEY_PATH}" \
+    --wait
+  xcrun stapler staple "${dmg}"
+  xcrun stapler validate "${dmg}"
+  spctl --assess --type open --context context:primary-signature --verbose=4 "${dmg}"
+done
+
+echo "Verified Developer ID signatures, notarization tickets, and Gatekeeper acceptance."

--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -4,6 +4,8 @@ import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import {
+  chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -44,10 +46,12 @@ async function main() {
   const releaseChannel = resolveReleaseChannel(process.env.BITFUN_RELEASE_CHANNEL);
   console.log(`[release] channel=${releaseChannel.channel}`);
 
-  const flashgrepBinary = ensureFlashgrepBinary();
-  process.env.FLASHGREP_DAEMON_BIN = flashgrepBinary;
-
   const desktopDir = join(ROOT, 'src', 'apps', 'desktop');
+  const flashgrepBinary = prepareMacOSFlashgrepForSigning(
+    ensureFlashgrepBinary(),
+    desktopDir,
+  );
+  process.env.FLASHGREP_DAEMON_BIN = flashgrepBinary;
   // Tauri CLI reads CI and rejects numeric "1" (common in CI providers).
   process.env.CI = 'true';
 
@@ -164,6 +168,46 @@ function optionValue(args, option) {
     }
   }
   return undefined;
+}
+
+export function prepareMacOSFlashgrepForSigning(
+  flashgrepBinary,
+  desktopDir,
+  runtime = {},
+) {
+  const platform = runtime.platform ?? process.platform;
+  const signingIdentity = runtime.signingIdentity ?? process.env.APPLE_SIGNING_IDENTITY;
+  if (platform !== 'darwin' || !signingIdentity) {
+    return flashgrepBinary;
+  }
+
+  const signedDir = join(desktopDir, 'gen', 'signed-resources', 'flashgrep');
+  const signedBinary = join(signedDir, basename(flashgrepBinary));
+  mkdirSync(signedDir, { recursive: true });
+  copyFileSync(flashgrepBinary, signedBinary);
+  chmodSync(signedBinary, statSync(signedBinary).mode | 0o111);
+
+  const run = runtime.spawnSync ?? spawnSync;
+  const result = run(
+    'codesign',
+    [
+      '--force',
+      '--sign',
+      signingIdentity,
+      '--options',
+      'runtime',
+      '--timestamp',
+      signedBinary,
+    ],
+    { encoding: 'utf8', shell: false },
+  );
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message || result.stderr || `exit status ${result.status}`;
+    throw new Error(`Failed to sign bundled flashgrep binary: ${detail}`);
+  }
+
+  console.log(`[tauri-build] Signed bundled flashgrep binary: ${signedBinary}`);
+  return signedBinary;
 }
 
 export function prepareTauriConfig(

--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -75,10 +75,6 @@ async function main() {
     process.exit(1);
   }
 
-  if (r.status === 0 && process.platform === 'darwin') {
-    patchDmgExtras(ROOT);
-  }
-
   // Keep only the latest useful Cargo caches for this build profile after tauri build ends.
   try {
     const { profileFromTauriBuildArgs, runGcBestEffort, targetFromTauriBuildArgs } = await import(
@@ -275,48 +271,6 @@ function bundledFlashgrepResources(primaryBinary) {
 
 function toTauriPath(value) {
   return value.split(sep).join('/');
-}
-
-// Find all .dmg files under target/ and inject the helper TXT files
-// (quarantine removal instructions) into each one.
-function patchDmgExtras(root) {
-  const patchScript = join(root, 'scripts', 'patch-dmg-extras.sh');
-  const targetDir = join(root, 'target');
-
-  const dmgFiles = findDmgFiles(targetDir);
-  if (dmgFiles.length === 0) {
-    console.log('[patch-dmg] No .dmg files found — skipping.');
-    return;
-  }
-
-  for (const dmg of dmgFiles) {
-    console.log(`[patch-dmg] Patching ${dmg}`);
-    const p = spawnSync('bash', [patchScript, dmg], {
-      stdio: 'inherit',
-      shell: false,
-    });
-    if (p.status !== 0) {
-      console.error(`[patch-dmg] Failed to patch ${dmg}`);
-      process.exit(1);
-    }
-  }
-}
-
-function findDmgFiles(dir) {
-  const results = [];
-  try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        results.push(...findDmgFiles(full));
-      } else if (entry.name.endsWith('.dmg')) {
-        results.push(full);
-      }
-    }
-  } catch {
-    // directory may not exist for some targets
-  }
-  return results;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/desktop-tauri-build.test.mjs
+++ b/scripts/desktop-tauri-build.test.mjs
@@ -3,7 +3,11 @@ import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { prepareTauriConfig, shouldRetryMacDmgBuild } from './desktop-tauri-build.mjs';
+import {
+  prepareMacOSFlashgrepForSigning,
+  prepareTauriConfig,
+  shouldRetryMacDmgBuild,
+} from './desktop-tauri-build.mjs';
 import { resolveProductDefinition } from './product-customization/resolver.mjs';
 
 const FAILED_BUILD = { status: 1 };
@@ -14,6 +18,79 @@ test('release builds do not mutate DMGs after Tauri signs and notarizes them', (
   const source = readFileSync(join(ROOT, 'scripts', 'desktop-tauri-build.mjs'), 'utf8');
   assert.doesNotMatch(source, /patchDmgExtras/);
   assert.doesNotMatch(source, /patch-dmg-extras\.sh/);
+});
+
+test('macOS release signing covers the bundled flashgrep executable', () => {
+  const fixture = join(tmpdir(), `bitfun-flashgrep-signing-${process.pid}-${Date.now()}`);
+  const desktopDir = join(fixture, 'src', 'apps', 'desktop');
+  const source = join(fixture, 'flashgrep-aarch64-apple-darwin');
+  const calls = [];
+  mkdirSync(desktopDir, { recursive: true });
+  writeFileSync(source, 'test-binary');
+
+  try {
+    const signed = prepareMacOSFlashgrepForSigning(source, desktopDir, {
+      platform: 'darwin',
+      signingIdentity: 'Developer ID Application: Test (TEAMID)',
+      spawnSync: (...args) => {
+        calls.push(args);
+        return { status: 0 };
+      },
+    });
+
+    assert.notEqual(signed, source);
+    assert.equal(readFileSync(signed, 'utf8'), 'test-binary');
+    assert.deepEqual(calls[0][0], 'codesign');
+    assert.deepEqual(calls[0][1], [
+      '--force',
+      '--sign',
+      'Developer ID Application: Test (TEAMID)',
+      '--options',
+      'runtime',
+      '--timestamp',
+      signed,
+    ]);
+  } finally {
+    rmSync(fixture, { force: true, recursive: true });
+  }
+});
+
+test('unsigned and non-macOS builds keep the original flashgrep executable', () => {
+  assert.equal(
+    prepareMacOSFlashgrepForSigning('/tmp/flashgrep', '/tmp/desktop', {
+      platform: 'darwin',
+      signingIdentity: '',
+    }),
+    '/tmp/flashgrep',
+  );
+  assert.equal(
+    prepareMacOSFlashgrepForSigning('/tmp/flashgrep', '/tmp/desktop', {
+      platform: 'linux',
+      signingIdentity: 'unused',
+    }),
+    '/tmp/flashgrep',
+  );
+});
+
+test('macOS packaging fails when bundled flashgrep signing fails', () => {
+  const fixture = join(tmpdir(), `bitfun-flashgrep-signing-failure-${process.pid}-${Date.now()}`);
+  const desktopDir = join(fixture, 'src', 'apps', 'desktop');
+  const source = join(fixture, 'flashgrep-x86_64-apple-darwin');
+  mkdirSync(desktopDir, { recursive: true });
+  writeFileSync(source, 'test-binary');
+
+  try {
+    assert.throws(
+      () => prepareMacOSFlashgrepForSigning(source, desktopDir, {
+        platform: 'darwin',
+        signingIdentity: 'Developer ID Application: Test (TEAMID)',
+        spawnSync: () => ({ status: 1, stderr: 'identity unavailable' }),
+      }),
+      /Failed to sign bundled flashgrep binary: identity unavailable/,
+    );
+  } finally {
+    rmSync(fixture, { force: true, recursive: true });
+  }
 });
 
 function retryFixture() {

--- a/scripts/desktop-tauri-build.test.mjs
+++ b/scripts/desktop-tauri-build.test.mjs
@@ -10,6 +10,12 @@ const FAILED_BUILD = { status: 1 };
 const DMG_ARGS = ['--target', 'x86_64-apple-darwin', '--bundles', 'app,dmg'];
 const ROOT = join(import.meta.dirname, '..');
 
+test('release builds do not mutate DMGs after Tauri signs and notarizes them', () => {
+  const source = readFileSync(join(ROOT, 'scripts', 'desktop-tauri-build.mjs'), 'utf8');
+  assert.doesNotMatch(source, /patchDmgExtras/);
+  assert.doesNotMatch(source, /patch-dmg-extras\.sh/);
+});
+
 function retryFixture() {
   const root = join(tmpdir(), `bitfun-dmg-retry-${process.pid}-${Date.now()}`);
   const desktopDir = join(root, 'src', 'apps', 'desktop');


### PR DESCRIPTION
## Summary

- import the Developer ID certificate and App Store Connect API key into macOS packaging jobs
- sign and notarize the Tauri app, then independently notarize and staple the final DMG
- stop rewriting DMGs after signing, which invalidated signatures and notarization tickets
- require complete Apple credentials for release uploads while allowing explicit unsigned non-release builds

## Verification

- `pnpm run check:github-config`
- `node --test scripts/desktop-tauri-build.test.mjs`
- `bash -n scripts/ci/setup-macos-signing.sh scripts/ci/verify-macos-signing.sh`
- setup script missing-secret branches tested for required and optional signing
- App Store Connect API credentials authenticated successfully with `notarytool history`
- local arm64 signed/notarized package build is still running; macOS arm64 and x64 package jobs will exercise the complete flow in CI

## Remote scenarios

Not applicable. This changes only GitHub-hosted packaging and Apple distribution signing; runtime remote workspace, remote control, Peer Device Mode, and Detached Dispatch behavior are unchanged.

## AI assistance

AI-assisted; focused packaging/config tests passed. Full macOS packaging validation is delegated to this PR CI and the in-progress local arm64 build.