### PR TITLE
fix(todos): replace the native date picker with an in-app one

### DIFF
--- a/src/web-ui/src/app/components/scheduled-jobs/DateTimePickerPopover.appearance.ts
+++ b/src/web-ui/src/app/components/scheduled-jobs/DateTimePickerPopover.appearance.ts
@@ -1,0 +1,16 @@
+import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
+
+export const dateTimePickerAppearanceDescriptor: AppearanceSurfaceDescriptor = {
+  id: 'datetime-picker',
+  parts: [
+    { id: 'root' },
+    { id: 'head' },
+    { id: 'grid' },
+    { id: 'day' },
+    { id: 'foot' },
+  ],
+  states: [
+    { id: 'selected', selector: { kind: 'self', suffix: '[data-bf-state~="selected"]' } },
+    { id: 'today', selector: { kind: 'self', suffix: '[data-bf-state~="today"]' } },
+  ],
+};

--- a/src/web-ui/src/app/components/scheduled-jobs/DateTimePickerPopover.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/DateTimePickerPopover.tsx
@@ -1,0 +1,215 @@
+/**
+ * Day picker for `LocalizedDateTimeField`.
+ *
+ * Replaces the browser's own picker, which was driven through `showPicker()` on
+ * a hidden anchor input and would not dismiss after a selection — its
+ * open/close lifecycle assumes a real, hit-testable anchor. Rendering the grid
+ * in-app puts that lifecycle under our control, and keeps the calendar in the
+ * app's own locale and theme.
+ *
+ * Scope is deliberately the date only: the time is easier to type than to click,
+ * and the text field already accepts it.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { IconButton, Button } from '@/component-library';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useI18n } from '@/infrastructure/i18n';
+import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+
+const POPOVER_WIDTH = 268;
+const POPOVER_HEIGHT = 300;
+
+/** Six-week grid (42 local days) covering the month `monthAnchorMs` falls in. */
+function buildMonthGrid(monthAnchorMs: number): Date[] {
+  const anchor = new Date(monthAnchorMs);
+  const firstOfMonth = new Date(anchor.getFullYear(), anchor.getMonth(), 1);
+  const gridStart = new Date(firstOfMonth);
+  gridStart.setDate(firstOfMonth.getDate() - firstOfMonth.getDay());
+
+  return Array.from({ length: 42 }, (_, index) => {
+    const day = new Date(gridStart);
+    day.setDate(gridStart.getDate() + index);
+    return day;
+  });
+}
+
+function isSameDay(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear()
+    && left.getMonth() === right.getMonth()
+    && left.getDate() === right.getDate();
+}
+
+export interface DateTimePickerPopoverProps {
+  /** Element the popover is positioned against. */
+  anchorRef: React.RefObject<HTMLElement | null>;
+  /** Currently selected day, or null when the field is empty. */
+  selected: Date | null;
+  onSelect: (day: Date) => void;
+  onClose: () => void;
+}
+
+const DateTimePickerPopover: React.FC<DateTimePickerPopoverProps> = ({
+  anchorRef,
+  selected,
+  onSelect,
+  onClose,
+}) => {
+  const { t, formatDate } = useI18n('common');
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  const [monthAnchorMs, setMonthAnchorMs] = useState(() => {
+    const base = selected ?? new Date();
+    return new Date(base.getFullYear(), base.getMonth(), 1).getTime();
+  });
+  const [position, setPosition] = useState(() => {
+    const rect = anchorRef.current?.getBoundingClientRect();
+    return rect
+      ? computeFixedPopoverPosition(rect, POPOVER_WIDTH, POPOVER_HEIGHT)
+      : { top: 0, left: 0 };
+  });
+
+  // Reposition against the live popover size once it has painted, and keep it
+  // anchored while the surrounding form scrolls.
+  useEffect(() => {
+    const reposition = () => {
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const element = popoverRef.current;
+      setPosition(computeFixedPopoverPosition(
+        rect,
+        element?.offsetWidth ?? POPOVER_WIDTH,
+        element?.offsetHeight ?? POPOVER_HEIGHT,
+      ));
+    };
+
+    reposition();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [anchorRef]);
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (popoverRef.current?.contains(target)) return;
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [anchorRef, onClose]);
+
+  const grid = useMemo(() => buildMonthGrid(monthAnchorMs), [monthAnchorMs]);
+  const anchorDate = useMemo(() => new Date(monthAnchorMs), [monthAnchorMs]);
+  const today = useMemo(() => new Date(), []);
+
+  const weekdayLabels = useMemo(
+    () => grid.slice(0, 7).map(day => formatDate(day, { weekday: 'narrow' })),
+    [formatDate, grid],
+  );
+
+  const shiftMonth = useCallback((delta: number) => {
+    setMonthAnchorMs(current => {
+      const date = new Date(current);
+      return new Date(date.getFullYear(), date.getMonth() + delta, 1).getTime();
+    });
+  }, []);
+
+  return createPortal(
+    <div
+      ref={popoverRef}
+      className="bf-datetime-picker"
+      data-bf-component="datetime-picker"
+      data-bf-part="root"
+      data-testid="datetime-picker"
+      role="dialog"
+      aria-label={t('dateTimeField.pickerLabel')}
+      style={{ top: position.top, left: position.left }}
+    >
+      <header className="bf-datetime-picker__head" data-bf-component="datetime-picker" data-bf-part="head">
+        <IconButton
+          type="button"
+          size="xs"
+          aria-label={t('dateTimeField.previousMonth')}
+          onClick={() => shiftMonth(-1)}
+        >
+          <ChevronLeft size={14} />
+        </IconButton>
+        <span className="bf-datetime-picker__month">
+          {formatDate(anchorDate, { year: 'numeric', month: 'long' })}
+        </span>
+        <IconButton
+          type="button"
+          size="xs"
+          aria-label={t('dateTimeField.nextMonth')}
+          onClick={() => shiftMonth(1)}
+        >
+          <ChevronRight size={14} />
+        </IconButton>
+      </header>
+
+      <div className="bf-datetime-picker__weekdays" aria-hidden="true">
+        {weekdayLabels.map((label, index) => (
+          <span key={index} className="bf-datetime-picker__weekday">{label}</span>
+        ))}
+      </div>
+
+      <div className="bf-datetime-picker__grid" role="grid" data-bf-component="datetime-picker" data-bf-part="grid">
+        {grid.map(day => {
+          const isCurrentMonth = day.getMonth() === anchorDate.getMonth();
+          const isSelected = selected != null && isSameDay(day, selected);
+          const isToday = isSameDay(day, today);
+
+          return (
+            <button
+              key={day.getTime()}
+              type="button"
+              role="gridcell"
+              className={[
+                'bf-datetime-picker__day',
+                isCurrentMonth ? '' : 'bf-datetime-picker__day--outside',
+                isToday ? 'bf-datetime-picker__day--today' : '',
+                isSelected ? 'bf-datetime-picker__day--selected' : '',
+              ].filter(Boolean).join(' ')}
+              data-bf-component="datetime-picker"
+              data-bf-part="day"
+              data-bf-state={isSelected ? 'selected' : isToday ? 'today' : undefined}
+              aria-pressed={isSelected}
+              aria-label={formatDate(day, { year: 'numeric', month: 'long', day: 'numeric' })}
+              onClick={() => onSelect(day)}
+            >
+              {day.getDate()}
+            </button>
+          );
+        })}
+      </div>
+
+      <footer className="bf-datetime-picker__foot" data-bf-component="datetime-picker" data-bf-part="foot">
+        <Button size="small" variant="ghost" onClick={() => onSelect(new Date())}>
+          {t('dateTimeField.now')}
+        </Button>
+        <Button size="small" variant="ghost" onClick={onClose}>
+          {t('dateTimeField.close')}
+        </Button>
+      </footer>
+    </div>,
+    getAppearanceOverlayHost(),
+  );
+};
+
+export default DateTimePickerPopover;

--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
@@ -1,6 +1,7 @@
 @use '../../../component-library/styles/tokens.scss' as *;
 
 .bf-datetime-field {
+  position: relative;
   display: flex;
   align-items: center;
   gap: $size-gap-1;
@@ -10,15 +11,97 @@
     flex: 1 1 auto;
     min-width: 0;
   }
+}
 
-  // Present only so the browser picker has an anchor; never shown or focused.
-  &__picker {
-    position: absolute;
-    width: 0;
-    height: 0;
+.bf-datetime-picker {
+  position: fixed;
+  z-index: 1000;
+  width: 268px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: $size-gap-2;
+  padding: $size-gap-3;
+  border: 1px solid var(--bf-appearance-token-border-subtle);
+  border-radius: $size-radius-lg;
+  background: var(--bf-appearance-token-element-bg-subtle);
+  box-shadow: var(--bf-appearance-token-shadow-sm);
+
+  &__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $size-gap-2;
+  }
+
+  &__month {
+    flex: 1 1 auto;
+    text-align: center;
+    font-size: var(--bf-appearance-token-font-size-sm);
+    font-weight: $font-weight-semibold;
+    color: var(--bf-appearance-token-color-text-primary);
+  }
+
+  &__weekdays,
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 2px;
+  }
+
+  &__weekday {
+    padding: 2px 0;
+    text-align: center;
+    font-size: var(--bf-appearance-token-font-size-2xs);
+    font-weight: $font-weight-semibold;
+    color: var(--bf-appearance-token-color-text-muted);
+  }
+
+  &__day {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 28px;
     padding: 0;
-    border: 0;
-    opacity: 0;
-    pointer-events: none;
+    border: 1px solid transparent;
+    border-radius: $size-radius-base;
+    background: transparent;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-size: var(--bf-appearance-token-font-size-xs);
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    transition: background $motion-fast $easing-standard;
+
+    &:hover {
+      background: var(--bf-appearance-token-element-bg-soft);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--bf-appearance-token-color-accent-500);
+      outline-offset: 1px;
+    }
+
+    &--outside {
+      color: var(--bf-appearance-token-color-text-muted);
+      opacity: 0.55;
+    }
+
+    &--today {
+      border-color: color-mix(in srgb, var(--bf-appearance-token-color-accent-500) 55%, transparent);
+    }
+
+    &--selected {
+      background: var(--bf-appearance-token-color-accent-500);
+      color: var(--bf-appearance-token-color-static-white);
+    }
+  }
+
+  &__foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $size-gap-2;
+    padding-top: $size-gap-2;
+    border-top: 1px solid color-mix(in srgb, var(--bf-appearance-token-border-subtle) 70%, transparent);
   }
 }

--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.tsx
@@ -8,21 +8,28 @@
  *
  * This is an ordinary text input so it looks and behaves like every other field
  * in the form, showing `2026/08/12 04:48` in Chinese and `08/12/2026 04:48` in
- * English. A calendar button opens the browser's own picker for anyone who
- * would rather click than type. Callers keep the native
- * `YYYY-MM-DDTHH:mm` value contract.
+ * English, with an in-app day picker on the calendar button. Callers keep the
+ * native `YYYY-MM-DDTHH:mm` value contract.
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CalendarDays } from 'lucide-react';
 import { IconButton, Input } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
+import DateTimePickerPopover from './DateTimePickerPopover';
 import {
   dateTimeFormatHint,
   formatDateTimeText,
   parseDateTimeText,
   resolveDateFieldOrder,
 } from './localizedDateTime';
+
+/** Time a picked day falls back to when the field has no time yet. */
+const DEFAULT_TIME = { hour: 9, minute: 0 };
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
 
 export interface LocalizedDateTimeFieldProps {
   /** `YYYY-MM-DDTHH:mm`, matching the native datetime-local value. */
@@ -43,8 +50,9 @@ const LocalizedDateTimeField: React.FC<LocalizedDateTimeFieldProps> = ({
   'aria-label': ariaLabel,
 }) => {
   const { t, currentLanguage } = useI18n('common');
-  const pickerRef = useRef<HTMLInputElement | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
   const editingRef = useRef(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const order = useMemo(() => resolveDateFieldOrder(currentLanguage), [currentLanguage]);
 
@@ -80,18 +88,36 @@ const LocalizedDateTimeField: React.FC<LocalizedDateTimeFieldProps> = ({
     setText(parsed ? formatDateTimeText(parsed, order) : text);
   }, [order, text]);
 
-  const openPicker = useCallback(() => {
-    const picker = pickerRef.current;
-    if (!picker) return;
-    picker.value = value;
-    picker.showPicker?.();
-  }, [value]);
+  /** Day currently represented by the field, for highlighting in the picker. */
+  const selectedDay = useMemo(() => {
+    const parsed = parseDateTimeText(text, order) ?? (value.trim() || null);
+    if (!parsed) return null;
+    const timestamp = new Date(parsed).getTime();
+    return Number.isFinite(timestamp) ? new Date(timestamp) : null;
+  }, [order, text, value]);
 
-  const canOpenPicker = typeof HTMLInputElement !== 'undefined'
-    && 'showPicker' in HTMLInputElement.prototype;
+  const handlePickDay = useCallback((day: Date) => {
+    // Keep whatever time is already set; picking a day should not silently
+    // rewind the clock to midnight.
+    const existing = selectedDay;
+    const hour = existing ? existing.getHours() : DEFAULT_TIME.hour;
+    const minute = existing ? existing.getMinutes() : DEFAULT_TIME.minute;
+
+    const next = [
+      String(day.getFullYear()).padStart(4, '0'),
+      pad(day.getMonth() + 1),
+      pad(day.getDate()),
+    ].join('-') + `T${pad(hour)}:${pad(minute)}`;
+
+    editingRef.current = false;
+    setText(formatDateTimeText(next, order));
+    onChange(next);
+    setPickerOpen(false);
+  }, [onChange, order, selectedDay]);
 
   return (
     <div
+      ref={anchorRef}
       className={['bf-datetime-field', className ?? ''].filter(Boolean).join(' ')}
       data-bf-component="localized-datetime-field"
       data-bf-part="root"
@@ -111,36 +137,25 @@ const LocalizedDateTimeField: React.FC<LocalizedDateTimeFieldProps> = ({
         onBlur={handleBlur}
       />
 
-      {canOpenPicker ? (
-        <>
-          <IconButton
-            type="button"
-            size="xs"
-            disabled={disabled}
-            aria-label={t('dateTimeField.openPicker')}
-            tooltip={t('dateTimeField.openPicker')}
-            onClick={openPicker}
-          >
-            <CalendarDays size={14} />
-          </IconButton>
-          {/*
-            Only ever opened programmatically: the browser picker is a good
-            input surface, its inline text rendering is the part we replaced.
-          */}
-          <input
-            ref={pickerRef}
-            type="datetime-local"
-            className="bf-datetime-field__picker"
-            tabIndex={-1}
-            aria-hidden="true"
-            onChange={event => {
-              editingRef.current = false;
-              const picked = event.currentTarget.value;
-              setText(formatDateTimeText(picked, order));
-              onChange(picked);
-            }}
-          />
-        </>
+      <IconButton
+        type="button"
+        size="xs"
+        disabled={disabled}
+        aria-label={t('dateTimeField.openPicker')}
+        tooltip={t('dateTimeField.openPicker')}
+        aria-expanded={pickerOpen}
+        onClick={() => setPickerOpen(open => !open)}
+      >
+        <CalendarDays size={14} />
+      </IconButton>
+
+      {pickerOpen && !disabled ? (
+        <DateTimePickerPopover
+          anchorRef={anchorRef}
+          selected={selectedDay}
+          onSelect={handlePickDay}
+          onClose={() => setPickerOpen(false)}
+        />
       ) : null}
     </div>
   );

--- a/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
+++ b/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
@@ -120,6 +120,7 @@ import { reviewPlatformAppearanceDescriptor } from '@/app/components/panels/revi
 import { remoteAccountPanelAppearanceDescriptor, remoteConnectDialogAppearanceDescriptor } from '@/app/components/RemoteConnectDialog/appearance';
 import { scheduledJobsViewAppearanceDescriptor } from '@/app/components/scheduled-jobs/appearance';
 import { localizedDateTimeFieldAppearanceDescriptor } from '@/app/components/scheduled-jobs/LocalizedDateTimeField.appearance';
+import { dateTimePickerAppearanceDescriptor } from '@/app/components/scheduled-jobs/DateTimePickerPopover.appearance';
 import { todosSceneAppearanceDescriptor } from '@/app/scenes/todos/appearance';
 import { flexiblePanelAppearanceDescriptor } from '@/app/components/panels/base/FlexiblePanel.appearance';
 import { btwSessionPanelAppearanceDescriptor } from '@/flow_chat/components/btw/BtwSessionPanel.appearance';
@@ -409,6 +410,7 @@ export function createDefaultAppearanceRegistry(): AppearanceRegistry {
     .registerComponent(remoteAccountPanelAppearanceDescriptor)
     .registerComponent(scheduledJobsViewAppearanceDescriptor)
     .registerComponent(localizedDateTimeFieldAppearanceDescriptor)
+    .registerComponent(dateTimePickerAppearanceDescriptor)
     .registerComponent(flexiblePanelAppearanceDescriptor)
     .registerComponent(btwSessionPanelAppearanceDescriptor)
     .registerComponent(modernFlowChatAppearanceDescriptor)

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -1553,6 +1553,11 @@
   "retry": "Retry",
   "dateTimeField": {
     "label": "Date and time",
-    "openPicker": "Open the date picker"
+    "openPicker": "Open the date picker",
+    "pickerLabel": "Choose a date",
+    "previousMonth": "Previous month",
+    "nextMonth": "Next month",
+    "now": "Now",
+    "close": "Close"
   }
 }

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -1553,6 +1553,11 @@
   "retry": "重试",
   "dateTimeField": {
     "label": "日期与时间",
-    "openPicker": "打开日期选择器"
+    "openPicker": "打开日期选择器",
+    "pickerLabel": "选择日期",
+    "previousMonth": "上个月",
+    "nextMonth": "下个月",
+    "now": "此刻",
+    "close": "关闭"
   }
 }

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -1553,6 +1553,11 @@
   "retry": "重試",
   "dateTimeField": {
     "label": "日期與時間",
-    "openPicker": "開啟日期選擇器"
+    "openPicker": "開啟日期選擇器",
+    "pickerLabel": "選擇日期",
+    "previousMonth": "上個月",
+    "nextMonth": "下個月",
+    "now": "此刻",
+    "close": "關閉"
   }
 }


### PR DESCRIPTION
Follow-up to #2246: the calendar opened but never dismissed after picking a date.

## Cause

That was the browser's own picker, opened with `showPicker()` on an anchor input I had made zero-size, `pointer-events: none` and `aria-hidden`. Chromium ties that popup's open/close lifecycle to a real, hit-testable anchor, so with nothing to hand focus back to it stayed on screen. The hidden-anchor trick was the bug, not the picker.

## Fix

Render the grid in-app instead of coaxing the native widget. A React popover has a dismissal path we own rather than one we have to infer from Chromium's internals, and it picks up the app's locale and theme for free.

It dismisses on all four paths: selecting a day, Escape, an outside click, and re-clicking the calendar button. Positioning reuses the existing `computeFixedPopoverPosition` helper and the shared overlay host, matching the workspace menu in `MainNav`, and repositions on resize and scroll.

Scope stays the date. Picking a day keeps the time already in the field rather than rewinding it to midnight — `2026/07/01 21:59` with 15 clicked gives `2026/07/15 21:59` — and the text field remains the way to set the time, which is quicker to type than to click.

## Verification

I drove the interaction this time rather than only inspecting the layout, since the last two rounds shipped interaction bugs that static checks could not have caught. Against a mock mirroring the component's logic:

- click day 15 → value `2026/07/01 21:59` → `2026/07/15 21:59`, time preserved, popover dismissed
- Escape → dismissed
- outside click → dismissed
- button toggle → dismissed

That exercises the behaviour that broke, though it is a mock of the interaction model rather than the live app.

`type-check:web`, `lint:web`, `i18n:audit`, `theme:color-audit:all` and the appearance-contract audit all pass; 54 tests in the touched areas pass.

One thing corrected in passing: the selected-day style first used `--bf-appearance-token-color-text-on-accent` with a `#fff` fallback. That token does not exist — it now uses the real `color-static-white`.

AI-assisted. Testing level: lightly tested.
