### PR TITLE
fix(flowchat): settle the transcript viewport across reopen, history paging and navigation

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/AGENTS.md
+++ b/src/web-ui/src/flow_chat/components/modern/AGENTS.md
@@ -46,6 +46,10 @@ before reporting a defect as new.
   waits for the animation at all. Neither may be a frame count: a frame count
   is not a duration, and a smooth scroll eases in slowly enough that its first
   frames do not move at all on a high-refresh display.
+- A jump to latest animates only within `FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS`
+  and lands outright past it. Measured in viewports, never in pixels: the
+  question is whether the reader can follow the movement, and what they can
+  follow is a share of what they can see.
 - Footer height represents only the current input-stack layout and real footer
   content such as history state and `RuntimeStatusSlot`. The tail spacer is a
   separate sibling and must not be folded into it.

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -321,12 +321,49 @@ Two properties are shared with the gesture path, and one is not:
 Native scroll anchoring cannot help here: `overflow-anchor: none` is set
 throughout the transcript, because it fights the virtualizer.
 
+## An Animation Only as Far as the Reader Can Follow
+
+A jump to latest animates within `FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS` of where
+the viewport already is, and lands outright past that. The distance is counted
+in viewports, not pixels: what a reader can follow is a share of what they can
+see, and the same 2000px is two and a half screens on a laptop and most of one
+on a tall display.
+
+**The animation is the affordance, not the movement.** Its job is spatial
+continuity — showing which way and how far the viewport went — and three screens
+on, the transcript in between goes past faster than anyone can read it. What is
+left is a wait where the answer was, which is why every other navigation in the
+transcript is instant already.
+
+Distance also costs more than it looks. Animating across N screens of a
+virtualized transcript renders and measures every item passed while the
+animation runs, and heights are estimates until they are measured — so the
+content end moves under an animation aimed at where it used to be, and the
+follow loop corrects that afterwards as a second, visible movement.
+
+And past a few screens the animation does not finish. The stand-down below is
+bounded, and what it does not cover is delivered as a jump: measured, a jump
+issued for 8717px animated 5480 of them and was finished by the loop in a single
+3290px write. Two thirds of a scroll and then a jump is worse than either half
+alone, and no yield budget fixes it — a longer one only makes the reader wait
+through more of an animation they cannot read.
+
+The other `'smooth'` request in `useFlowChatFollowOutput`, the post-streaming
+settle, needs no such test: the gap it closes is bounded by `tailHoldMaxGapPx`,
+which is 60% of one viewport.
+
+`followOutput.jumpBehavior` records the decision and the distance in viewports.
+It is also how the constant is checked: if `followOutput.animatedScrollEnded`
+still reports a `backstop` reason, an animation ran out its yield without
+arriving and the number is too high.
+
 ## The Frame Loop Yields to Its Own Animated Scrolls
 
 `applyFollowTarget` assigns `scrollTop` outright, which cancels an in-flight
 smooth scroll on the very next frame. Both `'smooth'` requests in
-`useFlowChatFollowOutput` — the jump to latest and the post-streaming settle —
-were therefore jumps in practice, so the loop stands down while one travels.
+`useFlowChatFollowOutput` — the near jump to latest and the post-streaming
+settle — were therefore jumps in practice, so the loop stands down while one
+travels.
 
 **What ends the stand-down is the viewport having sat still for
 `SMOOTH_SCROLL_STALL_MS`.** That says the animation is over, or was cancelled,
@@ -339,10 +376,11 @@ of the animation:
 
 - The budget was 45 frames — 0.75s at 60Hz, 0.52s on a busy 200Hz display — so
   what a caller bought depended on the machine. The browser scales a smooth
-  scroll's duration with its distance, and a jump to latest from the top of a
-  transcript is the longest thing this issues; measured, one aimed at 8717px
-  animated 5480 of them and was finished by the loop in a single 3290px write,
-  38% short.
+  scroll's duration with its distance; measured, a jump aimed at 8717px animated
+  5480 of them and was finished by the loop in a single 3290px write, 38% short.
+  A wall-clock budget is what makes that failure the same size everywhere, and
+  the distance cap above is what stops anything asking for a jump that size in
+  the first place.
 - The stall check was then two frames, which is 10ms at 200Hz. A programmatic
   smooth scroll *eases in* — measured, 2px in its first 50ms against 9734px to
   travel — and with scroll offsets quantised to 0.8px the early frames

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
@@ -83,21 +83,24 @@ group does not renumber the others.
    off once its answer overflows the viewport.
 2. With output streaming, scroll up and hold still. Follow must not write while
    the gesture is recent, and must resume once it goes quiet.
-3. Jump to latest is animated rather than an instant jump — including from the
-   top of a long transcript, which is the longest animation anything here
-   issues and the one a frame-counted stand-down used to cut short. It must
-   glide the whole way, with at most a small catch-up for content that arrived
-   while it travelled.
-4. While reading a history window, let output arrive from somewhere else. The
+3. Jump to latest from a screen or two up is animated rather than an instant
+   jump. It must glide the whole way, with at most a small catch-up for content
+   that arrived while it travelled — a stand-down counted in frames rather than
+   milliseconds used to cut this short.
+4. Jump to latest from the top of a long transcript lands outright. Half an
+   animation followed by a jump is the failure to look for, and it is what the
+   distance cap exists to prevent; `followOutput.jumpBehavior` says which of the
+   two was chosen and how many viewports away the target was.
+5. While reading a history window, let output arrive from somewhere else. The
    viewport must not move — this is the case the submission event exists to
    stay out of.
-5. Watch a Markdown answer stream past the bottom of the viewport. It must
+6. Watch a Markdown answer stream past the bottom of the viewport. It must
    scroll rather than step: no move of a whole line, and none of the ease's
    lag left behind once the stream stops.
-6. Stream a burst — a code fence or a table arriving at once — and confirm it
+7. Stream a burst — a code fence or a table arriving at once — and confirm it
    goes the whole way in one move rather than gliding through content nobody
    has seen, and that the jump-to-latest bar does not flash while it does.
-7. Turn on `prefers-reduced-motion` and stream again. The follow must step
+8. Turn on `prefers-reduced-motion` and stream again. The follow must step
    straight to its target, as it did before the ease.
 
 ### Collapse

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -99,6 +99,7 @@ import {
 } from '../../services/historySessionDiagnostics';
 import {
   resolveHistoryBoundaryTarget,
+  resolveTailBoundaryPrecondition,
   resolveTailWindowGrowth,
   transcriptReachesLatestTurn,
   type RenderedTranscriptRange,
@@ -1846,18 +1847,31 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
           ? renderedHistoryPresentationRef.current.range
           : null;
       if (!presentation) {
-        if (
-          direction !== 'before'
-          || session?.isPartial !== true
-          || session.turnCatalog?.sessionId !== sessionId
-        ) {
-          recordHistoryPagingEvent(sessionId, 'outcome_cancelled', {
-            direction,
-            reason: 'precondition',
-            isPartial: session?.isPartial,
-            turnCatalogMatches: session?.turnCatalog?.sessionId === sessionId,
-          });
-          return 'cancelled';
+        const precondition = resolveTailBoundaryPrecondition({
+          direction,
+          isPartial: session?.isPartial,
+          hasSession: session !== undefined,
+          turnCatalogMatches: session?.turnCatalog?.sessionId === sessionId,
+        });
+        if (precondition !== 'ask') {
+          /*
+           * Told apart because only one of them stops the asking. A boundary
+           * that answers `cancelled` is re-armed and asked again on the
+           * reader's next scroll event, which is right while the catalog is
+           * still on its way and is a treadmill once the session has every Turn
+           * it will ever have.
+           */
+          recordHistoryPagingEvent(
+            sessionId,
+            precondition === 'exhausted' ? 'outcome_exhausted' : 'outcome_cancelled',
+            {
+              direction,
+              reason: precondition === 'exhausted' ? 'no-window-nothing-loadable' : 'precondition',
+              isPartial: session?.isPartial,
+              turnCatalogMatches: session?.turnCatalog?.sessionId === sessionId,
+            },
+          );
+          return precondition;
         }
         const canonicalTailRange = flowChatStore.getSessionCanonicalTailRange(sessionId);
         if (!canonicalTailRange) {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -28,6 +28,16 @@ const mocks = vi.hoisted(() => ({
    */
   isFollowingOutput: false,
   followsNow: false,
+  scheduleFollowToLatest: vi.fn(),
+  /**
+   * The register the list built, reached through the hook it hands it to.
+   *
+   * Taking the viewport is what the follow hook does on entry, and the tests
+   * below need the list to face a register in that state — a displacement is
+   * refused by whoever holds a target, and that refusal is a contract with the
+   * holder rather than a dead end.
+   */
+  viewportOwner: null as null | { claim: (owner: string) => boolean },
   /** False stands in for a Turn the virtualizer can place but the DOM cannot. */
   renderItemMetadata: true,
 }));
@@ -154,28 +164,33 @@ vi.mock('../../store/chatInputStateStore', () => ({
 }));
 
 vi.mock('./useFlowChatFollowOutput', () => ({
-  useFlowChatFollowOutput: () => ({
-    isFollowingOutput: mocks.isFollowingOutput,
-    enterFollowOutput: mocks.enterFollowOutput,
-    exitFollowOutput: mocks.exitFollowOutput,
-    scheduleFollowToLatest: vi.fn(),
-    isFollowingOutputNow: () => mocks.followsNow,
-    // Nothing streams here, so the frame loop is never correcting: the band is
-    // judged on the viewport itself, exactly as it is for a resting transcript.
-    isFollowCorrectingViewport: () => false,
-    handleUserScrollIntent: () => {
-      // What the real one does first: release, synchronously.
-      mocks.followsNow = false;
-      mocks.handleUserScrollIntent();
-    },
-    handleTurnsRolledBack: vi.fn(),
-    handleScroll: vi.fn(),
-    handleScrollSettled: vi.fn(),
-    handleViewportResize: vi.fn(),
-    // Follow owns nothing here, which is what the real hook returns when
-    // `isFollowingOutput` is false.
-    getFollowTargetScrollTop: () => null,
-  }),
+  useFlowChatFollowOutput: (options: {
+    viewportOwner: { claim: (owner: string) => boolean };
+  }) => {
+    mocks.viewportOwner = options.viewportOwner;
+    return {
+      isFollowingOutput: mocks.isFollowingOutput,
+      enterFollowOutput: mocks.enterFollowOutput,
+      exitFollowOutput: mocks.exitFollowOutput,
+      scheduleFollowToLatest: mocks.scheduleFollowToLatest,
+      isFollowingOutputNow: () => mocks.followsNow,
+      // Nothing streams here, so the frame loop is never correcting: the band is
+      // judged on the viewport itself, exactly as it is for a resting transcript.
+      isFollowCorrectingViewport: () => false,
+      handleUserScrollIntent: () => {
+        // What the real one does first: release, synchronously.
+        mocks.followsNow = false;
+        mocks.handleUserScrollIntent();
+      },
+      handleTurnsRolledBack: vi.fn(),
+      handleScroll: vi.fn(),
+      handleScrollSettled: vi.fn(),
+      handleViewportResize: vi.fn(),
+      // Follow owns nothing here, which is what the real hook returns when
+      // `isFollowingOutput` is false.
+      getFollowTargetScrollTop: () => null,
+    };
+  },
 }));
 
 vi.mock('./VirtualItemRenderer', () => ({
@@ -215,11 +230,41 @@ function userMessage(turnId: string, id: string, content: string) {
 describe('VirtualMessageList natural scroll contract', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let animationFrames: Map<number, FrameRequestCallback>;
+  let nextAnimationFrameId: number;
+
+  /**
+   * Run the opening reveal to its end, which is what mounting a transcript
+   * really costs.
+   *
+   * The reveal holds the transcript hidden while it is placed, and the paging
+   * rule refuses a boundary derived from a viewport still being placed — so a
+   * test that asserts what the list asks for on mount has to get past it, the
+   * same way half a second of animation frames does in the app. Frames are a
+   * manual queue rather than jsdom's timer-backed ones so that draining them is
+   * a step in the test rather than a wait.
+   */
+  async function settleOpenReveal() {
+    // The reveal's own cap is 40 frames; a few more cover the commits its
+    // settling schedules.
+    for (let generation = 0; generation < 48; generation += 1) {
+      const pending = [...animationFrames.values()];
+      animationFrames.clear();
+      if (pending.length === 0) return;
+      await act(async () => {
+        pending.forEach(frame => frame(16));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+  }
 
   beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
+    animationFrames = new Map();
+    nextAnimationFrameId = 0;
     mocks.items = [
       userMessage('turn-1', 'message-1', 'First'),
       userMessage('turn-2', 'message-2', 'Second'),
@@ -236,11 +281,21 @@ describe('VirtualMessageList natural scroll contract', () => {
     mocks.enterFollowOutput.mockReset();
     mocks.exitFollowOutput.mockReset();
     mocks.handleUserScrollIntent.mockReset();
+    mocks.scheduleFollowToLatest.mockReset();
+    mocks.viewportOwner = null;
     mocks.setVisibleTurnInfo.mockReset();
     mocks.renderItemMetadata = true;
     vi.stubGlobal('ResizeObserver', class {
       observe() {}
       disconnect() {}
+    });
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      nextAnimationFrameId += 1;
+      animationFrames.set(nextAnimationFrameId, callback);
+      return nextAnimationFrameId;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      animationFrames.delete(id);
     });
   });
 
@@ -588,6 +643,44 @@ describe('VirtualMessageList natural scroll contract', () => {
 
       expect(scroller.scrollTop).toBe(500);
     });
+
+    it('wakes the follow rule it left the displacement to', () => {
+      /*
+       * Refusing the shift is a contract with whoever holds a target, and
+       * follow-output is the one holder that can be asleep: its ownership
+       * deliberately outlives its frame loop so streaming can resume without
+       * re-entering, and the loop stops once the transcript settles. So a page
+       * landing after that is left to a writer that will never act.
+       *
+       * Measured: 22301px of history arrived above a viewport at offset 0 on
+       * session open, the shift was refused with `heldBy: follow-output`, and
+       * nothing moved again — the transcript was revealed at the top of the
+       * window it had just pulled in, eight Turns above the tail.
+       */
+      withGrowingRange({ scrollHeightPx: 3000, growthPx: 120 }, scroller => {
+        // Follow-output takes the viewport, exactly as entering does.
+        mocks.viewportOwner?.claim('follow-output');
+        mocks.scheduleFollowToLatest.mockReset();
+
+        prependOlderTurns(3);
+
+        // Refused, because the holder owns a target of its own...
+        expect(scroller.scrollTop).toBe(500);
+        // ...and asked to go and reach it.
+        expect(mocks.scheduleFollowToLatest).toHaveBeenCalled();
+      });
+    });
+
+    it('wakes nobody when it could put the reader back itself', () => {
+      withGrowingRange({ scrollHeightPx: 3000, growthPx: 120 }, scroller => {
+        mocks.scheduleFollowToLatest.mockReset();
+
+        prependOlderTurns(3);
+
+        expect(scroller.scrollTop).toBe(620);
+        expect(mocks.scheduleFollowToLatest).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('asking for older Turns', () => {
@@ -608,10 +701,10 @@ describe('VirtualMessageList natural scroll contract', () => {
     /**
      * A transcript with a page already behind it.
      *
-     * The list opens at the top, so it asks and disarms `before` on mount. That
-     * is the state both of these are about: one page dispatched, and what has
-     * to happen for the next one. `asked` is cleared afterwards so it counts
-     * only what the scrolls produced.
+     * The list opens at the top, so once the reveal is over it asks and disarms
+     * `before`. That is the state both of these are about: one page dispatched,
+     * and what has to happen for the next one. `asked` is cleared afterwards so
+     * it counts only what the scrolls produced.
      */
     async function withPagedTranscript(
       run: (scroller: HTMLElement, asked: string[]) => Promise<void>,
@@ -638,6 +731,11 @@ describe('VirtualMessageList natural scroll contract', () => {
           await Promise.resolve();
           await Promise.resolve();
         });
+        // Nothing while the transcript is still being placed: at offset 0 of an
+        // unplaced viewport the head is trivially reached, and paging from
+        // there prepends history under the placement.
+        expect(asked).toEqual([]);
+        await settleOpenReveal();
         expect(asked).toEqual(['before']);
         asked.length = 0;
         await run(container.querySelector<HTMLElement>('[data-flowchat-scroller]')!, asked);
@@ -709,6 +807,7 @@ describe('VirtualMessageList natural scroll contract', () => {
           await Promise.resolve();
           await Promise.resolve();
         });
+        await settleOpenReveal();
         expect(asked).toEqual(['before']);
         asked.length = 0;
 
@@ -763,6 +862,7 @@ describe('VirtualMessageList natural scroll contract', () => {
           await Promise.resolve();
           await Promise.resolve();
         });
+        await settleOpenReveal();
         // Refused on mount, correctly: follow owned it and nobody had gestured.
         expect(asked).toEqual([]);
 
@@ -816,6 +916,7 @@ describe('VirtualMessageList natural scroll contract', () => {
           await Promise.resolve();
           await Promise.resolve();
         });
+        await settleOpenReveal();
         expect(asked).toContain('before');
         asked.length = 0;
 

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -1571,9 +1571,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (status === 'settled') preparedTurnNavigationRef.current = null;
   }, [navigateToTurnWithStatus, virtualItems]);
 
+  /**
+   * Land on a Turn by its position in the transcript on screen.
+   *
+   * Instant, like the other two ways the same request can be resolved. This is
+   * the last-resort branch of a focus request — `resolvedTurnId` and
+   * `resolvedVirtualIndex` are tried first, both instant — and which branch runs
+   * depends only on what the request happened to carry, not on anything the
+   * reader did. Animating this one made the same usage-report click animate or
+   * jump depending on whether the report knew the Turn's id.
+   */
   const scrollToTurn = useCallback((turnIndex: number) => {
     const target = userMessageItems[turnIndex - 1];
-    if (target) navigateToTurn(target.item.turnId, { behavior: 'smooth' });
+    if (target) navigateToTurn(target.item.turnId, { behavior: 'auto' });
   }, [navigateToTurn, userMessageItems]);
 
   const scrollToIndex = useCallback((index: number) => {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -109,6 +109,16 @@ const SCROLL_SETTLE_FALLBACK_MS = 140;
  */
 const TAIL_REALIGN_RESIZE_CALLBACKS = 6;
 const HISTORY_WINDOW_DIRECTIONS: readonly SessionHistoryWindowDirection[] = ['before', 'after'];
+/**
+ * Transcripts mounted this session, counted.
+ *
+ * The list is keyed on the session id, so a switch is a full remount: new
+ * scroller, empty measurement cache, fresh opening reveal, and a follow hook
+ * that has never followed anything. Nothing in the trail said which instance a
+ * line came from, and two of the three viewport faults measured here turned out
+ * to be two instances disagreeing rather than one instance changing its mind.
+ */
+let nextViewportInstanceId = 0;
 const IDLE_HISTORY_WINDOW_BOUNDARY_STATE: Record<
   SessionHistoryWindowDirection,
   'idle' | 'loading' | 'error'
@@ -379,6 +389,20 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
    * is the same bug wearing the opposite sign.
    */
   const latestTurnId = activeSession?.dialogTurns.at(-1)?.id ?? null;
+  const viewportIdRef = useRef<number | null>(null);
+  if (viewportIdRef.current === null) {
+    nextViewportInstanceId += 1;
+    viewportIdRef.current = nextViewportInstanceId;
+  }
+  const viewportId = viewportIdRef.current;
+  // Mirrors, so the unmount line below can report the state it ended on rather
+  // than the state it was created with.
+  const activeSessionIdRef = useRef(activeSessionId);
+  activeSessionIdRef.current = activeSessionId;
+  const isViewportActiveRef = useRef(isViewportActive);
+  isViewportActiveRef.current = isViewportActive;
+  const itemCountRef = useRef(virtualItems.length);
+  itemCountRef.current = virtualItems.length;
   const scrollerElementRef = useRef<HTMLElement | null>(null);
   /**
    * Who is moving the viewport, for everything in this transcript that moves
@@ -616,7 +640,39 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     resolveTurnTopScrollTop,
     isOpeningViewport,
     viewportOwner,
+    viewportId,
   });
+
+  /*
+   * The transcript's own lifetime, which every viewport line above is relative
+   * to. A remount resets the scroller to offset 0, empties the measurement
+   * cache and re-arms the opening reveal — so a placement that looks like it
+   * was undone is often a placement made to a scroller that no longer exists.
+   */
+  useEffect(() => {
+    traceViewport({
+      location: 'virtualMessageList.mounted',
+      message: 'a transcript was mounted',
+      data: () => ({
+        viewportId,
+        sessionId: activeSessionIdRef.current,
+        itemCount: itemCountRef.current,
+        isViewportActive: isViewportActiveRef.current,
+      }),
+    });
+    return () => {
+      traceViewport({
+        location: 'virtualMessageList.unmounted',
+        message: 'a transcript was unmounted',
+        data: () => ({
+          viewportId,
+          sessionId: activeSessionIdRef.current,
+          itemCount: itemCountRef.current,
+          scrollTopPx: roundViewportPx(scrollerElementRef.current?.scrollTop ?? 0),
+        }),
+      });
+    };
+  }, [viewportId]);
 
 
   /**
@@ -761,6 +817,29 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      */
     if (compensated) viewportAnchor.absorbViewportShift(shiftedPx);
     /*
+     * A refusal leaves the displacement to whoever holds a target — so make
+     * sure they are awake to take it.
+     *
+     * Follow-output is the only holder that can be asleep. Its ownership
+     * deliberately outlives its frame loop, so that streaming can resume
+     * without re-entering, and the loop stops on its own once the transcript
+     * settles; a navigation's aim and a snap back's animation are both still
+     * running by construction. So a page landing after the settle budget ran
+     * out is refused by a writer that will never act, and the reader is left
+     * holding an offset that now means something else.
+     *
+     * Measured, from the fault this was found in: 22301px of history arrived
+     * above a viewport at 0, the shift was refused with `heldBy:
+     * follow-output`, and nothing moved for the rest of the session — the
+     * transcript was revealed at the top of the window, eight Turns above the
+     * tail. Re-asserting is idempotent when the loop *is* running: it aims at
+     * the offset the follow rule already owns.
+     */
+    const wokeFollowOutput = !compensated
+      && shiftedPx > 0
+      && viewportOwner.currentOwner() === 'follow-output';
+    if (wokeFollowOutput) scheduleFollowToLatest();
+    /*
      * Both amounts, because their disagreement is the diagnosis. `prependedPx`
      * against what the scroll range actually grew by says how far the cache is
      * ahead of the DOM; against `shiftedPx` it says how much of the
@@ -770,27 +849,47 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     traceViewport({
       location: 'virtualMessageList.prependCompensated',
       message: 'history arrived above the reader',
-      data: () => ({
-        compensated,
-        prependedPx: roundViewportPx(prependedPx),
-        shiftedPx: roundViewportPx(shiftedPx),
-        scrollRangeGrowthPx: roundViewportPx(scrollRangeGrowthPx),
-        itemsAbove: movedTo,
-        fromPx: roundViewportPx(fromPx),
-        contentEndPx: roundViewportPx(contentEndPx),
-        scrollTopPx: roundViewportPx(scroller.scrollTop),
-        // The baseline every later `anchor.correct` in this settle is read
-        // against: a correction that arrives with the range unchanged is a
-        // compensation that over-shot, and one that arrives with the range
-        // smaller is the transcript above the reader measuring down.
-        scrollRangePx: roundViewportPx(scroller.scrollHeight),
-        presentationMode,
-      }),
+      data: () => {
+        const followTargetPx = getFollowTargetScrollTop();
+        return {
+          viewportId,
+          compensated,
+          prependedPx: roundViewportPx(prependedPx),
+          shiftedPx: roundViewportPx(shiftedPx),
+          scrollRangeGrowthPx: roundViewportPx(scrollRangeGrowthPx),
+          itemsAbove: movedTo,
+          fromPx: roundViewportPx(fromPx),
+          contentEndPx: roundViewportPx(contentEndPx),
+          scrollTopPx: roundViewportPx(scroller.scrollTop),
+          /*
+           * Who the displacement was left to, and where they are taking it.
+           * A refused shift is only correct if the holder then places the
+           * reader itself; read after the re-assertion above, so `null` here
+           * with `wokeFollowOutput` true is a holder that could not be woken —
+           * the register believes someone owns the viewport and the follow rule
+           * believes it is not following, which is the one state nothing can
+           * recover from on its own.
+           */
+          followTargetPx: followTargetPx === null ? null : roundViewportPx(followTargetPx),
+          wokeFollowOutput,
+          isOpening: isOpeningViewport(),
+          // The baseline every later `anchor.correct` in this settle is read
+          // against: a correction that arrives with the range unchanged is a
+          // compensation that over-shot, and one that arrives with the range
+          // smaller is the transcript above the reader measuring down.
+          scrollRangePx: roundViewportPx(scroller.scrollHeight),
+          presentationMode,
+        };
+      },
     });
   }, [
+    getFollowTargetScrollTop,
+    isOpeningViewport,
     presentationMode,
     readContentEndScrollTop,
+    scheduleFollowToLatest,
     viewportAnchor,
+    viewportId,
     viewportOwner,
     virtualItems,
     virtualizer,
@@ -957,13 +1056,26 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         traceViewport({
           location: 'virtualMessageList.openReveal',
           message: 'transcript revealed',
-          data: () => ({
-            settled: quietFrames >= OPEN_REVEAL_QUIET_FRAMES,
-            frames: frame,
-            itemCount: virtualItems.length,
-            scrollTopPx: roundViewportPx(scrollerElement.scrollTop),
-            contentEndPx: roundViewportPx(readContentEndScrollTop(scrollerElement)),
-          }),
+          data: () => {
+            const followTargetPx = getFollowTargetScrollTop();
+            return {
+              viewportId,
+              settled: quietFrames >= OPEN_REVEAL_QUIET_FRAMES,
+              frames: frame,
+              itemCount: virtualItems.length,
+              scrollTopPx: roundViewportPx(scrollerElement.scrollTop),
+              contentEndPx: roundViewportPx(readContentEndScrollTop(scrollerElement)),
+              /*
+               * Revealed away from the content end is the reader's "it opened
+               * on the wrong Turn", and these two say whose it is: a follow
+               * that owns a target it has not reached is a placement still on
+               * its way, and no target at all is nobody having taken the
+               * transcript on open.
+               */
+              followTargetPx: followTargetPx === null ? null : roundViewportPx(followTargetPx),
+              isFollowCorrecting: isFollowCorrectingViewport(),
+            };
+          },
         });
         setIsOpenViewportSettled(true);
         return;
@@ -975,7 +1087,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return () => {
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [isOpenViewportSettled, readContentEndScrollTop, scrollerElement, virtualItems.length]);
+  }, [
+    getFollowTargetScrollTop,
+    isFollowCorrectingViewport,
+    isOpenViewportSettled,
+    readContentEndScrollTop,
+    scrollerElement,
+    viewportId,
+    virtualItems.length,
+  ]);
 
   /*
    * "At the bottom" is a band, not a point. Its upper edge is the end of real
@@ -1548,7 +1668,20 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
   const requestHistoryBoundary = useCallback((direction: SessionHistoryWindowDirection) => {
     /*
-     * Two refusals, both asking whether the ask describes the reader.
+     * Three refusals, all asking whether the ask describes the reader.
+     *
+     * The first is the opening reveal. Until it ends the transcript is hidden
+     * and still being placed — item heights are estimates and the viewport is
+     * walking down to the content end — so the offset a boundary would be
+     * judged from is not a position anybody chose, and on a session whose
+     * loaded tail is shorter than one viewport the head is trivially "reached"
+     * at offset 0. Worse, what the page then does is prepend history *above*
+     * that viewport, and the compensation for it is deliberately left to
+     * whoever holds a target; landing it in the middle of the opening
+     * placement puts those two in a race that the reader loses by eight Turns.
+     * Measured: a re-opened session paged 140ms after mount, from a viewport
+     * still at 0, and was revealed at the top of the window it had just pulled
+     * in. Deferred rather than dropped — the reveal settling asks again.
      *
      * While the follow rule owns the viewport, the position the ask was derived
      * from is our own placement — as true of a history window being opened as
@@ -1558,14 +1691,27 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      * pages landed in 890ms, each one displacing the viewport and so requesting
      * the next, until history ran out.
      *
-     * The second is the arming latch; see `boundaryArmedRef`.
+     * The third is the arming latch; see `boundaryArmedRef`.
      *
-     * Both are invisible when they fire: the boundary status stays idle, which
-     * is also what "there is no more history" looks like. The faults have been
-     * at either extreme — pages arriving in a chain because neither refusal
+     * All three are invisible when they fire: the boundary status stays idle,
+     * which is also what "there is no more history" looks like. The faults have
+     * been at either extreme — pages arriving in a chain because no refusal
      * fired, and a boundary that never pages because the latch stayed shut — so
      * the reason is recorded rather than inferred from what did not happen.
      */
+    if (isOpeningViewport()) {
+      traceViewportRepeating(`paging|${direction}|opening`, {
+        location: 'historyPaging.refused',
+        message: 'the transcript is still being placed, so the boundary is not the reader\'s',
+        data: () => ({
+          direction,
+          reason: 'opening-reveal',
+          viewportId,
+          scrollTopPx: roundViewportPx(scrollerElementRef.current?.scrollTop ?? 0),
+        }),
+      });
+      return;
+    }
     if (isFollowingOutputNow()) {
       traceViewportRepeating(`paging|${direction}|following`, {
         location: 'historyPaging.refused',
@@ -1610,6 +1756,29 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     // Disarmed for as long as this page is the reason the window sits at the
     // boundary. Only the window moving off it arms the direction again.
     boundaryArmedRef.current[direction] = false;
+    /*
+     * The ask itself, and the viewport it was derived from.
+     *
+     * Every refusal above is recorded, and the one that goes through was not —
+     * so a page that arrives while the transcript is still opening, from a
+     * viewport nobody is following and at an offset the reader never chose,
+     * looked exactly like a page the reader asked for. That page prepends
+     * history above them, and the compensation for it is deliberately left to
+     * whoever holds a target; with nothing holding one, this line is where that
+     * chain starts.
+     */
+    traceViewport({
+      location: 'historyPaging.asked',
+      message: 'the boundary was reached by the reader, so history was asked for',
+      data: () => ({
+        direction,
+        viewportId,
+        isOpening: isOpeningViewport(),
+        presentationMode,
+        itemCount: virtualItems.length,
+        scrollTopPx: roundViewportPx(scrollerElementRef.current?.scrollTop ?? 0),
+      }),
+    });
     const request = Promise.resolve(onHistoryWindowBoundaryIntent(direction)).then(
       normalizeBoundaryResult,
     ).then(result => {
@@ -1627,7 +1796,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       boundaryRequestRef.current[direction] = null;
     });
     boundaryRequestRef.current[direction] = request;
-  }, [isFollowingOutputNow, onHistoryWindowBoundaryIntent]);
+  }, [
+    isFollowingOutputNow,
+    isOpeningViewport,
+    onHistoryWindowBoundaryIntent,
+    presentationMode,
+    viewportId,
+    virtualItems.length,
+  ]);
 
   /**
    * Whether either end of the loaded transcript is on screen, and act on it.
@@ -1732,6 +1908,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      * reason the last ask was declined.
      */
     isFollowingOutput,
+    /*
+     * And so is the transcript finishing its opening placement, for the same
+     * reason: the ask that the reveal refused above is owed a second chance,
+     * and this is the only thing that changes when the reveal ends. A session
+     * whose loaded tail is shorter than one viewport produces no scroll events
+     * at all — it has nowhere to scroll — so without this it would never page
+     * its older Turns in until the reader spun the wheel against a boundary
+     * that could not move.
+     */
+    isOpenViewportSettled,
     scheduleVisibleTurnInfoUpdate,
     virtualizer.rows,
   ]);

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -1399,7 +1399,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      * apart. The drift in particular: a navigation that lands and is then taken
      * away leaves the same final position as one that never aimed right.
      */
-    const traceNavigation = (branch: string, place: () => void, targetPx?: number) => {
+    const traceNavigation = (
+      branch: string,
+      place: () => void,
+      targetPx?: number,
+      extra?: () => Record<string, unknown>,
+    ) => {
       traceViewportPlacement(
         scroller,
         {
@@ -1423,6 +1428,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
             itemCount: virtualItems.length,
             behavior,
             presentationMode,
+            ...(extra?.() ?? {}),
           }),
         },
         place,
@@ -1448,31 +1454,55 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return 'settled';
     }
 
-    // Placed instantly on purpose: an animated scroll has not arrived yet, so
-    // there would be nothing to read back. The requested behaviour is spent on
-    // the placement, which is what turn-rail navigation already asks for.
-    traceNavigation('unrendered-placed-instantly', () => {
-      virtualizer.scrollItemIntoView(targetIndex, {
-        align: 'start',
-        owner: 'one-shot-navigation',
-        holdForMs: ONE_SHOT_NAVIGATION_HOLD_MS,
-      });
-    });
-    if (scroller && turnTopAlignmentEntersReservedBlank({
-      turnTopScrollTop: scroller.scrollTop,
-      // Re-read: placing the viewport renders items, which re-measures the
-      // transcript and moves the content end with it.
-      contentEndScrollTop: readContentEndScrollTop(scroller),
-    })) {
-      traceNavigation(
-        'unrendered-clamped-to-content-end',
-        () => scrollToContentEndThroughVirtualizer(
+    /*
+     * Placed instantly on purpose: an animated scroll has not arrived yet, so
+     * there would be nothing to read back. The requested behaviour is spent on
+     * the placement, which is what turn-rail navigation already asks for.
+     *
+     * The clamp belongs to the same placement rather than being a second one.
+     * It is decided from where the instant placement landed and applied in the
+     * same task, so the reader sees one movement — and tracing it as two made
+     * the first one's outcome sample compare the offset the viewport came to
+     * rest at against a position this function had itself replaced 20ms
+     * earlier. Measured: `driftPx: -892.7` against a target of 2484 that was
+     * superseded by 1591, which is the clamp working exactly as intended
+     * reported as the largest displacement in the recording.
+     */
+    let clampedToContentEnd = false;
+    let unclampedPx: number | null = null;
+    traceNavigation(
+      'unrendered-placed-instantly',
+      () => {
+        virtualizer.scrollItemIntoView(targetIndex, {
+          align: 'start',
+          owner: 'one-shot-navigation',
+          holdForMs: ONE_SHOT_NAVIGATION_HOLD_MS,
+        });
+        if (!scroller) return;
+        unclampedPx = scroller.scrollTop;
+        if (!turnTopAlignmentEntersReservedBlank({
+          turnTopScrollTop: scroller.scrollTop,
+          // Re-read: placing the viewport renders items, which re-measures the
+          // transcript and moves the content end with it.
+          contentEndScrollTop: readContentEndScrollTop(scroller),
+        })) {
+          return;
+        }
+        clampedToContentEnd = true;
+        scrollToContentEndThroughVirtualizer(
           'auto',
           'one-shot-navigation',
           ONE_SHOT_NAVIGATION_HOLD_MS,
-        ),
-      );
-    }
+        );
+      },
+      undefined,
+      // Where the Turn's own alignment would have put the viewport, kept
+      // because the clamp is only correct if that offset was in the blank.
+      () => ({
+        clampedToContentEnd,
+        unclampedPx: unclampedPx === null ? null : roundViewportPx(unclampedPx),
+      }),
+    );
     return 'settled';
   }, [
     exitFollowOutput,
@@ -1739,9 +1769,22 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
        * to fetch more. That is correct once history really is exhausted, and a
        * silent data loss when it is not — the boundary status stays idle either
        * way, so the transcript looks like it simply has no earlier Turns.
+       *
+       * The head, and only the head. `after` latches the moment the reader
+       * reaches the newest Turn, which is every session that has ever been
+       * paged, and a partial session stays partial throughout — so raising this
+       * for it is a warning that fires on the ordinary case and means nothing.
+       * Measured: four of them in one recording, all `after`, all correct
+       * behaviour. `resolveHistoryBoundaryTarget` draws the same line one layer
+       * down, between `reached-latest` and `beyond-known-total`.
        */
       const session = activeSessionRef.current;
-      if (latchedExhausted && session?.sessionId && session.isPartial === true) {
+      if (
+        direction === 'before'
+        && latchedExhausted
+        && session?.sessionId
+        && session.isPartial === true
+      ) {
         warnHistoryPagingRefusedWithPendingTurns(session.sessionId, {
           direction,
           reason: 'latched-exhausted-while-partial',

--- a/src/web-ui/src/flow_chat/components/modern/flowChatLiveTailWindow.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatLiveTailWindow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   resolveHistoryBoundaryTarget,
+  resolveTailBoundaryPrecondition,
   resolveTailWindowGrowth,
   transcriptReachesLatestTurn,
 } from './flowChatLiveTailWindow';
@@ -175,5 +176,50 @@ describe('resolveHistoryBoundaryTarget', () => {
       renderedRange: { startOrdinal: 41, endOrdinalExclusive: 48 },
       knownTurnCount: 40,
     })).toEqual({ status: 'exhausted', reason: 'beyond-known-total' });
+  });
+});
+
+describe('resolveTailBoundaryPrecondition', () => {
+  const ask = {
+    direction: 'before' as const,
+    isPartial: true,
+    hasSession: true,
+    turnCatalogMatches: true,
+  };
+
+  it('asks when there is history the catalog can resolve', () => {
+    expect(resolveTailBoundaryPrecondition(ask)).toBe('ask');
+  });
+
+  it('is exhausted for a session that holds every Turn it has', () => {
+    /*
+     * The treadmill this closes: 652 asks in one session, 648 answered
+     * `precondition` because the session was fully loaded and the reader was
+     * resting at its head. A cancel re-arms the direction, so the next scroll
+     * event asked again, and the next.
+     */
+    expect(resolveTailBoundaryPrecondition({ ...ask, isPartial: false })).toBe('exhausted');
+    expect(resolveTailBoundaryPrecondition({ ...ask, isPartial: undefined })).toBe('exhausted');
+  });
+
+  it('cancels below the tail rather than latch a direction that cannot re-arm', () => {
+    // True that nothing follows the canonical tail, but this is only reached
+    // through the retained continuous projection, whose bounds never change —
+    // so the latch would never be cleared again.
+    expect(resolveTailBoundaryPrecondition({ ...ask, direction: 'after' })).toBe('cancelled');
+  });
+
+  it('cancels rather than latches while the catalog is still on its way', () => {
+    // Expected to turn up, so the direction has to stay armed for it.
+    expect(resolveTailBoundaryPrecondition({ ...ask, turnCatalogMatches: false })).toBe('cancelled');
+  });
+
+  it('cancels for a session that is not in the store at all', () => {
+    // Absent is not the same fact as complete, and only one of them is final.
+    expect(resolveTailBoundaryPrecondition({
+      ...ask,
+      hasSession: false,
+      isPartial: undefined,
+    })).toBe('cancelled');
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/flowChatLiveTailWindow.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatLiveTailWindow.ts
@@ -75,6 +75,65 @@ export interface RenderedTranscriptRange {
   endOrdinalExclusive: number;
 }
 
+export type TailBoundaryPrecondition =
+  /** The ask can be resolved against the catalog; carry on. */
+  | 'ask'
+  /** There is nothing in this direction until the presentation changes. */
+  | 'exhausted'
+  /** Not answerable *yet*, so the direction stays armed. */
+  | 'cancelled';
+
+/**
+ * Whether a boundary ask made with no history window open is worth resolving.
+ *
+ * The three answers are not interchangeable, and the difference is entirely
+ * about what happens next: `cancelled` re-arms the direction, `exhausted`
+ * latches it off until the window moves. Getting that wrong in the safe-looking
+ * direction costs a boundary that asks forever — measured, 652 asks in one
+ * session, 648 of them answered `precondition` because the session had every
+ * Turn it was ever going to have and the reader was resting at its head. Every
+ * one re-armed, and the next scroll event asked again.
+ *
+ * A session that is not partial *is* the transcript on screen, so its head is
+ * the first Turn and there is nothing before it — the same fact
+ * `resolveHistoryBoundaryTarget` reports as `reached-start`, arrived at from
+ * the ledger rather than from an ordinal.
+ *
+ * A catalog that has not arrived is the opposite case and must stay
+ * `cancelled`: nothing can be resolved against it yet, and it is expected to
+ * turn up.
+ */
+export function resolveTailBoundaryPrecondition(input: {
+  direction: 'before' | 'after';
+  /** Absent when the session is not in the store at all. */
+  isPartial: boolean | undefined;
+  hasSession: boolean;
+  turnCatalogMatches: boolean;
+}): TailBoundaryPrecondition {
+  /*
+   * `after` is deliberately not latched, even though the canonical tail ends at
+   * the newest Turn by construction.
+   *
+   * It reaches here at all only through the retained continuous projection,
+   * which renders as a history window while the viewport intent is the live
+   * tail — and the latch is cleared by the *window bounds* changing, which that
+   * projection does not have. Latching would therefore be permanent for the
+   * rest of the presentation, to save asks that are not the ones being
+   * measured: of 652 wasted asks in the reported session, 648 were `before`
+   * against a fully loaded transcript and none were this.
+   */
+  if (input.direction === 'after') {
+    return 'cancelled';
+  }
+  if (!input.hasSession) {
+    return 'cancelled';
+  }
+  if (input.isPartial !== true) {
+    return 'exhausted';
+  }
+  return input.turnCatalogMatches ? 'ask' : 'cancelled';
+}
+
 export type HistoryBoundaryTargetResolution =
   /** The ordinal a page in this direction has to load. */
   | { status: 'ask'; targetOrdinal: number }

--- a/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   contentEndScrollTop,
+  FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS,
   FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
   isViewportAtTail,
   memorylessFollowState,
   nextTailFollowState,
+  resolveAnimatedJumpBehavior,
   tailHoldMaxGapPx,
   tailSnapBackScrollTop,
   tailSpacerPxForViewport,
@@ -323,5 +325,89 @@ describe('isViewportAtTail', () => {
       followTargetScrollTop: contentEnd,
       thresholdPx: THRESHOLD,
     })).toBe(false);
+  });
+});
+
+describe('resolveAnimatedJumpBehavior', () => {
+  const budget = VIEWPORT * FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS;
+
+  it('animates a jump the reader can follow', () => {
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 4000,
+      targetPx: 4000 + VIEWPORT,
+      clientHeight: VIEWPORT,
+    })).toBe('smooth');
+  });
+
+  it('animates a pinned Turn coming back into place, which is under a screen', () => {
+    // The `pin-turn-top` branch of a jump to latest, where the newest Turn's
+    // answer is shorter than the viewport by construction.
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 12_000,
+      targetPx: 12_180,
+      clientHeight: VIEWPORT,
+    })).toBe('smooth');
+  });
+
+  it('lands a jump from the head of a long transcript outright', () => {
+    /*
+     * The measurement the budget comes from: a jump issued for 8717px animated
+     * 5480 of them inside the yield and was finished by the follow loop in one
+     * 3290px write. Reading it as an animation is the mistake — what the reader
+     * saw was two thirds of a scroll and then a jump.
+     */
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 0,
+      targetPx: 8717,
+      clientHeight: VIEWPORT,
+    })).toBe('auto');
+  });
+
+  it('measures the distance in viewports, not pixels', () => {
+    // The same travel, on a display tall enough to still show where it went.
+    const travelPx = VIEWPORT * FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS + 400;
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 0,
+      targetPx: travelPx,
+      clientHeight: VIEWPORT,
+    })).toBe('auto');
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 0,
+      targetPx: travelPx,
+      clientHeight: travelPx,
+    })).toBe('smooth');
+  });
+
+  it('takes the budget itself as near enough', () => {
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 0,
+      targetPx: budget,
+      clientHeight: VIEWPORT,
+    })).toBe('smooth');
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 0,
+      targetPx: budget + 1,
+      clientHeight: VIEWPORT,
+    })).toBe('auto');
+  });
+
+  it('judges the distance travelled, whichever way it goes', () => {
+    // A jump to latest normally scrolls down, but `pin-turn-top` can aim above
+    // the viewport when a restored tail presentation arrives under a pin.
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 9000,
+      targetPx: 9000 - budget - 1,
+      clientHeight: VIEWPORT,
+    })).toBe('auto');
+  });
+
+  it('does not animate against a scroller that has not been measured', () => {
+    // No budget to scale and nothing on screen to follow. Every other reading
+    // of a zero height makes this a *short* jump, which is the wrong one.
+    expect(resolveAnimatedJumpBehavior({
+      fromPx: 0,
+      targetPx: 0,
+      clientHeight: 0,
+    })).toBe('auto');
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.ts
@@ -248,3 +248,61 @@ export function isViewportAtTail(input: ViewportAtTailInput): boolean {
   return input.scrollTop >= input.contentEndScrollTop - input.thresholdPx
     && input.scrollTop <= input.followTargetScrollTop + input.thresholdPx;
 }
+
+/**
+ * Viewports a jump to the latest output may animate across.
+ *
+ * Counted in viewports rather than pixels because the question is whether the
+ * reader can follow the movement, and what they can follow is a share of what
+ * they can see: the same 2000px is two and a half screens on a laptop and most
+ * of one on a tall display.
+ *
+ * Three is about the largest number the animation reliably finishes. The frame
+ * loop yields to a smooth scroll for a bounded time and takes the viewport back
+ * afterwards wherever it has got to — measured, a jump issued for 8717px
+ * animated 5480 of them and was finished by the loop in a single 3290px write.
+ * That is 38% of the distance delivered as a hard jump at the end of an
+ * animation, which is worse than either half on its own. The same measurement
+ * puts the sustained rate near 4570px/s, so three 800px viewports travel in
+ * roughly half the budget.
+ *
+ * `followOutput.animatedScrollEnded` is where this number is checked: a
+ * `backstop` reason means an animation ran out its yield without arriving, and
+ * this is then too high.
+ */
+export const FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS = 3;
+
+export interface AnimatedJumpInput {
+  /** Where the viewport is now. */
+  fromPx: number;
+  /** Where the jump would leave it. */
+  targetPx: number;
+  clientHeight: number;
+}
+
+/**
+ * How a jump to the latest output should travel.
+ *
+ * An animation earns its cost only while the reader can read it. Its whole job
+ * is spatial continuity — showing which way and how far the viewport went — and
+ * past a few screens the transcript in between goes by faster than anyone can
+ * track, leaving a wait where the answer was. So a far jump lands instantly,
+ * the way every other navigation in the transcript already does, and a near one
+ * animates.
+ *
+ * Distance also costs more than it looks. Animating across N screens of a
+ * virtualized transcript renders and measures every item passed while the
+ * animation runs, and heights are estimates until they are measured — so the
+ * content end moves under an animation aimed at where it used to be, and the
+ * follow loop corrects that afterwards as a second, visible movement. A jump
+ * inside a few viewports passes items that are already rendered and measured.
+ */
+export function resolveAnimatedJumpBehavior(input: AnimatedJumpInput): 'smooth' | 'auto' {
+  // An unmeasured scroller is not a short distance, it is no distance at all:
+  // there is nothing to scale the budget by and nothing on screen to follow.
+  if (input.clientHeight <= 0) return 'auto';
+  return Math.abs(input.targetPx - input.fromPx)
+    <= input.clientHeight * FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS
+    ? 'smooth'
+    : 'auto';
+}

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
@@ -2,6 +2,7 @@
 
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { flushSync } from 'react-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { tailSpacerPxForViewport } from './flowChatTailFollow';
 import {
@@ -1284,6 +1285,58 @@ describe('useFlowChatFollowOutput', () => {
       }));
 
       expect(scroller.scrollTop).toBe(200);
+    });
+  });
+
+  describe('ownership across renders', () => {
+    /*
+     * Ownership is a ref because the loop reads it between renders, and it was
+     * *also* assigned from the `isFollowingOutput` state on every render. Those
+     * two writers disagree for exactly as long as a state update is queued, and
+     * React is free to render in that window: an update scheduled from a
+     * passive effect sits at a lower priority than a synchronous render, which
+     * then renders the value from before it and put the ref back to `false`.
+     *
+     * Measured on session open, which is where this always happens — the entry
+     * comes from a mount effect: `followOutput.enter` recorded, then the very
+     * first frame of the loop stood down with `not-following` and its settle
+     * budget untouched, and no `followOutput.exit` anywhere in the trail
+     * because nothing had exited. The register still held `follow-output`, so
+     * the prepend compensation for a history window that arrived 90ms later was
+     * left to a writer that was no longer running, and the transcript stayed at
+     * offset 0 — the top of the window, eight Turns above the tail.
+     */
+    it('survives a render that has not seen the entry yet', () => {
+      act(() => {
+        root.render(
+          <Harness
+            scroller={scroller}
+            latestTurnId="turn-1"
+            isStreaming={false}
+            onController={(next) => { controller = next; }}
+          />,
+        );
+      });
+      act(() => controller?.handleUserScrollIntent());
+      expect(controller?.isFollowingOutputNow()).toBe(false);
+
+      // Outside `act`, so the state update this schedules is still queued.
+      controller?.enterFollowOutput('jump-to-latest');
+      expect(controller?.isFollowingOutputNow()).toBe(true);
+
+      // A synchronous render, which does not carry the queued update.
+      flushSync(() => {
+        root.render(
+          <Harness
+            scroller={scroller}
+            latestTurnId="turn-1"
+            isStreaming={false}
+            onController={(next) => { controller = next; }}
+          />,
+        );
+      });
+
+      expect(controller?.isFollowingOutputNow()).toBe(true);
     });
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
@@ -11,7 +11,11 @@ import {
   TAIL_EASE_SNAP_ABOVE_PX,
 } from '../../utils/flowChatTailEase';
 import { SMOOTH_SCROLL_STALL_MS, useFlowChatFollowOutput } from './useFlowChatFollowOutput';
-import { useFlowChatViewportOwner } from './useFlowChatViewportOwner';
+import {
+  useFlowChatViewportOwner,
+  type FlowChatViewportOwnerApi,
+} from './useFlowChatViewportOwner';
+import { USER_DRIVEN_SCROLL_WINDOW_MS } from './flowChatViewportAnchor';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -57,6 +61,8 @@ interface HarnessProps {
   resolveTurnTopScrollTop?: (turnId: string) => number | null;
   isOpeningViewport?: boolean;
   onController: (controller: Controller) => void;
+  /** The register the hook writes through, for a test that has to hold it. */
+  onViewportOwner?: (owner: FlowChatViewportOwnerApi) => void;
 }
 
 function Harness({
@@ -69,11 +75,13 @@ function Harness({
   resolveTurnTopScrollTop = () => null,
   isOpeningViewport = false,
   onController,
+  onViewportOwner,
 }: HarnessProps) {
   const scrollerRef = React.useRef<HTMLElement | null>(scroller);
   // The real register, not a stand-in: what this hook is allowed to write is
   // now part of its behaviour, so a permissive fake would test the wrong thing.
   const viewportOwner = useFlowChatViewportOwner(scrollerRef);
+  onViewportOwner?.(viewportOwner);
   const controller = useFlowChatFollowOutput({
     activeSessionId: 'session-1',
     latestTurnId,
@@ -1096,6 +1104,156 @@ describe('useFlowChatFollowOutput', () => {
       restInBlank(1000);
 
       expect(controller?.isFollowingOutput).toBe(true);
+    });
+
+    it('asks again once the gesture that refused it has lapsed', () => {
+      /*
+       * The gesture's claim is a lapse timer, because a wheel has no end of its
+       * own, and this correction is the one writer that asks from inside that
+       * window — coming to rest is what triggers it. So the first ask is
+       * refused by construction, and the answer is to ask again rather than to
+       * release the hold: a settle also lands *between* two notches of a
+       * gesture still in progress, and forcing the snap through there drags the
+       * reader out of the blank they are scrolling into, every 800ms.
+       *
+       * Measured, the case the retry is for: a wheel at the head of a
+       * three-Turn tail paged in 13 Turns, the compensation moved the reader
+       * 2727px on the virtualizer's estimates, the real heights landed ~1670px
+       * shorter and the browser clamped the offset to the end of the shrunken
+       * range — 841px past the content end, the whole reserved spacer, blank.
+       * The snap back was refused `heldBy: user-gesture` 57ms into a 200ms
+       * hold, and nothing moved for the four minutes that followed.
+       */
+      let owner: FlowChatViewportOwnerApi | null = null;
+      setScrollerMetrics(scroller, {
+        scrollHeight: 1500 + TAIL_SPACER,
+        clientHeight: VIEWPORT,
+        scrollTop: 0,
+      });
+      vi.useFakeTimers();
+      try {
+        act(() => {
+          root.render(
+            <Harness
+              latestTurnId="turn-1"
+              isStreaming={false}
+              scroller={scroller}
+              onController={next => { controller = next; }}
+              onViewportOwner={next => { owner = next; }}
+            />,
+          );
+        });
+        act(() => controller?.handleUserScrollIntent());
+        // The wheel, as the list takes it: the reader holds the viewport for
+        // the window the anchor uses, and the settle below lands inside it.
+        act(() => {
+          owner?.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
+        });
+        scrollTo.mockClear();
+
+        restInBlank(1000 + TAIL_SPACER);
+        // Refused, and rightly: as far as the register knows the reader still
+        // has the viewport.
+        expect(scrollTo).not.toHaveBeenCalled();
+
+        act(() => { vi.advanceTimersByTime(USER_DRIVEN_SCROLL_WINDOW_MS + 20); });
+
+        expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('stops asking rather than chase a reader who keeps scrolling', () => {
+      // Every retry is refused while the reader keeps re-taking the viewport,
+      // and none of them move it. Their own next settle is what asks again.
+      let owner: FlowChatViewportOwnerApi | null = null;
+      setScrollerMetrics(scroller, {
+        scrollHeight: 1500 + TAIL_SPACER,
+        clientHeight: VIEWPORT,
+        scrollTop: 0,
+      });
+      vi.useFakeTimers();
+      try {
+        act(() => {
+          root.render(
+            <Harness
+              latestTurnId="turn-1"
+              isStreaming={false}
+              scroller={scroller}
+              onController={next => { controller = next; }}
+              onViewportOwner={next => { owner = next; }}
+            />,
+          );
+        });
+        act(() => controller?.handleUserScrollIntent());
+        act(() => {
+          owner?.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
+        });
+        scrollTo.mockClear();
+        restInBlank(1000 + TAIL_SPACER);
+
+        // Notches inside the window they renew, for longer than the retry
+        // budget covers. This is what a wheel actually looks like: the register
+        // never stops answering with the reader.
+        for (let notch = 0; notch < 16; notch += 1) {
+          act(() => {
+            owner?.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
+            vi.advanceTimersByTime(USER_DRIVEN_SCROLL_WINDOW_MS / 2);
+          });
+        }
+
+        expect(scrollTo).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resumes on the end the content has now, not the one the snap aimed at', () => {
+      /*
+       * The snap is animated, and what it was aiming at can move while it
+       * travels — a history page whose items are still measuring is exactly
+       * that, and is also the reason the snap was needed. Resuming on
+       * `scrollTop` adopts the stale offset as the hold rule's memory, and the
+       * hold rule defends a gap rather than closing it.
+       *
+       * Measured on a 43-Turn session paged from a three-Turn tail: issued for
+       * 12336, landed 608ms later against a content end of 11972, and the first
+       * frame after it read `desired 11972, target 12336, onTarget true`. The
+       * reader kept 364px of reserved blank and a Turn cut off at the top.
+       */
+      setScrollerMetrics(scroller, {
+        scrollHeight: 1500 + TAIL_SPACER,
+        clientHeight: VIEWPORT,
+        scrollTop: 0,
+      });
+      act(() => {
+        root.render(
+          <Harness
+            latestTurnId="turn-1"
+            isStreaming={false}
+            scroller={scroller}
+            onController={next => { controller = next; }}
+          />,
+        );
+      });
+      act(() => controller?.handleUserScrollIntent());
+      restInBlank(1000 + TAIL_SPACER);
+      expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
+
+      // The items measured shorter while the snap travelled, so the end of
+      // content is 300px above where it was aimed.
+      setScrollerMetrics(scroller, {
+        scrollHeight: 1200 + TAIL_SPACER,
+        clientHeight: VIEWPORT,
+        scrollTop: 1000,
+      });
+      restInBlank(1000);
+
+      expect(controller?.isFollowingOutput).toBe(true);
+      // Not 1000, which is inside the gap the hold rule tolerates and would
+      // therefore have been kept for good.
+      expect(controller?.getFollowTargetScrollTop()).toBe(700);
     });
 
     it('does not take the viewport back when a gesture overrode the snap', () => {

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
@@ -569,8 +569,14 @@ describe('useFlowChatFollowOutput', () => {
     expect(cancelAnimationFrame).toHaveBeenCalled();
   });
 
-  it('uses smooth behavior only for an explicit jump to latest', () => {
+  /** Mount on a transcript of `contentEndPx`, then jump to latest from the top. */
+  function jumpToLatestAcross(contentEndPx: number) {
     const scrollToContentEnd = vi.fn();
+    setScrollerMetrics(scroller, {
+      scrollHeight: contentEndPx + VIEWPORT + TAIL_SPACER,
+      clientHeight: VIEWPORT,
+      scrollTop: 0,
+    });
     act(() => {
       root.render(
         <Harness
@@ -581,8 +587,32 @@ describe('useFlowChatFollowOutput', () => {
         />,
       );
     });
+    runNextFrame();
+    expect(scroller.scrollTop).toBe(contentEndPx);
+    scroller.scrollTop = 0;
+    scrollToContentEnd.mockClear();
     act(() => controller?.enterFollowOutput('jump-to-latest'));
-    expect(scrollToContentEnd).toHaveBeenCalledWith('smooth');
+    return scrollToContentEnd;
+  }
+
+  it('uses smooth behavior only for an explicit jump to latest', () => {
+    // Well inside `FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS`, so the distance is not
+    // what this is testing.
+    expect(jumpToLatestAcross(VIEWPORT)).toHaveBeenCalledWith('smooth');
+  });
+
+  it('lands a jump too far to follow rather than animate part of it', () => {
+    /*
+     * The animation cannot finish this and the frame loop takes the viewport
+     * back wherever it has got to — measured, a jump issued for 8717px animated
+     * 5480 of them and was finished in one 3290px write. The reader sees two
+     * thirds of a scroll and then a jump, which is worse than either.
+     *
+     * It would not be worth watching even if it did finish: three screens on,
+     * the transcript in between is going past faster than anyone can read it,
+     * so the continuity an animation exists to show is not there to see.
+     */
+    expect(jumpToLatestAcross(VIEWPORT * 10)).toHaveBeenCalledWith('auto');
   });
 
   it('yields the frame loop to its own animated scroll instead of overwriting it', () => {
@@ -633,9 +663,20 @@ describe('useFlowChatFollowOutput', () => {
       nowSpy.mockRestore();
     });
 
+    /*
+     * A viewport tall enough that the jump below is one the follow rule agrees
+     * to animate at all: only a jump inside
+     * `FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS` is animated, and everything in
+     * this block is about what happens *during* an animation, so it has to be
+     * given one. The distance is left where it was so the frame counts below
+     * still mean what their comments say.
+     */
+    const TALL_VIEWPORT = 1_600;
+    const CONTENT_END = 4_500;
+
     /**
-     * Mounts a transcript whose content ends at 4500, settles there, and then
-     * issues an animated jump to latest from the top.
+     * Mounts a transcript whose content ends at `CONTENT_END`, settles there,
+     * and then issues an animated jump to latest from the top.
      *
      * jsdom does not animate, so the animation is played by hand below. That is
      * the point of these tests: what ends the stand-down is the viewport having
@@ -644,8 +685,8 @@ describe('useFlowChatFollowOutput', () => {
      */
     function jumpToLatestFromTheTop() {
       setScrollerMetrics(scroller, {
-        scrollHeight: 5000 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
+        scrollHeight: CONTENT_END + TALL_VIEWPORT + spacerFor(TALL_VIEWPORT),
+        clientHeight: TALL_VIEWPORT,
         scrollTop: 0,
       });
       act(() => {
@@ -658,7 +699,7 @@ describe('useFlowChatFollowOutput', () => {
         );
       });
       runNextFrame();
-      expect(scroller.scrollTop).toBe(4500);
+      expect(scroller.scrollTop).toBe(CONTENT_END);
       scroller.scrollTop = 0;
       act(() => controller?.enterFollowOutput('jump-to-latest'));
     }
@@ -712,7 +753,7 @@ describe('useFlowChatFollowOutput', () => {
       expect(scroller.scrollTop).toBe(50);
 
       animateFrame(0, 20);
-      expect(scroller.scrollTop).toBe(4500);
+      expect(scroller.scrollTop).toBe(CONTENT_END);
     });
 
     it('takes the viewport back on the backstop when the animation never ends', () => {
@@ -722,7 +763,7 @@ describe('useFlowChatFollowOutput', () => {
         animateFrame(1, 100);
       }
 
-      expect(scroller.scrollTop).toBe(4500);
+      expect(scroller.scrollTop).toBe(CONTENT_END);
     });
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -13,6 +13,7 @@ import {
   shouldEaseTailFollow,
 } from '../../utils/flowChatTailEase';
 import type { FlowChatViewportOwnerApi } from './useFlowChatViewportOwner';
+import { USER_DRIVEN_SCROLL_WINDOW_MS } from './flowChatViewportAnchor';
 import { SNAP_BACK_HOLD_MS } from './flowChatViewportOwnership';
 import {
   contentEndScrollTop,
@@ -181,6 +182,27 @@ export const SMOOTH_SCROLL_STALL_MS = 120;
  */
 const SETTLE_FRAMES = 90;
 
+/**
+ * How long after a refused snap back it is asked for again.
+ *
+ * One gesture window plus a frame, because the gesture is what refuses it: the
+ * claim `notifyUserScrollIntent` takes lapses after `USER_DRIVEN_SCROLL_WINDOW_MS`,
+ * and asking before then can only be refused a second time.
+ */
+const SNAP_BACK_RETRY_DELAY_MS = USER_DRIVEN_SCROLL_WINDOW_MS + 20;
+
+/**
+ * Times a refused snap back is re-asked before it is left to the next settle.
+ *
+ * A reader who is still scrolling refuses every one of these and does not need
+ * them — their own next settle asks again with a fresh budget. This is for the
+ * reader who has *stopped* while something else was still moving the transcript
+ * under them, where no further scroll event is coming and this is the only
+ * thing left that will ask. A second of cover is enough for that; more would
+ * just be a timer chasing a viewport nobody is touching.
+ */
+const SNAP_BACK_RETRY_ATTEMPTS = 5;
+
 export function useFlowChatFollowOutput({
   activeSessionId,
   latestTurnId,
@@ -233,6 +255,11 @@ export function useFlowChatFollowOutput({
   /** Where the animation started, so the trace can say how far it got. */
   const smoothScrollFromPxRef = useRef(0);
   const pendingSnapBackTargetRef = useRef<number | null>(null);
+  /** A refused snap back waiting for the hold that refused it to lapse. */
+  const snapBackRetryTimerRef = useRef<number | null>(null);
+  const snapBackRetryAttemptsRef = useRef(0);
+  /** Assigned below, so a retry can re-enter the evaluation that scheduled it. */
+  const evaluateSnapBackRef = useRef<() => void>(() => {});
 
   /*
    * Deliberately *not* mirrored from `isFollowingOutput` here.
@@ -260,6 +287,13 @@ export function useFlowChatFollowOutput({
   isStreamingRef.current = isStreaming;
   isViewportActiveRef.current = isViewportActive;
   latestTurnIdRef.current = latestTurnId;
+
+  const clearSnapBackRetry = useCallback(() => {
+    if (snapBackRetryTimerRef.current !== null) {
+      window.clearTimeout(snapBackRetryTimerRef.current);
+      snapBackRetryTimerRef.current = null;
+    }
+  }, []);
 
   const stopFollowFrame = useCallback(() => {
     if (followFrameRef.current !== null) {
@@ -336,14 +370,15 @@ export function useFlowChatFollowOutput({
   }, [retirePin, resolveTurnTopScrollTop]);
 
   /**
-   * Offset the follow rule would own for the current geometry, ignoring any
-   * offset it was holding. Used to decide, and to aim, a snap back — both of
-   * which happen while the viewport belongs to nobody.
+   * The state the follow rule would hold for the current geometry, ignoring any
+   * offset it was holding. Used to decide and to aim a snap back — both of
+   * which happen while the viewport belongs to nobody — and to resume on one
+   * that has landed.
    *
    * Retires a pin that has crossed over on the way past: with no frame loop
    * running, this is the only place that crossover can be noticed.
    */
-  const resolveFollowTargetScrollTop = useCallback((scroller: HTMLElement) => {
+  const resolveFollowState = useCallback((scroller: HTMLElement): TailFollowState => {
     const desired = readContentEndScrollTop(scroller);
     const next = memorylessFollowState(
       pinTurnIdRef.current ? 'pin-turn-top' : 'hold-tail',
@@ -356,8 +391,12 @@ export function useFlowChatFollowOutput({
     if (next.mode === 'hold-tail') {
       retirePin();
     }
-    return next.target;
+    return next;
   }, [readContentEndScrollTop, readPinScrollTop, retirePin]);
+
+  const resolveFollowTargetScrollTop = useCallback((scroller: HTMLElement) => (
+    resolveFollowState(scroller).target
+  ), [resolveFollowState]);
 
   /**
    * Stand the frame loop down for an animated scroll this hook is about to
@@ -730,14 +769,29 @@ export function useFlowChatFollowOutput({
     const scroller = scrollerRef.current;
     const contentEnd = scroller ? readContentEndScrollTop(scroller) : 0;
 
-    // A snap back has already placed the viewport on the target it chose, and
-    // that target was resolved under whichever mode still applies. Resume
-    // ownership without a second move.
+    /*
+     * A snap back has already placed the viewport, so resume ownership without
+     * a second move — but on the offset the follow rule owns *now*, not on the
+     * one the animation stopped at.
+     *
+     * The two are the same only if nothing moved while it travelled, and the
+     * one thing that reliably does is the reason the snap was needed: a history
+     * page whose items are still measuring. Taking `scrollTop` instead adopts
+     * the stale offset as the hold rule's memory, and the hold rule then
+     * defends it — it tolerates a gap below the content end of up to 60% of the
+     * viewport, so the difference is not corrected, it is *kept*.
+     *
+     * Measured on a 43-Turn session paged from a three-Turn tail: the snap was
+     * issued for 12336 while the content end was there, landed 608ms later
+     * against a content end of 11972, and the first follow frame afterwards
+     * read `desired 11972, target 12336, onTarget true` and never moved again.
+     * The reader was left with 364px of reserved blank under the transcript and
+     * the fourth-from-last Turn cut off at the top of the viewport.
+     */
     if (reason === 'tail-snap-back') {
-      followStateRef.current = {
-        mode: pinTurnIdRef.current ? 'pin-turn-top' : 'hold-tail',
-        target: scroller?.scrollTop ?? contentEnd,
-      };
+      followStateRef.current = scroller
+        ? resolveFollowState(scroller)
+        : { mode: pinTurnIdRef.current ? 'pin-turn-top' : 'hold-tail', target: contentEnd };
       startFollowFrame();
       return;
     }
@@ -795,6 +849,7 @@ export function useFlowChatFollowOutput({
     endSmoothScrollYield,
     readContentEndScrollTop,
     readPinScrollTop,
+    resolveFollowState,
     retirePin,
     runContentEndScroll,
     scrollTurnToTop,
@@ -905,7 +960,7 @@ export function useFlowChatFollowOutput({
    * fighting momentum: the correction runs after the gesture is over, never
    * during it.
    */
-  const handleScrollSettled = useCallback(() => {
+  const evaluateSnapBack = useCallback(() => {
     const scroller = scrollerRef.current;
     if (!scroller || !isViewportActiveRef.current) {
       return;
@@ -998,12 +1053,51 @@ export function useFlowChatFollowOutput({
         fromPx: roundViewportPx(scroller.scrollTop),
         targetPx: roundViewportPx(snapTo),
         followTargetPx: roundViewportPx(followTarget),
+        // Who refused it. The gesture is the one that lapses on a timer, and
+        // the retry below is aimed at exactly that.
+        heldBy: viewportOwner.currentOwner(),
+        attempt: snapBackRetryAttemptsRef.current,
       }),
     });
     if (issued) {
       pendingSnapBackTargetRef.current = snapTo;
+      return;
     }
+
+    /*
+     * A refused snap back is still owed, so ask again rather than give up.
+     *
+     * What refuses it is almost always the reader's own gesture, and that claim
+     * is a lapse timer — a wheel has no end of its own, so the register goes on
+     * answering with them for a window after each notch. This correction is the
+     * one writer that asks from inside that window, because coming to rest is
+     * what triggers it.
+     *
+     * Which is also why the hold must not simply be released here. Tried, and
+     * measured: a settle lands between two wheel notches, so releasing put the
+     * snap back in the middle of a gesture that was still going — the reader
+     * scrolled down into the reserved blank and was dragged back out of it
+     * every 800ms, a dozen times, which is the transcript stuttering under
+     * their hands. The hold was doing its job; what was missing was a second
+     * ask once it had done it.
+     *
+     * So the ask repeats while the refusal is the kind that expires. A reader
+     * still scrolling keeps re-taking the viewport and keeps being answered
+     * with a refusal that moves nothing, and their next settle re-arms the
+     * whole thing anyway; a reader who has stopped is snapped back one window
+     * after their last notch.
+     */
+    if (snapBackRetryAttemptsRef.current >= SNAP_BACK_RETRY_ATTEMPTS) {
+      return;
+    }
+    snapBackRetryAttemptsRef.current += 1;
+    clearSnapBackRetry();
+    snapBackRetryTimerRef.current = window.setTimeout(() => {
+      snapBackRetryTimerRef.current = null;
+      evaluateSnapBackRef.current();
+    }, SNAP_BACK_RETRY_DELAY_MS);
   }, [
+    clearSnapBackRetry,
     viewportOwner,
     enterFollowOutput,
     isFollowCorrectingViewport,
@@ -1011,6 +1105,16 @@ export function useFlowChatFollowOutput({
     resolveFollowTargetScrollTop,
     scrollerRef,
   ]);
+  evaluateSnapBackRef.current = evaluateSnapBack;
+
+  const handleScrollSettled = useCallback(() => {
+    // A settle of the reader's own is a fresh ask, not a continuation of the
+    // last one: it gets the full retry budget, and supersedes what is left of
+    // the previous one.
+    snapBackRetryAttemptsRef.current = 0;
+    clearSnapBackRetry();
+    evaluateSnapBack();
+  }, [clearSnapBackRetry, evaluateSnapBack]);
 
   const getFollowTargetScrollTop = useCallback(() => (
     isFollowingOutputRef.current ? followStateRef.current.target : null
@@ -1221,6 +1325,7 @@ export function useFlowChatFollowOutput({
   }, [scheduleFollowToLatest]);
 
   useEffect(() => stopFollowFrame, [stopFollowFrame]);
+  useEffect(() => clearSnapBackRetry, [clearSnapBackRetry]);
 
   return {
     isFollowingOutput,

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import {
+  isViewportDiagnosticsEnabled,
   roundViewportPx,
   traceViewportRepeating,
 } from '@/infrastructure/diagnostics/flowChatViewportDiagnostics';
@@ -64,6 +65,17 @@ interface UseFlowChatFollowOutputOptions {
    * nothing else has to carry a private opinion about when this hook is busy.
    */
   viewportOwner: FlowChatViewportOwnerApi;
+  /**
+   * Which transcript this hook belongs to, for the trail only.
+   *
+   * The list is keyed on the session, so every switch is a fresh instance with
+   * a fresh scroller — and two of them can overlap, or a second pane can hold
+   * one of its own. Read on its own, `followOutput.enter` followed by a
+   * boundary ask that passes the "is follow following" gate reads as an exit
+   * that left no trace; with this it reads as two instances, which is a
+   * different fault entirely.
+   */
+  viewportId?: number;
 }
 
 export interface ViewportResizeInput {
@@ -183,6 +195,7 @@ export function useFlowChatFollowOutput({
   resolveTurnTopScrollTop,
   isOpeningViewport,
   viewportOwner,
+  viewportId = 0,
 }: UseFlowChatFollowOutputOptions): UseFlowChatFollowOutputResult {
   const [isFollowingOutput, setIsFollowingOutput] = useState(false);
   const isFollowingOutputRef = useRef(false);
@@ -221,7 +234,29 @@ export function useFlowChatFollowOutput({
   const smoothScrollFromPxRef = useRef(0);
   const pendingSnapBackTargetRef = useRef<number | null>(null);
 
-  isFollowingOutputRef.current = isFollowingOutput;
+  /*
+   * Deliberately *not* mirrored from `isFollowingOutput` here.
+   *
+   * Every other ref on this line is a prop, and a prop is whatever the render
+   * that assigned it was given — consistent by construction. Ownership is not:
+   * it is written imperatively by `enterFollowOutput` and `exitFollowOutput`,
+   * and the state is only how the rest of the component hears about it. Between
+   * the two, React is free to render the value from *before* the update — an
+   * update scheduled from a passive effect sits at a lower priority than a
+   * synchronous render, which then renders without it — and the assignment took
+   * ownership away from a writer that had just taken it, with nothing anywhere
+   * saying so.
+   *
+   * Measured on session open, which is the entry that comes from a mount
+   * effect and so hits this every time: `followOutput.enter` recorded at 31976,
+   * the first frame of the loop stood down 345ms later with `not-following` and
+   * its 90-frame budget untouched, and no `followOutput.exit` in the trail
+   * because nothing exited. The register still held `follow-output`, so the
+   * 22301px prepend that landed in between was left to a writer that was no
+   * longer running — `followTargetPx: null` while `heldBy: follow-output` — and
+   * the session was revealed at offset 0 of a window starting eight Turns above
+   * the tail.
+   */
   isStreamingRef.current = isStreaming;
   isViewportActiveRef.current = isViewportActive;
   latestTurnIdRef.current = latestTurnId;
@@ -419,6 +454,45 @@ export function useFlowChatFollowOutput({
     }
 
     const onTarget = Math.abs(next.target - scroller.scrollTop) <= BOTTOM_EPSILON_PX;
+    /*
+     * What the loop decided this frame, coalesced by the decision.
+     *
+     * A frame that writes nothing is the interesting one: it means the follow
+     * rule believes the viewport is already where it belongs, and the reader is
+     * looking at something else. Measured on a reopened session, that is the
+     * whole fault — a history window arrived above a viewport at 0 during the
+     * opening reveal, and whether the loop then aimed at the new content end or
+     * was still reading an unmeasured 0 could not be told apart from outside.
+     */
+    if (isViewportDiagnosticsEnabled()) {
+      // Guarded rather than left to the coalescer, which is the rule for
+      // anything on this path: it runs on every frame of every follow, and even
+      // the key would be a string built sixty times a second for a switch that
+      // is off.
+      traceViewportRepeating(
+        `follow|frame|${onTarget}|${isOpeningViewport()}|${next.mode}`,
+        {
+          location: 'followOutput.frame',
+          message: onTarget
+            ? 'the viewport is already on the offset the follow rule owns'
+            : 'the follow rule is moving the viewport to the offset it owns',
+          travelPx: next.target - scroller.scrollTop,
+          data: () => ({
+            viewportId,
+            onTarget,
+            mode: next.mode,
+            isOpening: isOpeningViewport(),
+            desiredPx: roundViewportPx(desired),
+            targetPx: roundViewportPx(next.target),
+            pinPx: pin === null ? null : roundViewportPx(pin),
+            scrollTopPx: roundViewportPx(scroller.scrollTop),
+            scrollRangePx: roundViewportPx(scroller.scrollHeight),
+            settleFrames: settleFramesRef.current,
+            smoothYieldActive: smoothScrollUntilMsRef.current !== 0,
+          }),
+        },
+      );
+    }
     if (smoothScrollUntilMsRef.current !== 0) {
       /*
        * An animated scroll of ours is in flight and heading for this same
@@ -517,21 +591,47 @@ export function useFlowChatFollowOutput({
     readPinScrollTop,
     retirePin,
     scrollerRef,
+    viewportId,
     viewportOwner,
   ]);
 
   const runFollowFrame = useCallback(() => {
     followFrameRef.current = null;
-    if (
-      !isFollowingOutputRef.current ||
-      !isViewportActiveRef.current ||
-      document.hidden
-    ) {
-      return;
-    }
-    // Streaming holds the loop open indefinitely; anything else runs only
-    // until the transcript stops moving.
-    if (!isStreamingRef.current && settleFramesRef.current <= 0) {
+    /*
+     * Why the loop is not running, which the trail could not say.
+     *
+     * "The session opened on the wrong Turn" has looked identical from outside
+     * whether follow was refused the viewport, was never following, or simply
+     * ran out of budget — all three are a viewport that stops where it was left
+     * and a log with nothing in it after `followOutput.enter`. Measured on a
+     * reopened session: `enter` at session-open, a history window prepended
+     * 22317px above 136ms later, and not one write for the next half second.
+     */
+    const standDownReason = !isFollowingOutputRef.current
+      ? 'not-following'
+      : !isViewportActiveRef.current
+        ? 'viewport-inactive'
+        : document.hidden
+          ? 'document-hidden'
+          : (!isStreamingRef.current && settleFramesRef.current <= 0)
+            // Streaming holds the loop open indefinitely; anything else runs
+            // only until the transcript stops moving.
+            ? 'settle-exhausted'
+            : null;
+    if (standDownReason !== null) {
+      traceViewportRepeating(`follow|standDown|${standDownReason}`, {
+        location: 'followOutput.frameStoodDown',
+        message: 'the follow loop stopped running',
+        data: () => ({
+          reason: standDownReason,
+          viewportId,
+          settleFrames: settleFramesRef.current,
+          isStreaming: isStreamingRef.current,
+          isOpening: isOpeningViewport(),
+          followTargetPx: roundViewportPx(followStateRef.current.target),
+          scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
+        }),
+      });
       return;
     }
     if (!isStreamingRef.current) {
@@ -540,7 +640,7 @@ export function useFlowChatFollowOutput({
 
     applyFollowTarget();
     followFrameRef.current = requestAnimationFrame(runFollowFrame);
-  }, [applyFollowTarget]);
+  }, [applyFollowTarget, isOpeningViewport, scrollerRef, viewportId]);
 
   const startFollowFrame = useCallback(() => {
     if (
@@ -554,6 +654,22 @@ export function useFlowChatFollowOutput({
 
   const enterFollowOutput = useCallback((reason: FollowOutputEnterReason) => {
     if (!isViewportActiveRef.current) {
+      /*
+       * The one way this hook can decline to take the viewport and leave no
+       * trace at all — and it leaves the transcript with no continuous writer
+       * for the rest of its life, because nothing asks again until a Turn
+       * arrives or the session changes. A second pane holding an inactive copy
+       * of the same transcript looks exactly like this from the trail.
+       */
+      traceViewportRepeating(`follow|enterDeclined|${reason}`, {
+        location: 'followOutput.enterDeclined',
+        message: 'follow-output was asked for a viewport that is not active',
+        data: () => ({
+          reason,
+          viewportId,
+          scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
+        }),
+      });
       return;
     }
 
@@ -596,6 +712,7 @@ export function useFlowChatFollowOutput({
       message: 'follow-output took the viewport',
       data: () => ({
         reason,
+        viewportId,
         pinnedTurnId: pinnedTurnToTop ? pinTurnId : pinTurnIdRef.current,
         isStreaming: isStreamingRef.current,
         scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
@@ -683,6 +800,7 @@ export function useFlowChatFollowOutput({
     scrollTurnToTop,
     scrollerRef,
     startFollowFrame,
+    viewportId,
   ]);
 
   /**
@@ -691,17 +809,25 @@ export function useFlowChatFollowOutput({
    * than fall through to the tail.
    */
   const exitFollowOutput = useCallback((reason: FollowOutputExitReason) => {
-    if (isFollowingOutputRef.current) {
-      traceViewportRepeating(`follow|exit|${reason}`, {
-        location: 'followOutput.exit',
-        message: 'follow-output gave the viewport up',
-        data: () => ({
-          reason,
-          pinnedTurnId: pinTurnIdRef.current,
-          scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
-        }),
-      });
-    }
+    /*
+     * Traced whether or not there was anything to give up. An exit that finds
+     * follow already released is the answer to "who ended the follow this
+     * session opened with" being nobody — and gating the line on ownership is
+     * what made that case indistinguishable from the exit never being reached.
+     */
+    traceViewportRepeating(`follow|exit|${reason}|${isFollowingOutputRef.current}`, {
+      location: 'followOutput.exit',
+      message: isFollowingOutputRef.current
+        ? 'follow-output gave the viewport up'
+        : 'follow-output was released while it held nothing',
+      data: () => ({
+        reason,
+        viewportId,
+        wasFollowing: isFollowingOutputRef.current,
+        pinnedTurnId: pinTurnIdRef.current,
+        scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
+      }),
+    });
     isFollowingOutputRef.current = false;
     setIsFollowingOutput(false);
     endSmoothScrollYield('superseded');
@@ -709,7 +835,7 @@ export function useFlowChatFollowOutput({
     viewportOwner.release('follow-output');
     viewportOwner.release('snap-back');
     stopFollowFrame();
-  }, [endSmoothScrollYield, scrollerRef, stopFollowFrame, viewportOwner]);
+  }, [endSmoothScrollYield, scrollerRef, stopFollowFrame, viewportId, viewportOwner]);
 
   /**
    * Re-assert ownership after a layout change. This deliberately does not force

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -20,6 +20,7 @@ import {
   FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
   memorylessFollowState,
   nextTailFollowState,
+  resolveAnimatedJumpBehavior,
   tailHoldMaxGapPx,
   tailSnapBackScrollTop,
   type TailFollowState,
@@ -455,6 +456,40 @@ export function useFlowChatFollowOutput({
     scrollToContentEnd(behavior);
   }, [beginSmoothScrollYield, endSmoothScrollYield, scrollToContentEnd]);
 
+  /**
+   * Decide how a jump to latest travels, and record the decision.
+   *
+   * Traced because the two outcomes are indistinguishable afterwards — an
+   * animation that was never issued and one the loop cut short both end as a
+   * viewport that arrived without moving through anything — and they call for
+   * opposite fixes. This line says which one a reader is describing.
+   */
+  const resolveJumpBehavior = useCallback((scroller: HTMLElement, targetPx: number) => {
+    const behavior = resolveAnimatedJumpBehavior({
+      fromPx: scroller.scrollTop,
+      targetPx,
+      clientHeight: scroller.clientHeight,
+    });
+    const distancePx = Math.abs(targetPx - scroller.scrollTop);
+    traceViewportRepeating(`follow|jumpBehavior|${behavior}`, {
+      location: 'followOutput.jumpBehavior',
+      message: behavior === 'smooth'
+        ? 'the jump to latest is near enough to animate'
+        : 'the jump to latest is too far to animate, so it lands outright',
+      travelPx: targetPx - scroller.scrollTop,
+      data: () => ({
+        behavior,
+        viewportId,
+        distancePx: roundViewportPx(distancePx),
+        viewports: scroller.clientHeight > 0
+          ? Math.round((distancePx / scroller.clientHeight) * 10) / 10
+          : null,
+        clientHeightPx: scroller.clientHeight,
+      }),
+    });
+    return behavior;
+  }, [viewportId]);
+
   /** Move the viewport to whatever the follow state currently owns. */
   const applyFollowTarget = useCallback(() => {
     const scroller = scrollerRef.current;
@@ -814,15 +849,21 @@ export function useFlowChatFollowOutput({
     ) {
       const pinTarget = readPinScrollTop() ?? scroller?.scrollTop ?? contentEnd;
       followStateRef.current = { mode: 'pin-turn-top', target: pinTarget };
-      // Animated like every other jump to latest. The frame loop would cancel
-      // the animation on its next tick, so it stands down for it exactly as it
-      // does for `runContentEndScroll`.
+      // Travels like every other jump to latest, animated or not. The frame
+      // loop would cancel an animation on its next tick, so it stands down for
+      // this one exactly as it does for `runContentEndScroll` — and an instant
+      // write of ours replaces whatever was still travelling.
       if (scroller && Math.abs(scroller.scrollTop - pinTarget) > BOTTOM_EPSILON_PX) {
-        beginSmoothScrollYield();
+        const behavior = resolveJumpBehavior(scroller, pinTarget);
+        if (behavior === 'smooth') {
+          beginSmoothScrollYield();
+        } else {
+          endSmoothScrollYield('superseded');
+        }
         viewportOwner.write({
           owner: 'follow-output',
           topPx: pinTarget,
-          behavior: 'smooth',
+          behavior,
         });
       }
       startFollowFrame();
@@ -839,7 +880,17 @@ export function useFlowChatFollowOutput({
     } else {
       retirePin();
       followStateRef.current = { mode: 'hold-tail', target: contentEnd };
-      runContentEndScroll(reason === 'jump-to-latest' ? 'smooth' : 'auto');
+      /*
+       * Only a jump to latest is ever a candidate for an animation, and only a
+       * near one. Every other entry reason is the transcript resuming a follow
+       * it already owned, where an animation would be a movement the reader did
+       * not ask for.
+       */
+      runContentEndScroll(
+        reason === 'jump-to-latest' && scroller
+          ? resolveJumpBehavior(scroller, contentEnd)
+          : 'auto',
+      );
     }
 
     startFollowFrame();
@@ -850,6 +901,7 @@ export function useFlowChatFollowOutput({
     readContentEndScrollTop,
     readPinScrollTop,
     resolveFollowState,
+    resolveJumpBehavior,
     retirePin,
     runContentEndScroll,
     scrollTurnToTop,


### PR DESCRIPTION
## Summary

Five viewport fixes in the modern FlowChat transcript: the root cause of a reopened session landing on the wrong Turn, where the viewport comes to rest after a history page, a boundary that asked for history forever, and two navigations whose motion did not match anything the reader did. Three diagnostics that were reporting the ordinary case as a fault are corrected along the way.

Fixes # <!-- no tracking issue; all five were reported during use, with logs -->

## Type and Areas

Type: bug fix / regression fix / docs

Areas: web UI — `src/web-ui/src/flow_chat/components/modern` (transcript viewport, follow rule, history paging, viewport diagnostics)

## Motivation / Impact

**1. Reopening a session no longer lands on the wrong Turn.** Reported: open a 12-Turn session, switch away, switch back, and the transcript comes up with Turn 5 pinned to the top instead of at the end where it was left. `isFollowingOutputRef` was assigned from render state, while ownership is written imperatively by enter/exit — an update queued from a passive effect can be skipped by a higher-priority synchronous render, and session-open enters from a mount effect. The register recorded follow-output as the holder while the follow loop believed it was not following, which is a state neither side recovers from. Three independent fixes, each of which alone leaves the viewport at the end: the mirror is gone; a refused prepend shift now wakes the holder it was left to; paging is refused while the transcript is still being placed, and the reveal settling asks again.

**2. A reader is no longer stranded in the reserved blank after a history page.** A refused snap back now retries within a bound instead of giving up — what refuses it is the reader's own gesture claim, which lapses.

**3. The snap back lands where the transcript ended up, not where the animation stopped.** `tail-snap-back` seeded the hold-tail memory with `scrollTop`, and hold-tail tolerates a gap of up to 60% of the viewport — so the difference was not corrected, it was *kept*. Measured on a 43-Turn session: 364px of reserved blank below the transcript and the fourth-from-last Turn cut off at the top.

**4. A session that holds every Turn it has is no longer asked for more.** 652 boundary asks in one recording, 648 answered `precondition`, each one re-arming the direction so the next scroll event asked again — 664 of 3077 log lines. The guard was one `||` over three unrelated facts, only one of which is transient.

**5. Navigation motion is consistent.** A focus request (usage-report entry, cross-session jump) resolves against three keys; the first two placed the viewport instantly and the third animated, so the same click animated or jumped depending on what the request happened to carry. Now uniformly instant. Jump to latest is decided by distance instead: animated within three viewports, instant beyond. Measured, a jump issued for 8717px animated 5480 of them and was finished by the frame loop in a single 3290px write — two thirds of a scroll and then a jump, which is worse than either half, and a longer yield budget only makes the reader wait through more of an animation they cannot read.

For developers: three decision functions move out of the components into pure, separately tested form (`resolveTailBoundaryPrecondition`, `resolveAnimatedJumpBehavior`, `resolveFollowState`). Probes that were absent by construction are added — an entry declined for an inactive viewport, an exit with nothing to give up, a frame loop standing down, and which transcript instance every viewport line came from — all behind the existing `app.logging.flow_chat_diagnostics` switch, with the one per-frame probe guarding its own key the way the register's write already does.

## Verification

```
npx tsc --noEmit                                # clean
npx eslint src/flow_chat/components/modern/     # clean
npx vitest run src/flow_chat/components/modern  # 39 files / 357 tests passed
npx vitest run                                  # 445/446 files, 3170/3171 tests
```

The single full-suite failure is `src/infrastructure/config/services/providerPresets.test.ts`, a dynamic import exceeding the 5s test timeout under full-suite load. It passes in 1.18s on its own and is untouched by this PR (nothing here is outside `flow_chat`).

Every fix has a test that fails without it. The ownership clobber reproduces the priority window with `flushSync`; the paging tests drive the opening reveal to its end through a manual rAF queue, the way half a second of animation frames does in the app; the snap back has both "asks again once the gesture that refused it has lapsed" and "stops asking rather than chase a reader who keeps scrolling"; the distance rule covers both sides of the boundary, a reverse-direction jump, and an unmeasured scroller.

Manual checks, all added to `FLOWCHAT_VERIFICATION.md`:

- Open a 12-Turn session, switch away, switch back — it comes up at the end.
- On a 43-Turn session whose last three Turns are shorter than one viewport, scroll up to trigger a history load — the junction is a continuation, with no reserved blank exposed.
- Jump to latest from a screen or two up glides the whole way; from the top of a long transcript it lands outright. Half an animation followed by a jump is the failure to look for.

## Reviewer Notes

**Read the pure functions first.** `flowChatLiveTailWindow.ts` and `flowChatTailFollow.ts` carry the reasoning and the measurements behind each decision, and they are faster to review than the component diffs that call them.

**Two deliberate asymmetries**, both commented in place but worth naming here:

- `resolveTailBoundaryPrecondition` answers `cancelled` for `after` rather than `exhausted`, even though nothing follows the canonical tail. That branch is only reached through the retained continuous projection, which has no window bounds — and the latch is cleared by the bounds changing, so latching would be permanent for the rest of the presentation.
- Neither the pinned-Turn jump nor the post-streaming settle is distance-gated. The first is under one viewport by construction; the second closes a gap bounded by `tailHoldMaxGapPx`, 60% of a viewport.

**One regression was introduced and fixed inside this series.** Releasing the `user-gesture` claim from `handleScrollSettled` made the snap back fire between wheel notches, which the reader saw as a shudder. It was replaced by the bounded retry; the route and its cost are recorded in `a41232644`. Reviewing "just release the other writer's claim" with the same suspicion is the useful takeaway.

**The threshold is tunable and has an acceptance signal.** `FLOWCHAT_ANIMATED_JUMP_MAX_VIEWPORTS = 3` comes from the sustained rate in the measurement above (~4570px/s). If `followOutput.animatedScrollEnded` still reports a `backstop` reason, an animation ran out its yield without arriving and the number is too high.

**Known and deliberately out of scope:** the pagination junction still shows one visible lurch — the compensation can only use the virtualizer's estimated heights, and the shrink happens in the tens-to-hundreds of milliseconds when nobody holds the viewport. The cure is capturing the anchor *before* the compensating shift, which touches the settle loop. Remembering the reading position across a session switch is also still unimplemented.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (No user-facing strings changed; `AGENTS.md`, `FLOWCHAT_SCROLL_STABILITY.md` and `FLOWCHAT_VERIFICATION.md` are updated.)
