### PR TITLE
chore: bump version to 0.2.18

### DIFF
--- a/BitFun-Installer/package-lock.json
+++ b/BitFun-Installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-installer",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-installer",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "BitFun Custom Installer - Modern branded installation experience",

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-installer"
-version = "0.2.17"
+version = "0.2.18"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun Custom Installer - Modern branded installation experience"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-acp"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -782,11 +782,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-content"
-version = "0.2.17"
+version = "0.2.18"
 
 [[package]]
 name = "bitfun-agent-runtime"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-agent-stream",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-runtime-ipc"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-events",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-stream"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-agent-tools"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-core-types",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-ai-adapters"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server-client"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server-protocol"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "agent-client-protocol",
  "bitfun-core-types",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-claude-code-adapter"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-cli"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-codex-adapter"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-core-types"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-desktop"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-dsh-adapter"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-plugin-runtime-client",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-events"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-external-sources"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bitfun-product-domains",
  "futures",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-harness"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "thiserror 2.0.19",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-miniapp-market-service"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-opencode-adapter"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-plugin-runtime-client",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-page-function-runtime"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "rquickjs",
  "serde",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-plugin-runtime-client"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-runtime-ports",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-capabilities"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-product-domains"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "dirs 6.0.0",
  "hex",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-relay-service"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-ports"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-runtime-services"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bitfun-agent-runtime",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-sdk-host-app"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-services-integrations"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-skin-market-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-skin-market-service"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-static-hook-support"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "bitfun-product-domains",
  "bitfun-services-core",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-call-jsonrepair"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -1684,11 +1684,11 @@ dependencies = [
 
 [[package]]
 name = "bitfun-tool-packs"
-version = "0.2.17"
+version = "0.2.18"
 
 [[package]]
 name = "bitfun-transport"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-webdriver"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -10444,7 +10444,7 @@ dependencies = [
 
 [[package]]
 name = "terminal-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10875,7 +10875,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tool-runtime"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anydoc",
  "bitfun-agent-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ resolver = "2"
 
 # Shared package metadata — single source of truth for version
 [workspace.package]
-version = "0.2.17" # x-release-please-version
+version = "0.2.18" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "BitFun",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "BitFun",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasInstallScript": true,
       "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "BitFun",
   "private": true,
-  "version": "0.2.17",
+  "version": "0.2.18",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/src/apps/relay-server/Cargo.toml
+++ b/src/apps/relay-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-server"
-version = "0.2.17" # x-release-please-version
+version = "0.2.18" # x-release-please-version
 authors = ["BitFun Team"]
 edition = "2021"
 description = "BitFun standalone Remote Connect relay server"

--- a/src/crates/services/page-function-runtime/Cargo.toml
+++ b/src/crates/services/page-function-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-page-function-runtime"
-version = "0.2.17"
+version = "0.2.18"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Embedded JS Page Function runtime for BitFun Pages (rquickjs)"

--- a/src/crates/services/relay-service/Cargo.toml
+++ b/src/crates/services/relay-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfun-relay-service"
-version = "0.2.17"
+version = "0.2.18"
 authors = ["BitFun Team"]
 edition = "2021"
 description = "Reusable relay runtime for BitFun Remote Connect"

--- a/src/miniapp-market-web/package.json
+++ b/src/miniapp-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-miniapp-market-web",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/mobile-web/package-lock.json
+++ b/src/mobile-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitfun-mobile-web",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",

--- a/src/mobile-web/package.json
+++ b/src/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-mobile-web",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/skin-market-web/package.json
+++ b/src/skin-market-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitfun-skin-market-web",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfun/web-ui",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "description": "BitFun Web UI - 支持 Desktop 和 Server 两种部署方式",
   "type": "module",


### PR DESCRIPTION
Bumps the release version from `0.2.17` to `0.2.18`.

Every manifest that `scripts/verify-release-version-sync.mjs` checks moves together, plus the other workspace manifests and lockfiles that carry the same number:

- `package.json`, `package-lock.json`
- `Cargo.toml` (`x-release-please-version`), `Cargo.lock`
- `BitFun-Installer/package.json`, `BitFun-Installer/package-lock.json`, `BitFun-Installer/src-tauri/Cargo.toml`
- `src/apps/relay-server/Cargo.toml` (`x-release-please-version`)
- `src/crates/services/page-function-runtime/Cargo.toml`, `src/crates/services/relay-service/Cargo.toml`
- `src/web-ui/package.json`, `src/mobile-web/package.json` + lockfile, `src/skin-market-web/package.json`, `src/miniapp-market-web/package.json`

`Cargo.lock` was refreshed with `cargo update --workspace --offline`, so only workspace members moved — no dependency was re-resolved.

Verified with `node scripts/verify-release-version-sync.mjs --version 0.2.18`.

Note that merging this triggers the `Release On Version Bump` workflow, which tags `v0.2.18` and starts a release.