### PR TITLE
docs: refine TUI runtime and management boundaries

### DIFF
--- a/docs/architecture/agent-runtime-deployment-design.md
+++ b/docs/architecture/agent-runtime-deployment-design.md
@@ -4,9 +4,9 @@
 
 Agent Runtime 的模块职责见 [`agent-runtime-services-design.md`](agent-runtime-services-design.md)，公开 SDK 见
 [`agent-sdk-product-architecture.md`](agent-sdk-product-architecture.md)，第三方 JS/TS 进程见
-[`extensions/plugin-runtime-design.md`](extensions/plugin-runtime-design.md)。Rich Client 的 App Server 协议、Embedded/Shared Host
-和 transport 提案见 [`app-server-architecture.md`](app-server-architecture.md)。该提案通过架构评审前，当前部署和调用路径以本文及
-已接线代码为准。
+[`extensions/plugin-runtime-design.md`](extensions/plugin-runtime-design.md)。Rich Client 的 Embedded direct-runtime 决策、App Server 协议
+和 Shared transport 提案见 [`app-server-architecture.md`](app-server-architecture.md)。Embedded 迁移完成前，当前调用路径以本文及
+已接线代码为准；Shared transport 未通过独立评审前继续使用 v17。
 
 ## 1. 决策与当前状态
 
@@ -19,7 +19,7 @@ flowchart TB
   Desktop["Desktop GUI"] --> DesktopAdapter["Desktop / Tauri adapter"]
   Web["Web UI"] --> WebAS["loopback WebSocket App Server"]
   TUI["Interactive TUI"] --> Backend["TuiBackend"]
-  Backend -->|"Embedded"| EmbeddedAS["in-process App Server"]
+  Backend -->|"Embedded current"| EmbeddedAS["in-process App Server"]
   Backend -->|"--shared"| SharedIPC["private Runtime IPC v17"]
   Other["Headless CLI · ACP · Peer Host · SDK Host"] --> Adapter["独立 first-party adapters"]
   DesktopAdapter --> API["Agent Runtime API / owner ports"]
@@ -40,42 +40,52 @@ flowchart LR
   Runtime -. "injects Runtime API and owner ports" .-> Host
 ```
 
-两张图中的实线表示当前业务请求，虚线只表示启动期构造与依赖注入。
+Current 图只表示已经接线的业务请求路径；下方 composition 图中的虚线只表示启动期构造与依赖注入。
 
-### 1.2 Proposed Rich Client target
+### 1.2 Approved Embedded target
 
 ```mermaid
 flowchart TB
-  Rich["Desktop GUI · Web UI · Interactive TUI"] --> Host["Rich Client Host"]
-  Host --> Client["App Server client"]
-  Client --> Transport["Host-selected Embedded / Shared transport"]
-  Transport --> AppServer["App Server"]
-  Other["Headless CLI · ACP · Peer Host"] --> Adapter["独立 first-party adapters"]
-  SDK["Public Agent SDK"] --> SDKHost["SDK Host adapter"]
-  AppServer --> API["Agent Runtime API / owner ports"]
-  Adapter --> API
-  SDKHost --> API
+  TUI["Embedded interactive TUI"] --> Composition["TuiBackend composition"]
+  Composition --> RuntimePort["TuiRuntimePort"]
+  RuntimePort --> Direct["DirectRuntimeTuiRuntime"]
+  Direct --> API["Agent Runtime API / owner ports"]
+  Composition --> Management["owner service/provider interfaces"]
+  API --> Owners["Session / Tool / Permission / MCP owners"]
 ```
 
-该图是待评审目标，不是当前调用链。Shared App Server 只有达到 v17 的连接治理、安全、恢复、取消、限制、性能和回滚门槛后，
-才可替换 compatibility transport；评审也可以决定保留 private v17 作为 Shared TUI 的物理 wire。
+这是已批准但尚未交付的 Embedded direct-runtime 目标，属于 Phase 5；在 Host 完成迁移和验证前，Current 图中的 Embedded App Server 路径保持不变。
 
-### 1.3 Current implementation facts
+### 1.3 Optional Shared App Server proposal
+
+```mermaid
+flowchart LR
+  C1["Shared Rich Client 1"] --> Transport["candidate private Pipe / UDS"]
+  C2["Shared Rich Client 2"] --> Transport
+  Transport --> Host["Shared App Server Host"]
+  Host --> Runtime["one Agent Runtime owner"]
+  Runtime --> Storage["Workspace / Session storage"]
+```
+
+这是 Phase 6 的待评审提案，不是当前 Shared TUI 的必经链路，也不改变 Current 图中的 private Runtime IPC v17。只有完成连接治理、安全、恢复、取消、限制、性能和回滚门槛后，才可评审是否替换 v17；评审也可以决定长期保留 v17。
+
+### 1.4 Current implementation facts
 
 | 范围 | 当前状态 |
 |---|---|
-| Embedded Desktop GUI | 继续使用 Desktop 事件投影和 Tauri adapter；按实际打开的本机 workspace 延迟取得并持有 Embedded ownership，不增加后台进程；目标迁入同进程私有 App Server |
-| Embedded interactive TUI | 已组装同进程私有 App Server，通过 in-memory transport、`AppServerClient` 和 `AppServerTuiBackend` 完成当前核心聊天、Session 与 Phase 3/4 管理面路径 |
+| Embedded Desktop GUI | 当前继续使用 Desktop 事件投影和 Tauri adapter；按实际打开的本机 workspace 延迟取得并持有 Embedded ownership，不增加后台进程；Embedded direct Runtime 是后续 Host/infrastructure 目标，不在此处宣称已接线 |
+| Embedded interactive TUI | 当前仍通过同进程私有 App Server、in-memory transport、`AppServerClient` 和 `AppServerTuiBackend`；目标切换为 backend composition，由 `DirectRuntimeTuiRuntime` 直接调用 `AgentRuntime` typed API |
 | Embedded Headless CLI/Peer Host | 保留各自独立 Runtime adapter、展示和断流策略；不因交互式 TUI 迁移而强制使用 App Server |
 | ACP/SDK Host | 使用同一个 Runtime 事件入口的 session-scoped 订阅；各自协议和进程生命周期保持独立 |
 | Runtime ownership | Desktop、CLI、ACP、SDK Host 和现有 Server agent bootstrap 共用 Core owner；Embedded 取得共享锁，Shared TUI 取得独占锁，同一 workspace 上两种 deployment 互斥 |
 | Session 写入 | BitFun Runtime 的持久化 Session 由 `SessionManager` 管理；同一存储位置中的同一 Session 同时只允许一个本机进程写入，list/view 等只读操作不受影响 |
 | 当前 HTTP Server | 已组装 Embedded Runtime 和 `BitfunAppServer`，每个 `/ws` 连接通过 WebSocket transport 运行一条 App Server connection；当前固定 loopback、单用户且缺少连接级身份与作用域绑定，不构成远程或多用户 Server API |
 | Shared local IPC | 未发布的 v17 本机协议已有 discovery、实例锁、严格握手、Session 控制权、有界事件流和 cleanup；唯一 consumer 是第一方交互式 TUI compatibility adapter；是否由 Shared App Server 替换仍待评审与等价证据 |
-| Shared TUI | `bitfun --shared` / `bitfun chat --shared` 可列出、创建、恢复 Session，删除未被控制的空闲非当前 Session，通过 `/fork` 从完整历史或选中提示词之前创建分支，重命名当前 Session，读取 transcript，通过 **View subagents** 只读查看当前根 Session 的子会话并定向取消子会话活动 Turn，切换当前 Session 的 Agent mode/model，通过 `/reload [skills|instructions]` 刷新声明式上下文，通过 `/compact` 或 `/summarize` 压缩当前 Session 上下文，在 Turn 空闲时通过 `/diff` 读取 Runtime 绑定工作区的只读差异，提交/取消 Turn，处理 Permission 和 UserInput；Model、Skill、Subagent、MCP、External Source V1 和 Hook 管理由 Shared CLI Host 显式装配 App Server 的具体 `AppManagementService` 保留；Account/Settings Sync、Worktree 和后续 External Application V2 未由当前 Shared Host 提供，默认仍是 Embedded |
+| Shared TUI | `bitfun --shared` / `bitfun chat --shared` 可列出、创建、恢复 Session，删除未被控制的空闲非当前 Session，通过 `/fork` 从完整历史或选中提示词之前创建分支，重命名当前 Session，读取 transcript，通过 **View subagents** 只读查看当前根 Session 的子会话并定向取消子会话活动 Turn，切换当前 Session 的 Agent mode/model，通过 `/reload [skills|instructions]` 刷新声明式上下文，通过 `/compact` 或 `/summarize` 压缩当前 Session 上下文，在 Turn 空闲时通过 `/diff` 读取 Runtime 绑定工作区的只读差异，提交/取消 Turn，处理 Permission 和 UserInput；当前管理面具体接线为 `SharedTuiBackend -> concrete AppManagementService -> existing product owners`，其中 `AppManagementService` 是现有 owner 上的 adapter；按 domain 拆分 owner service/provider 是 Phase 5 的后续工作；Account/Settings Sync、Worktree 和后续 External Application V2 未由当前 Shared Host 提供，默认仍是 Embedded |
 | Shared GUI/Headless/ACP/SDK Host/Remote | 未交付，也不会由 `--shared` 隐式启用；Replay、Observer、通用 Controller transfer 和 Session archive 同样不在当前协议中 |
 
-因此当前交付的是 Embedded TUI App Server 与一条窄的、显式启用的 Shared TUI compatibility deployment，不是通用本机 Server。
+因此当前交付的是 Embedded TUI App Server 与一条窄的、显式启用的 Shared TUI compatibility deployment；
+下一步将先把 Embedded TUI 切换为 direct Runtime adapter，不把它扩展成通用本机 Server。
 具体 `EventQueue` 仍由 Core 产品装配；当前 Shared IPC 只把 TUI 必需的强类型操作和事件映射到同一个 Runtime owner，
 没有公开协议承诺。是否以 App Server Shared transport 替换并删除它，由行为等价、性能、安全和回滚证据决定。
 
@@ -86,7 +96,8 @@ flowchart TB
 | Agent Runtime | 负责 Session、Turn、Tool、MCP、Permission、Hook、事件和持久化行为的既有模块 | 进程名、Server 或 SDK |
 | Embedded deployment | Runtime 与调用入口位于同一 Rust 进程 | 简化版 Runtime |
 | Shared deployment | 同一 Runtime 由一个本机进程承载，多个第一方 Client 通过私有 IPC 使用 | 新 Runtime、公开 Server 或 Agent SDK |
-| Embedded App Server | 与 Rich Client Host 同进程的私有 App Server 实例和 in-memory transport | Runtime 直连、后台进程或网络 Server |
+| Embedded direct Runtime | Host 通过稳定 Rust typed facade 调用同进程 Runtime owner | 第二套 Runtime、Core singleton 直连或 App Server wire |
+| Embedded App Server | 当前 TUI 使用、仅作迁移前基线的同进程 App Server 实例和 in-memory transport | Embedded 的目标默认路径、后台进程或网络 Server；Phase 5 切换后删除 |
 | Shared App Server | 独立本机 Host 承载、由多个已认证 Rich Client 通过受控 transport 使用的 App Server | 公网 API 或每个 Client 一个 Runtime |
 | Agent SDK Host | 将公开 SDK 合同映射到 Runtime API 的私有进程/adapter | CLI、Shared deployment 或 Plugin Host |
 | Plugin Host | 运行 Node/Bun 和第三方插件代码的受监督子进程 | Agent Runtime 或 Rust IPC client |
@@ -106,19 +117,26 @@ flowchart TB
 
   Desktop["Desktop GUI"] --> DesktopAdapter["Desktop / Tauri adapter"]
   Web["Web UI"] --> AppServer["loopback WebSocket App Server"]
-  EmbeddedTUI["Embedded TUI"] --> AppServer
+  EmbeddedTUI["Embedded TUI"] --> EmbeddedCurrent["in-process App Server · current"]
+  EmbeddedTUI -. "target" .-> Composition["TuiBackend composition"]
+  Composition --> RuntimePort["TuiRuntimePort"]
+  RuntimePort --> DirectRuntime["DirectRuntimeTuiRuntime"]
+  Composition --> Management["owner service/provider interfaces"]
   DesktopAdapter --> API
   AppServer --> API
+  DirectRuntime --> API
   SharedCompat["Shared Runtime IPC · temporary compatibility"] --> API
   Headless["Headless / ACP adapters"] --> API
   SDK["SDK Host adapter"] --> API
   Remote["Remote adapter"] --> API
 ```
 
-当前复用的是 Runtime API、权威事实和 owner；Web 与 Embedded TUI 额外复用 App Server wire，Shared TUI 使用 private v17，Desktop
-仍使用自己的 adapter。第 1.2 节目标只有通过评审并完成迁移后才扩大 App Server 复用范围。各入口不复用 renderer、CLI 参数、SDK
-wire、远程认证或平台窗口生命周期。任何新能力必须先进入既有 Runtime owner，再由 App Server 或需要它的独立 adapter 映射，禁止
-在 Embedded、Shared 或其他入口复制业务实现。
+当前复用的是 Runtime API、权威事实和 owner；Web 额外使用 App Server wire，Embedded TUI
+当前使用 App Server、目标改为 direct Runtime adapter，Shared TUI 的共同 Runtime 行为使用
+private v17。TUI 管理面由 composition 按 domain 注入 owner service/provider，不随 Runtime
+port 进入 Shared wire。各入口不复用 renderer、CLI 参数、SDK wire、远程认证或平台窗口生命周期。
+任何新能力必须先进入既有 Runtime 或 owner service，再由 App Server、direct adapter 或其他独立
+adapter 映射，禁止在 Embedded、Shared 或其他入口复制业务实现。
 
 ### 3.1 Embedded 事件交付
 
@@ -126,9 +144,11 @@ wire、远程认证或平台窗口生命周期。任何新能力必须先进入�
 flowchart LR
   Queue["EventQueue"] --> Owner["Core product event queue owner"]
   Owner -->|"injects read-only AgentEventSource"| Runtime["Agent Runtime API"]
-  Runtime --> AppServer["Embedded App Server"]
-  AppServer --> TUI["Interactive TUI client"]
-  AppServer --> GUI["Desktop GUI client · target"]
+  Runtime --> AppServer["App Server · Web/Shared when needed"]
+  Runtime --> Direct["Embedded direct Runtime adapter"]
+  AppServer --> TUI["Rich Client connection"]
+  Direct --> TUIEmbedded["Embedded TUI client"]
+  AppServer --> GUI["Desktop/Web client"]
   Runtime --> Exec["Headless adapter"]
   Runtime --> Peer["Peer fanout adapter"]
   Runtime --> ACP["ACP adapter"]
@@ -136,7 +156,8 @@ flowchart LR
 ```
 
 - Core product assembly 创建事件 source，并维持旧消费队列的排空 task；第一方产品入口不再获得第二个订阅 API。
-- App Server server 从注入的 `AgentEventSource` 转发 Rich Client 权威事件；Rich Client 不得从 `AgentRuntime` 或 Core `EventQueue` 旁路订阅。
+- App Server server 从注入的 `AgentEventSource` 转发需要连接边界的 Rich Client 权威事件；这些 client 不得绕过 App Server 订阅 Core `EventQueue`。
+- Phase 5 的 Embedded direct adapter 将通过 `AgentRuntime` 提供的 typed event/Permission subscription 直接订阅同一 Runtime owner，再映射为 `TuiRuntimePort` semantic event；它不得创建第二个 Core `EventQueue` owner 或把 Runtime 内部 receiver 暴露给 TUI。
 - Headless CLI、Peer Host、ACP 和 SDK Host 从各自独立 Runtime adapter 订阅，不能直接持有 Core-specific event source。
 - `bitfun-core` 的旧 event-source/builder API 仅保留为 deprecated 源码兼容 facade；它们委托给同一个 Core owner，不形成第二套运行时或第一方调用路径。
 - 各 adapter 继续拥有自己的失败投影：TUI 标记当前视图不可信，Headless CLI 返回非成功终态，Peer Host 中断其拥有的 turns，ACP 取消 turn 并返回协议错误，SDK Host 终结 Query 并提供 `RestartHost` recovery。
@@ -145,7 +166,7 @@ flowchart LR
   持久化 replay/resume：重连后的旧 cursor 不能继续消费，client 必须重新 initialize 并执行权威 sync。
 - Shared Runtime IPC v17 不复用 App Server cursor。它按自己的有界队列规则处理 lag/closed：Agent 流失效后 fail closed；Permission lag
   尝试从 Runtime 的 pending 集合重建，重建失败或流关闭时取消当前 Turn 并退出。任何路径都不能把流失效伪装成透明恢复。
-- 这条链路仍全部位于当前 Embedded 进程；Rich Client 使用 private in-memory transport，不增加 SDK Host、跨进程 IPC 或后台进程依赖。
+- 当前旧 Embedded App Server 链路位于 Embedded 进程；direct-runtime 目标会删除 private in-memory transport、App Server task/thread 和其 JSON-RPC 编解码，不增加 SDK Host、跨进程 IPC 或后台进程依赖。
 
 ## 4. Process View · Level 1
 
@@ -284,13 +305,13 @@ sequenceDiagram
 - v15 为后代 transcript 读取增加 `required_settled_turn_ids` 一致性前置条件：Runtime 必须确认这些 Turn 已由 owner 持久化为终态，否则返回 `outcome_unknown`，由 TUI 在同一绝对期限内退避重试；TUI 只保留事件投影和该读屏障，不合并或重写权威 transcript。后代取消同时携带用户实际看到的 `expected_active_turn_id`，并在 owner 锁内拒绝已经切换的 Turn，避免迟到操作取消后续执行。lineage 查询和 transcript 读取是每连接至多一个的可抢占推测读取；更新的请求会取消旧读取，使后代取消和 Session 切换不会排在慢 transcript I/O 之后。该行为不放宽 controller 校验，不引入 observer 或通用多路复用。
 - v16 增加只读、workspace-scoped main Agent 摘要，用于 Shared TUI 与 Runtime host 的 selector 投影一致。启动页以 Runtime 启动工作区查询且不取得 Session lease；已有 Session 由 Runtime owner 解析其执行工作区并要求当前 controller。响应只包含逻辑 ID、描述、可选固定 model ID 与 ecosystem-neutral 的 external-source 分类；发现、审批、冲突消解、generation 与执行仍由既有 Agent Registry 和 external-source owner 负责，不经 IPC 暴露安装、变更、激活、Subagent 管理或 runtime lifecycle API。
 - v17 扩展原子 restore，使响应带回 Runtime Session state；增加结构化 Session usage、等待指定 Turn settlement，以及记录本地命令
-  transcript turn 的 operation。它只补齐当前 Shared TUI 与 `TuiBackend` 的行为等价，没有增加 replay、observer、通用 controller
-  transfer、多 Session multiplex 或公开 SDK 能力。
+  transcript turn 的 operation。它补齐当前 Shared TUI 的行为，并为 Phase 5 将冻结的 `TuiRuntimePort` 提供 operation 基线；没有增加
+  replay、observer、通用 controller transfer、多 Session multiplex 或公开 SDK 能力。
 - 一个连接最多控制一个 Session、同时最多提交一个活动 Turn；一个 Session 同时只有一个 controller。create/restore/fork 在完整结果通过大小检查后才原子切换控制权，失败时保留原 Session。fork 只接受当前 controller 的空闲 Session；无选中 Turn 时复制到最新持久化 Turn，指定 `before_turn_id` 时只复制该 Turn 之前的历史。活动 Turn 期间不能切换或 fork Session，也不能修改其名称、Agent mode 或 model；删除只作用于非当前且未被任何连接控制的 Session。
 - Submit 与手动 context compaction 都使用调用方已有的 `turn_id` 标识不确定结果；若操作超时，返回 `outcome_unknown`、关闭连接并按该 ID 取消。手动 compaction 要求当前 controller 且 Session 空闲，由 Core 通过与普通对话 Turn 共用的原子准入路径创建一个可审计 maintenance Turn，并在取得所有权后读取压缩上下文：planning 阶段允许取消，atomic commit 开始后忽略晚到取消并保持 Processing 直至终态持久化完成。maintenance Turn 保留在权威 transcript 中但不进入模型上下文，live/restored payload 使用同一 compression ID 和 `applied` 事实；commit 后的持久化故障发布明确失败终态而不是遗留 Processing。断连取消只有得到确认后才释放 Session 控制权；无法确认时继续隔离该 Session，直到 Runtime 进程退出。
 - Session delete/rename 和 Agent mode/model update 复用既有 Runtime 端口和校验，Runtime 对最终结果保持权威并拒绝无效目标。它们都是有副作用操作；发送前编码或 frame 上限失败表示请求未执行，连接仍可使用。rename 写入失败时恢复旧 metadata：确认恢复后返回明确失败，无法确认时返回 `outcome_unknown`。Shared Client 在请求写入后响应超时或丢失连接时也返回 `outcome_unknown` 并断开连接。两种情况都不自动重试：rename 由用户恢复 Session 并核对当前值；delete 由用户重新打开 `/sessions` 核对目标是否仍存在。模型目录以及完整 Agent/Subagent 管理仍是同版本第一方产品事实，不加入 IPC；v16 的 main Agent 摘要只是 host-owned selector 所需的最小只读投影。
 - 声明式上下文 reload 只失效当前 Session 的 instructions 缓存，并按目标复用 Skill Registry 刷新；它可在活动 Turn 中执行但不改写该 Turn，generation 保护保证下一条消息重建上下文。它不引入 watcher、热替换或第二套 Runtime owner。
-- v17 保留 `update current Session model` operation 及其 controller/idle/unknown-outcome 合同，但模型目录和默认值不进入该 wire。Phase 3 移除 TUI controller 对本机产品配置 owner 的直连后，`SharedTuiBackend` 通过 Host 显式注入的具体 `AppManagementService` 保留模型选择和配置；该 capability 只描述当前本机 Shared CLI adapter，不伪装成 v17 或 Remote capability。
+- v17 保留 `update current Session model` operation 及其 controller/idle/unknown-outcome 合同，但模型目录和默认值不进入该 wire。Phase 3 移除 TUI controller 对本机产品配置 owner 的直连后，`SharedTuiBackend` 通过其持有的具体 `AppManagementService` 保留模型选择和配置；Phase 5 再拆成 Host 注入的 owner service/provider adapter。该 capability 只描述当前本机 Shared CLI adapter，不伪装成 v17 或 Remote capability。
 - Agent 事件流 lag/closed 后 fail closed；Permission lag 先从 Runtime 权威 pending 集合重建，重建失败或流关闭时取消当前 Turn 并退出。路由到父 Session 的嵌套 Permission 与 AskUserQuestion 复用现有 TUI 交互，不新增第二套 UI 状态。
 - Windows Shared Runtime 在初始化前把自身放入 kill-on-close Job；Unix 仅在应用内优雅退出路径中通过受管子进程组回收后代。Runtime 被 `SIGTERM`、`SIGKILL` 或崩溃直接终止后的 Unix 后代回收不在当前保证内。两者都只负责生命周期，不是安全沙箱。
 - 最后一个连接离开后等待 30 秒再退出；新连接会取消 idle 退出。退出只删除自己发布的 discovery；Unix 下继任 owner 会在持有实例锁后清理同一 identity 的陈旧 socket。
@@ -313,7 +334,8 @@ flowchart LR
 
 | 路径 | 数据边界 | 性能约束 |
 |---|---|---|
-| Embedded Rich Client | `AppServerClient` 通过 private in-memory transport 调用同进程 App Server | 不初始化跨进程 IPC 或后台进程；保持与 Shared 相同的 JSON-RPC、DTO、错误和事件语义，编解码成本通过测量优化而不增加直连旁路 |
+| Embedded Rich Client（目标） | TUI backend composition 通过 `TuiRuntimePort` 和 owner service/provider adapter 调用同进程 Agent Runtime | 不初始化 App Server client/server、in-memory transport、跨进程 IPC 或后台进程；Runtime port 保持与 Shared/Web 相同的行为、错误、权限和事件语义，但不要求共享 JSON-RPC；管理 capability 单独按 provider 可用性验证 |
+| Embedded App Server（当前迁移基线） | 迁移前由旧 `AppServerClient` 通过 private in-memory transport 调用同进程 App Server | 仅在 Phase 5 切换前有效；切换到 direct adapter 后删除，不保留回滚路径 |
 | Embedded non-Rich Client | Headless、ACP、Peer 和 SDK Host 的独立 adapter 以 Rust 类型调用 Runtime API | 不因 Rich Client 合同承担 App Server wire；保持各自协议和生命周期 |
 | Shared request | Client 将 operation 编码一次并写入一个长度前缀 frame | 请求保持 128 KiB 上限；业务层只接收类型化 operation |
 | Shared response/event | Server 将结果或事件编码一次后写出 | 响应/事件保持 8 MiB 上限；超限使事件流明确失效，不能无界分配 |
@@ -355,56 +377,82 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-  TUI["Interactive TUI"] --> Backend["TuiBackend"]
-  Backend -->|"Embedded"| Client["AppServerClient"]
-  Client --> Memory["in-memory transport"]
-  Memory --> AppServer["BitfunAppServer"]
-  Backend -->|"Shared compatibility"| IPC["adapters/agent-runtime-ipc v17"]
+  TUI["Interactive TUI · Phase 5 target"] --> Composition["TuiBackend composition"]
+  Composition --> Port["TuiRuntimePort"]
+  Port -->|"Embedded default"| Direct["DirectRuntimeTuiRuntime"]
+  Direct --> Runtime["AgentRuntime typed API"]
+  Composition --> Management["owner service/provider interfaces"]
+  Port -->|"Shared compatibility"| SharedAdapter["SharedIpcTuiRuntime"]
+  SharedAdapter --> IPC["adapters/agent-runtime-ipc v17"]
   IPC --> Handler["CLI Shared handler"]
-  AppServer --> Runtime["execution/agent-runtime / owners"]
   Handler --> Runtime
 ```
 
-CLI Host 负责命令解析、TUI 状态、错误文案、App Server 组装和 transport 生命周期；`TuiBackend` 隔离当前 Shared compatibility adapter。
-App Server 或私有 IPC 只负责协议、连接控制和类型映射；Agent Runtime 与 owner 负责 Session 校验、持久化和权威结果。
-TUI 业务代码不根据部署形态复制业务分支，Shared 达到 App Server 语义等价后替换 compatibility adapter。
+第二张图只描述已批准但尚未交付的 Phase 5 TUI composition 目标。当前生产接线仍以第一张图为准：
+Embedded 使用 `AppServerTuiBackend`，Shared 使用 `SharedTuiBackend -> Runtime IPC v17`。Phase 5 中，
+CLI Host 将负责命令解析、TUI 状态、错误文案、direct Runtime adapter 选择和生命周期；
+backend composition 将由 `TuiRuntimePort` 承载共同 Runtime 行为，并按 domain 注入 owner service/provider
+接口承载管理面。Direct adapter 负责 typed request/result/event 映射，Shared adapter 负责私有 IPC
+的协议与连接控制；Agent Runtime 与 owner 负责 Session 校验、持久化和权威结果。TUI 业务代码
+不根据部署形态复制业务分支，Shared 是否替换 v17 仍按独立门槛决定。这里不定义一个总括性的
+`TuiManagementPort`。
 
 - CLI 不依赖 SDK Host，GUI/TUI 也不依赖公开 SDK package。
-- 交互式 TUI 的启动页和会话页复用 app-local `TuiBackend`；Embedded backend 使用正式 `AppServerClient`，Shared backend 暂时映射 private Runtime IPC v17。TUI 不直接依赖 Rust Runtime SDK、Core/Service owner 或 IPC operation。
+- Phase 5 完成后，交互式 TUI 的启动页和会话页将复用 app-local backend composition；Embedded Runtime 调用使用 `DirectRuntimeTuiRuntime`，Shared Runtime 调用经 `SharedIpcTuiRuntime` 映射 private Runtime IPC v17。TUI 不直接依赖 Rust Runtime SDK、Core/Service owner 或 IPC operation。
+- 管理面由 composition 按 domain 直接注入 owner-owned 的稳定 service/provider trait；原始接口若暴露内部类型，或需要 TUI DTO、权限/上下文和 capability 裁剪，才抽取薄 facade。不得创建 `TuiManagementPort` 总接口，也不得把 App Server 的 `AppManagementService` 原样迁入 CLI/TUI。
+- Web 当前独立使用自己的 loopback WebSocket App Server Host，不进入 TUI backend composition。Shared 当前只有 private Runtime IPC v17；Shared App Server 只存在于第 1.3 节的 Phase 6 candidate 图中。
 - Headless CLI 和 Peer Host 使用同一 Runtime 订阅入口，但分别保留确定性退出与 Peer fanout 语义；共享订阅入口不等于共享 renderer 或产品生命周期。
-- TUI 不是 Server；Embedded Host 在同进程组装私有 App Server，是否连接 Shared deployment 是部署选择，不改变 TUI 的 renderer/键位职责或 App Server 行为合同。
+- TUI 不是 Server；Phase 5 目标中的 Embedded Host 在同进程直接调用 Runtime，是否连接 Shared deployment 是部署选择，不改变 TUI 的 renderer/键位职责或行为合同。
 - Agent SDK Host 只服务外部 SDK 合同，不成为第一方 rich-client 的通用底座。
 - Headless CLI 默认继续 Embedded；CI 或测试可保持独立进程和独立 workspace，不承担后台实例成本。
-- Tauri 仍负责窗口和桌面能力，并逐步收窄为 App Server Host adapter；未来它可以管理 Shared process 的启动/重连，但不拥有 Agent Runtime 业务生命周期。
+- Tauri 仍负责窗口和桌面能力，并逐步收窄为 product Host adapter；Embedded 产品请求可由 direct Runtime adapter 承载，需要连接边界时再使用 App Server，未来也可以管理 Shared process 的启动/重连，但不拥有 Agent Runtime 业务生命周期。
 
 ### 5.2 Physical View
 
+#### 5.2.1 Current production
+
 ```mermaid
 flowchart TB
-  subgraph Embedded["默认 Embedded"]
-    TUI["Interactive TUI"] --> AppServer["private in-process App Server"]
+  subgraph Embedded["Embedded · current"]
+    TUI["Interactive TUI"] --> AppServer["in-process App Server"]
     AppServer --> Runtime["in-process Agent Runtime"]
     Headless["Headless / CI"] --> Runtime
   end
-  subgraph Shared["显式 --shared"]
+  subgraph Shared["Shared · current explicit --shared"]
     Clients["one or more TUI processes"] -->|"Named Pipe / UDS · current compatibility"| SharedRuntime["Shared Runtime Host process"]
   end
   Runtime --> Data["workspace + Session storage"]
   SharedRuntime --> Data
 ```
 
-默认交互式 TUI、Headless CLI 和 CI 保持 Embedded；交互式 TUI 通过 private in-process App Server，Headless/CI 保留独立 adapter。
-只有显式 `--shared` 的交互式 TUI 进入 Shared；同一 workspace 的两种部署互斥。多开 TUI 增加 Client 进程和有界连接，
-不按 Client 数量复制 Runtime、Session owner 或 Plugin Host。
+当前默认交互式 TUI 通过同进程 App Server，Headless CLI 和 CI 通过各自 adapter 调用同进程
+Runtime。只有显式 `--shared` 的交互式 TUI 进入 Shared；同一 workspace 的两种部署互斥。
+多开 TUI 增加 Client 进程和有界连接，不按 Client 数量复制 Runtime、Session owner 或 Plugin Host。
 
-### 5.3 Scenario (+1) · Rename current Session
+#### 5.2.2 Approved Phase 5 Embedded target
+
+```mermaid
+flowchart LR
+  TUI["Embedded interactive TUI"] --> Direct["Direct Runtime adapter · not yet delivered"]
+  Direct --> Runtime["in-process Agent Runtime"]
+  Runtime --> Data["workspace + Session storage"]
+```
+
+Phase 5 只把 Embedded interactive TUI 从当前 App Server 一次性切到 direct Runtime adapter，并删除
+旧 in-process App Server；Headless/CI 保留独立 adapter，Shared 继续使用前一张 Current 图中的
+private Runtime IPC v17。旧 App Server 不作为回滚配置保留。
+
+### 5.3 Scenario (+1) · Phase 5 target: rename current Session
+
+该场景将尚未交付的 Embedded direct adapter 与当前 Shared v17 行为放在同一等价目标中；它不表示
+Embedded Phase 5 已完成。
 
 ```mermaid
 sequenceDiagram
   participant U as User
   participant T as TUI adapter
   participant B as TuiBackend
-  participant E as Embedded App Server adapter
+  participant E as Embedded direct Runtime adapter
   participant S as Shared Runtime IPC v17 adapter
   participant R as Agent Runtime
 
@@ -412,8 +460,8 @@ sequenceDiagram
   T->>T: trim + require idle Session
   T->>B: typed TuiBackend request
   alt Embedded
-    B->>E: typed App Server request
-    E->>R: owner port call
+    B->>E: typed Runtime request
+    E->>R: AgentRuntime method
     R->>R: validate ownership + persist
     R-->>E: applied / failed / outcome_unknown
     E-->>B: mapped typed result
@@ -430,14 +478,14 @@ sequenceDiagram
 
 Embedded 和 Shared 最终调用同一 `AgentRuntime::rename_session`。Runtime 只有在确认旧名称已保留时才返回明确失败；持久化恢复无法确认时，两种部署都返回 `outcome_unknown`。Shared 还会在请求已发送但权威响应丢失时返回该结果并关闭连接。用户恢复 Session、检查当前名称后再决定是否重试。
 
-### 5.4 Scenario (+1) · Delete an idle Session
+### 5.4 Scenario (+1) · Phase 5 target: delete an idle Session
 
 ```mermaid
 sequenceDiagram
   participant U as User
   participant T as TUI adapter
   participant B as TuiBackend
-  participant E as Embedded App Server adapter
+  participant E as Embedded direct Runtime adapter
   participant S as Shared Runtime IPC v17 adapter
   participant R as Agent Runtime
 
@@ -445,8 +493,8 @@ sequenceDiagram
   T->>T: reject current or active target
   T->>B: typed TuiBackend request
   alt Embedded
-    B->>E: typed App Server request
-    E->>R: owner port call
+    B->>E: typed Runtime request
+    E->>R: AgentRuntime method
     R->>R: existing delete owner
     R-->>E: applied / failed / outcome_unknown
     E-->>B: mapped typed result
@@ -509,18 +557,18 @@ Session/Turn、事件恢复、Permission/UserInput、Controller、配置管理�
 | [Codex App Server](https://developers.openai.com/codex/app-server/) | App Server 为 rich client 和 remote TUI 提供 JSON-RPC；自动化继续使用 SDK；WebSocket transport 仍是实验性接口 | Rich Client 使用 App Server，自动化/公开 SDK 保持独立，并为 Shared 入口保留有界本机 transport | 不复制其完整 schema，也不把实验性远程 transport 当作已交付公网 API |
 | [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/typescript) | Agent loop 由长期运行的 CLI 子进程承载，并提供 `startup()` 预热以减少首次请求成本 | 长期 Shared 交互可以复用已启动进程，空闲后回收 | Embedded Rich Client 不增加子进程，多 TUI 也不映射为多个 Runtime |
 
-三种产品说明了不同部署的有效边界：稳定 Rich Client 合同可以同时承载进程内和多客户端 transport，长期子进程适合 Shared
+三种产品说明了不同部署的有效边界：稳定产品行为合同可以分别映射到进程内 direct adapter 和多客户端 transport，长期子进程适合 Shared
 交互或语言 SDK，独立强类型 adapter 适合 Headless/ACP 等非 Rich Client。BitFun 采用混合部署，不把 App Server 强制成所有入口的
 公共底座；当前也没有为了追赶功能表一次性增加 Session/Tool/Permission 超集。
 
 ## 9. 不变量
 
 - 只有一套 Agent Runtime 业务实现；部署差异不能产生第二套 Session、Tool、Permission 或 MCP owner。
-- 当前入口使用第 1.1 节列出的 adapter；若第 1.2 节目标通过评审并迁移完成，Desktop GUI、Web UI 和交互式 TUI 才统一使用 App Server。
+- 当前入口使用第 1.1 节列出的 adapter；Embedded TUI 的下一步是从 App Server 切换到 direct Runtime adapter，Web/需要连接边界的 Rich Client 继续使用 App Server。
 - Client、窗口、Session 或 workspace 数量不会自动等量增加 Runtime 或 Plugin Host 进程。
 - 当前 Shared Runtime IPC 是第一方 TUI 的 private compatibility transport，不成为公开 SDK、Remote、Peer、HTTP 或浏览器协议；是否由 App Server Shared transport 替换仍待评审。
-- Shared TUI 的 Model、Skill、Subagent、MCP、External Source V1 和 Hook 管理暂由 CLI Host 显式装配的 App Server `AppManagementService` 承接；Account/Settings Sync、Worktree 和后续 External Application V2 未由当前 Shared Host 提供并返回 typed unsupported。这不扩展 v17，不改变 Shared Runtime 对 Session/chat 的权威性，也不能用于 Remote workspace 的控制端本机回退。MCP service 的进程状态和 tool registry 只属于当前 CLI 进程，不即时重配已经运行的 Shared Runtime Host；跨进程 MCP 管理需要单独的同步/restart contract。
-- 默认 GUI/TUI/Headless CLI、ACP 与 SDK Host 保持 Embedded；只有交互式 TUI 的显式 `--shared` 选择 Shared。互斥按 `workspace + product` 生效，不再按入口名称缩窄。
+- Shared TUI 的 Model、Skill、Subagent、MCP、External Source V1 和 Hook 管理当前由 `SharedTuiBackend` 委托其持有的具体 `AppManagementService`；Phase 5 再拆成 CLI Host 显式装配的 owner service/provider adapter。这些管理 capability 不进入 Phase 5 的 `TuiRuntimePort` 或 v17 wire。Account/Settings Sync、Worktree 和后续 External Application V2 未由当前 Shared Host 提供并返回 typed unsupported。这不扩展 v17，不改变 Shared Runtime 对 Session/chat 的权威性，也不能用于 Remote workspace 的控制端本机回退。MCP service 的进程状态和 tool registry 只属于当前 CLI 进程，不即时重配已经运行的 Shared Runtime Host；跨进程 MCP 管理需要单独的同步/restart contract。
+- 默认 GUI/TUI/Headless CLI、ACP 与 SDK Host 保持 Embedded；Phase 5 完成后，只有 Embedded TUI 产品请求切换为直接调用同进程 Runtime，并删除旧 Embedded App Server。Desktop direct Runtime 是独立的已批准迁移步骤，不由 TUI Phase 5 的完成状态代替；Headless CLI、ACP 与 SDK Host 继续使用各自 adapter。只有交互式 TUI 的显式 `--shared` 选择 Shared。互斥按 `workspace + product` 生效，不再按入口名称缩窄。
 - Account/session cloud sync 仍使用既有 Core compatibility 边界，不属于 Shared Runtime 支持。
 - Remote workspace 的文件、凭据、进程和 Runtime 位于目标执行域，禁止静默回落本机。
 - 未经真实 consumer 验证的接口不进入 wire；当前 wire 只包含表中列出的 Shared TUI 操作。

--- a/docs/architecture/app-server-architecture.md
+++ b/docs/architecture/app-server-architecture.md
@@ -1,42 +1,61 @@
 # App Server 架构设计
 
-> 状态：Proposed target；关键决策与替换门槛尚待架构评审。
+> 状态：Embedded direct-runtime 已确定为下一步实现方向；Shared App Server 仍是待评审提案。
 >
-> 基线日期：2026-08-05。
+> 基线日期：2026-08-13。
 >
-> 本文记录 BitFun Rich Client 与产品后端之间的候选 App Server 边界，不是已批准的权威架构。具体 TUI 迁移阶段、接口盘点和当前缺口见
+> 本文记录 Embedded direct-runtime 决策，以及需要连接边界时的 App Server 约束和 Shared transport 提案。具体 TUI 迁移阶段、接口盘点和当前缺口见
 > [`tui-app-server-decoupling-refactor-plan.md`](../plans/tui-app-server-decoupling-refactor-plan.md)；Agent Runtime 的进程、所有权和实例隔离见
 > [`agent-runtime-deployment-design.md`](agent-runtime-deployment-design.md)；产品 owner 与分层依赖见
-> [`product-architecture.md`](product-architecture.md)。评审完成前，当前调用路径以已接线代码和上述稳定架构文档为准。
+> [`product-architecture.md`](product-architecture.md)。迁移完成前，当前调用路径仍以已接线代码为准；Shared transport 未通过独立评审前继续使用 v17。
 
-## 1. Proposed decision
+## 1. Decision and remaining proposal
 
-当前首选候选是用 App Server 统一第一方 Rich Client 的产品后端接口。它尚未批准；下列约束只描述该候选被选中后的目标状态：
+本次重构采用候选 B/C 的受限组合：**Embedded deployment 直接调用同进程
+Agent Runtime 的 typed API；需要进程间或网络边界的 Rich Client 才使用 App
+Server**。因此，Rich Client 这一产品分类不再意味着所有部署都必须经过同一
+wire。
 
-- Desktop GUI、Web UI 和交互式 TUI 都是 App Server Rich Client。
-- Rich Client 的 Embedded deployment 也必须经过 App Server；它创建同进程私有 App Server，并通过私有 in-memory transport 连接。
-- Embedded 不表示直连 Runtime，也不要求独立后台进程、网络监听或跨客户端实例发现。
-- Embedded 与 Shared 复用同一 App Server client、协议版本、method、DTO、类型化错误、能力发现、事件和取消语义。
-- Embedded 与 Shared 只在 transport、App Server 实例所有权、客户端数量、连接治理和资源生命周期上不同。
-- Headless CLI/CI、ACP、Peer Host 和公开 Agent SDK 不是 Rich Client，不因该候选被强制改用 App Server；它们继续使用各自经评审的 adapter。
-- App Server 是协议适配层，不接管 Agent Runtime、Service 或 Product Domain 的业务所有权。
+- Embedded Host 直接持有产品组装得到的 `AgentRuntime` 和必要的 owner/provider
+  facade，通过 Rust 类型调用 Runtime 方法；不创建 `BitfunAppServer`、
+  `AppServerClient` 或 in-memory transport。
+- Embedded TUI 仍只依赖 app-local backend composition。TUI 不直接依赖 Runtime、Core
+  singleton、具体 Service 实现或私有 IPC operation；composition 内部由窄的
+  `TuiRuntimePort` 承载跨 Embedded/Shared 的 Runtime 行为，并由
+  `DirectRuntimeTuiRuntime` 完成 direct request/result/event/error 映射。
+- Model、Skill、Subagent、MCP、Account、Settings Sync、Worktree、External Source 和
+  Hook 等管理面不进入 `TuiRuntimePort`，也不定义总括性的 `TuiManagementPort`。它们由
+  backend composition 按 domain 直接注入 owner-owned 的稳定 service/provider trait；只有
+  原始接口暴露内部类型，或需要 TUI DTO、权限/上下文和 capability 裁剪时，才增加最薄的
+  owner/provider facade。`AppManagementService` 继续是 App Server wiring，不原样迁移到 CLI。
+- Web UI / WebSocket Host 继续使用 App Server，因为它们需要连接、transport、
+  认证、作用域和事件转发边界。
+- Shared TUI 继续使用 private Runtime IPC v17，直到 Shared App Server 通过
+  独立的鉴权、controller/lease、恢复、取消、背压、限制、性能和回滚门槛；本次
+  Embedded 重构不自动替换或删除 v17。
+- Headless CLI/CI、ACP、Peer Host 和公开 Agent SDK 继续使用各自经评审的
+  adapter，不因 Rich Client 的 App Server 合同被强制改用 App Server。
+- App Server 仍是协议适配层，不接管 Agent Runtime、Service 或 Product Domain
+  的业务所有权。直接 Runtime adapter 也只能调用既有 owner，不得复制业务状态。
 
-若选择该候选，不能用“Embedded 位于同一进程”作为 Rich Client 绕过 App Server 的理由，也不能用“统一 GUI/TUI 接口”把所有自动化和外部协议强制收敛到 App Server。
+Embedded 直调不是绕过安全或行为合同。它省略的是进程内无意义的 wire 和连接治理，
+仍必须传递明确的 workspace、execution domain、权限和 request context，并复用同一
+Runtime owner、错误语义、事件语义和持久化规则。
 
-### 1.1 Alternatives under review
+### 1.1 Decision rationale and remaining alternatives
 
 | 候选 | 结构 | 收益 | 成本与风险 | 采用门槛 |
 | --- | --- | --- | --- | --- |
-| A. App Server-first Rich Clients（当前首选） | Desktop、Web、Embedded/Shared TUI 复用一个 wire 与 typed client | 跨 Rich Client 合同和 fixture 最集中 | Embedded 编解码与 runtime/thread 成本；Desktop/Web 迁移面大；Shared 必须重新交付连接治理 | 真实 Desktop/TUI consumer、跨 transport parity、性能和安全门槛全部通过 |
-| B. Deployment-specific product adapters | Desktop、Web、Embedded TUI、Shared TUI 各保留窄 adapter，共享 owner ports | 每个 Host 可按自身生命周期优化，迁移风险较低 | DTO、错误、恢复和行为 fixture 可能分叉；跨入口一致性需额外治理 | 证明长期重复成本低于统一 wire 成本，并建立跨 adapter 行为合同 |
-| C. Shared Runtime use cases with separate wires | 提取稳定用例/结果，Embedded 使用 Rust adapter，Shared 保留 v17 或后继 wire，Web 使用 App Server | 业务语义集中，同时允许 deployment-specific framing、安全和性能 | 需要清晰区分 use-case DTO 与 wire DTO；client 不能假装同一协议 | 证明共享 use case 不泄漏 Runtime 实现，并分别验证每条 wire 的故障语义 |
+| A. App Server-first Rich Clients | Desktop、Web、Embedded/Shared TUI 复用一个 wire 与 typed client | 跨 Rich Client 合同和 fixture 最集中 | Embedded 编解码与 runtime/thread 成本；Shared 必须重新交付连接治理 | 仅适用于确实需要进程/网络边界的 Host；不再作为 Embedded 默认方案 |
+| B. Deployment-specific product adapters（Embedded 采用） | Embedded 直接调用 Runtime API；Web/Remote/Shared 按部署选择 transport adapter，共享 owner ports | 消除同进程编解码和 server task，保持 Host 生命周期简单 | DTO、错误、恢复和行为 fixture 可能分叉；需要统一行为合同 | Direct adapter 无 owner 复制，且通过跨入口行为等价测试 |
+| C. Shared Runtime use cases with separate wires（保留） | 提取稳定用例/结果，Embedded 使用 Rust adapter，Shared 保留 v17 或后继 wire，Web 使用 App Server | 业务语义集中，同时允许 deployment-specific framing、安全和性能 | 需要清晰区分 use-case DTO 与 wire DTO；client 不能假装同一协议 | Shared transport 只有通过独立门槛后才可替换 v17 |
 
-评审可以选择 A、B、C 或其受限组合。已有 `TuiBackend`、App Server 和 v17 是评估证据，不自动决定最终架构。
+Embedded 已选择 B/C 的受限组合，A 不再是 Embedded 默认方案。Shared 仍可选择经门槛验证的 App Server transport，或把 private v17/后继协议保留为部署专用 wire；已有 DTO 或 adapter 不能替代该评审。
 
 ### 1.2 Costs of the preferred candidate
 
-- Embedded Rich Client 需要承担 App Server client/server、JSON-RPC 编解码、事件队列和专用 runtime/thread 的启动、内存与延迟成本；必须以基准证明该成本可接受。
-- 迁移期会同时维护 App Server 与 Runtime IPC v17 两条 wire；新增核心用例需保持 `TuiBackend` 行为等价，不能让双写期形成两个业务 owner。
+- Embedded direct adapter 需要维护 Runtime typed API 与 TUI-facing contract 的映射；必须以行为 fixture 证明它没有复制 Session、Permission、Config 或 capability 状态。
+- 迁移前继续使用现有 Embedded App Server 作为行为基线；Phase 5 切换到 direct-runtime 后删除旧路径，不保留回滚 adapter，也不能在 direct adapter 返回 unsupported 后静默回退。
 - Shared App Server 需要重新交付 v17 已有的 framing、方向性 limits、鉴权、实例身份、controller/lease、断连取消、未知结果和空闲退出，不能只复用 method/DTO。
 - Desktop 迁移必须划清 controller-local capability、Tauri 生命周期和工作区 Host capability；Web/Remote 扩展还需要独立的认证、授权和多租户资源治理。
 
@@ -46,18 +65,30 @@
 
 | 范围 | 当前状态 | 目标 |
 | --- | --- | --- |
-| Embedded TUI | 已创建私有 `BitfunAppServer`，通过 in-memory transport 连接 `AppServerClient` | 完成剩余管理面迁移和行为等价验证 |
-| Shared TUI | 仍通过私有 Runtime IPC v17 连接独立 Runtime Host | App Server Shared transport 达到可靠性等价后迁移 |
-| Desktop GUI | 主要仍使用 Tauri command 和桌面事件投影 | Tauri 收窄为 Host adapter，产品请求统一进入 App Server |
+| Embedded TUI | 当前仍通过私有 `BitfunAppServer`、in-memory transport 和 `AppServerClient` 运行 | 切换为 backend composition，由 `TuiRuntimePort`、同进程 `AgentRuntime` 和 owner service/provider 直接提供用例 |
+| Shared TUI | 仍通过私有 Runtime IPC v17 连接独立 Runtime Host | 保留 v17；是否迁入 Shared App Server 由可靠性、安全、性能和回滚证据决定 |
+| Desktop GUI | 主要仍使用 Tauri command 和桌面事件投影 | Embedded 时使用 direct Runtime adapter；需要连接边界时使用 App Server，Tauri 保留平台能力 |
 | Web Host | 当前 Server 已组装 Embedded Runtime，WebSocket 直接承载 `BitfunAppServer`；仅适用于 loopback 单用户模式 | 补齐连接身份、作用域绑定和 Host allowlist 后才能扩展部署范围 |
 | App Server protocol/client | 已拆为 behavior-light crate，已有版本、能力、限制、错误和部分事件恢复类型 | 补齐 Host 注入能力、可靠性语义及跨 transport 合同测试 |
 | App Server server | 已注册 app、agent、session、permission、TUI/workspace、git、config 和 i18n handler | 按真实 owner 和 Host 装配收窄能力，不以已存在 DTO 代替可用性证据 |
 
-Shared TUI 继续使用 Runtime IPC 是当前 compatibility boundary。只有候选 A 获批且替换门槛通过后，才迁移或删除该 IPC；候选 B/C 可能将 private v17 或后继协议保留为受控的长期物理 wire。
+Shared TUI 继续使用 Runtime IPC 是当前 compatibility boundary。Embedded direct-runtime
+迁移不改变该边界。只有 Shared App Server 通过替换门槛后，才评审迁移或删除 v17；候选
+B/C 允许将 private v17 或后继协议保留为受控的长期物理 wire。
 
-### 1.4 Decision and replacement gates
+### 1.4 Migration and replacement gates
 
-在满足下列门槛前，不得把候选 A 标记为 approved，也不得用 Shared App Server 替换 v17：
+Embedded direct-runtime 完成迁移前必须满足：
+
+| 门槛 | 必需证据 |
+| --- | --- |
+| Typed facade 与 owner | direct adapter 只调用稳定 Runtime/owner-provider facade；不暴露内部类型，不复制 Session、Permission、Config、capability 或事件状态 |
+| 上下文与能力 | workspace、execution domain、permission、remote facts 和 capability 来自真实 Host/Runtime 组装；不从 UI 猜测，不静默本机回退 |
+| 行为与事件 | 请求结果、事件顺序、pending Permission、取消、`unsupported`、lag/closed 和 `outcome_unknown` 与既有行为合同等价 |
+| 生命周期与性能 | 不创建 App Server client/server、in-memory transport 或额外 Runtime；订阅和任务可回收，并记录启动、延迟和内存对比 |
+| 迁移与删除 | 同一 TUI fixture 覆盖 direct 与旧 App Server；升级/降级读取兼容，旧路径仅作为迁移基线并在切换后删除 |
+
+Shared App Server 只有满足以下连接治理门槛后才可替换 v17：
 
 | 门槛 | 必需证据 |
 | --- | --- |
@@ -67,7 +98,7 @@ Shared TUI 继续使用 Runtime IPC 是当前 compatibility boundary。只有候
 | 事件恢复 | 明确 snapshot/replay owner、连接内 cursor、跨连接是否持久化、lag/closed/invalidation 和 resync 行为 |
 | 取消与未知结果 | disconnect/shutdown 取消、迟到响应、operation identity、`outcome_unknown` 查询/恢复和禁止盲重试 |
 | Host capability | Desktop local effect 与工作区 capability 边界、provider 注入、Remote unsupported 和 Web/Remote auth 已定稿 |
-| 生命周期与性能 | discovery、startup、idle exit、crash cleanup、延迟、吞吐、内存和 Embedded thread/runtime 成本有预算与测量 |
+| 生命周期与性能 | discovery、startup、idle exit、crash cleanup、延迟、吞吐和内存有预算与测量 |
 | 迁移与回滚 | 同一第一方 consumer 完成 opt-in 双栈 parity；升级/降级和 v17 rollback 可重复验证；删除条件有明确 owner 批准 |
 
 ## 2. 问题与目标
@@ -80,14 +111,14 @@ GUI、Web 和 TUI 若分别围绕 Tauri command、WebSocket route、CLI/Core 直
 - UI 组件与 Tauri、Core singleton 或私有 Runtime IPC 绑定，无法验证跨入口行为等价。
 - “handler 已存在”“DTO 已生成”或“能力被硬编码为 available”被误当成端到端能力已交付。
 
-App Server 的目标是提供一个可版本化、可生成 client、可跨 Embedded/Shared transport 验证的 Rich Client 合同，同时保持业务 owner 平台无关。它统一的是产品后端行为，不统一 GUI/TUI renderer、布局、键位、窗口、终端或 controller-local effect。
+BitFun 的目标是让 direct adapter 与连接型 App Server adapter 共享可验证的产品后端行为合同，同时保持业务 owner 平台无关。App Server 为需要连接边界的 Host 提供可版本化、可生成 client 的 wire；它不再是 Embedded 的统一 transport，也不统一 GUI/TUI renderer、布局、键位、窗口、终端或 controller-local effect。
 
 ## 3. 范围与非目标
 
 本文范围包括：
 
 - Rich Client 的请求、响应、notification、错误、取消和恢复合同。
-- Embedded、Shared 和 WebSocket Host 的 transport 与生命周期边界。
+- Embedded direct adapter、Shared/WebSocket transport 与 Host 生命周期边界。
 - Host 能力、transport limit、身份和执行域的协商。
 - Desktop/Tauri、Web 和 TUI 的接入规则。
 - App Server crate、Runtime owner 和产品装配之间的依赖方向。
@@ -99,17 +130,18 @@ App Server 的目标是提供一个可版本化、可生成 client、可跨 Embe
 - 强制 Headless CLI/CI、ACP、Peer Host 或公开 Agent SDK 使用 App Server。
 - 统一 GUI 与 TUI 的状态机、renderer、布局、主题键或键位模型。
 - 把 WebSocket transport 宣称为已具备多用户或公网安全性的公开 API。
-- 不允许临时兼容路径在没有明确决策、维护责任、版本规则和退出条件的情况下意外变成永久协议。若最终选择候选 B/C，应把保留的 Shared wire 明确定义为正式的部署专用协议，而不是继续称为临时兼容路径。
+- 不把缺少维护责任、版本规则和退出条件的临时兼容路径默认为永久协议；若保留 Shared wire，应将其明确定义为正式的部署专用协议。
 
 ## 4. 术语
 
 | 名词 | 含义 | 不等于 |
 | --- | --- | --- |
-| App Server | 将版本化 Rich Client wire 映射到 Runtime API、Service 和 Product Domain owner 的协议适配层 | 业务 owner、通用 RPC 总线、必然独立的进程 |
+| App Server | 将版本化 Rich Client wire 映射到 Runtime API、Service 和 Product Domain owner 的协议适配层；只用于需要该边界的 Host | 业务 owner、通用 RPC 总线、Embedded 的必经路径 |
 | App Server Client | 只依赖 wire contract、由 Host 提供 transport 的类型化客户端 | Runtime SDK、Server 构造器、UI 状态 owner |
 | Rich Client | 需要持续会话、交互事件和产品管理面的第一方 GUI/Web/TUI | Headless automation、ACP、公开 SDK |
-| Host | 组装 App Server、选择 transport、注入能力并管理生命周期的产品入口 | 新业务层、普通用户必须管理的 Server 产品 |
-| Embedded App Server | 与 Rich Client Host 位于同一 OS 进程的私有 App Server 实例 | Runtime 直连、网络 Server、共享后台进程 |
+| Host | 组装 direct Runtime adapter 或 App Server、选择 transport、注入能力并管理生命周期的产品入口 | 新业务层、普通用户必须管理的 Server 产品 |
+| Embedded direct Runtime | 与 Rich Client Host 同进程、由 `AgentRuntime` typed API 和 owner/provider facade 提供用例的部署方式 | 第二套 Runtime、App Server wire、跨进程后台服务 |
+| Embedded App Server | 迁移前 TUI 使用的同进程私有 App Server 实例和 in-memory transport | Embedded 的目标默认路径、网络 Server、共享后台进程；Phase 5 完成后删除 |
 | Shared App Server | 由独立本机 Host 承载、允许多个已认证第一方 client 使用的 App Server 实例 | 公网 API、Agent SDK Host、每个 client 一个 Runtime |
 | Runtime owner | 持有 Session、Turn、Permission、Tool/MCP、Hook、事件和持久化事实的既有模块 | App Server handler 或 UI read model |
 | Host capability | 当前 Host 确实组装并允许调用的产品能力 | schema 中存在的方法全集 |
@@ -128,16 +160,25 @@ flowchart LR
   GUI --> Host["Host adapter"]
   Web --> Host
   TUI --> Host
-  Host --> Client["App Server Client"]
+  Host --> Route{"Deployment route"}
+  Route -->|"Embedded direct · approved target"| Direct["Direct Runtime adapter"]
+  Route -->|"Web / candidate Shared · Phase 6"| Client["App Server Client"]
   Client --> Transport["Host-selected transport"]
   Transport --> Server["App Server"]
-  Server --> API["Runtime API / owner ports"]
+  Direct --> API["Runtime API / owner ports"]
+  Server --> API
   API --> Owners["Runtime · Services · Product Domains"]
 ```
 
-依赖和调用方向始终从入口流向 owner。Host 负责 transport 认证、连接作用域、capability/allowlist 和平台能力；App Server handler
-负责 method 合同校验、handler 注册、DTO 转换和 Runtime/domain error 到 wire error 的映射。业务一致性、权限上限、持久化和权威状态
-仍由对应 owner 提交。
+依赖和调用方向始终从入口流向 owner。Embedded Host 负责 direct adapter 的 context
+构造、能力选择和生命周期；需要连接边界的 Host 负责 transport 认证、连接作用域、
+capability/allowlist 和平台能力。App Server handler 负责 method 合同校验、handler
+注册、DTO 转换和 Runtime/domain error 到 wire error 的映射。业务一致性、权限上限、
+持久化和权威状态仍由对应 owner 提交。
+
+图中的 Web 分支是当前 loopback WebSocket App Server 路径；Shared 分支仅表示 Phase 6
+candidate，不是当前或已批准的必经链路。当前 Shared TUI 仍只使用 private Runtime IPC v17，
+Web 也不经过 TUI backend composition。
 
 ### 5.1 四层合同
 
@@ -148,37 +189,51 @@ flowchart LR
 | Host 合同 | transport、可用能力、限制、身份、作用域、生命周期和 controller-local provider | 复制业务规则或权威状态 |
 | Owner 合同 | Runtime/Service/Product Domain 的业务事实、校验和提交 | JSON-RPC、Tauri、WebSocket、Ratatui |
 
-行为合同是 Embedded 与 Shared 等价的核心。仅复用 JSON 字段但在断连、超时、事件落后或权限上表现不同，不算统一 App Server 接口。
+行为合同是 Embedded direct-runtime 与 Shared wire 等价的核心；迁移前的 Embedded App Server
+仅作为 direct-runtime 切换前的行为基线，不构成迁移后的第三条运行路径。其中，Phase 5 将引入的
+`TuiRuntimePort` 是 Shared IPC operation 集合在 TUI 侧的窄语义边界；管理 service/provider
+不是 Shared Runtime wire 的组成部分。行为合同不要求三者共享 JSON；只要 Runtime port
+在断连、超时、事件落后、权限、取消和 unknown outcome 上保持明确且可验证的语义，
+即可共享同一 Runtime 用例合同。管理面按各自 service/provider 的可用性单独验证。
 
-## 6. Embedded deployment
+## 6. Phase 5 Embedded interactive TUI target
 
-Embedded Rich Client 的标准路径是：
+本节只定义交互式 TUI 的 Phase 5 目标路径。它不描述 Desktop 或 Web 的迁移完成状态；
+Desktop direct Runtime 是独立的已批准迁移步骤，尚未实施。
 
 ```text
-Rich Client
+Embedded interactive TUI
   -> Host adapter
-  -> AppServerClient
-  -> private in-memory transport
-  -> private App Server instance
+  -> TuiBackend composition
+  -> TuiRuntimePort -> DirectRuntimeTuiRuntime -> AgentRuntime typed API
+  -> owner-owned service/provider interfaces (management only)
   -> Runtime API / owners
 ```
 
 Embedded Host 必须：
 
-1. 组装 Runtime 和 App Server，并将同一 owner 的端口注入 server。
-2. 创建方向固定的私有 in-memory transport pair。
-3. 通过正式 App Server Client 完成 initialize、请求、事件和 shutdown。
-4. 保证 server task/thread 在 Host 退出时被取消并回收。
-5. 使用与 Shared 相同的 schema、错误和行为测试。
+1. 从产品组装结果取得唯一的 `AgentRuntime` 和必要的 owner/provider facade。
+2. 通过稳定 Rust Runtime API 构造 typed request，补齐 workspace、execution domain、
+   permission 和 remote facts；不得从 UI 或全局环境猜测这些事实。
+3. 将 `AgentRuntime` 的事件/Permission receiver 映射为 `TuiRuntimePort` 可消费的
+    semantic event，
+    不创建第二个 Core `EventQueue` 订阅或第二份 read model 权威状态。
+4. 将 Runtime/domain error 映射为 Runtime port 或对应 owner service 的 TUI error，保留 `unsupported`、取消、
+   `outcome_unknown` 等可观察语义。
+5. 在 Host 退出时取消并回收由 direct adapter 创建的订阅和任务，并使用与 Shared
+   和 Web 路径相同的行为 fixture。
 
-Embedded 可以省略只对跨进程多客户端有意义的机制：endpoint discovery、进程 token、外部实例锁、多客户端 controller lease 和空闲后台退出。省略这些机制不能改变请求结果、事件顺序、取消结果或 capability 语义。
+Embedded 可以省略只对跨进程多客户端有意义的机制：endpoint discovery、进程 token、
+外部实例锁、多客户端 controller lease、frame 编解码和空闲后台退出。省略这些机制
+不能改变请求结果、事件顺序、取消结果、权限边界或 capability 语义。
 
-进程内 transport 仍可能执行 JSON-RPC 编解码。该成本是候选 A 必须测量的工程取舍；只有基准、资源预算和真实 consumer 证明可接受后，
-才能把强制经过 App Server 作为批准约束。允许评估 transport buffer、生成代码和批量事件优化，但不能用未经验证的性能假设提前排除候选 B/C。
+迁移窗口内可以用现有 Embedded App Server 与 direct adapter 做行为对照，但不保留可选的
+rollback adapter，也不得在 direct adapter 返回 unsupported 后静默回退。完成 direct-runtime
+行为、性能和升级兼容验证后，Phase 5 必须删除旧路径。
 
 ## 7. Shared deployment
 
-Shared deployment 由一个本机 App Server Host 承载一个 Runtime owner，多个第一方 Rich Client 通过受控 Pipe、UDS 或等价私有 transport 连接：
+当前 Shared deployment 由独立 Runtime Host 通过 private Runtime IPC v17 服务交互式 TUI，不运行 App Server。若后续采用 Shared App Server，则目标拓扑为一个本机 App Server Host 承载一个 Runtime owner，多个第一方 Rich Client 通过受控 Pipe、UDS 或等价私有 transport 连接：
 
 ```mermaid
 flowchart LR
@@ -190,7 +245,7 @@ flowchart LR
   R --> D["Workspace and Session storage"]
 ```
 
-Shared Host 在基础 App Server 合同之外必须提供：
+采用 App Server 的 Shared Host 在基础 App Server 合同之外必须提供：
 
 - 安全 endpoint discovery、实例身份和同用户认证材料。
 - initialize-first 握手、协议版本和 client identity 校验。
@@ -206,24 +261,32 @@ Shared Host 在基础 App Server 合同之外必须提供：
 
 ## 8. Desktop GUI 与 Tauri
 
-Desktop 的目标调用路径是：
+Desktop 的调用路径按部署选择：
 
 ```text
 React UI
   -> frontend infrastructure / generated App Server client
   -> Desktop Host transport adapter
-  -> Embedded or Shared App Server
+  -> App Server（Web/Shared 或明确需要连接边界时）
+
+Embedded Desktop 的同进程产品请求可以走：
+
+React UI
+  -> frontend infrastructure
+  -> Desktop direct Runtime adapter
+  -> Runtime API / owner ports
 ```
 
-Tauri 继续拥有窗口、菜单、系统托盘、文件选择器、剪贴板、通知和进程级生命周期。Session、Turn、Workspace、Permission、Config、MCP、Skill、Hook 等产品后端能力必须迁入 App Server。
+Tauri 继续拥有窗口、菜单、系统托盘、文件选择器、剪贴板、通知和进程级生命周期。Session、Turn、Workspace、Permission、Config、MCP、Skill、Hook 等产品后端能力必须迁入既有 Runtime/owner；Embedded 时由 direct adapter 调用，需要连接边界时再由 App Server 做协议适配。
 
 迁移规则：
 
 - UI 组件不得直接调用 Tauri API；调用进入前端 infrastructure/adapter。
-- Tauri command 若只承载产品后端用例，应由 App Server method 替代并逐步删除。
-- 必须由桌面原生 API 完成的 client-local capability 保留 Host-native 实现；需要与工作区或 Runtime 交互时拆成 App Server 数据流和本地 effect 两段。
-- Tauri event bridge 只能投递 App Server typed notification 或桌面专属事件，不能形成第二套 Runtime 事件语义。
-- Desktop Host 可在 Embedded 与 Shared 之间切换，但 UI 和生成 client 不包含 Runtime 直连分支。
+- Tauri command 若只承载产品后端用例，应由稳定 Runtime typed facade 或需要连接边界时的 App Server method 替代并逐步删除。
+- 必须由桌面原生 API 完成的 client-local capability 保留 Host-native 实现；需要与工作区或 Runtime 交互时拆成 direct/App Server 数据流和本地 effect 两段。
+- Tauri event bridge 只能投递 direct Runtime/App Server typed notification 或桌面专属事件，不能形成第二套 Runtime 事件语义。
+- Desktop Host 可在 direct Embedded 与 Shared/App Server 之间切换，但 UI 不包含部署分支；
+  route 选择留在 Host/infrastructure。
 
 ## 9. Web 与远程 Host
 
@@ -263,7 +326,7 @@ WebSocket 是 App Server 的一种 transport，不是另一套业务 API。Web H
 
 ## 11. 事件、恢复与取消
 
-权威 Runtime 事件通过同一 App Server connection 以 typed notification 发送。Host 不得让 client 绕过 App Server 直接订阅 Core `EventQueue`，也不得用有损 frontend projection 替代权威事件流。
+需要连接边界的 client 通过其 App Server connection 接收 typed Runtime notification；Embedded direct adapter 则通过 Runtime typed subscription 订阅同一权威 owner。App Server client 不得绕过连接直接订阅 Core `EventQueue`，direct adapter 也不得持有 Core queue receiver 或创建第二个事件 owner；两条路径都不得用有损 frontend projection 替代权威事件流。
 
 每个事件流至少需要：
 
@@ -307,7 +370,7 @@ App Server 是完整产品控制面，安全决策必须绑定到连接和业务
 | 资源治理 | 连接、请求、frame、队列、并发、速率和任务生命周期有界 |
 | 远程边界 | 凭据、文件、进程和 Runtime 留在目标执行域；禁止本地 fallback |
 
-Embedded 的私有 transport 可以依赖同进程构造身份，但仍必须传递明确的 Host/connection context，不能让 handler 从全局环境猜测调用主体。
+Embedded direct invocation 可以依赖同进程构造身份，但仍必须传递明确的 Host/request context，不能让 adapter 或 owner 从全局环境猜测调用主体。App Server connection 继续使用显式 connection context。
 
 ## 14. Crate 与所有权边界
 
@@ -332,13 +395,28 @@ Embedded 的私有 transport 可以依赖同进程构造身份，但仍必须传
 
 迁移按行为闭环推进，不按 method 数量推进：
 
-1. **锁定合同基础**：稳定 protocol/client crate、版本、错误、能力、限制和事件 envelope；增加 Embedded contract test。
-2. **完成 Embedded TUI**：所有交互式 TUI 产品请求经 `TuiBackend -> AppServerClient`；移除 Core、Runtime SDK、Service singleton 和 Runtime IPC 的 TUI-facing 依赖。
-3. **迁移 Desktop GUI**：按 Session/Turn/Permission、Workspace、Config/MCP/Extension 等垂直切片迁移；每片完成后删除重复 Tauri DTO/handler。
-4. **补齐 Shared 语义**：把 authentication、instance identity、controller/lease、framing、背压、断连取消、idle exit、event recovery 和 `outcome_unknown` 纳入 App Server Host/transport。
-5. **评审 Shared TUI 迁移**：候选 A 获批且 1.4 节门槛通过后，才用同一 client/schema 替换 Runtime IPC compatibility adapter；旧 wire 仅在 rollback 窗口结束并获得 owner 批准后删除。若选择 B/C，则记录 v17 的长期 owner、版本和删除条件。
-6. **收紧 Web Host**：由 Host 注入 allowlist、作用域和真实 limits；完成安全绑定前保持 loopback 单用户限制。
-7. **删除旁路**：移除 Rich Client 的 Core/Runtime 直连、重复事件投影和无生产消费方的旧 route。
+ 1. **锁定 Runtime 行为合同**：按当前 Shared IPC v17 operation 集合冻结窄
+   `TuiRuntimePort`，稳定 Runtime request/response/event 类型、错误、能力、取消和事件语义；
+   为 direct Embedded 和 Shared 增加同一 Runtime 行为 fixture，迁移前可用旧 App Server 建立行为基线。
+ 2. **拆分 TUI backend composition**：将当前单体 `TuiBackend` 拆为 `TuiRuntimePort` 与按
+   domain 注入的 owner service/provider 接口；不定义总括性的 `TuiManagementPort`。管理 service
+   能直接复用稳定 owner trait 的直接注入；只有需要 TUI DTO、权限/上下文或 capability 裁剪时
+   才增加薄 facade。
+ 3. **迁移 Embedded TUI**：实现 `DirectRuntimeTuiRuntime`，将 Runtime 调用从
+   `AppServerTuiBackend` 移出；再移除 in-memory transport、Embedded `BitfunAppServer`、
+   server thread 和 TUI-facing App Server client 依赖。管理面使用 owner-owned service/provider，
+   不把具体 `AppManagementService` 原样搬入 CLI/TUI。
+4. **迁移 Desktop GUI**：Embedded 时使用 direct Runtime adapter；Web/Shared 或需要连接治理
+   的场景保留 App Server。Tauri 继续承载平台能力与生命周期。
+5. **补齐 Shared 语义**：把 authentication、instance identity、controller/lease、framing、
+   背压、断连取消、idle exit、event recovery 和 `outcome_unknown` 纳入 App Server Host/transport。
+6. **评审 Shared TUI 迁移**：Shared App Server 只有通过 1.4 节门槛后才可替换 Runtime IPC
+   compatibility adapter；v17 是否删除由独立评审和验证证据决定。若选择 B/C，
+   记录 v17 的长期 owner、版本和删除条件。
+7. **收紧 Web Host**：由 Host 注入 allowlist、作用域和真实 limits；完成安全绑定前保持 loopback
+   单用户限制。
+8. **删除旁路**：移除 Rich Client 的重复 Runtime 事件投影、旧 Embedded App Server route 和
+   无生产消费方的兼容代码。
 
 迁移期间不得在 App Server 返回 unsupported 后静默调用旧 Tauri/Core/IPC 路径。需要暂存旧路径时，必须由 Host 在启动时明确选择完整 adapter，且 UI 只看到一个 `TuiBackend` 或 frontend infrastructure 接口。
 
@@ -347,7 +425,11 @@ Embedded 的私有 transport 可以依赖同进程构造身份，但仍必须传
 ### 16.1 必需验证
 
 - protocol serialization、版本上下界、未知字段和类型化错误合同测试。
-- 同一用例在 Embedded in-memory 与 Shared process transport 上的行为等价测试。
+- 同一用例在 Embedded direct-runtime、Shared process transport 和 WebSocket App Server（适用时）
+  的行为等价测试；迁移前旧 Embedded App Server 仅用于建立基线，不作为持续测试路径。
+- `TuiRuntimePort` coverage：当前 Shared IPC v17 的每个 Runtime operation 都有对应的
+  port 行为测试；管理 service/provider 则单独验证 capability、权限、unsupported 和 Remote
+  fail-closed，不以 Runtime port parity 代替管理面验证。
 - Host capability/provider/allowlist 组合测试，以及真实 transport limit 测试。
 - request identity、取消、断连、超时和 `outcome_unknown` 测试。
 - 事件顺序、lag、invalidated、cursor/snapshot resync 和慢 client 测试。
@@ -356,26 +438,36 @@ Embedded 的私有 transport 可以依赖同进程构造身份，但仍必须传
 - Cargo 依赖闭包和 `product-full` 禁止规则。
 - TypeScript/Rust client 生成结果与 schema 一致性检查。
 
-### 16.2 完成定义
+### 16.2 TUI/App Server 解耦完成定义
 
-若选择候选 A，只有同时满足以下条件，App Server Rich Client 架构才算完成：
+只有交互式 TUI 同时满足以下条件，TUI/App Server 解耦才算完成；这一定义不涵盖
+Desktop 的独立 direct Runtime 迁移：
 
-1. Desktop GUI、Web UI 和交互式 TUI 的产品后端请求与订阅均经过 App Server。
-2. Embedded 与 Shared 使用同一 client、method、DTO、错误和事件恢复合同，UI 不包含部署分支。
-3. Shared transport 达到现有 Runtime IPC 的鉴权、lease、取消、背压、限制、失效和生命周期等价。
-4. capability 和 limits 来自 Host 的真实装配与 transport，不再由通用 handler 无条件硬编码。
-5. Rich Client 不直接依赖 Core singleton、Runtime SDK、Tauri 业务 command 或私有 Runtime IPC。
-6. App Server handler 不持有业务权威状态，不复制 owner 校验和策略。
-7. Remote workspace 和多用户连接具有明确身份、作用域、授权和 fail-closed 行为。
-8. 重复 Tauri/Web/IPC DTO、旧 handler 和事件旁路已删除，或有明确的兼容期限与删除证据。
-9. 上述合同、行为、安全、依赖和跨入口测试全部通过。
+1. Embedded TUI 的产品请求和订阅经过 `TuiAgentClient` 的 backend composition；Runtime
+   行为经过 `TuiRuntimePort -> DirectRuntimeTuiRuntime`，管理能力经过对应 owner service/provider，
+   TUI view/reducer 不执行 backend I/O。
+2. direct adapter 只调用既有 Runtime API、owner-owned service/provider 和必要的薄 facade，
+   不复制 Session、Permission、Config、capability 或事件权威状态，也不定义 `TuiManagementPort`。
+3. Embedded direct-runtime 与 Shared v17 的行为合同覆盖请求结果、事件顺序、
+   取消、权限、unsupported、断连和 unknown outcome。
+4. capability、作用域和 remote facts 来自真实 Host/Runtime 组装；Remote workspace 不存在
+   controller-local fallback。
+5. Embedded 不创建 App Server client/server、in-memory transport 或额外 Runtime 进程；
+   direct adapter 的任务和订阅在 Host 退出时可回收。
+6. App Server 仍可被 Web/Shared Host 使用，且 handler 不持有业务权威状态或复制 owner 策略。
+7. 旧 Embedded App Server 路径已删除且不再作为 rollback adapter；70 方法单体 `TuiBackend`
+   不再作为稳定接口边界。
+8. Shared transport 若要替换 v17，仍需单独满足鉴权、lease、取消、背压、限制、失效和生命周期
+   等价门槛。
+9. 上述合同、行为、安全、依赖、升级兼容和跨入口测试全部通过。
 
-## 17. Proposed constraints and open decisions
+## 17. Constraints and open decisions
 
-### 17.1 Proposed target constraints
+### 17.1 Accepted target constraints
 
-- 若候选 A 获批，Rich Client Embedded 必须经过私有 in-process App Server。
-- Embedded 和 Shared 只有部署与连接治理差异，不产生第二套产品行为。
+- Embedded 默认直接调用同进程 Runtime typed API；只有需要连接/进程边界的 Rich Client 才经过 App Server。
+- Embedded direct-runtime 和 Shared 只有适配与连接治理差异，不产生第二套产品行为；旧
+  Embedded App Server 仅是迁移前基线。
 - App Server 只映射 owner，不成为 Session、Turn、Permission、Tool/MCP、Config 或事件 owner。
 - Host capability 必须由真实装配、授权和 transport 共同决定。
 - 事件丢失、断连和未知副作用结果必须显式可见，不能用轮询或盲重试掩盖。
@@ -391,4 +483,7 @@ Embedded 的私有 transport 可以依赖同进程构造身份，但仍必须传
 - Desktop client-local capability 的请求方向：App Server 反向 request、Host provider port，或显式两段式工作流。
 - Web/Remote 的认证凭据来源、刷新、撤销和多租户资源配额。
 
-这些待决项会影响候选选择，不能被实现默认值或迁移进度替代。评审结论必须记录所选候选、拒绝其他候选的理由、门槛 owner、验证证据和回滚/删除条件；在此之前，当前 Embedded App Server 与 Shared v17 路径都保持有效。
+这些待决项会影响 Shared transport 的选择，不能被实现默认值或迁移进度替代。Shared 评审结论必须记录
+所选 transport、拒绝其他方案的理由、门槛 owner、验证证据和回滚/删除条件。Embedded direct-runtime
+迁移完成后，旧 Embedded App Server 必须删除且不保留回滚路径；WebSocket App Server 与 Shared v17
+按各自部署合同继续有效。

--- a/docs/architecture/product-architecture.md
+++ b/docs/architecture/product-architecture.md
@@ -20,10 +20,10 @@
 Headless CLI 与各产品入口的统一心智见
 [`agent-sdk-product-architecture.md`](agent-sdk-product-architecture.md)；多个 GUI/TUI/Remote/CLI/SDK 实例共存时的 Agent Runtime 部署、
 状态共享、隔离、容量与 Plugin Host 关系见
-[`agent-runtime-deployment-design.md`](agent-runtime-deployment-design.md)；Desktop GUI、Web UI 和交互式 TUI 的统一产品后端协议、
-Embedded/Shared App Server 边界及迁移约束见
-[`app-server-architecture.md`](app-server-architecture.md)。该专题当前是待评审的目标提案；在决策门槛通过前，当前调用路径和稳定
-owner 边界仍以本文及已接线代码为准。其他已批准的详细设计与本文件冲突时，以本文件为准。
+[`agent-runtime-deployment-design.md`](agent-runtime-deployment-design.md)；Desktop GUI、Web UI 和交互式 TUI 的产品后端边界、
+Embedded direct-runtime、Shared App Server 及迁移约束见
+[`app-server-architecture.md`](app-server-architecture.md)。Embedded direct-runtime 已确定为下一步实现方向；Shared App Server
+仍是待评审提案。在迁移或决策门槛通过前，当前调用路径和稳定 owner 边界仍以本文及已接线代码为准。其他已批准的详细设计与本文件冲突时，以本文件为准。
 
 Cargo feature、第三方依赖 owner、测试目标和本地/CI 验证分工见
 [`rust-build-dependency-boundaries.md`](rust-build-dependency-boundaries.md)。该文档补充本架构的构建视图，不改变本文定义的运行时 owner 和分层依赖方向。
@@ -308,9 +308,9 @@ flowchart LR
 
 ### 2.4 Physical View · Level 0
 
-Physical View 展示当前可执行单元到设备、主机和存储的映射。Desktop、CLI、ACP 和 SDK Host 使用 Embedded Runtime；
-Embedded 交互式 TUI 已在同一 CLI 进程内通过私有 App Server 使用 Runtime，交互式 TUI 也可以显式连接当前 Shared Runtime IPC。
-Desktop GUI 的 App Server 迁移尚未完成。当前 loopback Web Server 已承载 Embedded Runtime 和 WebSocket App Server；Relay Server
+Physical View 展示当前生产环境中可执行单元到设备、主机和存储的映射。Desktop、CLI、ACP 和 SDK Host 使用 Embedded Runtime；
+Embedded 交互式 TUI 当前仍在同一 CLI 进程内通过私有 App Server 使用 Runtime；交互式 TUI 也可以显式连接当前 Shared Runtime IPC。
+Desktop GUI 当前仍使用 Tauri adapter；独立 direct Runtime 迁移尚未实施。当前 loopback Web Server 已承载 Embedded Runtime 和 WebSocket App Server；Relay Server
 不承载 Agent Runtime。
 
 ```mermaid
@@ -374,8 +374,8 @@ flowchart LR
 
 | Deployment unit | Main contents |
 |---|---|
-| Desktop App | Web UI、Tauri Host、embedded Agent Runtime；Rich Client App Server 迁移尚未完成 |
-| CLI App | 交互式 TUI 通过 private in-process App Server 使用 Embedded Runtime；Headless、Peer 保留独立 adapter；可显式使用 Shared TUI |
+| Desktop App | Web UI、Tauri Host、embedded Agent Runtime；当前 Desktop 产品请求使用现有 Tauri adapter |
+| CLI App | 交互式 TUI 当前通过 in-process App Server 使用 Embedded Runtime；Headless、Peer 保留独立 adapter；可显式使用 Shared TUI |
 | Shared Runtime | 私有本机 IPC；当前只有交互式 TUI consumer；是否迁入 Shared App Server transport 仍待评审与等价证据 |
 | ACP | Embedded Agent Runtime、ACP 协议生命周期 |
 | SDK Host | 私有跨进程 adapter；公开 SDK 产品尚未交付 |
@@ -423,10 +423,18 @@ flowchart TB
 ## 3. 接口边界
 
 BitFun 只保留四个稳定业务接口边界；工具、事件和权限作为归属子接口被复用，不在插件层重复定义。App Server
-是 Agent Runtime API 和其他 owner 接口面向当前 Web/Embedded TUI 以及候选 Rich Client 目标的版本化 wire adapter，不新增第五个
-业务 owner 或能力分类。是否扩大到全部 Rich Client 由 4.2 节所述评审决定。本文使用
+是 Agent Runtime API 和其他 owner 接口面向当前 Web/Embedded TUI，以及未来确实需要连接边界的 Rich Client 的版本化 wire adapter，不新增第五个
+业务 owner 或能力分类。Embedded TUI 的目标改为 direct Runtime adapter；Shared 是否使用 App Server 由 4.3 节所述评审决定。本文使用
 “接口”描述可被调用或依赖的能力面；只有描述跨进程消息封装、结构化 schema、序列化对象或强兼容约束时才使用
 “契约”；只读状态视图表示从权威状态派生出的查询结果。
+
+Phase 5 将为 Embedded/Shared TUI 冻结窄的 `TuiRuntimePort`，其范围按 Shared IPC v17
+实际承载的 Session、Turn、Permission/UserInput、Workspace、lineage、usage/settlement、
+model/mode 更新、agent mode catalog 和事件订阅确定。Model/Skill/Subagent/MCP、Account、
+Settings Sync、Worktree、External Source 和 Hook 等管理面不组成一个 `TuiManagementPort`，
+也不因为存在 TUI 用例就进入 Shared Runtime wire；它们由 TUI backend composition 按 domain
+直接依赖 owner-owned 的稳定 service/provider trait。只有需要 TUI DTO、权限/上下文适配、
+内部类型隔离或 capability 裁剪时，才增加薄 facade。
 
 | 接口边界 | 谁使用 | 提供 | 不包含 |
 |---|---|---|---|
@@ -480,17 +488,18 @@ client 或未来 CLI/HarmonyOS 计划，不能证明同名 Rust transport adapte
 
 前后端契约按能力语义归属，不按 Tauri command 名称归属。稳定的请求、响应、状态事实和类型化错误放在对应
 `contracts/*`、Agent Runtime API 或能力归属模块。当前 Desktop GUI 仍使用 Tauri adapter，Web UI 使用 loopback WebSocket
-App Server，Embedded TUI 使用 in-process App Server，Shared TUI 通过 `TuiBackend` 映射 private Runtime IPC v17。待评审目标是让
-Desktop GUI、Web UI 和交互式 TUI 复用同一 Rich Client App Server 行为与 wire contract；Tauri 和各 Rich Client Host 负责
-transport、平台能力及生命周期。ACP、Headless CLI、Peer Host 与公开 SDK 继续由各自 adapter 映射到稳定 owner 接口，不因该目标
-复用 App Server wire。该规则降低框架耦合，但不要求把 controller-local Desktop DTO 搬进共享 crate。
+App Server，Embedded TUI 当前使用 in-process App Server，Shared TUI 通过 `TuiBackend` 映射 private Runtime IPC v17。目标是让
+Embedded GUI/TUI 通过 Host-owned direct adapter 调用 Runtime typed API，需要连接边界的 Web/Shared Rich Client 使用 App Server；
+Tauri 和各 Rich Client Host 负责 adapter、transport、平台能力及生命周期。ACP、Headless CLI、Peer Host 与公开 SDK 继续由各自
+adapter 映射到稳定 owner 接口，不因该目标复用 App Server wire。该规则降低框架耦合，但不要求把 controller-local Desktop DTO
+搬进共享 crate。
 
 | 层 | 允许 | 禁止 |
 |---|---|---|
 | 能力归属模块 / Agent Runtime API | 字段明确的请求和响应、状态事实、权限/取消规则、与框架无关的用例方法 | `tauri::State`、`AppHandle`、窗口/菜单对象、command 宏、HTTP/WebSocket/ACP/SDK Host 消息结构 |
-| Desktop Tauri / proposed App Server Host adapter | 当前组装 Tauri adapter；目标组装 transport、注入真实 capability 与平台 provider、管理窗口和桌面生命周期、投递 App Server typed notification 或桌面专属事件 | 复制业务校验、持有第二份权威状态、在目标迁移完成后为同一能力保留第二条 Runtime 旁路、把 Tauri 类型传入下层 |
+| Desktop Tauri / product Host adapter | 当前组装 Tauri adapter；目标按部署组装 direct Runtime adapter 或 App Server transport、注入真实 capability 与平台 provider、管理窗口和桌面生命周期、投递 typed Runtime/App Server notification 或桌面专属事件 | 复制业务校验、持有第二份权威状态、在目标迁移完成后为同一能力保留第二条 Runtime 旁路、把 Tauri 类型传入下层 |
 | Server / Remote adapter | 路由鉴权、协议消息、连接生命周期、流量控制与取消转换 | 为同一能力另建业务含义不同的 DTO 或 handler |
-| GUI / Web / TUI frontend | 当前依赖各自 infrastructure 或 `TuiBackend`；目标依赖生成的 App Server client、稳定读模型和 Host-local capability adapter；各自保留渲染状态 | 在 UI component/view 中直接依赖 Runtime/Core/Service、公开 Python/TypeScript SDK、Tauri 业务 command 或私有 Shared IPC |
+| GUI / Web / TUI frontend | 当前依赖各自 infrastructure 或 `TuiBackend`；目标依赖 frontend/app infrastructure，由其组合 `TuiRuntimePort`、owner service/provider adapter 和需要时的 App Server client；各自保留渲染状态 | 在 UI component/view 中直接依赖 Runtime/Core/Service、公开 Python/TypeScript SDK、Tauri 业务 command 或私有 Shared IPC |
 
 本文其他章节和历史设计中出现的“Runtime SDK”，如果指 `agent-runtime::sdk`，统一称为
 **Rust Runtime SDK（当前 preview）**；它是共享 **Agent Runtime API** 的当前 Rust 入口。只有
@@ -538,8 +547,9 @@ Desktop command 使用的序列化对象继续留在 `src/apps/desktop`；即使
 
 ## 4. 运行协作细节
 
-本节在 Process View Level 0 之下展开产品入口、插件调用和平台能力。Current 图只描述当前已接线请求路径；Proposed target 图
-描述待评审方向。两者都只描述组件协作，不构成新的 4+1 视图。
+本节在 Process View Level 0 之下展开产品入口、插件调用和平台能力。Current 图只描述当前已接线请求路径；Approved Embedded target
+和 Optional Shared proposal 分别描述已批准但未交付的 Embedded direct-runtime，以及仍待评审的 Shared App Server。三者都只描述组件协作，
+不构成新的 4+1 视图。
 
 ### 4.1 Current product entry paths
 
@@ -548,7 +558,7 @@ flowchart LR
   Desktop["Desktop GUI"] --> Tauri["Desktop / Tauri adapter"]
   Web["Web UI"] --> WebHost["loopback WebSocket App Server"]
   TUI["Interactive TUI"] --> Backend["TuiBackend"]
-  Backend -->|"Embedded"| EmbeddedAS["in-process App Server"]
+  Backend -->|"Embedded current"| EmbeddedAS["in-process App Server"]
   Backend -->|"--shared"| SharedIPC["private Runtime IPC v17"]
   Other["Headless CLI · ACP · Server · Remote"] --> Adapter["独立入口适配器"]
   SDK["Rust Runtime SDK / SDK Host preview"] --> SDKAdapter["独立 SDK adapter"]
@@ -561,43 +571,52 @@ flowchart LR
   API --> Runtime["共享 Runtime"]
 ```
 
-当前 Embedded TUI 核心路径经过 App Server，Shared TUI 则由 `TuiBackend` compatibility adapter 映射到 private Runtime IPC v17。
-Desktop GUI 尚未完成 App Server 迁移；当前 loopback Web Host 已通过 WebSocket 承载 App Server。Headless CLI/CI、ACP、Peer Host
-和 SDK Host 保留独立 adapter。所有路径最终消费同一 Runtime API 或 owner port，部署选择不能进入业务 owner。
+当前 Embedded TUI 核心路径经过 in-process App Server，Shared TUI 通过 private Runtime IPC v17；Web UI 通过 loopback WebSocket App Server，
+Desktop GUI 通过 Tauri adapter。Headless CLI/CI、ACP、Peer Host 和 SDK Host 保留独立 adapter。所有路径最终消费同一 Runtime API 或 owner
+port，部署选择不能进入业务 owner。目标路径不在本图中展开。
 
 Server bootstrap 和产品组装只创建对象并注入依赖，不是客户端请求的第二条旁路：
 
 ```mermaid
 flowchart LR
-  Assembly["产品组装"] -. "constructs" .-> Host["Host-owned App Server + transport"]
+  Assembly["产品组装"] -. "constructs" .-> Host["Host-owned adapter + transport when needed"]
   Assembly -. "constructs" .-> Runtime["Runtime / owner implementations"]
   Runtime -. "injects owner ports" .-> Host
 ```
 
 图中的虚线全部表示启动期 composition；业务请求仍只沿前一张 Current 图中的实线进入 Runtime API 或 owner port。
 
-### 4.2 Proposed target product entry paths
+### 4.2 Approved Embedded target
 
 ```mermaid
 flowchart LR
-  Rich["Desktop GUI · Web UI · Interactive TUI"] --> Host["Rich Client Host"]
-  Host --> Client["App Server client"]
-  Client --> Transport["Host-selected transport"]
-  Transport --> AppServer["App Server"]
-  Other["Headless CLI · ACP · Peer Host"] --> Adapter["独立入口适配器"]
-  SDK["Public Agent SDK"] --> SDKHost["SDK Host"]
-  AppServer --> API["Runtime API / owner ports"]
-  Adapter --> API
-  SDKHost --> API
+  TUI["Embedded interactive TUI"] --> Composition["TuiBackend composition"]
+  Composition --> RuntimePort["TuiRuntimePort"]
+  RuntimePort --> DirectRuntime["Direct Runtime adapter"]
+  DirectRuntime --> API["Runtime API / owner ports"]
+  Composition --> Management["owner service/provider adapters"]
   API --> Runtime["共享 Runtime"]
 ```
 
-提案目标是让 Desktop GUI、Web UI 和交互式 TUI 复用 App Server 行为与 wire contract，并让 Embedded/Shared 只在 Host 与
-transport 层不同。是否用 Shared App Server 替换 v17，仍取决于鉴权、实例身份、controller/lease、事件恢复、取消、限制、性能和
-回滚门槛；目标图不表示这些能力已经交付。各入口仍各自拥有 renderer、平台能力和生命周期。Headless CLI/CI、ACP、Peer Host 和
-公开 SDK 不共享 App Server wire。
+这是已批准但尚未交付的 Embedded direct-runtime 目标，属于 Phase 5。迁移完成前，Embedded TUI 继续使用 Current 图中的 in-process
+App Server；管理能力按 domain 由 composition 注入 owner service/provider，不组成 `TuiManagementPort`。
 
-### 4.3 插件调用
+### 4.3 Optional Shared App Server proposal
+
+```mermaid
+flowchart LR
+  C1["Shared Rich Client 1"] --> Transport["candidate private Pipe / UDS"]
+  C2["Shared Rich Client 2"] --> Transport
+  Transport --> Host["Shared App Server Host"]
+  Host --> Runtime["one Agent Runtime owner"]
+  Runtime --> Storage["Workspace / Session storage"]
+```
+
+这是 Phase 6 的待评审提案，不是当前 Shared TUI 的必经链路，也不改变 Current 图中的 private Runtime IPC v17。只有完成鉴权、实例身份、
+controller/lease、事件恢复、取消、限制、性能和回滚门槛后，才可评审是否替换 v17；评审也可以决定长期保留 v17。Web UI 不经过 TUI
+composition，而是继续通过自己的 loopback WebSocket App Server 入口。
+
+### 4.4 插件调用
 
 ```mermaid
 flowchart LR
@@ -614,7 +633,7 @@ flowchart LR
   Adapter["生态 adapter"] --> Provider["能力 Provider"] --> Owner["能力归属模块"]
 ```
 
-### 4.4 平台能力
+### 4.5 平台能力
 
 ```mermaid
 flowchart LR
@@ -625,7 +644,7 @@ flowchart LR
 
 关键规则：
 
-- Current 产品请求遵循 4.1 节；4.2 节的 Rich Client App Server 统一路径只有在相应 Host 完成迁移和验证后才成为当前路径。
+- Current 产品请求遵循 4.1 节；4.2 节的 Embedded direct 路径只有在相应 Host 完成迁移和验证后才成为当前路径，Shared App Server 分支还需独立评审。
   其他产品入口先经过自己的 adapter，再消费 Agent Runtime API、owner port 和只读视图；公开 SDK 只多一层 SDK Host 跨进程适配。
   Agent Runtime API 是一组小而明确的用例接口，不是必须实例化的总入口；adapter 可以调用对应归属模块的少量接口，
   但不能访问内部状态、绕过既有编排或复制业务规则。任何入口都不直接调用 Plugin Host。
@@ -649,7 +668,7 @@ flowchart LR
   可以选择下层提供方，但不能依赖 app crate；需要同时被独立应用和嵌入式模式复用的实现必须下沉到可复用 owner，
   再由各 app 和 assembly 组合。
 
-### 4.5 名词与定义归属
+### 4.6 名词与定义归属
 
 全仓人工维护文档、AGENTS、README 和代码注释遵守以下规则：
 

--- a/docs/plans/tui-app-server-decoupling-refactor-plan.md
+++ b/docs/plans/tui-app-server-decoupling-refactor-plan.md
@@ -1,8 +1,8 @@
 # TUI 与 App Server 解耦重构计划
 
-> 状态：Phase 0-4 已完成当前定义的边界、协议基础、核心聊天、配置管理和外部集成接口迁移；Phase 5 Shared App Server 目标待评审。
+> 状态：Phase 0-4 已完成当前定义的边界、协议基础、核心聊天、配置管理和外部集成接口迁移；Phase 5 Embedded direct-runtime 迁移待实现，Shared App Server 目标待评审。
 >
-> 当前状态基线：2026-08-09。一次性的运行证据保留在对应 PR/Actions 记录中；本文不绑定会因 rebase 失效的提交 SHA。
+> 当前状态基线：2026-08-13。一次性的运行证据保留在对应 PR/Actions 记录中；本文不绑定会因 rebase 失效的提交 SHA。
 >
 > 本文只记录当前差距、阶段和完成证据。稳定架构约束见相邻架构文档；Phase 0 的历史盘点已失效，不再作为当前能力清单。
 
@@ -18,8 +18,8 @@
 本计划只迁移交互式 TUI 的产品后端调用：
 
 1. TUI 保留终端输入、状态、渲染和 controller-local effect。
-2. TUI 通过 app-local `TuiBackend` 使用产品后端，不直接依赖 Core、Runtime 实现、Service、全局 singleton 或私有 IPC operation。
-3. Embedded TUI 使用 `AppServerTuiBackend`；Shared TUI 在 Shared App Server 交付前使用 `SharedTuiBackend` compatibility adapter。
+2. TUI 当前通过 app-local `TuiBackend` 使用产品后端；Phase 5 再把它拆成 Runtime port 与按 domain 注入的管理接口。`TuiAgentClient` 不直接依赖 Core、Runtime 实现、具体 Service、全局 singleton 或私有 IPC operation；view/reducer 也不执行 backend I/O。
+3. Embedded TUI 当前使用 `AppServerTuiBackend`；Shared TUI 当前使用 `SharedTuiBackend` 映射 private Runtime IPC v17。Phase 5 才引入 `TuiRuntimePort`、`DirectRuntimeTuiRuntime` 和 Shared IPC Runtime adapter，并把管理用例移到 backend composition 的 owner service/provider 接口。
 4. App Server 只适配稳定合同，不接管 Runtime、Service 或 Product Domain 的业务所有权。
 5. Headless `exec`、ACP、Peer Host 和公开 SDK 保留各自经评审的 adapter。
 
@@ -38,7 +38,7 @@
 当前 head 有两条交互式 TUI 后端路径：
 
 ```text
-Embedded TUI
+Embedded TUI（当前）
   -> TuiAgentClient
   -> TuiBackend
   -> AppServerTuiBackend
@@ -56,50 +56,81 @@ Shared TUI (--shared)
   -> Runtime API / owners
 ```
 
-两条路径统一的是 TUI 可见的行为端口。Shared compatibility adapter 会把 Runtime IPC 的结果和事件映射为 `TuiBackend` 使用的类型，但它没有运行 `BitfunAppServer`，也不是 Shared App Server transport。
+当前两条路径共用的是包含 Runtime 与管理方法的单体 `TuiBackend`。`AppServerTuiBackend`
+把 Embedded 请求委托给 App Server client；`SharedTuiBackend` 把 Session/chat 请求映射到
+private Runtime IPC v17，并直接持有具体 `AppManagementService` 承接 Host-local 管理能力。
+Phase 3/4 已让 controller 使用 typed backend API，不代表 Phase 5 的 port 拆分或 adapter 接线已经完成。
 
-Phase 3 已将 Mode/Model、Skill、Subagent 和 MCP 管理面迁移到 `TuiBackend` 的 owner-specific typed API。Phase 4 进一步迁移了 External Source、native/external Hook、Account、Settings Sync 和 Worktree 管理面。具体 DTO/owner 适配由 App Server 的 `AppManagementService` 持有，并由 Host 显式装配；Embedded TUI 经 App Server 访问既有 owner，TUI controller 不再直接访问这些 compatibility owner。
+### 2.2 Approved Embedded target
 
-Shared 的 Session/chat/mode authority 继续映射 v17；Host 实际提供的本机管理 capability 由 `SharedTuiBackend` 委托同一个具体 management service。当前 Shared Host 提供 Phase 4 的 External Source V1 和 Hook 管理，但不注入 Account/Settings Sync 或 Worktree owner；这些能力返回 typed unsupported。Remote workspace 对所有 controller-local management capability fail closed，不回落到控制端本机。Phase 4 完成表示接口边界已迁移，不表示所有 deployment 的 capability 完全相同。Phase 4 之后新增的 External Application V2 控制面目前只在 Embedded App Server 接线，Shared Runtime 明确 unsupported，不重新打开 Phase 4 的旧 owner 直连预算。
-
-### 2.2 Proposed target
-
-若 [App Server 目标架构](../architecture/app-server-architecture.md) 通过评审，交互式 Rich Client 的目标路径为：
+Phase 5 将当前单体 backend 拆成下面的 app-local composition：
 
 ```text
-TUI renderer / input / state / local effects
-                    |
-                    v
-              TuiBackend trait
-                    |
-                    v
-          AppServerTuiBackend adapter
-                    |
-                    v
-              AppServerClient
-                    |
-         Host-selected transport
-          /                     \
- in-memory Embedded       controlled Shared local
-          \                     /
-                    v
-               App Server
-                    |
-                    v
- Runtime API / Services / Product Domain owners
+TuiAgentClient
+  -> TuiBackend composition
+     -> TuiRuntimePort
+        -> DirectRuntimeTuiRuntime
+        -> SharedIpcTuiRuntime
+     -> owner-owned service/provider interfaces (management only)
 ```
 
-Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controller/lease、事件恢复、断连取消、`outcome_unknown`、frame 限制和空闲退出达到行为等价前继续保留。是否最终删除 v17 由等价测试、性能数据、真实 Rich Client 消费方和回滚证据决定，不能只依据 schema 相同或 adapter 已存在。
+这是已批准但尚未交付的 Phase 5 目标。`TuiRuntimePort` 将只覆盖 Embedded 和 Shared
+都需要、且当前 private Runtime IPC v17 已经承载的 Runtime 行为：initialize/health、
+Session、Turn、Permission/UserInput、shell、compact/undo/redo/reload、usage/settlement、
+workspace reference/diff、lineage、fork、当前 Session 的 model/mode 更新、agent mode
+catalog 和事件订阅。Phase 5 完成后，`DirectRuntimeTuiRuntime` 将 direct Runtime 映射到
+该 port，Shared IPC adapter 将 v17 的结果和事件映射到同一组 TUI semantic types；后者
+不运行 `BitfunAppServer`，也不是 Shared App Server transport。
+
+Model catalog/CRUD、Skill、Subagent、MCP、Account、Settings Sync、Worktree、External
+Source 和 Hook 不因为被 TUI 使用就进入 `TuiRuntimePort`，也不需要一个总括性的
+`TuiManagementPort`。backend composition 按 domain 注入各 owner 已有的稳定 service/provider
+trait；Embedded 直接使用同进程 owner service，Shared 使用 Host-local service/provider
+adapter。只有原始 service 接口暴露内部类型、无法表达 TUI 所需的权限/上下文/unsupported，
+或需要跨部署稳定 DTO 时，才在 owning crate 或 adapter 内增加最薄的 facade。不得把
+`AppManagementService` 整体搬入 direct adapter，也不得让 controller/view 直接依赖具体
+service 实现。缺少 provider 的 Shared/Remote 场景返回 typed unsupported，禁止静默回落控制端本机。
+
+Phase 3 已将 Mode/Model、Skill、Subagent 和 MCP 管理面迁移到 TUI-facing typed API。Phase 4 进一步迁移了 External Source、native/external Hook、Account、Settings Sync 和 Worktree 管理面。当前这些方法仍位于单体 `TuiBackend`；Embedded 经 App Server 的 `AppManagementService` wiring 调用 owner，Shared 则由 `SharedTuiBackend` 委托其持有的具体 `AppManagementService`。Phase 5 将按 owner 归属把管理用例拆到 service/provider 接口，不建立管理总接口；TUI controller 仍不直接访问 compatibility owner。
+
+Phase 5 中，`DirectRuntimeTuiRuntime` 将实现 `TuiRuntimePort`，可以依赖 Rust Runtime SDK 暴露的稳定 typed facade，但不得把 Runtime 内部类型、Core singleton 或事件队列 owner 暴露给 TUI。管理面 backend 可以直接调用 owner-owned 的稳定 service/provider trait；若该接口暴露内部类型，或需要 TUI-specific DTO、权限、上下文和 capability 裁剪，才在 owning crate 抽取薄 facade。不得把 `AppManagementService` 原样搬到 CLI，也不得由 direct adapter 复制其业务状态或策略。
+
+当前 Shared 的 Session/chat/mode authority 由 `SharedTuiBackend` 映射 v17；Phase 5 完成后才由 Shared IPC Runtime adapter 实现 `TuiRuntimePort`。Host 实际提供的本机管理 capability 当前由 `SharedTuiBackend` 委托具体 `AppManagementService`，Phase 5 再改为 backend composition 按 domain 调用 Host-local service/provider adapter。当前 Shared Host 提供 Phase 4 的 External Source V1 和 Hook 管理，但不注入 Account/Settings Sync 或 Worktree owner；这些能力返回 typed unsupported。Remote workspace 对所有 controller-local management capability fail closed，不回落到控制端本机。Phase 4 完成表示 typed API 和 wiring 已迁移，不表示所有 deployment 的 capability 完全相同，也不表示 Phase 5 已完成。Phase 4 之后新增的 External Application V2 控制面目前只在 Embedded App Server 接线，Shared Runtime 明确 unsupported，不重新打开 Phase 4 的旧 owner 直连预算。
+
+### 2.3 Optional Shared App Server proposal
+
+Web 当前继续通过自己的 loopback WebSocket App Server 入口，不经过 TUI composition：
+
+```text
+Web UI -> Web Host -> loopback WebSocket App Server
+       -> Runtime API / owner ports
+
+Shared Rich Client（Phase 6 candidate）
+  -> AppServerClient
+  -> candidate private Pipe / UDS
+  -> Shared App Server Host
+  -> Runtime API / owner ports
+```
+
+Shared App Server 仍是 Phase 6 待评审提案，不是 Phase 5 的既定结果。Private Runtime IPC
+v17 在候选 transport 的鉴权、实例身份、controller/lease、事件恢复、断连取消、
+`outcome_unknown`、frame 限制和空闲退出达到行为等价前继续保留；评审也可以决定长期保留
+v17。Embedded direct-runtime 不替换 v17，也不要求 direct facade 与 wire DTO 相同；两者只需
+满足同一行为合同。
 
 ## 3. 当前能力矩阵
 
 状态定义：
 
 - **已交付**：生产 handler/client 已接线，并被当前 Embedded TUI 路径使用。
-- **兼容映射**：Shared TUI 通过 Runtime IPC v17 和 `SharedTuiBackend` 提供等价 TUI 用例，但没有经过 App Server wire。
+- **兼容映射**：Shared TUI 通过 Runtime IPC v17 和 `SharedTuiBackend` 提供与 Embedded 对照的 TUI Runtime 用例，但没有经过 App Server wire。
 - **部分交付**：已有合同或 handler，但 Host 能力、恢复、安全或 TUI 调用路径仍不完整。
 - **未迁移**：当前 TUI 仍使用既有 compatibility owner 路径，或尚无生产接口。
 - **本地保留**：属于 TUI 或 controller-local effect，不迁移。
+
+本矩阵的 Embedded 列记录 Phase 5 之前的 App Server 基线。Phase 5 完成后，Runtime 用例由
+`DirectRuntimeTuiRuntime` 调用 Runtime typed facade；管理用例由 backend composition 调用
+对应 owner service/provider。表中的行为合同和 Shared 对照场景保持不变。
 
 ### 3.1 核心聊天与 Session
 
@@ -107,11 +138,11 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 | --- | --- | --- | --- |
 | 初始化、版本、健康 | `app/initialize`、`app/health` | adapter 根据 v17 握手结果合成 TUI-facing initialize/health | Embedded 已交付；Shared 尚不是 App Server connection |
 | Agent、Permission 事件 | `agent/event`、`agent/permissionEvent` | IPC 事件桥映射为 `AppServerEvent` | 两边均可驱动当前核心 TUI；底层恢复合同不同 |
-| Config 事件 | `config/event` | 当前 Shared bridge 不投影 Config 事件 | Embedded 已接线；Shared 的 TUI-facing 管理 capability 来自 Host 装配的 App Server management service，不代表 v17 已有 Config 事件 |
+| Config 事件 | `config/event` | 当前 Shared bridge 不投影 Config 事件 | Embedded 已接线；Shared 的 TUI-facing 管理 capability 当前由 `SharedTuiBackend` 委托其具体 `AppManagementService`，不代表 v17 已有 Config 事件；Phase 5 再拆成 owner service/provider adapter |
 | 流失效与重同步 | `app/eventStreamState`、`app/syncEvents`、`session/sync` | adapter 投影 connection-local cursor、invalidation/resync 和 closed | 已有连接内 cursor/sync；没有跨连接持久 replay/resume |
 | Session list/create/sync | `agent/listSessions`、`agent/createSession`、`session/sync` | list/create/atomic restore operation | 已交付；sync 包含 Runtime 状态、transcript、workspace binding 和 pending Permission |
 | Session delete/rename/fork | typed App Server methods | v17 controller-scoped operations | 已交付或兼容映射；Shared 继续执行 controller/idle 规则 |
-| Model/mode update | `session/updateModel`、`session/updateMode` | v17 current-controller operations | Session update wire 已覆盖；Embedded 与 Shared 都经 typed 管理 API 取得目录/defaults，Shared 的目录来自 Host 装配的 App Server management service |
+| Model/mode update | `session/updateModel`、`session/updateMode` | v17 current-controller operations | Session update wire 已覆盖；当前 Embedded 经 `AppServerTuiBackend` 提交，Shared 经 `SharedTuiBackend -> Runtime IPC v17` 提交；Phase 5 完成后再分别由 Direct/Shared Runtime adapter 实现 `TuiRuntimePort` |
 | Submit/cancel/steer | typed Agent methods | v17 Turn operations | 已交付或兼容映射 |
 | User Shell/UserInput | `agent/runUserShellCommand`、`agent/submitUserAnswers` | v17 typed operations | 已交付或兼容映射；执行和权限仍由 Runtime owner 持有 |
 | Permission pending/respond | typed Permission methods/events | v17 pending/respond and event stream | 已交付或兼容映射 |
@@ -131,14 +162,14 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 
 | Domain | 当前状态 | 当前结论 / 后续 |
 | --- | --- | --- |
-| Mode/Model 管理 | Embedded 经 typed mode catalog 和 model list/get/add/update/delete/default API；read DTO 只含 secret configured metadata，mutation 使用 preserve/replace/clear | Phase 3 已完成；Shared mode catalog 来自 Runtime Host，model 管理由 Host 装配的 App Server management service 转发，Session model mutation 仍由 v17 owner 提交 |
-| Skill/Subagent | TUI 经 typed list/toggle API 消费 visible/manageable read model；App Server management service 委托既有 registry owner | Phase 3 已完成；Embedded 与 Shared 共用具体 service，Shared capability 明确属于本机 CLI compatibility scope |
-| MCP | 当前 TUI 用例经 typed catalog/status/toggle/add/delete/external decision/conflict API；read projection 与 Debug 输出不暴露凭据 | Phase 3 已完成当前定义；Shared 通过当前 CLI 进程的本地 MCP compatibility service 保留迁移前管理行为。该 service 的 MCP 进程状态和 tool registry 不会即时重配已经运行的 Shared Runtime Host；要取得 Host 侧新状态仍需显式的同步/restart contract，不能把本地 toggle 描述成 v17 远端控制 |
-| External Source/Tool/Command/Agent | TUI 经 typed snapshot/control/review、conflict choice、command expansion 和事件接口消费既有 owner；后续 External Application V2 snapshot/review/action 已在 Embedded 接线 | Phase 4 当前定义已完成；Shared 保留 V1 本机 compatibility，V2 明确 unsupported，Remote 不回落本机 |
-| Hooks | TUI 经 typed native overview 与 external snapshot/plan/apply/mutate API 消费既有 owner | Phase 4 已完成；native user hooks、compiled-in `post_call_hooks` 和 external hook catalog 继续分离，Remote 明确 unsupported |
+| Mode/Model 管理 | Embedded App Server 提供 typed mode catalog 和 model list/get/add/update/delete/default API；read DTO 只含 secret configured metadata，mutation 使用 preserve/replace/clear | Phase 3 已完成 typed API 与 wiring；Shared mode catalog 来自 Runtime Host，model 目录/管理由 `SharedTuiBackend` 持有的具体 `AppManagementService` 提供，Session model mutation 由 `SharedTuiBackend` 提交给 v17 owner；Phase 5 再拆分 owner service/provider 与 Runtime port |
+| Skill/Subagent | 当前 `TuiBackend` 提供 typed list/toggle API 和 visible/manageable read model；Embedded 经 App Server wiring，Shared 由 `SharedTuiBackend` 委托其具体 `AppManagementService` | Phase 3 已完成 typed API 与 wiring；Shared capability 明确属于本机 CLI compatibility scope，Phase 5 再拆成 owner service/provider adapter |
+| MCP | 当前 `TuiBackend` 提供 typed catalog/status/toggle/add/delete/external decision/conflict API；read projection 与 Debug 输出不暴露凭据 | Phase 3 已完成当前定义；Shared 由 `SharedTuiBackend` 委托当前 CLI 进程的具体 `AppManagementService`，以本地 MCP compatibility service 保留迁移前管理行为。该 service 的 MCP 进程状态和 tool registry 不会即时重配已经运行的 Shared Runtime Host；要取得 Host 侧新状态仍需显式的同步/restart contract，不能把本地 toggle 描述成 v17 远端控制 |
+| External Source/Tool/Command/Agent | 当前 `TuiBackend` 提供 typed snapshot/control/review、conflict choice、command expansion 和事件接口；Embedded 经 App Server wiring，Shared V1 由 `SharedTuiBackend` 委托其具体 `AppManagementService` | Phase 4 当前定义已完成；Shared 保留 V1 本机 compatibility，V2 明确 unsupported，Remote 不回落本机；Phase 5 再拆成 owner service/provider adapter |
+| Hooks | 当前 `TuiBackend` 提供 typed native overview 与 external snapshot/plan/apply/mutate API；Embedded 经 App Server wiring，Shared 由 `SharedTuiBackend` 委托其具体 `AppManagementService` | Phase 4 已完成 typed API 与 wiring；native user hooks、compiled-in `post_call_hooks` 和 external hook catalog 继续分离，Remote 明确 unsupported；Phase 5 再拆成 owner service/provider adapter |
 | Account/Settings Sync | typed snapshot/login/finalize/logout 与 sync start/snapshot/cancel/local-changed 已接线；凭据不进入 read model 或 Debug 输出 | Phase 4 接口迁移已完成；Embedded Host 注入共享 `AccountRuntime`，App Server 直接做 domain-to-wire 适配；当前 Shared Host 未注入并返回 typed unsupported |
 | Worktree | typed repository status、bind/release 和 operation identity 已接线 | Phase 4 接口迁移已完成；Embedded Host 注入 Worktree owner，当前 Shared Host 与 Remote workspace 明确 unsupported |
-| Desktop/Web Host 安全 | WebSocket Host 仅为 loopback 单用户；Desktop 尚未迁移为 App Server Host | Host allowlist、身份/作用域、真实 limits 与平台 capability provider |
+| Desktop/Web Host 安全 | WebSocket Host 仅为 loopback 单用户；Desktop 当前仍使用 Tauri adapter，独立 direct Runtime 迁移尚未实施 | Host allowlist、身份/作用域、真实 limits 与平台 capability provider |
 
 ### 3.4 本地保留
 
@@ -164,7 +195,7 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 | `src/crates/interfaces/app-server-protocol` | behavior-light method、DTO、wire error、event envelope 和角色定义 |
 | `src/crates/interfaces/app-server-client` | 类型化请求、事件分发和 host-supplied transport 抽象 |
 | `src/crates/interfaces/app-server` | server 生命周期、生产 handler 注册、Runtime/domain 与 wire 转换、错误映射 |
-| `src/apps/cli` | `TuiBackend`、Embedded/Shared adapter 选择、transport 和进程生命周期、TUI-local effect |
+| `src/apps/cli` | 当前拥有 `TuiAgentClient`、单体 `TuiBackend`、`AppServerTuiBackend`、`SharedTuiBackend`、transport 和进程生命周期、TUI-local effect；Phase 5 再引入 Runtime port 与按 domain 注入的 owner service/provider composition |
 | Runtime/Service/Product Domain owners | Session、Turn、Permission、Workspace、配置和其他业务权威事实 |
 
 边界规则：
@@ -173,6 +204,10 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 - `bitfun-app-server` 可依赖生产 handler 所需的明确 owner feature，但禁止选择 `bitfun-core/product-full`。
 - Host 负责 transport、认证、作用域、真实 capability/limits、平台能力和进程生命周期。
 - handler 只做合同校验、DTO 转换和错误映射，不持有第二份业务权威状态。
+- Phase 5 引入的 `TuiRuntimePort` 只抽取 Embedded/Shared 共同需要的 Runtime 行为；不定义总括性的 `TuiManagementPort`。
+- Phase 5 将管理面按 domain 拆到 owner-owned 的稳定 service/provider trait；只有需要 DTO、权限/上下文
+  适配或 capability 裁剪时才增加薄 facade，不能把具体 service 实现或 `AppManagementService`
+  整体暴露给 TUI。
 - DTO 提取不代表 Runtime owner 迁移。
 
 ## 5. 分阶段状态
@@ -183,17 +218,18 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 | --- | --- | --- | --- | --- |
 | Phase 0：边界 | `TuiBackend`、behavior-light protocol/client crate、source/Cargo guard 已建立 | Core boundary tests 和 dependency checks | 已完成 | [PR #2034 checks](https://github.com/GCWing/BitFun/pull/2034/checks) |
 | Phase 1：协议基础 | initialize/health、typed events、connection-local cursor、resync、稳定错误和 Embedded connection 已接线 | App Server protocol/client/server focused tests | 已完成 | [PR #2034 checks](https://github.com/GCWing/BitFun/pull/2034/checks) |
-| Phase 2：核心聊天 | Embedded 核心用例经 App Server；Shared 经同一 `TuiBackend` 映射 v17；TUI 核心不引用 Runtime SDK/IPC operation | CLI、App Server、Runtime IPC 和 boundary focused tests | 已完成当前定义 | [PR #2034 checks](https://github.com/GCWing/BitFun/pull/2034/checks) |
+| Phase 2：核心聊天（旧路径） | Embedded 核心用例经 App Server；Shared 经同一 `TuiBackend` 映射 v17；TUI 核心不引用 Runtime SDK/IPC operation | CLI、App Server、Runtime IPC 和 boundary focused tests | 已完成当前定义，作为迁移基线 | [PR #2034 checks](https://github.com/GCWing/BitFun/pull/2034/checks) |
 | Phase 3：配置管理 | TUI controller 不再访问 config/registry/MCP compatibility owner；secret-safe typed APIs 完成，CLI Host adapter 可保留显式 compatibility forwarding | owner tests、App Server contract tests、CLI behavior tests | 已完成当前定义 | 本变更的 protocol/client/server/CLI focused tests 与 Core boundary checks |
 | Phase 4：外部集成 | External Source、Hook、Account、Settings Sync、Worktree 管理面经 typed backend；remote 不回落本机 | owner/remote/security contract tests | 已完成当前定义 | [PR #2146 checks](https://github.com/GCWing/BitFun/pull/2146/checks)、zero-budget contract 与 Core boundary checks |
-| Phase 5：Shared App Server | Shared Host 达到 v17 治理等价，opt-in 双栈验证完成，并有回滚与删除证据 | 跨 transport parity、故障、性能和安全测试 | 未开始，目标待评审 | - |
+| Phase 5：Embedded direct-runtime | `TuiRuntimePort` 与 owner service/provider 接入边界拆分完成；Embedded TUI 删除 App Server client/server 与 in-memory transport，改用 direct Runtime adapter；管理面不进入 Shared IPC，旧路径随切换删除 | Runtime port 对 Shared v17 operation 的覆盖测试；direct-runtime 与 Shared v17 的 Runtime 行为测试；各管理 service/provider 的 capability/unsupported 测试 | 待实现 | - |
+| Phase 6：Shared App Server | Shared Host 达到 v17 治理等价，opt-in 双栈验证完成，并有回滚与删除证据 | 跨 transport parity、故障、性能和安全测试 | 未开始，目标待评审 | - |
 
 ### 5.1 Phase 0-2 已交付摘要
 
-- `TuiAgentClient`、Startup 和 `ChatMode` 只消费 app-local `TuiBackend`。
-- Embedded Host 在专用 OS 线程的 current-thread Tokio runtime + `LocalSet` 中运行 private `BitfunAppServer`，TUI 保持在原多线程 runtime。
-- `AppServerTuiBackend` 通过正式 `AppServerClient` 和 in-memory transport 完成核心用例。
-- `SharedTuiBackend` 将相同用例映射到 private Runtime IPC v17；TUI client/controller 不引用 IPC operation。
+- `TuiAgentClient`、Startup 和 `ChatMode` 只消费 app-local `TuiBackend`；Runtime 调用和管理调用均不下沉到 view/reducer。
+- Embedded Host 当前在专用 OS 线程的 current-thread Tokio runtime + `LocalSet` 中运行 private `BitfunAppServer`，TUI 保持在原多线程 runtime；这是 direct-runtime 迁移前的基线。
+- `AppServerTuiBackend` 通过正式 `AppServerClient` 和 in-memory transport 完成核心用例，后续由 direct Runtime composition 替换。
+- `SharedTuiBackend` 将相同 Runtime 行为映射到 private Runtime IPC v17；TUI client/controller 不引用 IPC operation。将这些方法抽取为 Runtime port 属于 Phase 5。
 - App Server 核心 handler 覆盖 sync、turn、Permission、revert、context、usage、settlement、Workspace 和 lineage；Config 事件也已在 Embedded connection 接线。
 - Runtime IPC v17 为当前 parity 增加 restore Runtime 状态、usage、settlement 和本地命令 transcript 记录；没有增加 replay、observer、通用 controller transfer 或公开 SDK 能力。
 - capability 声明列出当前注册方法，但 Host-specific availability 和方向性 limits 仍是后续收紧项。
@@ -215,8 +251,8 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 
 - `app-server-protocol` 提供 Mode、Model、Skill、Subagent 和 MCP 的 owner-specific DTO 与 method；model read model 不返回 secret 值，model mutation 使用 preserve/replace/clear 语义。
 - App Server 由 Host 显式注入具体 `AppManagementService`，按 `tui.modes`、`tui.models`、`tui.skills`、`tui.subagents` 和 `tui.mcp` 发布真实 availability；service 缺失或 unavailable 时返回带 capability id 的 structured unsupported。
-- `AppManagementService` 位于 App Server server wiring，复用现有 config、registry、MCP 和 external-source owner，不成为第二个业务 owner；Startup 与 Chat controller 只经 `TuiAgentClient -> TuiBackend` 调用这些管理用例。
-- `SharedTuiBackend` 继续映射 v17 mode catalog，并将 Model、Skill、Subagent 和 MCP 管理委托 Host 装配的具体 App Server management service。v17 不承载这些目录、CRUD 或 defaults；Shared 发布的是 adapter-scoped 本地 capability，current-Session model update 仍按 v17 controller/idle/outcome-unknown 合同提交给 Runtime Host。Shared MCP service 的运行态只属于当前 CLI 进程，不宣称可以即时控制已经运行的 Shared Runtime Host。
+- `AppManagementService` 位于 App Server server wiring，复用现有 config、registry、MCP 和 external-source owner，不成为第二个业务 owner；Startup 与 Chat controller 只调用 `TuiBackend` 的 typed 方法。Phase 5 才把这些方法按 domain 拆到 owner service/provider，且不会建立 direct TUI 的总管理接口。
+- `SharedTuiBackend` 继续映射 v17 mode catalog，并将 Model、Skill、Subagent 和 MCP 管理委托其持有的具体 `AppManagementService`。v17 不承载这些目录、CRUD 或 defaults；Shared 发布的是 adapter-scoped 本地 capability，current-Session model update 仍按 v17 的 controller/idle/outcome-unknown 合同提交给 Runtime Host。Phase 5 再以 owner service/provider adapter 和 Shared IPC Runtime adapter 替换这段单体 wiring。Shared MCP service 的运行态只属于当前 CLI 进程，不宣称可以即时控制已经运行的 Shared Runtime Host。
 - Core boundary budgets 已移除 Phase 3 owner 直连债务，并要求 Startup 的 Subagent 管理继续使用 typed backend。
 
 ### 5.3 Phase 4
@@ -235,14 +271,23 @@ Shared Runtime IPC v17 在 Shared App Server 的鉴权、实例身份、controll
 交付摘要：
 
 - `app-server-protocol`、client 和 production handlers 已提供 External Source、native/external Hook、Account、Settings Sync 与 Worktree 的 owner-specific typed API；side-effecting 请求使用 operation identity，External Source 与 Hook mutation 保留 owner revision/stale 合同，Settings Sync 提供显式取消与 snapshot。
-- `TuiAgentClient`、Startup 和 Chat controller 只经 `TuiBackend` 调用这些用例。Phase 4 涉及的 `bitfun_core`、account/account-sync compatibility marker 已从 controller 文件移除，对应 Core boundary budget 固定为零。
+- `TuiAgentClient`、Startup 和 Chat controller 只经单体 `TuiBackend` 的 typed API 调用这些用例；Embedded 由 `AppServerTuiBackend` 委托 App Server wiring，Shared 由 `SharedTuiBackend` 委托 v17 或其具体 `AppManagementService`。Phase 4 涉及的 `bitfun_core`、account/account-sync compatibility marker 已从 controller 文件移除，对应 Core boundary budget 固定为零；Runtime port 与按 domain 的 management composition 仍留给 Phase 5。
 - Embedded Host 显式注入共享 `AccountRuntime` 并启用 App Server 内建的本机 Worktree 映射；App Server management service 直接适配 owner，不定义 `AccountManagementHost` 或持有第二份账户、同步、外部来源、Hook、Worktree 权威状态。CLI 的窄 `AccountRuntimeHost` 只实现 daemon、Relay/Peer 路由宿主效果，Session 备份通过独立端口读取 Agent Runtime compatibility owner。
 - Shared adapter 只发布 Host 实际可用的 capability。External Source V1 与 Hook 管理可使用当前本机 compatibility service；Account/Settings Sync、Worktree、Remote workspace 和后续未接线的 External Application V2 返回 typed unsupported，不静默回落本机。
-- Phase 4 未扩展 private Runtime IPC v17，也未改变 Phase 5 的评审门槛。
+- Phase 4 未扩展 private Runtime IPC v17，也未改变 Phase 6 的 Shared transport 评审门槛。
 
 ### 5.4 Phase 5
 
-Phase 5 不以“删除 v17”为起点。建议顺序：
+Embedded direct-runtime Phase 5 建议顺序：
+
+1. 按当前 Shared IPC v17 operation 集合冻结窄 `TuiRuntimePort`，定义统一的 TUI semantic request/result/event/error；direct facade 与 v17 wire 不要求共享 DTO。
+2. 将当前包含 Runtime 和管理面方法的单体 `TuiBackend` 拆为 backend composition：Runtime 调用进入 `TuiRuntimePort`，Model/Skill/Subagent/MCP/Account/Settings/Worktree/External Source/Hook 按 domain 进入各自 owner service/provider 接口；不创建 `TuiManagementPort` 总接口。
+3. 逐项检查管理 service 的暴露面：能直接复用稳定 owner-owned trait 的直接注入；暴露内部类型或需要 TUI DTO、权限/上下文、capability 裁剪的，才抽取最薄 facade。`AppManagementService` 仅保留为 App Server wiring，不原样迁入 CLI。
+4. 为 `DirectRuntimeTuiRuntime` 和 Shared IPC adapter 实现 Runtime port；再将 Embedded Host 从 `EmbeddedAppServerHost` 切换为 direct Runtime Host，删除 in-memory transport、App Server thread 和 initialize/health wire handshake。
+5. 按 Chat、Session、Permission/UserInput、Workspace、Config/Management 垂直切片迁移并验证事件订阅、pending Permission、取消、unknown outcome、workspace/execution binding、错误映射和 Host shutdown 回收。
+6. 完成 direct Runtime 的性能、升级兼容和跨入口行为验证后删除旧 App Server；不保留 rollback adapter，direct adapter 不支持的能力必须返回 typed unsupported。
+
+Shared App Server Phase 6 不以“删除 v17”为起点。建议顺序：
 
 1. 在 Shared Host 中增加默认关闭的 App Server local transport。
 2. 两条 transport 复用同一 Host-scoped connection authority、controller registry、Session 事件过滤、operation identity/deadline/cancel 和未知结果登记。
@@ -278,19 +323,19 @@ Phase 0-2 的具体命令结果和 CI 状态保留在 [PR #2034 checks](https://
 | Workspace | binding、references、diff、remote facts |
 | Lineage | tree、descendant transcript、settlement、targeted cancellation |
 | Failure | unsupported、lag、invalidated、disconnect、deadline、`outcome_unknown` |
-| Deployment | Embedded App Server 与 Shared v17 compatibility 的 TUI behavior parity |
+| Deployment | 当前覆盖 Embedded App Server 与 Shared v17 compatibility；Phase 5 切换到 direct-runtime 并删除旧 Embedded App Server |
 
-Shared App Server 实现后，同一 fixture 必须增加 Embedded App Server、Shared App Server 和 v17 rollback 三方验证，直到 v17 被正式保留或删除。
+Embedded direct-runtime 实现后，同一 fixture 必须覆盖 direct Runtime 和 Shared v17；迁移前可用旧 Embedded App Server 建立基线，但不维护第三条回滚路径。Shared App Server 实现后再增加候选 transport 路径。
 
 ## 7. 完成定义
 
 只有同时满足以下条件，才能宣布 TUI/App Server 解耦完成：
 
-1. Phase 3/4 当前定义的管理面已迁移；后续新增 capability 也不得绕过 `TuiBackend` 或恢复旧 owner 直连。
-2. TUI 产品请求和订阅只经过 `TuiBackend`，TUI view/reducer 不执行 backend I/O。
-3. protocol/client 和 TUI-facing 依赖闭包不包含 Core、Runtime/Service 实现、`product-full` 或 private IPC operation。
-4. capability、limits、身份和作用域来自真实 Host/transport，而不是通用 protocol 默认值。
-5. 事件、断线、恢复、权限、取消和 unknown outcome 有明确合同与故障测试。
+1. Phase 3/4 当前定义的管理面已迁移；Phase 5 direct-runtime 已完成；后续新增 capability 也不得绕过 backend composition 或恢复旧 owner 直连。
+2. TUI 产品请求和订阅经过 `TuiAgentClient` 的 backend composition；Runtime 行为经过 `TuiRuntimePort`，管理能力经过对应 owner service/provider，TUI view/reducer 不执行 backend I/O。
+3. protocol/client 和 TUI-facing 依赖闭包不包含 Core、Runtime/Service 实现、`product-full` 或 private IPC operation；只有 CLI Host/backend composition 可以按 owner 注入已审核的 service/provider。
+4. capability、limits、身份和作用域来自真实 Host/transport，而不是通用 protocol 默认值；管理 service/provider 缺失时返回 typed unsupported。
+5. 事件、断线、恢复、权限、取消和 unknown outcome 有明确合同与故障测试；Runtime port 的每个 Shared v17 operation 都有对应覆盖证据。
 6. remote workspace 不存在 controller-local fallback。
-7. 重复 DTO、无效 handler 和无生产消费方的旁路已删除。
-8. 若采用 Shared App Server，迁移满足 Phase 5 的双栈、回滚、性能、安全和删除门槛；否则文档明确 v17 是保留的私有 compatibility transport。
+7. 重复 DTO、无效 handler、70 方法单体管理 trait 和无生产消费方的旁路已删除或不再属于稳定边界。
+8. 旧 Embedded App Server 已删除且不再作为 rollback adapter；若采用 Shared App Server，迁移满足 Phase 6 的双栈、回滚、性能、安全和删除门槛；否则文档明确 v17 是保留的私有 compatibility transport。

--- a/src/apps/cli/AGENTS.md
+++ b/src/apps/cli/AGENTS.md
@@ -42,8 +42,9 @@ ChatView -> TuiAgentClient -> TuiBackend -> App Server client
 Embedded TUI uses an in-memory App Server connection. During the migration,
 Shared TUI uses a CLI Host compatibility adapter that implements `TuiBackend`
 over the private versioned Runtime IPC; the TUI client and controllers must not
-reference that IPC. Replacing the physical Shared transport with App Server
-Pipe/UDS framing belongs to Phase 5. Side-effecting operations need stable
+reference that IPC. Embedded direct-runtime migration belongs to Phase 5;
+replacing the physical Shared transport with App Server Pipe/UDS framing belongs
+to the separately reviewed Phase 6. Side-effecting operations need stable
 identities, controller/idle rules, bounded frames, and outcome-unknown handling
 before a connection can retry.
 


### PR DESCRIPTION
## Summary

- Clarify the product-backend decision for interactive TUI deployments:
  - Current Embedded TUI continues to use the in-process App Server.
  - Embedded direct-runtime is the approved but not yet delivered Phase 5 target.
  - Shared TUI continues to use private Runtime IPC v17.
  - Shared App Server remains an optional Phase 6 proposal subject to separate review.
- Split architecture diagrams into three explicit views:
  - Current production paths
  - Approved Embedded target
  - Optional Shared App Server proposal
- Define `TuiRuntimePort` as the narrow Session/Turn/Permission/Event behavior boundary shared by Embedded and Shared TUI paths.
- Keep Model, Skill, Subagent, MCP, Account, Settings Sync, Worktree, External Source, and Hook management behind their owner-owned service/provider interfaces instead of introducing a broad `TuiManagementPort`.
- Synchronize the phase descriptions in the CLI agent guide and TUI/App Server refactor plan.

Fixes: N/A

## Type and Areas

Type:

Docs / architecture clarification

Areas:

- Product architecture
- Agent Runtime deployment
- App Server architecture
- CLI/TUI architecture
- TUI/App Server refactor plan

## Motivation / Impact

The previous documentation mixed three different states in the same topology:

- behavior that is currently wired in production,
- the approved Embedded direct-runtime target,
- and the still-unreviewed Shared App Server proposal.

That made it possible to read `TuiRuntimePort` and `DirectRuntimeTuiRuntime` as already delivered, or to interpret Shared App Server as an approved replacement for Runtime IPC v17.

This change separates those states and makes the migration order explicit:

1. Phase 5 migrates Embedded TUI from the in-process App Server to a direct Runtime adapter.
2. Phase 6 separately evaluates whether Shared App Server should replace v17.
3. Keeping private v17 as the long-term Shared transport remains a valid outcome.

No direct user-facing or runtime behavior change.

## Verification

- `pnpm run check:repo-hygiene`
  - Passed.
- `git diff --check`
  - Passed.
- Runtime and build tests were not run because this PR changes documentation and agent guidance only.

## Reviewer Notes

Current production paths remain unchanged:

- Desktop GUI uses the Desktop/Tauri adapter.
- Web UI uses the loopback WebSocket App Server.
- Embedded interactive TUI uses the in-process App Server.
- Shared interactive TUI uses private Runtime IPC v17.

The approved Embedded direct-runtime target does not imply that management capabilities enter `TuiRuntimePort` or the Shared wire. Those capabilities remain owned and supplied by their domain-specific service/provider interfaces.

The Shared App Server diagram is explicitly a Phase 6 proposal. It does not make App Server a required Shared transport, and Web UI does not pass through TUI backend composition.

Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised because this is a documentation-only change with no runtime or protocol behavior changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.