### PR TITLE
fix(todos): make the date picker surface opaque

### DIFF
--- a/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
+++ b/src/web-ui/src/app/components/scheduled-jobs/LocalizedDateTimeField.scss
@@ -15,7 +15,7 @@
 
 .bf-datetime-picker {
   position: fixed;
-  z-index: 1000;
+  z-index: 9999;
   width: 268px;
   box-sizing: border-box;
   display: flex;
@@ -24,8 +24,10 @@
   padding: $size-gap-3;
   border: 1px solid var(--bf-appearance-token-border-subtle);
   border-radius: $size-radius-lg;
-  background: var(--bf-appearance-token-element-bg-subtle);
-  box-shadow: var(--bf-appearance-token-shadow-sm);
+  // Opaque elevated surface, matching the nav workspace menu. A translucent
+  // element background let the form behind it read through the grid.
+  background: var(--bf-appearance-token-color-bg-elevated);
+  box-shadow: 0 4px 12px var(--bf-appearance-token-color-overlay-black-30);
 
   &__head {
     display: flex;


### PR DESCRIPTION
Follow-up to #2252: the date picker was translucent enough that the form behind it read through the grid, so day numbers collided with the prompt counter and the 取消 / 创建待办 buttons underneath.

## Cause

I had given the popover `--bf-appearance-token-element-bg-subtle`. That is an *element* background, meant to sit inside a panel and blend with it — the wrong class of token for something floating over other content.

## Fix

Use `--bf-appearance-token-color-bg-elevated`, with the same border, shadow and stacking as the nav workspace menu, which is the closest existing precedent for a portal-rendered floating surface.

That token resolves to an opaque colour in every builtin appearance (`#1c1c1f` dark, `#2b2d30` midnight, `#262626` slate and china-night, `#f0ede0` china-style), so the surface stays readable wherever it opens and in whichever theme.

## Verification

Rendered the popover over deliberately dense backdrop text and confirmed the content behind is fully occluded — the text cuts off exactly at the popover edge with nothing showing through the grid.

`lint:web` and `theme:color-audit:all` pass, and the web build succeeds. This is a three-line style change with no behaviour or markup difference, so the existing picker tests still cover the interaction.

AI-assisted. Testing level: lightly tested.
