### PR TITLE
fix(agents): hide MCP tools from mode profiles

### DIFF
--- a/src/crates/assembly/core/src/service/config/mode_config_canonicalizer.rs
+++ b/src/crates/assembly/core/src/service/config/mode_config_canonicalizer.rs
@@ -19,6 +19,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
 
+const DYNAMIC_MCP_TOOL_PREFIX: &str = "mcp__";
+
 /// Agent-profile config canonicalization report.
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct AgentProfileConfigCanonicalizationReport {
@@ -57,6 +59,16 @@ fn normalize_tools(tools: Vec<String>, valid_tools: &HashSet<String>) -> Vec<Str
     dedupe_preserving_order(tools)
         .into_iter()
         .filter(|tool| valid_tools.contains(tool))
+        .collect()
+}
+
+fn normalize_added_tool_overrides(
+    tools: Vec<String>,
+    valid_tools: &HashSet<String>,
+) -> Vec<String> {
+    dedupe_preserving_order(tools)
+        .into_iter()
+        .filter(|tool| valid_tools.contains(tool) || tool.starts_with(DYNAMIC_MCP_TOOL_PREFIX))
         .collect()
 }
 
@@ -198,7 +210,10 @@ fn stored_agent_profile_from_overrides(
     } = overrides;
     let profile_id = resolve_profile_id(agent_id);
     let default_set: HashSet<String> = default_tools.iter().cloned().collect();
-    let mut added_tools = normalize_tools(added_tools, valid_tools);
+    // MCP tools are registered only after deferred server initialization. Keep
+    // their stored overrides during startup canonicalization even when the
+    // current registry snapshot cannot validate them yet.
+    let mut added_tools = normalize_added_tool_overrides(added_tools, valid_tools);
     let mut removed_tools = normalize_tools(removed_tools, valid_tools);
     let (disabled_user_skills, enabled_user_skills) =
         normalize_skill_override_lists(disabled_user_skills, enabled_user_skills);
@@ -811,6 +826,27 @@ mod tests {
                 .expect("null mode config should be ignored");
 
         assert!(canonical.is_none());
+    }
+
+    #[test]
+    fn canonicalize_agent_profile_preserves_mcp_override_before_registration() {
+        let raw = serde_json::json!({
+            "profile_id": "coding_shared",
+            "added_tools": ["mcp__github__list_issues", "missing_static_tool"]
+        });
+        let canonical = canonicalize_agent_profile(
+            "coding_shared",
+            Some(&raw),
+            &["Read".to_string()],
+            &HashSet::from(["Read".to_string()]),
+        )
+        .expect("profile should canonicalize")
+        .expect("the MCP override should keep the profile");
+
+        assert_eq!(
+            canonical.added_tools,
+            vec!["mcp__github__list_issues".to_string()]
+        );
     }
 
     #[test]

--- a/src/web-ui/src/app/scenes/agents/AgentsScene.test.tsx
+++ b/src/web-ui/src/app/scenes/agents/AgentsScene.test.tsx
@@ -25,12 +25,20 @@ vi.mock('./components/CreateAgentPage', () => ({
 vi.mock('./components/AgentCard', () => ({
   default: ({
     agent,
+    toolCount,
     onOpenDetails,
   }: {
     agent: { name: string };
+    toolCount?: number;
     onOpenDetails: (agent: unknown) => void;
   }) => (
-    <button type="button" onClick={() => onOpenDetails(agent)}>{agent.name}</button>
+    <button
+      type="button"
+      data-tool-count={toolCount}
+      onClick={() => onOpenDetails(agent)}
+    >
+      {agent.name}
+    </button>
   ),
 }));
 
@@ -57,6 +65,19 @@ vi.mock('./components/useUserSkillGroups', () => ({
 vi.mock('./components/SkillGroupPicker', () => ({
   SkillGroupPicker: () => <div data-testid="agent-detail-skill-groups">skill picker</div>,
   SkillGroupSummary: () => <div data-testid="agent-detail-skill-summary">skill summary</div>,
+}));
+
+vi.mock('./components/ToolGroupPicker', () => ({
+  ToolGroupPicker: ({ tools }: { tools: Array<{ name: string }> }) => (
+    <div data-testid="agent-detail-tool-groups">
+      {tools.map((tool) => tool.name).join(',')}
+    </div>
+  ),
+  ToolGroupSummary: ({ tools }: { tools: Array<{ name: string }> }) => (
+    <div data-testid="agent-detail-tool-summary">
+      {tools.map((tool) => tool.name).join(',')}
+    </div>
+  ),
 }));
 
 vi.mock('@/component-library', () => ({
@@ -303,5 +324,57 @@ describeWithJsdom('AgentsScene', () => {
       manageButton?.click();
     });
     expect(container.querySelector('[data-testid="agent-detail-skill-groups"]')).toBeTruthy();
+  });
+
+  it('keeps MCP tools out of mode cards and tool details', async () => {
+    const mode = {
+      key: 'mode::custom-mode',
+      id: 'custom-mode',
+      name: 'Custom mode',
+      description: 'General coding mode.',
+      isReadonly: false,
+      isReview: false,
+      toolCount: 2,
+      defaultTools: ['Read'],
+      defaultEnabled: true,
+      effectiveEnabled: true,
+      source: 'user',
+      agentKind: 'mode' as const,
+      capabilities: [],
+    };
+    mockAgentsList({
+      allAgents: [mode],
+      filteredAgents: [mode],
+      availableTools: [
+        { name: 'Read', description: 'Read files.', is_readonly: true },
+        {
+          name: 'mcp__github__list_issues',
+          description: 'List issues.',
+          is_readonly: true,
+        },
+      ],
+      getModeConfig: () => ({
+        profile_id: 'coding_shared',
+        enabled_tools: ['Read', 'mcp__github__list_issues'],
+        default_tools: ['Read'],
+      }),
+    });
+    const { default: AgentsScene } = await import('./AgentsScene');
+
+    await act(async () => {
+      root.render(<AgentsScene />);
+    });
+
+    const card = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === mode.name);
+    expect(card?.dataset.toolCount).toBe('1');
+
+    await act(async () => {
+      card?.click();
+    });
+
+    const summary = container.querySelector('[data-testid="agent-detail-tool-summary"]');
+    expect(summary?.textContent).toBe('Read');
+    expect(summary?.textContent).not.toContain('mcp__github__list_issues');
   });
 });

--- a/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
+++ b/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
@@ -43,7 +43,7 @@ import { AGENT_ICON_MAP } from './agentsIcons';
 import { CAPABILITY_ACCENT, CORE_AGENT_ACCENTS, DEFAULT_CORE_AGENT_ACCENT } from './agentAppearance';
 import { getCardGradient } from '@/shared/utils/cardGradients';
 import { getMotionAwareScrollBehavior } from '@/shared/utils/motionPreference';
-import { isUserSelectableToolName } from '@/shared/utils/toolVisibility';
+import { isAgentProfileConfigurableToolName } from './agentToolVisibility';
 import { getAgentBadge, getAgentDescription, getCapabilityLabel } from './utils';
 import './AgentsView.scss';
 import './AgentsScene.scss';
@@ -321,11 +321,11 @@ const AgentsHomeView: React.FC = () => {
       : (selectedAgent?.defaultTools ?? [])
   ), [selectedAgent, selectedAgentModeConfig]);
   const selectedAgentTools = useMemo(
-    () => selectedAgentConfiguredTools.filter(isUserSelectableToolName),
+    () => selectedAgentConfiguredTools.filter(isAgentProfileConfigurableToolName),
     [selectedAgentConfiguredTools],
   );
-  const userSelectableAvailableTools = useMemo(
-    () => availableTools.filter((tool) => isUserSelectableToolName(tool.name)),
+  const agentProfileAvailableTools = useMemo(
+    () => availableTools.filter((tool) => isAgentProfileConfigurableToolName(tool.name)),
     [availableTools],
   );
   const selectedAgentHasSkillTool = hasSkillTool(selectedAgentConfiguredTools);
@@ -383,7 +383,7 @@ const AgentsHomeView: React.FC = () => {
       ? (getModeConfig(agent.id)?.enabled_tools ?? agent.defaultTools)
       : agent.defaultTools;
     if (configuredTools) {
-      return configuredTools.filter(isUserSelectableToolName).length;
+      return configuredTools.filter(isAgentProfileConfigurableToolName).length;
     }
     return agent.toolCount ?? 0;
   }, [getModeConfig]);
@@ -450,11 +450,11 @@ const AgentsHomeView: React.FC = () => {
     if (selectedAgentTools.length > 0) {
       const currentToolCount = selectedAgent?.agentKind === 'mode'
         ? (toolsEditing
-          ? (pendingTools ?? selectedAgentConfiguredTools).filter(isUserSelectableToolName).length
+          ? (pendingTools ?? selectedAgentTools).length
           : selectedAgentTools.length)
         : selectedAgentTools.length;
       const totalToolCount = selectedAgent?.agentKind === 'mode'
-        ? userSelectableAvailableTools.length
+        ? agentProfileAvailableTools.length
         : selectedAgentTools.length;
 
       tabs.push({
@@ -495,13 +495,12 @@ const AgentsHomeView: React.FC = () => {
 
     return tabs;
   }, [
-    userSelectableAvailableTools.length,
+    agentProfileAvailableTools.length,
     pendingSkills,
     pendingSubagentIds,
     pendingTools,
     selectedAgent,
     selectedAgentIsExternal,
-    selectedAgentConfiguredTools,
     selectedAgentEnabledSubagentIds,
     selectedAgentHasSkillTool,
     selectedAgentHasTaskTool,
@@ -1093,7 +1092,7 @@ const AgentsHomeView: React.FC = () => {
                           size="small"
                           onClick={() => {
                             if (currentCapabilityTab === 'tools') {
-                              setPendingTools([...selectedAgentConfiguredTools]);
+                              setPendingTools([...selectedAgentTools]);
                               setToolsEditing(true);
                               return;
                             }
@@ -1135,8 +1134,8 @@ const AgentsHomeView: React.FC = () => {
                 {currentCapabilityTab === 'tools' ? (
                   selectedAgent.agentKind === 'mode' && toolsEditing ? (
                     <ToolGroupPicker
-                      tools={userSelectableAvailableTools}
-                      selectedToolNames={pendingTools ?? selectedAgentConfiguredTools}
+                      tools={agentProfileAvailableTools}
+                      selectedToolNames={pendingTools ?? selectedAgentTools}
                       userGroups={userToolGroups}
                       onSelectionChange={setPendingTools}
                       onSaveUserGroups={saveUserToolGroups}
@@ -1145,7 +1144,7 @@ const AgentsHomeView: React.FC = () => {
                     />
                   ) : (
                     <ToolGroupSummary
-                      tools={userSelectableAvailableTools}
+                      tools={agentProfileAvailableTools}
                       selectedToolNames={selectedAgentTools}
                       userGroups={userToolGroups}
                     />

--- a/src/web-ui/src/app/scenes/agents/agentToolVisibility.test.ts
+++ b/src/web-ui/src/app/scenes/agents/agentToolVisibility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isAgentProfileConfigurableToolName } from './agentToolVisibility';
+
+describe('isAgentProfileConfigurableToolName', () => {
+  it('hides MCP tools from per-agent profile configuration', () => {
+    expect(isAgentProfileConfigurableToolName('mcp__github__list_issues')).toBe(false);
+  });
+
+  it('keeps regular product tools configurable', () => {
+    expect(isAgentProfileConfigurableToolName('Read')).toBe(true);
+  });
+
+  it('continues to hide internal gateway tools', () => {
+    expect(isAgentProfileConfigurableToolName('GetToolSpec')).toBe(false);
+  });
+});

--- a/src/web-ui/src/app/scenes/agents/agentToolVisibility.ts
+++ b/src/web-ui/src/app/scenes/agents/agentToolVisibility.ts
@@ -1,0 +1,6 @@
+import { isMcpToolName } from '@/infrastructure/mcp/toolName';
+import { isUserSelectableToolName } from '@/shared/utils/toolVisibility';
+
+export function isAgentProfileConfigurableToolName(toolName: string): boolean {
+  return isUserSelectableToolName(toolName) && !isMcpToolName(toolName);
+}


### PR DESCRIPTION
- Exclude MCP tools from agent card counts, summaries, and mode tool editing
- Preserve stored MCP overrides when startup canonicalization runs before MCP registration
- Add frontend and backend regression coverage
