### PR TITLE
feat(agent): resume interrupted dialog turns

### DIFF
--- a/docs/development/ui-testids-CN.md
+++ b/docs/development/ui-testids-CN.md
@@ -182,6 +182,7 @@
 | Chat 输入可编辑区域 | `chat-input-textarea` | 富文本可编辑区域。 |
 | Chat 发送按钮 | `chat-input-send-btn` | 输入有效时的发送动作。 |
 | Chat 取消按钮 | `chat-input-cancel-btn` | 存在时用于取消进行中的发送/生成。 |
+| Chat 继续中断任务按钮 | `chat-input-continue-interrupted-btn` | 输入框为空时继续最近一个可恢复的中断 Turn。 |
 | Chat 输入工作区条 | `chat-input-workspace-strip` | composer 上方的活动工作区条。 |
 | Chat 输入目标切换器 | `chat-input-target-switcher` | 目标/模式切换器。 |
 | Chat 输入图片条 | `chat-input-image-strip` | 已附加图片条。 |

--- a/docs/development/ui-testids.md
+++ b/docs/development/ui-testids.md
@@ -183,6 +183,7 @@ Avoid adding IDs to these surfaces unless there is a clear automated workflow.
 | Chat input editable region | `chat-input-textarea` | Rich text editable region. |
 | Chat send button | `chat-input-send-btn` | Send action when input is valid. |
 | Chat cancel button | `chat-input-cancel-btn` | Cancels in-progress send/generation when present. |
+| Chat continue interrupted button | `chat-input-continue-interrupted-btn` | Resumes the latest recoverably interrupted turn when the composer is empty. |
 | Chat input workspace strip | `chat-input-workspace-strip` | Active workspace strip above composer. |
 | Chat input target switcher | `chat-input-target-switcher` | Target/mode switcher. |
 | Chat input image strip | `chat-input-image-strip` | Attached image strip. |

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -16,12 +16,13 @@ use crate::runtime::{
 use crate::startup_trace::DesktopStartupTrace;
 use bitfun_agent_runtime::deep_review::sanitize_focused_review_public_metadata;
 use bitfun_agent_runtime::sdk::{
-    AgentDialogSteerRequest, AgentDialogTurnExecution, AgentDialogTurnRequest,
-    AgentInputAttachment, AgentSessionCreateResult, AgentSessionModeUpdateRequest,
-    AgentSessionModelSelection, AgentSessionModelSelectionUpdateRequest,
-    AgentSessionModelUpdateRequest, AgentSubmissionSource, AgentTurnCancellationRequest,
-    DialogSteerOutcome, PermissionAuditRecord, PermissionGrant, PermissionGrantKey,
-    PermissionReply, PermissionRequest,
+    AgentDialogSteerRequest, AgentDialogTurnExecution, AgentDialogTurnRecoveryOutcome,
+    AgentDialogTurnRecoveryRequest, AgentDialogTurnRequest, AgentInputAttachment,
+    AgentSessionCreateResult, AgentSessionModeUpdateRequest, AgentSessionModelSelection,
+    AgentSessionModelSelectionUpdateRequest, AgentSessionModelUpdateRequest, AgentSubmissionSource,
+    AgentTurnCancellationRequest, AgentTurnInterruptionRequest, DialogSteerOutcome,
+    PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PermissionReply, PermissionRequest,
+    RuntimeError,
 };
 use bitfun_core::agentic::agents::AgentSource;
 use bitfun_core::agentic::coordination::{
@@ -65,7 +66,7 @@ use bitfun_core_types::{
     WorktreeError, WorktreeErrorCode,
 };
 use bitfun_product_domains::tool_permissions::PermissionRule;
-use bitfun_runtime_ports::{PermissionMode, SessionTurnWindowRequest};
+use bitfun_runtime_ports::{PermissionMode, PortErrorKind, SessionTurnWindowRequest};
 
 const SESSION_VIEW_TOOL_RESULT_TOTAL_CHAR_BUDGET: usize = 512 * 1024;
 const SESSION_VIEW_TOOL_RESULT_STRING_CHAR_LIMIT: usize = 16 * 1024;
@@ -762,6 +763,20 @@ fn omit_assistant_only_tool_results_for_session_view(turns: &mut [DialogTurnData
 pub struct CancelDialogTurnRequest {
     pub session_id: String,
     pub dialog_turn_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoverInterruptedDialogTurnRequest {
+    pub session_id: String,
+    pub dialog_turn_id: String,
+    pub execution_generation: u32,
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+    #[serde(default)]
+    pub remote_connection_id: Option<String>,
+    #[serde(default)]
+    pub remote_ssh_host: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2886,6 +2901,97 @@ pub async fn cancel_dialog_turn(
         .map(|_| ())
 }
 
+/// Request a recoverable interruption for a native local dialog turn. The
+/// command returns only after the old execution has settled and the
+/// `dialog-turn-interrupted` event is safe to act on.
+#[tauri::command]
+pub async fn interrupt_dialog_turn(
+    runtime: State<'_, DesktopRuntimeContext>,
+    request: CancelDialogTurnRequest,
+) -> Result<(), String> {
+    let interruption = runtime
+        .agent_runtime()
+        .interrupt_turn(AgentTurnInterruptionRequest {
+            session_id: request.session_id.clone(),
+            turn_id: request.dialog_turn_id.clone(),
+            source: Some(AgentSubmissionSource::DesktopUi),
+            wait_timeout_ms: Some(30_000),
+        })
+        .await;
+    match interruption {
+        Ok(_) => Ok(()),
+        // Stop remains universally available. Unsupported recovery surfaces
+        // (external routes, Goal, remote, non-standard sessions) degrade to
+        // the existing hard cancellation and emit DialogTurnCancelled.
+        Err(RuntimeError::Port(error))
+            if matches!(error.kind, PortErrorKind::InvalidRequest | PortErrorKind::Timeout) => runtime
+            .agent_runtime()
+            .cancel_turn(AgentTurnCancellationRequest {
+                session_id: request.session_id.clone(),
+                turn_id: Some(request.dialog_turn_id.clone()),
+                source: Some(AgentSubmissionSource::DesktopUi),
+                requester_session_id: None,
+                reason: Some(if error.kind == PortErrorKind::Timeout {
+                    "recoverable interruption timed out".to_string()
+                } else {
+                    "recoverable interruption unavailable".to_string()
+                }),
+                wait_timeout_ms: None,
+                cancel_descendants: true,
+            })
+            .await
+            .map(|_| ())
+            .map_err(|fallback_error| {
+                log::error!(
+                    "Failed to cancel dialog turn after interruption was unavailable: session_id={}, dialog_turn_id={}, error={}",
+                    request.session_id,
+                    request.dialog_turn_id,
+                    fallback_error
+                );
+                format!("Failed to cancel dialog turn: {}", fallback_error.into_message())
+            }),
+        Err(error) => {
+            log::error!(
+                "Failed to interrupt dialog turn: session_id={}, dialog_turn_id={}, error={}",
+                request.session_id,
+                request.dialog_turn_id,
+                error
+            );
+            Err(format!("Failed to interrupt dialog turn: {}", error.into_message()))
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn recover_interrupted_dialog_turn(
+    runtime: State<'_, DesktopRuntimeContext>,
+    request: RecoverInterruptedDialogTurnRequest,
+) -> Result<AgentDialogTurnRecoveryOutcome, String> {
+    runtime
+        .agent_runtime()
+        .recover_interrupted_turn(AgentDialogTurnRecoveryRequest {
+            session_id: request.session_id.clone(),
+            turn_id: request.dialog_turn_id.clone(),
+            execution_generation: request.execution_generation,
+            workspace_path: request.workspace_path,
+            remote_connection_id: request.remote_connection_id,
+            remote_ssh_host: request.remote_ssh_host,
+        })
+        .await
+        .map_err(|error| {
+            log::error!(
+                "Failed to recover interrupted dialog turn: session_id={}, dialog_turn_id={}, error={}",
+                request.session_id,
+                request.dialog_turn_id,
+                error
+            );
+            format!(
+                "Failed to recover interrupted dialog turn: {}",
+                error.into_message()
+            )
+        })
+}
+
 #[tauri::command]
 pub async fn steer_dialog_turn(
     runtime: State<'_, DesktopRuntimeContext>,
@@ -4281,6 +4387,8 @@ mod tests {
             token_usage: None,
             finish_reason: None,
             has_final_response: None,
+            recovery: None,
+            recovery_epoch: None,
             error: None,
             error_detail: None,
             status: TurnStatus::Completed,
@@ -4365,6 +4473,8 @@ mod tests {
             token_usage: None,
             finish_reason: None,
             has_final_response: None,
+            recovery: None,
+            recovery_epoch: None,
             error: None,
             error_detail: None,
             status: TurnStatus::Completed,
@@ -4430,6 +4540,8 @@ mod tests {
             token_usage: None,
             finish_reason: None,
             has_final_response: None,
+            recovery: None,
+            recovery_epoch: None,
             error: None,
             error_detail: None,
             status: TurnStatus::Completed,

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -247,6 +247,7 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         RemoteWorkspacePolicy::LegacyUnaudited,
     ),
     ("cancel_dialog_turn", RemoteWorkspacePolicy::LegacyUnaudited),
+    ("interrupt_dialog_turn", RemoteWorkspacePolicy::LocalOnly),
     (
         "cancel_insights_generation",
         RemoteWorkspacePolicy::LocalOnly,
@@ -1400,6 +1401,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
     (
         "remove_project_permission_grant",
         RemoteWorkspacePolicy::WorkspaceAgnostic,
+    ),
+    (
+        "recover_interrupted_dialog_turn",
+        RemoteWorkspacePolicy::LocalOnly,
     ),
     (
         "clear_project_permission_grants",

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1219,6 +1219,8 @@ pub async fn run() {
             api::agentic_api::ensure_assistant_bootstrap,
             api::agentic_api::run_init_agents_md,
             api::agentic_api::cancel_dialog_turn,
+            api::agentic_api::interrupt_dialog_turn,
+            api::agentic_api::recover_interrupted_dialog_turn,
             api::agentic_api::steer_dialog_turn,
             api::agentic_api::control_deep_review_queue,
             api::agentic_api::cancel_session,

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -41,7 +41,15 @@ use crate::agentic::session::revert::{
     resolve_redo, resolve_targeted, resolve_undo, SessionRevertPhase, SessionRevertTransition,
 };
 use crate::agentic::session::session_store_port::CoreSessionStorePort;
-use crate::agentic::session::{SessionManager, SessionReferenceLocator};
+use crate::agentic::session::{
+    SessionManager, SessionReferenceLocator, TurnAdmissionSessionFacts,
+    INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY,
+    INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY,
+    INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY,
+};
 use crate::agentic::side_question::build_btw_user_input;
 use crate::agentic::skill_agent_snapshot::{
     diff_skill_agent_snapshot, resolve_skill_agent_snapshot, TurnSkillAgentSnapshot,
@@ -1076,6 +1084,66 @@ fn lineage_post_admission_cancellation_error(
     ))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DialogTurnStopDisposition {
+    Cancelled,
+    Interrupted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InterruptedTurnIntentState {
+    Pending,
+    Committed,
+    Revoked,
+}
+
+fn interrupted_turn_intent_is_pending(
+    intents: &DashMap<String, InterruptedTurnIntentState>,
+    key: &str,
+) -> bool {
+    intents
+        .get(key)
+        .is_some_and(|state| *state == InterruptedTurnIntentState::Pending)
+}
+
+fn commit_interrupted_turn_intent(
+    intents: &DashMap<String, InterruptedTurnIntentState>,
+    key: &str,
+) -> bool {
+    let Some(mut state) = intents.get_mut(key) else {
+        return false;
+    };
+    match *state {
+        InterruptedTurnIntentState::Pending => {
+            *state = InterruptedTurnIntentState::Committed;
+            true
+        }
+        InterruptedTurnIntentState::Committed => true,
+        InterruptedTurnIntentState::Revoked => false,
+    }
+}
+
+fn revoke_interrupted_turn_intent_or_observe_commit(
+    intents: &DashMap<String, InterruptedTurnIntentState>,
+    key: &str,
+) -> bool {
+    let Some(mut state) = intents.get_mut(key) else {
+        return false;
+    };
+    match *state {
+        InterruptedTurnIntentState::Pending => {
+            *state = InterruptedTurnIntentState::Revoked;
+            false
+        }
+        InterruptedTurnIntentState::Committed => true,
+        InterruptedTurnIntentState::Revoked => false,
+    }
+}
+
+fn turn_stop_key(session_id: &str, turn_id: &str) -> String {
+    format!("{session_id}\u{1f}{turn_id}")
+}
+
 /// Conversation coordinator
 pub struct ConversationCoordinator {
     session_manager: Arc<SessionManager>,
@@ -1095,7 +1163,7 @@ pub struct ConversationCoordinator {
     /// Parent-owned terminal outcomes consumed only through AgentWait.
     background_subagent_outcomes: Arc<BackgroundSubagentOutcomeStore>,
     /// Notifies DialogScheduler of turn outcomes; injected after construction
-    scheduler_notify_tx: OnceLock<mpsc::Sender<(String, TurnOutcome)>>,
+    scheduler_notify_tx: OnceLock<mpsc::UnboundedSender<(String, TurnOutcome)>>,
     /// Round-boundary user steering source (mid-turn user message injection); injected after construction
     round_injection_source: OnceLock<Arc<dyn DialogRoundInjectionSource>>,
     /// In-flight dialog turn tracker per session, used to serialize cancel→start
@@ -1111,6 +1179,9 @@ pub struct ConversationCoordinator {
     /// Manual-compaction turns need an atomic planning/cancel/commit decision
     /// before the normal cancellation path may expose the Session as idle.
     manual_compaction_controls: Arc<DashMap<String, Arc<ManualCompactionCommitGate>>>,
+    /// Recoverable stop intent observed by the spawned execution owner when
+    /// cancellation reaches its terminal persistence boundary.
+    interrupted_turn_intents: Arc<DashMap<String, InterruptedTurnIntentState>>,
     thread_goal_runtime: Arc<ThreadGoalRuntime>,
     terminal_port: OnceLock<Arc<dyn TerminalPort>>,
     remote_exec_port: OnceLock<Arc<dyn RemoteExecPort>>,
@@ -2150,6 +2221,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             active_turns_per_session: Arc::new(DashMap::new()),
             turn_settlements: Arc::new(TurnSettlementTracker::default()),
             manual_compaction_controls: Arc::new(DashMap::new()),
+            interrupted_turn_intents: Arc::new(DashMap::new()),
             thread_goal_runtime: Arc::new(ThreadGoalRuntime::new()),
             terminal_port: OnceLock::new(),
             remote_exec_port: OnceLock::new(),
@@ -2314,7 +2386,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
 
     /// Inject the DialogScheduler notification channel after construction.
     /// Called once during app initialization after the scheduler is created.
-    pub fn set_scheduler_notifier(&self, tx: mpsc::Sender<(String, TurnOutcome)>) {
+    pub fn set_scheduler_notifier(&self, tx: mpsc::UnboundedSender<(String, TurnOutcome)>) {
         let _ = self.scheduler_notify_tx.set(tx);
     }
 
@@ -2797,11 +2869,13 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     }
 
     async fn persist_completed_dialog_turn(
+        event_queue: &EventQueue,
         session_manager: &SessionManager,
-        scheduler_notify_tx: Option<&mpsc::Sender<(String, TurnOutcome)>>,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
         session_id: &str,
         turn_id: &str,
         execution_result: &ExecutionResult,
+        recovery_generation: Option<u32>,
     ) -> (crate::service::session::TurnStatus, String) {
         let final_response = match &execution_result.final_message.content {
             MessageContent::Text(text) => text.clone(),
@@ -2814,25 +2888,84 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             session_id, turn_id, execution_result.total_rounds
         );
 
-        if let Err(error) = session_manager
-            .complete_dialog_turn(
-                session_id,
-                turn_id,
-                final_response.clone(),
-                &execution_result.new_messages,
-                TurnStats {
-                    total_rounds: execution_result.total_rounds,
-                    total_tools: 0, // TODO: get from execution_result
-                    total_tokens: 0,
-                    duration_ms: 0,
-                },
-            )
-            .await
-        {
+        let stats = TurnStats {
+            total_rounds: execution_result.total_rounds,
+            total_tools: execution_result.total_tools,
+            total_tokens: 0,
+            duration_ms: execution_result.duration_ms,
+        };
+        let persistence_result = match recovery_generation {
+            Some(execution_generation) => {
+                session_manager
+                    .complete_recovered_dialog_turn(
+                        session_id,
+                        turn_id,
+                        execution_generation,
+                        final_response.clone(),
+                        &execution_result.new_messages,
+                        stats,
+                    )
+                    .await
+            }
+            None => {
+                session_manager
+                    .complete_dialog_turn(
+                        session_id,
+                        turn_id,
+                        final_response.clone(),
+                        &execution_result.new_messages,
+                        stats,
+                    )
+                    .await
+            }
+        };
+        if let Err(error) = persistence_result {
             error!(
                 "Failed to complete dialog turn: session_id={}, turn_id={}, error={}",
                 session_id, turn_id, error
             );
+            if recovery_generation.is_some() {
+                // A recovered generation is Runtime-owned. Never acknowledge
+                // completion when its authoritative Turn payload was not made
+                // durable; put the same generation back behind the recovery
+                // gate so the user can retry without losing its prior rounds.
+                let status = Self::persist_interrupted_dialog_turn(
+                    event_queue,
+                    session_manager,
+                    scheduler_notify_tx,
+                    session_id,
+                    turn_id,
+                    &execution_result.new_messages,
+                    None,
+                )
+                .await;
+                return (status, String::new());
+            }
+        }
+
+        if recovery_generation.is_some() {
+            if let Err(error) = event_queue
+                .enqueue(
+                    AgenticEvent::DialogTurnCompleted {
+                        session_id: session_id.to_string(),
+                        turn_id: turn_id.to_string(),
+                        total_rounds: execution_result.total_rounds,
+                        total_tools: execution_result.total_tools,
+                        duration_ms: execution_result.duration_ms,
+                        partial_recovery_reason: execution_result.partial_recovery_reason.clone(),
+                        success: Some(execution_result.success),
+                        finish_reason: Some(execution_result.effective_finish_reason.clone()),
+                        has_final_response: Some(execution_result.has_final_response),
+                    },
+                    None,
+                )
+                .await
+            {
+                error!(
+                    "Failed to emit recovered DialogTurnCompleted event: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+            }
         }
 
         match session_manager
@@ -2855,7 +2988,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
 
         if let Some(tx) = scheduler_notify_tx {
-            if let Err(error) = tx.try_send((
+            if let Err(error) = tx.send((
                 session_id.to_string(),
                 TurnOutcome::Completed {
                     turn_id: turn_id.to_string(),
@@ -2878,20 +3011,168 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
     async fn persist_cancelled_dialog_turn(
         event_queue: &EventQueue,
         session_manager: &SessionManager,
-        scheduler_notify_tx: Option<&mpsc::Sender<(String, TurnOutcome)>>,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
         session_id: &str,
         turn_id: &str,
         emit_lifecycle_events: bool,
+    ) -> crate::service::session::TurnStatus {
+        Self::persist_cancelled_dialog_turn_with_messages(
+            event_queue,
+            session_manager,
+            scheduler_notify_tx,
+            session_id,
+            turn_id,
+            emit_lifecycle_events,
+            &[],
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn report_terminal_persistence_failure(
+        event_queue: &EventQueue,
+        session_manager: &SessionManager,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
+        session_id: &str,
+        turn_id: &str,
+        terminal_kind: &str,
+        persistence_error: &BitFunError,
+        emit_lifecycle_events: bool,
+    ) -> crate::service::session::TurnStatus {
+        let error = BitFunError::OutcomeUnknown(format!(
+            "Failed to persist authoritative {terminal_kind} outcome: session_id={session_id}, turn_id={turn_id}; {persistence_error}"
+        ));
+        let error_text = error.to_string();
+        error!("{error_text}");
+
+        if emit_lifecycle_events {
+            if let Err(queue_error) = event_queue
+                .enqueue(
+                    AgenticEvent::DialogTurnFailed {
+                        session_id: session_id.to_string(),
+                        turn_id: turn_id.to_string(),
+                        error: error_text.clone(),
+                        error_category: Some(error.error_category()),
+                        error_detail: Some(error.error_detail()),
+                    },
+                    Some(EventPriority::Critical),
+                )
+                .await
+            {
+                error!(
+                    "Failed to emit terminal persistence failure: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, queue_error
+                );
+            }
+        }
+
+        if let Err(state_error) = session_manager
+            .update_session_state_for_turn_if_processing(
+                session_id,
+                turn_id,
+                SessionState::Error {
+                    error: error_text.clone(),
+                    recoverable: true,
+                },
+            )
+            .await
+        {
+            error!(
+                "Failed to set Session Error after terminal persistence failure: session_id={}, turn_id={}, error={}",
+                session_id, turn_id, state_error
+            );
+        }
+
+        if let Some(tx) = scheduler_notify_tx {
+            if let Err(notify_error) = tx.send((
+                session_id.to_string(),
+                TurnOutcome::Failed {
+                    turn_id: turn_id.to_string(),
+                    error: error_text,
+                },
+            )) {
+                error!(
+                    "Failed to notify scheduler of terminal persistence failure: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, notify_error
+                );
+            }
+        }
+
+        crate::service::session::TurnStatus::Error
+    }
+
+    async fn persist_cancelled_dialog_turn_with_messages(
+        event_queue: &EventQueue,
+        session_manager: &SessionManager,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
+        session_id: &str,
+        turn_id: &str,
+        emit_lifecycle_events: bool,
+        generation_messages: &[Message],
+    ) -> crate::service::session::TurnStatus {
+        Self::persist_cancelled_dialog_turn_with_messages_and_policy(
+            event_queue,
+            session_manager,
+            scheduler_notify_tx,
+            session_id,
+            turn_id,
+            emit_lifecycle_events,
+            generation_messages,
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn persist_cancelled_dialog_turn_with_messages_and_policy(
+        event_queue: &EventQueue,
+        session_manager: &SessionManager,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
+        session_id: &str,
+        turn_id: &str,
+        emit_lifecycle_events: bool,
+        generation_messages: &[Message],
+        preserve_recovery_on_persist_failure: bool,
     ) -> crate::service::session::TurnStatus {
         info!(
             "Dialog turn cancelled: session={}, turn={}",
             session_id, turn_id
         );
 
+        if let Err(error) = session_manager
+            .cancel_dialog_turn_with_messages(session_id, turn_id, generation_messages)
+            .await
+        {
+            error!(
+                "Failed to cancel dialog turn in persistence: session_id={}, turn_id={}, error={}",
+                session_id, turn_id, error
+            );
+            if preserve_recovery_on_persist_failure {
+                return Box::pin(Self::persist_interrupted_dialog_turn(
+                    event_queue,
+                    session_manager,
+                    scheduler_notify_tx,
+                    session_id,
+                    turn_id,
+                    generation_messages,
+                    None,
+                ))
+                .await;
+            }
+            return Self::report_terminal_persistence_failure(
+                event_queue,
+                session_manager,
+                scheduler_notify_tx,
+                session_id,
+                turn_id,
+                "cancelled",
+                &error,
+                emit_lifecycle_events,
+            )
+            .await;
+        }
+
         if emit_lifecycle_events {
-            // The execution engine only emits DialogTurnCancelled when cancellation is
-            // detected between rounds. If cancellation interrupted streaming mid-round,
-            // no event was emitted. Emit it here unconditionally; duplicates are harmless.
             if let Err(error) = event_queue
                 .enqueue(
                     AgenticEvent::DialogTurnCancelled {
@@ -2907,16 +3188,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     session_id, turn_id, error
                 );
             }
-        }
-
-        if let Err(error) = session_manager
-            .cancel_dialog_turn(session_id, turn_id)
-            .await
-        {
-            error!(
-                "Failed to cancel dialog turn in persistence: session_id={}, turn_id={}, error={}",
-                session_id, turn_id, error
-            );
         }
 
         match session_manager
@@ -2939,7 +3210,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
 
         if let Some(tx) = scheduler_notify_tx {
-            if let Err(error) = tx.try_send((
+            if let Err(error) = tx.send((
                 session_id.to_string(),
                 TurnOutcome::Cancelled {
                     turn_id: turn_id.to_string(),
@@ -2955,19 +3226,192 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         crate::service::session::TurnStatus::Cancelled
     }
 
+    async fn persist_interrupted_dialog_turn(
+        event_queue: &EventQueue,
+        session_manager: &SessionManager,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
+        session_id: &str,
+        turn_id: &str,
+        generation_messages: &[Message],
+        interruption_intents: Option<&DashMap<String, InterruptedTurnIntentState>>,
+    ) -> crate::service::session::TurnStatus {
+        info!(
+            "Dialog turn interrupted: session={}, turn={}",
+            session_id, turn_id
+        );
+        let recovery = match session_manager
+            .mark_dialog_turn_interrupted_with_messages(session_id, turn_id, generation_messages)
+            .await
+        {
+            Ok(recovery) => recovery,
+            Err(error) => {
+                error!(
+                    "Failed to persist recoverable interruption; falling back to cancellation: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+                return Self::persist_cancelled_dialog_turn_with_messages(
+                    event_queue,
+                    session_manager,
+                    scheduler_notify_tx,
+                    session_id,
+                    turn_id,
+                    true,
+                    generation_messages,
+                )
+                .await;
+            }
+        };
+
+        match session_manager
+            .update_session_state_for_turn_if_processing(session_id, turn_id, SessionState::Idle)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => debug!(
+                "Interrupted turn no longer owns Processing state: session_id={}, turn_id={}",
+                session_id, turn_id
+            ),
+            Err(error) => error!(
+                "Failed to settle interrupted Session as Idle: session_id={}, turn_id={}, error={}",
+                session_id, turn_id, error
+            ),
+        }
+
+        if let Some(interruption_intents) = interruption_intents {
+            let key = turn_stop_key(session_id, turn_id);
+            if !commit_interrupted_turn_intent(interruption_intents, &key) {
+                interruption_intents.remove(&key);
+                info!(
+                    "Interrupted turn was superseded by hard cancellation before settlement: session_id={}, turn_id={}",
+                    session_id, turn_id
+                );
+                return Self::persist_cancelled_dialog_turn_with_messages_and_policy(
+                    event_queue,
+                    session_manager,
+                    scheduler_notify_tx,
+                    session_id,
+                    turn_id,
+                    true,
+                    generation_messages,
+                    true,
+                )
+                .await;
+            }
+        }
+
+        if let Some(tx) = scheduler_notify_tx {
+            if let Err(error) = tx.send((
+                session_id.to_string(),
+                TurnOutcome::Interrupted {
+                    turn_id: turn_id.to_string(),
+                    execution_generation: recovery.execution_generation,
+                },
+            )) {
+                error!(
+                    "Failed to notify scheduler of turn interruption: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+            }
+        }
+
+        if let Err(error) = event_queue
+            .enqueue_with_guaranteed_legacy_storage(
+                AgenticEvent::DialogTurnInterrupted {
+                    session_id: session_id.to_string(),
+                    turn_id: turn_id.to_string(),
+                    execution_generation: recovery.execution_generation,
+                    model_id: recovery.model_id.clone(),
+                },
+                Some(EventPriority::Critical),
+            )
+            .await
+        {
+            error!(
+                "Failed to emit DialogTurnInterrupted event: session_id={}, turn_id={}, error={}",
+                session_id, turn_id, error
+            );
+        }
+
+        crate::service::session::TurnStatus::Cancelled
+    }
+
     async fn persist_failed_dialog_turn(
         event_queue: &EventQueue,
         session_manager: &SessionManager,
-        scheduler_notify_tx: Option<&mpsc::Sender<(String, TurnOutcome)>>,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
         session_id: &str,
         turn_id: &str,
         error: &BitFunError,
         emit_lifecycle_events: bool,
     ) -> crate::service::session::TurnStatus {
+        Self::persist_failed_dialog_turn_with_messages(
+            event_queue,
+            session_manager,
+            scheduler_notify_tx,
+            session_id,
+            turn_id,
+            error,
+            emit_lifecycle_events,
+            &[],
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn persist_failed_dialog_turn_with_messages(
+        event_queue: &EventQueue,
+        session_manager: &SessionManager,
+        scheduler_notify_tx: Option<&mpsc::UnboundedSender<(String, TurnOutcome)>>,
+        session_id: &str,
+        turn_id: &str,
+        error: &BitFunError,
+        emit_lifecycle_events: bool,
+        generation_messages: &[Message],
+        preserve_recovery_on_persist_failure: bool,
+    ) -> crate::service::session::TurnStatus {
         let error_text = error.to_string();
         let recoverable = !matches!(error, BitFunError::AIClient(_) | BitFunError::Timeout(_));
 
         error!("Dialog turn execution failed: {}", error_text);
+
+        if let Err(persist_error) = session_manager
+            .fail_dialog_turn_with_messages(
+                session_id,
+                turn_id,
+                error_text.clone(),
+                generation_messages,
+            )
+            .await
+        {
+            error!(
+                "Failed to mark dialog turn as failed: session_id={}, turn_id={}, error={}",
+                session_id, turn_id, persist_error
+            );
+            if preserve_recovery_on_persist_failure {
+                return Self::persist_interrupted_dialog_turn(
+                    event_queue,
+                    session_manager,
+                    scheduler_notify_tx,
+                    session_id,
+                    turn_id,
+                    generation_messages,
+                    None,
+                )
+                .await;
+            }
+            return Self::report_terminal_persistence_failure(
+                event_queue,
+                session_manager,
+                scheduler_notify_tx,
+                session_id,
+                turn_id,
+                "failed",
+                &persist_error,
+                emit_lifecycle_events,
+            )
+            .await;
+        }
 
         if emit_lifecycle_events {
             if let Err(queue_error) = event_queue
@@ -2988,16 +3432,6 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     session_id, turn_id, queue_error
                 );
             }
-        }
-
-        if let Err(persist_error) = session_manager
-            .fail_dialog_turn(session_id, turn_id, error_text.clone())
-            .await
-        {
-            error!(
-                "Failed to mark dialog turn as failed: session_id={}, turn_id={}, error={}",
-                session_id, turn_id, persist_error
-            );
         }
 
         match session_manager
@@ -3027,7 +3461,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         }
 
         if let Some(tx) = scheduler_notify_tx {
-            if let Err(notify_error) = tx.try_send((
+            if let Err(notify_error) = tx.send((
                 session_id.to_string(),
                 TurnOutcome::Failed {
                     turn_id: turn_id.to_string(),
@@ -3350,7 +3784,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let kickoff_query = Self::assistant_bootstrap_kickoff_query(is_chinese);
         let expected_reply_language = if is_chinese { "Chinese" } else { "English" };
         let workspace_binding = WorkspaceBinding::new(None, workspace_root.clone());
-        let model_id = self
+        let (model_id, _) = self
             .execution_engine
             .resolve_model_id_for_turn(
                 &session,
@@ -3358,6 +3792,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 Some(&workspace_binding),
                 kickoff_query,
                 0,
+                None,
+                None,
             )
             .await?;
 
@@ -4056,7 +4492,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                             final_response: String::new(),
                         }
                     };
-                    if let Err(error) = tx.try_send((session_id.clone(), outcome)) {
+                    if let Err(error) = tx.send((session_id.clone(), outcome)) {
                         error!(
                         "Failed to notify scheduler of delegated command settlement: session_id={}, turn_id={}, error={}",
                         session_id, turn_id, error
@@ -5004,7 +5440,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             turn_index,
             agent_type: runtime_agent_type,
             workspace: manual_workspace,
-            context: HashMap::new(),
+            context: HashMap::from([(
+                "cancel_lifecycle_owner".to_string(),
+                "coordinator".to_string(),
+            )]),
             subagent_parent_info: None,
             permission_delegation: None,
             permission_runtime_ceiling: None,
@@ -5014,7 +5453,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             terminal_port,
             remote_exec_port,
             round_injection: None,
-            emit_lifecycle_events: true,
+            emit_lifecycle_events: false,
             recover_partial_on_cancel: false,
         };
         let session_max_tokens = session.config.max_context_tokens;
@@ -5596,11 +6035,84 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             user_message_metadata = Some(metadata);
         }
 
+        // Resolve and freeze the concrete model before the Turn becomes
+        // visible. Symbolic selectors such as `auto` may change between
+        // generations; a recovered generation must keep the model selected
+        // for the first generation.
+        let (resolved_model_id, resolved_model_binding_fingerprint) = self
+            .execution_engine
+            .resolve_model_id_for_turn(
+                &session,
+                &effective_agent_type,
+                session_workspace.as_ref(),
+                &original_user_input,
+                turn_index,
+                None,
+                None,
+            )
+            .await?;
+        let reasoning_preset = self
+            .session_manager
+            .reconcile_session_reasoning_preset_for_turn(&session_id, "turn_admission")
+            .await?;
+        let (resolved_reasoning_preset, resolved_reasoning_fingerprint) =
+            SessionManager::resolve_effective_reasoning_preset_for_turn(
+                &resolved_model_id,
+                reasoning_preset.as_deref(),
+            )
+            .await?;
+        let admission_facts = TurnAdmissionSessionFacts::from_session(&session)
+            .with_reasoning_preset(reasoning_preset.clone());
+
+        // Persist the first generation's effective permission as the maximum
+        // authority a recovered generation may use. Ordinary rounds still read
+        // current turn/session/global settings; recovery may tighten this
+        // baseline per round, but can never widen it.
+        let submission_permission_mode = resolve_submission_permission_mode(
+            permission_mode_from_metadata(user_message_metadata.as_ref()),
+            session.config.permission_mode,
+            default_permission_mode_from_global_config().await,
+        );
+        let mut metadata = Self::ensure_user_message_metadata_object(user_message_metadata.take());
+        if let Some(object) = metadata.as_object_mut() {
+            object.insert(
+                INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY.to_string(),
+                serde_json::Value::String(submission_permission_mode.mode.as_str().to_string()),
+            );
+            object.insert(
+                INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY.to_string(),
+                serde_json::Value::String(resolved_model_id.clone()),
+            );
+            object.insert(
+                INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY.to_string(),
+                serde_json::Value::String(resolved_model_binding_fingerprint.clone()),
+            );
+            object.insert(
+                INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY.to_string(),
+                resolved_reasoning_preset
+                    .clone()
+                    .map(serde_json::Value::String)
+                    .unwrap_or(serde_json::Value::Null),
+            );
+            object.insert(
+                INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY.to_string(),
+                reasoning_preset
+                    .clone()
+                    .map(serde_json::Value::String)
+                    .unwrap_or(serde_json::Value::Null),
+            );
+            object.insert(
+                INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY.to_string(),
+                serde_json::Value::String(resolved_reasoning_fingerprint.clone()),
+            );
+        }
+        user_message_metadata = Some(metadata);
+
         // Start new dialog turn (sets state to Processing internally)
         // Pass frontend turnId, generate if not provided
         let turn_id = self
             .session_manager
-            .start_dialog_turn_with_prepended_messages(
+            .start_dialog_turn_with_prepended_messages_if_session_matches(
                 &session_id,
                 effective_agent_type.clone(),
                 effective_user_input.clone(),
@@ -5608,6 +6120,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 image_contexts,
                 prepended_messages,
                 user_message_metadata.clone(),
+                &admission_facts,
             )
             .await?;
         if let Some(turn_mode) = permission_mode_from_metadata(user_message_metadata.as_ref()) {
@@ -5759,11 +6272,39 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             "edit_constraint_revocation_authorized".to_string(),
             revocation_authorized.to_string(),
         );
+        // The coordinator persists and emits exactly one terminal cancellation
+        // kind after settlement: ordinary Cancelled or recoverable Interrupted.
+        context_vars.insert(
+            "cancel_lifecycle_owner".to_string(),
+            "coordinator".to_string(),
+        );
 
         // Pass model_id for token usage tracking
         if let Some(model_id) = &session.config.model_id {
             context_vars.insert("model_name".to_string(), model_id.clone());
         }
+        context_vars.insert(
+            INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY.to_string(),
+            resolved_model_id,
+        );
+        context_vars.insert(
+            INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY.to_string(),
+            resolved_model_binding_fingerprint,
+        );
+        context_vars.insert(
+            INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY.to_string(),
+            serde_json::to_string(&resolved_reasoning_preset)
+                .expect("Option<String> reasoning preset must serialize"),
+        );
+        context_vars.insert(
+            INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY.to_string(),
+            serde_json::to_string(&reasoning_preset)
+                .expect("Option<String> reasoning selection must serialize"),
+        );
+        context_vars.insert(
+            INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY.to_string(),
+            resolved_reasoning_fingerprint,
+        );
 
         // Pass snapshot session ID
         if let Some(snapshot_id) = &session.snapshot_session_id {
@@ -5922,6 +6463,8 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let runtime_agent_type_clone = runtime_agent_type;
         let user_message_metadata_clone = user_message_metadata;
         let scheduler_notify_tx = self.scheduler_notify_tx.get().cloned();
+        let interrupted_turn_intents = Arc::clone(&self.interrupted_turn_intents);
+        let interrupted_turn_key = turn_stop_key(&session_id, &turn_id);
 
         tokio::spawn(async move {
             // Keep the exact approved external prompt/tool/permission/model
@@ -6018,28 +6561,51 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             {
                 Ok(execution_result) => Some(
                     Self::persist_completed_dialog_turn(
+                        event_queue.as_ref(),
                         session_manager.as_ref(),
                         scheduler_notify_tx.as_ref(),
                         &session_id_clone,
                         &turn_id_clone,
                         &execution_result,
+                        None,
                     )
                     .await
                     .0,
                 ),
                 Err(e) => {
+                    let generation_messages = execution_engine
+                        .take_generation_messages(&session_id_clone, &turn_id_clone);
                     if matches!(&e, BitFunError::Cancelled(_)) {
-                        Some(
-                            Self::persist_cancelled_dialog_turn(
-                                event_queue.as_ref(),
-                                session_manager.as_ref(),
-                                scheduler_notify_tx.as_ref(),
-                                &session_id_clone,
-                                &turn_id_clone,
-                                true,
+                        if interrupted_turn_intent_is_pending(
+                            interrupted_turn_intents.as_ref(),
+                            &interrupted_turn_key,
+                        ) {
+                            Some(
+                                Self::persist_interrupted_dialog_turn(
+                                    event_queue.as_ref(),
+                                    session_manager.as_ref(),
+                                    scheduler_notify_tx.as_ref(),
+                                    &session_id_clone,
+                                    &turn_id_clone,
+                                    &generation_messages,
+                                    Some(interrupted_turn_intents.as_ref()),
+                                )
+                                .await,
                             )
-                            .await,
-                        )
+                        } else {
+                            Some(
+                                Self::persist_cancelled_dialog_turn_with_messages(
+                                    event_queue.as_ref(),
+                                    session_manager.as_ref(),
+                                    scheduler_notify_tx.as_ref(),
+                                    &session_id_clone,
+                                    &turn_id_clone,
+                                    true,
+                                    &generation_messages,
+                                )
+                                .await,
+                            )
+                        }
                     } else {
                         Some(
                             Self::persist_failed_dialog_turn(
@@ -6074,6 +6640,520 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         active_registration.disarm();
 
         Ok(())
+    }
+
+    /// Recover the latest settled interrupted user turn in place.
+    ///
+    /// This is intentionally separate from `start_dialog_turn_internal`: a
+    /// recovery must not rerun prompt-submit hooks, rematerialize references,
+    /// append another user message, or allocate another dialog turn.
+    pub async fn recover_interrupted_dialog_turn(
+        &self,
+        request: &bitfun_runtime_ports::AgentDialogTurnRecoveryRequest,
+    ) -> BitFunResult<bitfun_runtime_ports::AgentDialogTurnRecoveryOutcome> {
+        bitfun_core_types::validate_session_id(&request.session_id)
+            .map_err(BitFunError::Validation)?;
+        bitfun_core_types::validate_session_id(&request.turn_id)
+            .map_err(|message| BitFunError::Validation(format!("Invalid turn_id: {message}")))?;
+        self.ensure_session_runtime_ownership(&request.session_id, None)?;
+
+        let session = self
+            .session_manager
+            .get_session(&request.session_id)
+            .ok_or_else(|| {
+                BitFunError::NotFound(format!("Session not found: {}", request.session_id))
+            })?;
+        if session.kind != SessionKind::Standard {
+            return Err(BitFunError::Validation(
+                "Interrupted turn recovery is supported only for standard user sessions"
+                    .to_string(),
+            ));
+        }
+        if request.remote_connection_id.is_some()
+            || request.remote_ssh_host.is_some()
+            || session.config.remote_connection_id.is_some()
+            || session.config.remote_ssh_host.is_some()
+        {
+            return Err(BitFunError::Validation(
+                "Interrupted turn recovery is unavailable for remote workspaces".to_string(),
+            ));
+        }
+        if let Some(requested_workspace) = request.workspace_path.as_deref() {
+            let matches_session_workspace = session.config.workspace_path.as_deref()
+                == Some(requested_workspace)
+                || session.config.project_workspace_path.as_deref() == Some(requested_workspace);
+            if !matches_session_workspace {
+                return Err(BitFunError::Validation(
+                    "Interrupted turn recovery workspace does not match the session".to_string(),
+                ));
+            }
+        }
+        if !matches!(session.state, SessionState::Idle) {
+            return Err(BitFunError::Validation(format!(
+                "Session must be idle before recovering an interrupted turn: {:?}",
+                session.state
+            )));
+        }
+        let goal_storage_path = self
+            .require_main_session_storage_path(&request.session_id)
+            .await?;
+        if self
+            .thread_goal_store()
+            .get_thread_goal(&request.session_id, goal_storage_path.as_path())
+            .await?
+            .is_some_and(|goal| {
+                matches!(
+                    goal.status,
+                    ThreadGoalStatus::Active | ThreadGoalStatus::Paused
+                )
+            })
+        {
+            return Err(BitFunError::Validation(
+                "Use the Thread Goal controls to resume goal work".to_string(),
+            ));
+        }
+
+        // The interruption event may reach the UI just before the old spawn
+        // drops its tail-write guards. Recovery is strict: never overlap those
+        // writes with a new execution generation.
+        self.ensure_session_execution_drained(&request.session_id, Duration::from_secs(30))
+            .await?;
+
+        let session_workspace = Self::build_workspace_binding(&session.config).await;
+        if session_workspace
+            .as_ref()
+            .is_some_and(WorkspaceBinding::is_remote)
+        {
+            return Err(BitFunError::Validation(
+                "Interrupted turn recovery is unavailable for remote workspaces".to_string(),
+            ));
+        }
+        let primary_agent_binding =
+            Self::resolve_session_primary_agent(&session, &session.agent_type, &session_workspace)
+                .await?;
+        if primary_agent_binding.route_owner != SessionAgentRouteOwner::Local {
+            return Err(BitFunError::Validation(
+                "Interrupted turn recovery is unavailable for externally owned agent routes"
+                    .to_string(),
+            ));
+        }
+        let runtime_agent_type = primary_agent_binding.runtime_agent_key;
+        let external_agent_generation_lease = primary_agent_binding.lease;
+        let workspace_services = Self::build_workspace_services(&session_workspace).await;
+        let persisted_subagent_context = self
+            .load_persisted_subagent_continuation_context(&session)
+            .await;
+        let session_workspace_path = session_workspace
+            .as_ref()
+            .map(|workspace| workspace.root_path_string());
+        let session_storage_path = session_workspace
+            .as_ref()
+            .map(|workspace| workspace.session_storage_dir().to_path_buf());
+        // This is the compare-and-set boundary. After it succeeds, no fallible
+        // preparation remains before the execution is registered and spawned.
+        let plan = self
+            .session_manager
+            .reopen_interrupted_dialog_turn(
+                &request.session_id,
+                &request.turn_id,
+                request.execution_generation,
+            )
+            .await?;
+        info!(
+            "Recovering interrupted dialog turn: session_id={}, turn_id={}, execution_generation={}, resume_count={}",
+            plan.session_id, plan.turn_id, plan.execution_generation, plan.resume_count
+        );
+        // Recovery admission is serialized by the scheduler, but settings may
+        // have changed while the previous generation drained. Re-read the
+        // authoritative Session after the CAS before deriving permission and
+        // execution facts.
+        let session = self
+            .session_manager
+            .get_session(&request.session_id)
+            .unwrap_or(session);
+
+        let original_user_input = plan
+            .user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("original_text"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or(&plan.user_input)
+            .to_string();
+        let runtime_tool_restrictions = runtime_tool_restrictions_for_session_lifetime(
+            miniapp_agent_run_tool_restrictions(
+                plan.user_message_metadata.as_ref(),
+                session.created_by.as_deref(),
+            ),
+            self.session_manager
+                .is_transient_session(&request.session_id),
+        );
+        let mut context_vars = HashMap::new();
+        context_vars.insert(
+            "max_context_tokens".to_string(),
+            session.config.max_context_tokens.to_string(),
+        );
+        context_vars.insert(
+            "enable_tools".to_string(),
+            session.config.enable_tools.to_string(),
+        );
+        context_vars.insert("original_user_input".to_string(), original_user_input);
+        context_vars.insert("turn_index".to_string(), plan.turn_index.to_string());
+        context_vars.insert(
+            "initial_round_index".to_string(),
+            plan.initial_round_index.to_string(),
+        );
+        context_vars.insert(
+            "edit_constraint_revocation_authorized".to_string(),
+            "false".to_string(),
+        );
+        context_vars.insert(
+            "cancel_lifecycle_owner".to_string(),
+            "coordinator".to_string(),
+        );
+        context_vars.insert(
+            INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY.to_string(),
+            plan.resolved_permission_mode.as_str().to_string(),
+        );
+        if let Some(model_id) = &session.config.model_id {
+            context_vars.insert("model_name".to_string(), model_id.clone());
+        }
+        context_vars.insert(
+            INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY.to_string(),
+            plan.resolved_model_id.clone(),
+        );
+        context_vars.insert(
+            INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY.to_string(),
+            plan.model_binding_fingerprint.clone(),
+        );
+        if let Some(reasoning_value) = plan
+            .user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY))
+        {
+            context_vars.insert(
+                INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY.to_string(),
+                reasoning_value.to_string(),
+            );
+        }
+        if let Some(reasoning_selection) = plan
+            .user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY))
+        {
+            context_vars.insert(
+                INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY.to_string(),
+                reasoning_selection.to_string(),
+            );
+        }
+        if let Some(reasoning_fingerprint) = plan
+            .user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY))
+            .and_then(serde_json::Value::as_str)
+        {
+            context_vars.insert(
+                INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY.to_string(),
+                reasoning_fingerprint.to_string(),
+            );
+        }
+        if let Some(snapshot_id) = &session.snapshot_session_id {
+            context_vars.insert("snapshot_session_id".to_string(), snapshot_id.clone());
+        }
+        if let Some(user_input_available) = metadata_bool(
+            plan.user_message_metadata.as_ref(),
+            USER_INPUT_AVAILABLE_CONTEXT_KEY,
+        ) {
+            context_vars.insert(
+                USER_INPUT_AVAILABLE_CONTEXT_KEY.to_string(),
+                user_input_available.to_string(),
+            );
+        }
+        if let Some(auto_approve_ask) = metadata_bool(
+            plan.user_message_metadata.as_ref(),
+            AUTO_APPROVE_ASK_CONTEXT_KEY,
+        ) {
+            context_vars.insert(
+                AUTO_APPROVE_ASK_CONTEXT_KEY.to_string(),
+                auto_approve_ask.to_string(),
+            );
+        }
+
+        let execution_context = ExecutionContext {
+            session_id: plan.session_id.clone(),
+            dialog_turn_id: plan.turn_id.clone(),
+            turn_index: plan.turn_index,
+            agent_type: plan.agent_type.clone(),
+            workspace: session_workspace,
+            context: context_vars,
+            subagent_parent_info: persisted_subagent_context.subagent_parent_info,
+            permission_delegation: persisted_subagent_context.permission_delegation,
+            permission_runtime_ceiling: None,
+            delegation_policy: DelegationPolicy::top_level(),
+            runtime_tool_restrictions,
+            workspace_services,
+            terminal_port: self.terminal_port(),
+            remote_exec_port: self.remote_exec_port(),
+            round_injection: self.round_injection_source.get().cloned(),
+            // Recovered terminal lifecycle is published only after the Runtime-owned
+            // Turn payload is durably committed by the coordinator.
+            emit_lifecycle_events: false,
+            recover_partial_on_cancel: false,
+        };
+
+        let active_counter = self
+            .active_turns_per_session
+            .entry(plan.session_id.clone())
+            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
+            .clone();
+        active_counter.fetch_add(1, Ordering::SeqCst);
+        let turn_settlement_registration = self
+            .turn_settlements
+            .register_accepted(plan.session_id.clone(), plan.turn_id.clone());
+        let cancellation_token = CancellationToken::new();
+        self.execution_engine
+            .register_cancel_token(&plan.turn_id, cancellation_token);
+
+        let session_manager = self.session_manager.clone();
+        let execution_engine = self.execution_engine.clone();
+        let event_queue = self.event_queue.clone();
+        let scheduler_notify_tx = self.scheduler_notify_tx.get().cloned();
+        let interrupted_turn_intents = Arc::clone(&self.interrupted_turn_intents);
+        let interrupted_turn_key = turn_stop_key(&plan.session_id, &plan.turn_id);
+        let session_id = plan.session_id.clone();
+        let turn_id = plan.turn_id.clone();
+        let turn_index = plan.turn_index;
+        let effective_agent_type = plan.agent_type.clone();
+        let user_input = plan.user_input.clone();
+        let user_message_metadata = plan.user_message_metadata.clone();
+        let execution_generation = plan.execution_generation;
+        let messages = plan.messages;
+
+        tokio::spawn(async move {
+            let _external_agent_generation_lease = external_agent_generation_lease;
+            let _turn_settlement_registration = turn_settlement_registration;
+            struct RecoveredExecutionGuard {
+                session_manager: Arc<SessionManager>,
+                session_id: String,
+                turn_id: String,
+                active_counter: Arc<AtomicUsize>,
+            }
+            impl Drop for RecoveredExecutionGuard {
+                fn drop(&mut self) {
+                    self.active_counter.fetch_sub(1, Ordering::SeqCst);
+                    self.session_manager
+                        .reset_session_state_if_processing(&self.session_id, &self.turn_id);
+                    self.session_manager
+                        .clear_active_turn_permission_mode(&self.session_id, &self.turn_id);
+                }
+            }
+            let _guard = RecoveredExecutionGuard {
+                session_manager: session_manager.clone(),
+                session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
+                active_counter,
+            };
+
+            let recovered_dequeue_ack = match event_queue
+                .enqueue_with_legacy_dequeue_ack(
+                    AgenticEvent::DialogTurnRecovered {
+                        session_id: session_id.clone(),
+                        turn_id: turn_id.clone(),
+                        execution_generation,
+                    },
+                    // Preserve FIFO with any normal-priority data already
+                    // queued by the interrupted generation. The frontend keeps
+                    // the Turn quarantined until this fence arrives, so stale
+                    // text/tool events cannot cross into the recovered one.
+                    Some(EventPriority::Normal),
+                )
+                .await
+            {
+                Ok((_, acknowledgement)) => acknowledgement,
+                Err(error) => {
+                    error!(
+                        "Failed to enqueue DialogTurnRecovered fence: session_id={}, turn_id={}, error={}",
+                        session_id, turn_id, error
+                    );
+                    Self::persist_interrupted_dialog_turn(
+                        event_queue.as_ref(),
+                        session_manager.as_ref(),
+                        scheduler_notify_tx.as_ref(),
+                        &session_id,
+                        &turn_id,
+                        &[],
+                        None,
+                    )
+                    .await;
+                    return;
+                }
+            };
+            let fence_failure =
+                match tokio::time::timeout(Duration::from_secs(5), recovered_dequeue_ack.wait())
+                    .await
+                {
+                    Ok(Ok(())) => None,
+                    Ok(Err(error)) => Some(error.to_string()),
+                    Err(_) => Some("timed out waiting for legacy dequeue".to_string()),
+                };
+            if let Some(error) = fence_failure {
+                error!(
+                    "DialogTurnRecovered fence failed before dequeue: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+                Self::persist_interrupted_dialog_turn(
+                    event_queue.as_ref(),
+                    session_manager.as_ref(),
+                    scheduler_notify_tx.as_ref(),
+                    &session_id,
+                    &turn_id,
+                    &[],
+                    None,
+                )
+                .await;
+                return;
+            }
+            if let Err(error) = event_queue
+                .enqueue(
+                    AgenticEvent::SessionStateChanged {
+                        session_id: session_id.clone(),
+                        new_state: "processing".to_string(),
+                    },
+                    Some(EventPriority::Normal),
+                )
+                .await
+            {
+                error!(
+                    "Failed to emit recovered SessionStateChanged event: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+            }
+
+            let _ = session_manager
+                .update_session_state_for_turn_if_processing(
+                    &session_id,
+                    &turn_id,
+                    SessionState::Processing {
+                        current_turn_id: turn_id.clone(),
+                        phase: ProcessingPhase::Thinking,
+                    },
+                )
+                .await;
+
+            let workspace_turn_status = match execution_engine
+                .execute_dialog_turn(runtime_agent_type, messages, execution_context)
+                .await
+            {
+                Ok(execution_result) => Some(
+                    Self::persist_completed_dialog_turn(
+                        event_queue.as_ref(),
+                        session_manager.as_ref(),
+                        scheduler_notify_tx.as_ref(),
+                        &session_id,
+                        &turn_id,
+                        &execution_result,
+                        Some(execution_generation),
+                    )
+                    .await
+                    .0,
+                ),
+                Err(error) if matches!(&error, BitFunError::Cancelled(_)) => {
+                    let generation_messages =
+                        execution_engine.take_generation_messages(&session_id, &turn_id);
+                    if interrupted_turn_intent_is_pending(
+                        interrupted_turn_intents.as_ref(),
+                        &interrupted_turn_key,
+                    ) {
+                        Some(
+                            Self::persist_interrupted_dialog_turn(
+                                event_queue.as_ref(),
+                                session_manager.as_ref(),
+                                scheduler_notify_tx.as_ref(),
+                                &session_id,
+                                &turn_id,
+                                &generation_messages,
+                                Some(interrupted_turn_intents.as_ref()),
+                            )
+                            .await,
+                        )
+                    } else {
+                        Some(
+                            Self::persist_cancelled_dialog_turn_with_messages_and_policy(
+                                event_queue.as_ref(),
+                                session_manager.as_ref(),
+                                scheduler_notify_tx.as_ref(),
+                                &session_id,
+                                &turn_id,
+                                true,
+                                &generation_messages,
+                                true,
+                            )
+                            .await,
+                        )
+                    }
+                }
+                Err(error)
+                    if ExecutionEngine::is_frozen_reasoning_contract_error(&error)
+                        || ExecutionEngine::is_frozen_model_contract_error(&error) =>
+                {
+                    let generation_messages =
+                        execution_engine.take_generation_messages(&session_id, &turn_id);
+                    warn!(
+                        "Recovered dialog turn execution contract changed before execution; preserving recovery eligibility: session_id={}, turn_id={}, error={}",
+                        session_id, turn_id, error
+                    );
+                    Some(
+                        Self::persist_interrupted_dialog_turn(
+                            event_queue.as_ref(),
+                            session_manager.as_ref(),
+                            scheduler_notify_tx.as_ref(),
+                            &session_id,
+                            &turn_id,
+                            &generation_messages,
+                            None,
+                        )
+                        .await,
+                    )
+                }
+                Err(error) => {
+                    let generation_messages =
+                        execution_engine.take_generation_messages(&session_id, &turn_id);
+                    Some(
+                        Self::persist_failed_dialog_turn_with_messages(
+                            event_queue.as_ref(),
+                            session_manager.as_ref(),
+                            scheduler_notify_tx.as_ref(),
+                            &session_id,
+                            &turn_id,
+                            &error,
+                            true,
+                            &generation_messages,
+                            true,
+                        )
+                        .await,
+                    )
+                }
+            };
+
+            Self::finalize_persisted_turn_in_workspace_if_needed(
+                session_manager.as_ref(),
+                &session_id,
+                &turn_id,
+                turn_index,
+                &effective_agent_type,
+                &user_input,
+                session_workspace_path.as_deref(),
+                session_storage_path.as_deref(),
+                workspace_turn_status,
+                user_message_metadata,
+            )
+            .await;
+        });
+
+        Ok(bitfun_runtime_ports::AgentDialogTurnRecoveryOutcome {
+            session_id: plan.session_id,
+            turn_id: plan.turn_id,
+            execution_generation: plan.execution_generation,
+        })
     }
 
     /// P0-8: Wait until all in-flight spawn tasks for this session have
@@ -6254,6 +7334,23 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             dialog_turn_id,
             true,
             Duration::from_millis(1500),
+            DialogTurnStopDisposition::Cancelled,
+        )
+        .await
+    }
+
+    pub async fn interrupt_dialog_turn(
+        &self,
+        session_id: &str,
+        dialog_turn_id: &str,
+        drain_timeout: Duration,
+    ) -> BitFunResult<()> {
+        self.cancel_dialog_turn_with_descendant_policy(
+            session_id,
+            dialog_turn_id,
+            true,
+            drain_timeout,
+            DialogTurnStopDisposition::Interrupted,
         )
         .await
     }
@@ -6264,11 +7361,82 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         dialog_turn_id: &str,
         cancel_descendants: bool,
         drain_timeout: Duration,
+        disposition: DialogTurnStopDisposition,
     ) -> BitFunResult<()> {
         info!(
-            "Received cancel request: dialog_turn_id={}, session_id={}, cancel_descendants={}",
-            dialog_turn_id, session_id, cancel_descendants
+            "Received stop request: dialog_turn_id={}, session_id={}, cancel_descendants={}, disposition={:?}",
+            dialog_turn_id, session_id, cancel_descendants, disposition
         );
+
+        if disposition == DialogTurnStopDisposition::Interrupted {
+            let session = self
+                .session_manager
+                .get_session(session_id)
+                .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
+            if session.kind != SessionKind::Standard {
+                return Err(BitFunError::Validation(
+                    "Recoverable interruption is supported only for standard user sessions"
+                        .to_string(),
+                ));
+            }
+            if session.config.remote_connection_id.is_some()
+                || session.config.remote_ssh_host.is_some()
+            {
+                return Err(BitFunError::Validation(
+                    "Recoverable interruption is not available for remote workspaces".to_string(),
+                ));
+            }
+            if session.config.agent_route_owner != SessionAgentRouteOwner::Local {
+                return Err(BitFunError::Validation(
+                    "Recoverable interruption is unavailable for externally owned agent routes"
+                        .to_string(),
+                ));
+            }
+            if !matches!(
+                session.state,
+                SessionState::Processing { ref current_turn_id, .. }
+                    if current_turn_id == dialog_turn_id
+            ) {
+                if session.dialog_turn_ids.last().map(String::as_str) == Some(dialog_turn_id)
+                    && self
+                        .session_manager
+                        .latest_dialog_turn_holds_dispatch(session_id)
+                        .await?
+                {
+                    debug!(
+                        "Ignoring duplicate interruption for an already interrupted turn: session_id={}, turn_id={}",
+                        session_id, dialog_turn_id
+                    );
+                    return Ok(());
+                }
+                return Err(BitFunError::Validation(format!(
+                    "Dialog turn is not the active turn: {dialog_turn_id}"
+                )));
+            }
+            let goal_storage_path = self.require_main_session_storage_path(session_id).await?;
+            if self
+                .thread_goal_store()
+                .get_thread_goal(session_id, goal_storage_path.as_path())
+                .await?
+                .is_some_and(|goal| {
+                    matches!(
+                        goal.status,
+                        ThreadGoalStatus::Active | ThreadGoalStatus::Paused
+                    )
+                })
+            {
+                return Err(BitFunError::Validation(
+                    "Use the Thread Goal controls to pause or resume goal work".to_string(),
+                ));
+            }
+            self.interrupted_turn_intents.insert(
+                turn_stop_key(session_id, dialog_turn_id),
+                InterruptedTurnIntentState::Pending,
+            );
+        } else {
+            self.interrupted_turn_intents
+                .remove(&turn_stop_key(session_id, dialog_turn_id));
+        }
 
         if let Some(control) = self.manual_compaction_controls.get(dialog_turn_id) {
             if !control.try_cancel() && control.commit_started() {
@@ -6293,14 +7461,17 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         // cancellation still targets the currently processing turn. A delayed
         // cancel request for an older turn must not clear a newer turn.
         debug!("Conditionally updating session state to Idle for cancelled turn");
-        let state_update_result = self
-            .session_manager
-            .update_session_state_for_turn_if_processing(
-                session_id,
-                dialog_turn_id,
-                SessionState::Idle,
-            )
-            .await;
+        let state_update_result = if disposition == DialogTurnStopDisposition::Cancelled {
+            self.session_manager
+                .update_session_state_for_turn_if_processing(
+                    session_id,
+                    dialog_turn_id,
+                    SessionState::Idle,
+                )
+                .await
+        } else {
+            Ok(false)
+        };
 
         // A persistence failure can occur after SessionManager has already
         // changed the in-memory state. Cancellation has been admitted at that
@@ -6382,11 +7553,41 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 drain_timeout.as_millis(),
                 session_id, dialog_turn_id, pending
             );
+            if disposition == DialogTurnStopDisposition::Interrupted {
+                let key = turn_stop_key(session_id, dialog_turn_id);
+                // Atomically revoke a still-pending interrupt, or observe that
+                // the execution owner already committed the durable recovery
+                // fact. A separate persistence read leaves a read-to-revoke
+                // race where hard cancellation can overwrite a committed
+                // Interrupted turn while its terminal event is still in flight.
+                if revoke_interrupted_turn_intent_or_observe_commit(
+                    self.interrupted_turn_intents.as_ref(),
+                    &key,
+                ) {
+                    self.interrupted_turn_intents.remove(&key);
+                    info!(
+                        "Interrupted turn committed before execution tail drained: session_id={}, turn_id={}",
+                        session_id, dialog_turn_id
+                    );
+                    return Ok(());
+                }
+                return Err(BitFunError::Timeout(format!(
+                    "Interrupted turn did not settle within {}ms: session_id={}, turn_id={}",
+                    drain_timeout.as_millis(),
+                    session_id,
+                    dialog_turn_id
+                )));
+            }
         } else {
             debug!(
                 "Cancelled turn fully drained: session_id={}, dialog_turn_id={}",
                 session_id, dialog_turn_id
             );
+        }
+
+        if disposition == DialogTurnStopDisposition::Interrupted {
+            self.interrupted_turn_intents
+                .remove(&turn_stop_key(session_id, dialog_turn_id));
         }
 
         if let Some(error) = state_update_error {
@@ -6435,6 +7636,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             &current_turn_id,
             cancel_descendants,
             drain_timeout,
+            DialogTurnStopDisposition::Cancelled,
         )
         .await?;
 
@@ -7975,7 +9177,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             user_input_text,
             created_by,
             subagent_parent_info,
-            context,
+            mut context,
             permission_runtime_ceiling,
             delegation_policy,
             runtime_tool_restrictions,
@@ -7987,6 +9189,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             execution_lease,
             external_generation_lease: _external_generation_lease,
         } = request;
+        context.insert(
+            "cancel_lifecycle_owner".to_string(),
+            "coordinator".to_string(),
+        );
         let prepared_target_session_id = target_session_id.clone();
         let deep_review_run_manifest = context
             .get("deep_review_run_manifest")
@@ -8597,6 +9803,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             SubagentExecutionOutcome::Completed(join_result) => match join_result {
                 Ok(result) => result,
                 Err(error) => {
+                    let _ = self
+                        .execution_engine
+                        .take_generation_messages(&session_id, &dialog_turn_id);
                     let join_error = BitFunError::tool(format!(
                         "Subagent '{}' failed to join: {}",
                         agent_type, error
@@ -8689,6 +9898,10 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     }
                 }
 
+                let _ = self
+                    .execution_engine
+                    .take_generation_messages(&session_id, &dialog_turn_id);
+
                 Self::persist_cancelled_dialog_turn(
                     self.event_queue.as_ref(),
                     self.session_manager.as_ref(),
@@ -8762,11 +9975,13 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 {
                     Ok(Ok(Ok(exec_result))) => {
                         let (_status, response_text) = Self::persist_completed_dialog_turn(
+                            self.event_queue.as_ref(),
                             self.session_manager.as_ref(),
                             None,
                             &session_id,
                             &dialog_turn_id,
                             &exec_result,
+                            None,
                         )
                         .await;
                         Self::finalize_persisted_turn_in_workspace_if_needed(
@@ -8816,6 +10031,9 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         None
                     }
                 };
+                let _ = self
+                    .execution_engine
+                    .take_generation_messages(&session_id, &dialog_turn_id);
 
                 if let Some(mut partial_result) = partial_timeout_result {
                     warn!(
@@ -8892,15 +10110,20 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         let (workspace_turn_status, response_text) = match result {
             Ok(exec_result) => {
                 Self::persist_completed_dialog_turn(
+                    self.event_queue.as_ref(),
                     self.session_manager.as_ref(),
                     None,
                     &session_id,
                     &dialog_turn_id,
                     &exec_result,
+                    None,
                 )
                 .await
             }
             Err(e) => {
+                let _ = self
+                    .execution_engine
+                    .take_generation_messages(&session_id, &dialog_turn_id);
                 let turn_status = if matches!(&e, BitFunError::Cancelled(_)) {
                     Self::persist_cancelled_dialog_turn(
                         self.event_queue.as_ref(),
@@ -12502,6 +13725,32 @@ impl bitfun_runtime_ports::AgentTurnCancellationPort for ConversationCoordinator
             requested,
         })
     }
+
+    async fn interrupt_turn(
+        &self,
+        request: bitfun_runtime_ports::AgentTurnInterruptionRequest,
+    ) -> bitfun_runtime_ports::PortResult<bitfun_runtime_ports::AgentTurnInterruptionResult> {
+        let wait_timeout = Duration::from_millis(request.wait_timeout_ms.unwrap_or(30_000));
+        self.interrupt_dialog_turn(&request.session_id, &request.turn_id, wait_timeout)
+            .await
+            .map_err(|error| {
+                bitfun_runtime_ports::PortError::new(
+                    match error {
+                        BitFunError::Validation(_) => {
+                            bitfun_runtime_ports::PortErrorKind::InvalidRequest
+                        }
+                        BitFunError::NotFound(_) => bitfun_runtime_ports::PortErrorKind::NotFound,
+                        _ => bitfun_runtime_ports::PortErrorKind::Backend,
+                    },
+                    error.to_string(),
+                )
+            })?;
+        Ok(bitfun_runtime_ports::AgentTurnInterruptionResult {
+            session_id: request.session_id,
+            turn_id: request.turn_id,
+            requested: true,
+        })
+    }
 }
 
 #[async_trait::async_trait]
@@ -12928,18 +14177,19 @@ fn merge_prepended_messages_for_turn(
 mod tests {
     use super::{
         apply_primary_agent_model_default, btw_session_memory_mode,
-        build_subagent_session_relationship, lineage_active_turn_after_transcript,
-        lineage_post_admission_cancellation_error,
+        build_subagent_session_relationship, commit_interrupted_turn_intent,
+        lineage_active_turn_after_transcript, lineage_post_admission_cancellation_error,
         lineage_session_is_settling_without_active_state, logical_subagent_type_or_runtime,
         merge_prepended_messages_for_turn, normalize_subagent_max_concurrency,
         permission_mode_from_metadata, resolve_agent_session_create_created_by,
         resolve_agent_submission_turn_id, resolve_subagent_model_selection,
-        resolve_submission_permission_mode, runtime_port_error_preserving_message,
-        runtime_session_summary, runtime_tool_restrictions_for_session_lifetime,
-        runtime_transcript_messages_from_turns, session_storage_workspace_locator,
-        turn_review_manifest_for_agent, validate_required_lineage_turns_settled,
-        ActiveSubagentExecution, BackgroundSubagentWaitMode, ContextCompactionOutcome,
-        ConversationCoordinator, ManualCompactionCommitGate, SessionMemoryMode,
+        resolve_submission_permission_mode, revoke_interrupted_turn_intent_or_observe_commit,
+        runtime_port_error_preserving_message, runtime_session_summary,
+        runtime_tool_restrictions_for_session_lifetime, runtime_transcript_messages_from_turns,
+        session_storage_workspace_locator, turn_review_manifest_for_agent,
+        validate_required_lineage_turns_settled, ActiveSubagentExecution,
+        BackgroundSubagentWaitMode, ContextCompactionOutcome, ConversationCoordinator,
+        InterruptedTurnIntentState, ManualCompactionCommitGate, SessionMemoryMode,
         SessionReferenceLocator, SessionRelationshipKind, SubagentExecutionRequest,
         TEST_AGENT_MODEL_DEFAULTS,
     };
@@ -12954,7 +14204,8 @@ mod tests {
     };
     use crate::agentic::events::{AgenticEvent, EventQueue, EventQueueConfig, EventRouter};
     use crate::agentic::execution::{
-        ExecutionEngine, ExecutionEngineConfig, RoundExecutor, StreamProcessor,
+        restrict_recovered_permission_mode, ExecutionEngine, ExecutionEngineConfig, RoundExecutor,
+        StreamProcessor,
     };
     use crate::agentic::goal_mode::thread_goal_patch;
     use crate::agentic::persistence::PersistenceManager;
@@ -12977,6 +14228,50 @@ mod tests {
     use bitfun_agent_runtime::permission::PermissionRequestManager;
     use bitfun_runtime_services::test_support::FakeRuntimePort;
     use bitfun_services_core::permission_store::ProjectPermissionSqliteStore;
+
+    #[test]
+    fn interrupted_turn_intent_commit_wins_over_timeout_revocation() {
+        let intents = dashmap::DashMap::new();
+        intents.insert(
+            "session\u{1f}turn".to_string(),
+            InterruptedTurnIntentState::Pending,
+        );
+
+        assert!(commit_interrupted_turn_intent(
+            &intents,
+            "session\u{1f}turn"
+        ));
+        assert!(revoke_interrupted_turn_intent_or_observe_commit(
+            &intents,
+            "session\u{1f}turn"
+        ));
+        assert_eq!(
+            *intents.get("session\u{1f}turn").unwrap(),
+            InterruptedTurnIntentState::Committed
+        );
+    }
+
+    #[test]
+    fn interrupted_turn_timeout_revocation_blocks_late_commit() {
+        let intents = dashmap::DashMap::new();
+        intents.insert(
+            "session\u{1f}turn".to_string(),
+            InterruptedTurnIntentState::Pending,
+        );
+
+        assert!(!revoke_interrupted_turn_intent_or_observe_commit(
+            &intents,
+            "session\u{1f}turn"
+        ));
+        assert!(!commit_interrupted_turn_intent(
+            &intents,
+            "session\u{1f}turn"
+        ));
+        assert_eq!(
+            *intents.get("session\u{1f}turn").unwrap(),
+            InterruptedTurnIntentState::Revoked
+        );
+    }
 
     #[cfg(not(feature = "remote-workspace"))]
     #[tokio::test]
@@ -13728,6 +15023,25 @@ mod tests {
         );
         assert_eq!(turn_scoped.mode, PermissionMode::Ask);
         assert_eq!(turn_scoped.source, PermissionModeSource::Turn);
+    }
+
+    #[test]
+    fn recovered_permission_never_exceeds_original_or_current_mode() {
+        assert_eq!(
+            restrict_recovered_permission_mode(PermissionMode::FullAccess, PermissionMode::Ask),
+            PermissionMode::Ask
+        );
+        assert_eq!(
+            restrict_recovered_permission_mode(PermissionMode::Ask, PermissionMode::FullAccess),
+            PermissionMode::Ask
+        );
+        assert_eq!(
+            restrict_recovered_permission_mode(
+                PermissionMode::FullAccess,
+                PermissionMode::AutoApprove,
+            ),
+            PermissionMode::AutoApprove
+        );
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -39,15 +39,16 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use bitfun_agent_runtime::scheduler::{
     build_thread_goal_objective_updated_delivery_plan, build_thread_goal_resumed_delivery_plan,
     resolve_agent_session_reply_action, resolve_background_delivery_action,
-    resolve_background_delivery_injection, resolve_background_delivery_injection_for_turn,
-    resolve_dialog_start_route, resolve_dialog_steering_action,
-    resolve_turn_outcome_lifecycle_plan, ActiveDialogTurn, ActiveDialogTurnStore,
+    resolve_background_delivery_injection, resolve_dialog_start_route,
+    resolve_dialog_steering_action, resolve_turn_outcome_lifecycle_plan,
+    target_background_delivery_injection_to_turn, ActiveDialogTurn, ActiveDialogTurnStore,
     ActiveDialogTurnTakeResult, AgentSessionReplyAction, AgentSessionReplyPlan,
     BackgroundDeliveryAction, BackgroundDeliveryFacts, BackgroundInjectionKind,
     DialogReplySuppressionSet, DialogStartRoute, DialogStartRouteFacts, DialogSteeringAction,
@@ -336,8 +337,11 @@ pub struct DialogScheduler {
     retired_maintenance_outcomes: Arc<DialogReplySuppressionSet>,
     /// Set when the user cancels an in-flight turn; aborts goal-continuation submit retries.
     goal_continuation_abort: Arc<SessionAbortFlags>,
+    /// Wakes recovery admission after the previous execution generation has
+    /// retired from the authoritative active-turn table.
+    active_turn_retired: Arc<Notify>,
     /// Cloneable sender given to ConversationCoordinator for turn outcome notifications
-    outcome_tx: mpsc::Sender<(String, TurnOutcome)>,
+    outcome_tx: mpsc::UnboundedSender<(String, TurnOutcome)>,
     /// Per-session FIFO buffer of round injections drained at round boundaries
     /// by the engine and injected into the running dialog turn.
     round_injection_buffer: Arc<SessionRoundInjectionBuffer>,
@@ -374,6 +378,32 @@ fn take_active_turn_for_outcome(
     }
 }
 
+struct RecoveryActiveTurnAdmission {
+    active_turns: Arc<ActiveDialogTurnStore>,
+    active_turn_retired: Arc<Notify>,
+    session_id: String,
+    turn_id: String,
+    armed: bool,
+}
+
+impl RecoveryActiveTurnAdmission {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RecoveryActiveTurnAdmission {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let _ = self
+            .active_turns
+            .take_for_outcome(&self.session_id, &self.turn_id);
+        self.active_turn_retired.notify_waiters();
+    }
+}
+
 fn queued_submission_outcome(
     session_id: String,
     resolved_turn_id: String,
@@ -401,7 +431,10 @@ impl DialogScheduler {
         coordinator: Arc<ConversationCoordinator>,
         session_manager: Arc<SessionManager>,
     ) -> Arc<Self> {
-        let (outcome_tx, outcome_rx) = mpsc::channel(128);
+        // Turn outcomes are lifecycle control messages, not bulk data. They
+        // must never be dropped or back-pressured behind the interrupt RPC:
+        // retirement of the active-turn owner depends on their delivery.
+        let (outcome_tx, outcome_rx) = mpsc::unbounded_channel();
         let round_injection_buffer = Arc::new(SessionRoundInjectionBuffer::default());
         let round_injection_source = Arc::new(SchedulerRoundInjectionSource {
             buffer: round_injection_buffer.clone(),
@@ -417,6 +450,7 @@ impl DialogScheduler {
             suppressed_cancelled_replies: Arc::new(DialogReplySuppressionSet::default()),
             retired_maintenance_outcomes: Arc::new(DialogReplySuppressionSet::default()),
             goal_continuation_abort: Arc::new(SessionAbortFlags::default()),
+            active_turn_retired: Arc::new(Notify::new()),
             outcome_tx,
             round_injection_buffer,
             round_injection_source,
@@ -432,7 +466,7 @@ impl DialogScheduler {
     }
 
     /// Returns a sender to give to ConversationCoordinator for turn outcome notifications.
-    pub fn outcome_sender(&self) -> mpsc::Sender<(String, TurnOutcome)> {
+    pub fn outcome_sender(&self) -> mpsc::UnboundedSender<(String, TurnOutcome)> {
         self.outcome_tx.clone()
     }
 
@@ -533,6 +567,7 @@ impl DialogScheduler {
         goal: ThreadGoal,
     ) -> Result<(), String> {
         let plan = build_thread_goal_resumed_delivery_plan(&goal);
+        let operation_guard = self.lock_session_operation(&session_id).await;
         let state = self
             .session_manager
             .get_session(&session_id)
@@ -542,19 +577,33 @@ impl DialogScheduler {
             session_state: Self::session_state_fact(state.as_ref()),
         }) {
             BackgroundDeliveryAction::InjectIntoRunningTurn => {
+                let Some(current_turn_id) = state.as_ref().and_then(|state| match state {
+                    SessionState::Processing {
+                        current_turn_id, ..
+                    } => Some(current_turn_id.clone()),
+                    _ => None,
+                }) else {
+                    return Err(format!(
+                        "Thread goal resume resolved to injection without an active turn: session_id={session_id}"
+                    ));
+                };
                 self.round_injection_buffer.push(
                     &session_id,
-                    resolve_background_delivery_injection(
-                        BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
-                        Uuid::new_v4().to_string(),
-                        plan.injection_prompt,
-                        Some(plan.injection_display),
-                        SystemTime::now(),
+                    target_background_delivery_injection_to_turn(
+                        resolve_background_delivery_injection(
+                            BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
+                            Uuid::new_v4().to_string(),
+                            plan.injection_prompt,
+                            Some(plan.injection_display),
+                            SystemTime::now(),
+                        ),
+                        current_turn_id,
                     ),
                 );
                 Ok(())
             }
             BackgroundDeliveryAction::SubmitAgentSessionFollowUp { queue_priority } => {
+                drop(operation_guard);
                 let prepended = thread_goal_delivery_messages(plan.prepended_reminders);
                 self.submit_with_prepended_messages(
                     session_id,
@@ -588,6 +637,7 @@ impl DialogScheduler {
         goal: ThreadGoal,
     ) -> Result<(), String> {
         let plan = build_thread_goal_objective_updated_delivery_plan(&goal);
+        let operation_guard = self.lock_session_operation(&session_id).await;
         let state = self
             .session_manager
             .get_session(&session_id)
@@ -597,19 +647,33 @@ impl DialogScheduler {
             session_state: Self::session_state_fact(state.as_ref()),
         }) {
             BackgroundDeliveryAction::InjectIntoRunningTurn => {
+                let Some(current_turn_id) = state.as_ref().and_then(|state| match state {
+                    SessionState::Processing {
+                        current_turn_id, ..
+                    } => Some(current_turn_id.clone()),
+                    _ => None,
+                }) else {
+                    return Err(format!(
+                        "Thread goal update resolved to injection without an active turn: session_id={session_id}"
+                    ));
+                };
                 self.round_injection_buffer.push(
                     &session_id,
-                    resolve_background_delivery_injection(
-                        BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
-                        Uuid::new_v4().to_string(),
-                        plan.injection_prompt,
-                        Some(plan.injection_display),
-                        SystemTime::now(),
+                    target_background_delivery_injection_to_turn(
+                        resolve_background_delivery_injection(
+                            BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
+                            Uuid::new_v4().to_string(),
+                            plan.injection_prompt,
+                            Some(plan.injection_display),
+                            SystemTime::now(),
+                        ),
+                        current_turn_id,
                     ),
                 );
                 Ok(())
             }
             BackgroundDeliveryAction::SubmitAgentSessionFollowUp { queue_priority } => {
+                drop(operation_guard);
                 let prepended = thread_goal_delivery_messages(plan.prepended_reminders);
                 self.submit_with_prepended_messages(
                     session_id,
@@ -698,12 +762,14 @@ impl DialogScheduler {
                     ));
                 };
                 let injection_id = Uuid::new_v4().to_string();
-                let injection = resolve_background_delivery_injection_for_turn(
-                    BackgroundInjectionKind::BackgroundResult,
-                    injection_id.clone(),
-                    delivery.content.clone(),
-                    delivery.display_content.clone(),
-                    SystemTime::now(),
+                let injection = target_background_delivery_injection_to_turn(
+                    resolve_background_delivery_injection(
+                        BackgroundInjectionKind::BackgroundResult,
+                        injection_id.clone(),
+                        delivery.content.clone(),
+                        delivery.display_content.clone(),
+                        SystemTime::now(),
+                    ),
                     current_turn_id,
                 );
                 self.round_injection_buffer.push(&session_id, injection);
@@ -1028,6 +1094,28 @@ impl DialogScheduler {
             .map_err(SchedulerSubmitError::Port)
     }
 
+    async fn restore_missing_session_before_admission(
+        &self,
+        session_id: &str,
+        requested_storage_path: &Path,
+    ) -> Result<Option<crate::agentic::core::Session>, SchedulerSubmitError> {
+        if self.session_manager.get_session(session_id).is_some() {
+            return Ok(None);
+        }
+        match self
+            .coordinator
+            .restore_session_from_storage_path(requested_storage_path, session_id)
+            .await
+        {
+            Ok(session) => Ok(Some(session)),
+            Err(BitFunError::NotFound(_)) => {
+                // A genuinely new Session has no persisted state to restore.
+                Ok(None)
+            }
+            Err(error) => Err(SchedulerSubmitError::Core(error)),
+        }
+    }
+
     async fn submit_queued_turn(
         &self,
         session_id: String,
@@ -1061,6 +1149,16 @@ impl DialogScheduler {
                 queued_turn.remote_ssh_host.as_deref(),
             )
             .await?;
+            if let Some(restored_session) = self
+                .restore_missing_session_before_admission(&session_id, &requested_storage_path)
+                .await?
+            {
+                queued_turn.workspace_path = session_storage_workspace_locator(
+                    queued_turn.workspace_path.as_deref(),
+                    restored_session.config.workspace_path.as_deref(),
+                    restored_session.config.project_workspace_path.as_deref(),
+                );
+            }
             self.session_manager
                 .validate_session_storage_path_binding(&session_id, &requested_storage_path)
                 .map_err(SchedulerSubmitError::Core)?;
@@ -1069,7 +1167,25 @@ impl DialogScheduler {
             .session_manager
             .get_session(&session_id)
             .map(|s| s.state.clone());
-        let state_fact = if self.active_turns.contains(&session_id) {
+        let mut interrupted_hold = matches!(state, Some(SessionState::Idle))
+            && self
+                .session_manager
+                .latest_dialog_turn_holds_dispatch(&session_id)
+                .await
+                .map_err(SchedulerSubmitError::Core)?;
+        let interrupted_turn_to_abandon = if interrupted_hold
+            && !matches!(
+                queued_turn.policy.trigger_source,
+                DialogTriggerSource::AgentSession | DialogTriggerSource::ScheduledJob
+            ) {
+            interrupted_hold = false;
+            self.session_manager
+                .get_session(&session_id)
+                .and_then(|session| session.dialog_turn_ids.last().cloned())
+        } else {
+            None
+        };
+        let state_fact = if self.active_turns.contains(&session_id) || interrupted_hold {
             DialogSessionStateFact::Processing
         } else {
             Self::session_state_fact(state.as_ref())
@@ -1114,6 +1230,18 @@ impl DialogScheduler {
         match action {
             DialogSubmitQueueAction::StartImmediately => {
                 let tid = self.start_turn(&session_id, &queued_turn).await?;
+                if let Err(error) = self
+                    .abandon_superseded_interrupted_turn(
+                        &session_id,
+                        interrupted_turn_to_abandon.as_deref(),
+                    )
+                    .await
+                {
+                    warn!(
+                        "Failed to clear superseded interrupted turn after starting new user work: session_id={}, error={}",
+                        session_id, error
+                    );
+                }
                 queued_turn.accept_settlement();
                 self.record_last_submitted_agent_type(&session_id, &queued_turn.agent_type)
                     .await;
@@ -1126,6 +1254,18 @@ impl DialogScheduler {
             DialogSubmitQueueAction::ClearQueueAndStartImmediately => {
                 let _ = self.clear_queue(&session_id).await;
                 let tid = self.start_turn(&session_id, &queued_turn).await?;
+                if let Err(error) = self
+                    .abandon_superseded_interrupted_turn(
+                        &session_id,
+                        interrupted_turn_to_abandon.as_deref(),
+                    )
+                    .await
+                {
+                    warn!(
+                        "Failed to clear superseded interrupted turn after starting new user work: session_id={}, error={}",
+                        session_id, error
+                    );
+                }
                 queued_turn.accept_settlement();
                 self.record_last_submitted_agent_type(&session_id, &queued_turn.agent_type)
                     .await;
@@ -1137,6 +1277,12 @@ impl DialogScheduler {
 
             DialogSubmitQueueAction::EnqueueThenStartNext => {
                 self.enqueue(&session_id, queued_turn.clone())?;
+                self.abandon_interrupted_turn_after_enqueue(
+                    &session_id,
+                    &resolved_turn_id,
+                    interrupted_turn_to_abandon.as_deref(),
+                )
+                .await?;
                 queued_turn.accept_settlement();
                 self.record_last_submitted_agent_type(&session_id, &queued_turn.agent_type)
                     .await;
@@ -1149,6 +1295,12 @@ impl DialogScheduler {
             DialogSubmitQueueAction::EnqueueForActiveTurn => {
                 let accepted_agent_type = queued_turn.agent_type.clone();
                 self.enqueue(&session_id, queued_turn.clone())?;
+                self.abandon_interrupted_turn_after_enqueue(
+                    &session_id,
+                    &resolved_turn_id,
+                    interrupted_turn_to_abandon.as_deref(),
+                )
+                .await?;
                 queued_turn.accept_settlement();
                 self.record_last_submitted_agent_type(&session_id, &accepted_agent_type)
                     .await;
@@ -1158,6 +1310,46 @@ impl DialogScheduler {
                 })
             }
         }
+    }
+
+    async fn abandon_superseded_interrupted_turn(
+        &self,
+        session_id: &str,
+        interrupted_turn_id: Option<&str>,
+    ) -> BitFunResult<()> {
+        let Some(interrupted_turn_id) = interrupted_turn_id else {
+            return Ok(());
+        };
+        if let Some(abandoned_turn_id) = self
+            .session_manager
+            .abandon_interrupted_dialog_turn(session_id, Some(interrupted_turn_id))
+            .await?
+        {
+            self.round_injection_buffer
+                .drain_for_turn(session_id, &abandoned_turn_id);
+        }
+        Ok(())
+    }
+
+    async fn abandon_interrupted_turn_after_enqueue(
+        &self,
+        session_id: &str,
+        queued_turn_id: &str,
+        interrupted_turn_id: Option<&str>,
+    ) -> Result<(), SchedulerSubmitError> {
+        if let Err(error) = self
+            .abandon_superseded_interrupted_turn(session_id, interrupted_turn_id)
+            .await
+        {
+            if let Some(removed_turn) =
+                remove_queued_turn_by_id(&self.queues, session_id, queued_turn_id)
+            {
+                self.finish_removed_queued_turn(session_id, removed_turn)
+                    .await;
+            }
+            return Err(SchedulerSubmitError::Core(error));
+        }
+        Ok(())
     }
 
     async fn record_last_submitted_agent_type(&self, session_id: &str, agent_type: &str) {
@@ -1239,6 +1431,28 @@ impl DialogScheduler {
         }
 
         if !self.active_turns.matches_turn(session_id, turn_id) {
+            if self
+                .session_manager
+                .abandon_interrupted_dialog_turn(session_id, Some(turn_id))
+                .await
+                .map_err(|error| error.to_string())?
+                .is_some()
+            {
+                self.round_injection_buffer
+                    .drain_for_turn(session_id, turn_id);
+                self.coordinator
+                    .emit_event(AgenticEvent::DialogTurnCancelled {
+                        session_id: session_id.to_string(),
+                        turn_id: turn_id.to_string(),
+                    })
+                    .await;
+                if let Err(error) = self.try_start_next_queued_locked(session_id).await {
+                    warn!(
+                        "Failed to dispatch held queue after abandoning interrupted turn: session_id={}, turn_id={}, error={}",
+                        session_id, turn_id, error
+                    );
+                }
+            }
             debug!(
                 "Ignoring cancellation for a turn that is not active in the requested session: session_id={}, turn_id={}",
                 session_id, turn_id
@@ -1249,6 +1463,34 @@ impl DialogScheduler {
         self.coordinator
             .cancel_dialog_turn(session_id, turn_id)
             .await?;
+        // The coordinator may have committed an Interrupted recovery fact
+        // while this hard-cancel request was waiting for the active execution
+        // to drain. Always attempt the generation-aware abandon after the
+        // drain so the result does not depend on whether the scheduler outcome
+        // retired the active projection first. Ordinary Cancelled turns return
+        // None, making this an idempotent no-op.
+        if self
+            .session_manager
+            .abandon_interrupted_dialog_turn(session_id, Some(turn_id))
+            .await
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            self.round_injection_buffer
+                .drain_for_turn(session_id, turn_id);
+            self.coordinator
+                .emit_event(AgenticEvent::DialogTurnCancelled {
+                    session_id: session_id.to_string(),
+                    turn_id: turn_id.to_string(),
+                })
+                .await;
+            if let Err(error) = self.try_start_next_queued_locked(session_id).await {
+                warn!(
+                    "Failed to dispatch held queue after hard cancellation abandoned interrupted recovery: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+            }
+        }
         Ok(false)
     }
 
@@ -1457,8 +1699,11 @@ impl DialogScheduler {
         requested_storage_path: &std::path::Path,
         wait_timeout: Duration,
     ) -> BitFunResult<SessionMaintenancePermit> {
-        self.begin_session_maintenance(session_id, requested_storage_path, wait_timeout)
-            .await
+        let permit = self
+            .begin_session_maintenance(session_id, requested_storage_path, wait_timeout)
+            .await?;
+        self.round_injection_buffer.clear(session_id);
+        Ok(permit)
     }
 
     fn retire_active_turn_for_maintenance(&self, session_id: &str) -> Option<String> {
@@ -1467,6 +1712,7 @@ impl DialogScheduler {
         };
         let turn_id = active_turn.turn_id().to_string();
         self.retired_maintenance_outcomes.mark(session_id, &turn_id);
+        self.active_turn_retired.notify_waiters();
         self.active_internal_turns.remove(session_id);
         self.round_injection_buffer
             .drain_for_turn(session_id, &turn_id);
@@ -1573,6 +1819,13 @@ impl DialogScheduler {
             .get_session(session_id)
             .map(|s| s.state.clone());
         if matches!(state, Some(SessionState::Processing { .. })) {
+            return Ok(None);
+        }
+        if self
+            .session_manager
+            .latest_dialog_turn_holds_dispatch(session_id)
+            .await?
+        {
             return Ok(None);
         }
 
@@ -1794,18 +2047,14 @@ impl DialogScheduler {
                 .cleanup_prepared_hidden_subagent_session_if_unsubmitted(&execution.request)
                 .await;
             // This path can run while the caller holds the session operation
-            // permit. Never await the bounded outcome channel here: its
-            // receiver may be waiting for the same permit.
-            tokio::spawn(async move {
-                let _ = outcome_tx
-                    .send((
-                        session_id_owned,
-                        TurnOutcome::Cancelled {
-                            turn_id: turn_id_for_task,
-                        },
-                    ))
-                    .await;
-            });
+            // permit. The lifecycle channel is unbounded so retirement never
+            // waits for the receiver to acquire that same permit.
+            let _ = outcome_tx.send((
+                session_id_owned,
+                TurnOutcome::Cancelled {
+                    turn_id: turn_id_for_task,
+                },
+            ));
             result_tx.send(Err(BitFunError::Cancelled(
                 "Subagent task has been cancelled".to_string(),
             )));
@@ -1863,39 +2112,33 @@ impl DialogScheduler {
                 .await;
             match outcome {
                 Ok(result) => {
-                    let _ = outcome_tx
-                        .send((
-                            session_id_owned.clone(),
-                            TurnOutcome::Completed {
-                                turn_id: turn_id_for_task.clone(),
-                                final_response: result.text.clone(),
-                            },
-                        ))
-                        .await;
+                    let _ = outcome_tx.send((
+                        session_id_owned.clone(),
+                        TurnOutcome::Completed {
+                            turn_id: turn_id_for_task.clone(),
+                            final_response: result.text.clone(),
+                        },
+                    ));
                     result_tx.send(Ok(result));
                 }
                 Err(BitFunError::Cancelled(error_text)) => {
-                    let _ = outcome_tx
-                        .send((
-                            session_id_owned.clone(),
-                            TurnOutcome::Cancelled {
-                                turn_id: turn_id_for_task.clone(),
-                            },
-                        ))
-                        .await;
+                    let _ = outcome_tx.send((
+                        session_id_owned.clone(),
+                        TurnOutcome::Cancelled {
+                            turn_id: turn_id_for_task.clone(),
+                        },
+                    ));
                     result_tx.send(Err(BitFunError::Cancelled(error_text)));
                 }
                 Err(error) => {
                     let error_text = error.to_string();
-                    let _ = outcome_tx
-                        .send((
-                            session_id_owned.clone(),
-                            TurnOutcome::Failed {
-                                turn_id: turn_id_for_task.clone(),
-                                error: error_text.clone(),
-                            },
-                        ))
-                        .await;
+                    let _ = outcome_tx.send((
+                        session_id_owned.clone(),
+                        TurnOutcome::Failed {
+                            turn_id: turn_id_for_task.clone(),
+                            error: error_text.clone(),
+                        },
+                    ));
                     result_tx.send(Err(error));
                 }
             }
@@ -1959,7 +2202,10 @@ impl DialogScheduler {
     }
 
     /// Background loop that receives turn outcome notifications from the coordinator.
-    async fn run_outcome_handler(&self, mut outcome_rx: mpsc::Receiver<(String, TurnOutcome)>) {
+    async fn run_outcome_handler(
+        &self,
+        mut outcome_rx: mpsc::UnboundedReceiver<(String, TurnOutcome)>,
+    ) {
         while let Some((session_id, outcome)) = outcome_rx.recv().await {
             let (active_turn, active_internal_turn, lifecycle_plan) = {
                 let _operation_guard = self.lock_session_operation(&session_id).await;
@@ -1980,7 +2226,10 @@ impl DialogScheduler {
                     continue;
                 };
                 let active_turn = match active_turn_result {
-                    ActiveDialogTurnTakeResult::Matched(turn) => Some(turn),
+                    ActiveDialogTurnTakeResult::Matched(turn) => {
+                        self.active_turn_retired.notify_waiters();
+                        Some(turn)
+                    }
                     ActiveDialogTurnTakeResult::Absent => None,
                     ActiveDialogTurnTakeResult::DifferentTurn => {
                         self.round_injection_buffer
@@ -2021,6 +2270,9 @@ impl DialogScheduler {
             if lifecycle_plan.drain_finished_turn_injections {
                 self.round_injection_buffer
                     .drain_for_turn(&session_id, outcome.turn_id());
+            } else if status == TurnOutcomeStatus::Interrupted {
+                self.round_injection_buffer
+                    .discard_current_running(&session_id);
             }
             let suppressed_cancelled_reply =
                 self.take_suppressed_cancelled_reply(&session_id, outcome.turn_id());
@@ -2059,6 +2311,14 @@ impl DialogScheduler {
                             session_id,
                             outcome.turn_id()
                         );
+                        }
+                        GoalContinuationAfterTurnAction::AbortForInterrupted => {
+                            self.goal_continuation_abort.mark(&session_id);
+                            debug!(
+                                "Holding thread goal continuation after interrupted turn: session_id={}, turn_id={}",
+                                session_id,
+                                outcome.turn_id()
+                            );
                         }
                         GoalContinuationAfterTurnAction::Evaluate { turn_completed } => {
                             self.goal_continuation_abort.clear(&session_id);
@@ -2187,6 +2447,33 @@ impl DialogScheduler {
                             "Failed to dispatch next queued message after {}: session_id={}, error={}",
                             status, session_id, e
                         );
+                    }
+                }
+                TurnOutcomeQueueAction::HoldQueue => {
+                    match self
+                        .session_manager
+                        .latest_dialog_turn_holds_dispatch(&session_id)
+                        .await
+                    {
+                        Ok(true) => debug!(
+                            "Turn interrupted, holding queued messages until recovery or a new user turn: session_id={}",
+                            session_id
+                        ),
+                        Ok(false) => {
+                            // An explicit user submission can abandon recovery
+                            // after the coordinator has settled Idle but before
+                            // this outcome retires the previous active entry.
+                            if let Err(error) = self.dispatch_next_if_idle(&session_id).await {
+                                warn!(
+                                    "Failed to dispatch queue after interrupted hold was released: session_id={}, error={}",
+                                    session_id, error
+                                );
+                            }
+                        }
+                        Err(error) => warn!(
+                            "Failed to verify interrupted queue hold; keeping queued work parked: session_id={}, error={}",
+                            session_id, error
+                        ),
                     }
                 }
                 TurnOutcomeQueueAction::ClearQueue => {}
@@ -2423,9 +2710,8 @@ impl AgentDialogTurnPort for DialogScheduler {
     ) -> PortResult<DialogSteerOutcome> {
         // An empty-but-attachment-free message and a malformed attachment are
         // both bad requests; only a live-turn mismatch means "session in use".
-        let invalid_request =
-            request.content.trim().is_empty() && request.attachments.is_empty()
-                || agent_dialog_turn_image_contexts(&request.attachments).is_err();
+        let invalid_request = request.content.trim().is_empty() && request.attachments.is_empty()
+            || agent_dialog_turn_image_contexts(&request.attachments).is_err();
         DialogScheduler::buffer_steering(
             self,
             request.session_id,
@@ -2446,6 +2732,116 @@ impl AgentDialogTurnPort for DialogScheduler {
                 error,
             )
         })
+    }
+
+    async fn recover_interrupted_turn(
+        &self,
+        request: bitfun_runtime_ports::AgentDialogTurnRecoveryRequest,
+    ) -> PortResult<bitfun_runtime_ports::AgentDialogTurnRecoveryOutcome> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let mut retired = Box::pin(self.active_turn_retired.notified());
+            retired.as_mut().enable();
+            let operation_guard = self.lock_session_operation(&request.session_id).await;
+            let session = self
+                .session_manager
+                .get_session(&request.session_id)
+                .ok_or_else(|| {
+                    PortError::new(
+                        PortErrorKind::NotFound,
+                        format!("Session not found: {}", request.session_id),
+                    )
+                })?;
+            if !self.active_turns.contains(&request.session_id) {
+                let active_turn = ActiveDialogTurn::new(
+                    request.turn_id.clone(),
+                    request
+                        .workspace_path
+                        .clone()
+                        .or_else(|| session.config.workspace_path.clone())
+                        .or_else(|| session.config.project_workspace_path.clone()),
+                    request.remote_connection_id.clone(),
+                    request.remote_ssh_host.clone(),
+                    session.agent_type.clone(),
+                    String::new(),
+                    None,
+                    DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopUi),
+                    None,
+                );
+                self.active_turns.insert(&request.session_id, active_turn);
+                let active_admission = RecoveryActiveTurnAdmission {
+                    active_turns: self.active_turns.clone(),
+                    active_turn_retired: self.active_turn_retired.clone(),
+                    session_id: request.session_id.clone(),
+                    turn_id: request.turn_id.clone(),
+                    armed: true,
+                };
+                let coordinator = self.coordinator.clone();
+                let (recovery_tx, recovery_rx) = oneshot::channel();
+                tokio::spawn(async move {
+                    let mut active_admission = active_admission;
+                    let outcome = coordinator.recover_interrupted_dialog_turn(&request).await;
+                    if outcome.is_ok() {
+                        active_admission.disarm();
+                    }
+                    let _ = recovery_tx.send(outcome);
+                    drop(operation_guard);
+                });
+                let outcome = recovery_rx
+                    .await
+                    .map_err(|_| {
+                        PortError::new(
+                            PortErrorKind::OutcomeUnknown,
+                            "Interrupted turn recovery admission ended without an outcome",
+                        )
+                    })?
+                    .map_err(|error| {
+                        PortError::new(
+                            match error {
+                                BitFunError::Validation(_) => PortErrorKind::InvalidRequest,
+                                BitFunError::NotFound(_) => PortErrorKind::NotFound,
+                                BitFunError::Timeout(_) => PortErrorKind::Timeout,
+                                _ => PortErrorKind::Backend,
+                            },
+                            error.to_string(),
+                        )
+                    })?;
+                return Ok(outcome);
+            }
+            if !self
+                .active_turns
+                .matches_turn(&request.session_id, &request.turn_id)
+            {
+                return Err(PortError::new(
+                    PortErrorKind::SessionInUse,
+                    format!(
+                        "A different dialog turn is active: session_id={}, requested_turn_id={}",
+                        request.session_id, request.turn_id
+                    ),
+                ));
+            }
+            if !matches!(session.state, SessionState::Idle) {
+                return Err(PortError::new(
+                    PortErrorKind::SessionInUse,
+                    format!(
+                        "Session is still executing a dialog turn: {}",
+                        request.session_id
+                    ),
+                ));
+            }
+            drop(operation_guard);
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() || tokio::time::timeout(remaining, retired).await.is_err() {
+                return Err(PortError::new(
+                    PortErrorKind::Timeout,
+                    format!(
+                        "Previous interrupted turn generation did not retire in time: session_id={}, turn_id={}",
+                        request.session_id, request.turn_id
+                    ),
+                ));
+            }
+        }
     }
 }
 
@@ -2546,6 +2942,46 @@ impl AgentTurnCancellationPort for DialogScheduler {
             turn_id: cancelled_turn_id,
         })
     }
+
+    async fn interrupt_turn(
+        &self,
+        request: bitfun_runtime_ports::AgentTurnInterruptionRequest,
+    ) -> PortResult<bitfun_runtime_ports::AgentTurnInterruptionResult> {
+        // Serialize the route check with submit/start registration. Without
+        // this guard an AgentSession turn could be spawned just before its
+        // reply route becomes visible in `active_turns` and then be recovered
+        // without the route required to settle its requester.
+        let _operation_guard = self.lock_session_operation(&request.session_id).await;
+        if self
+            .active_turns
+            .matches_agent_session_request(&request.session_id, &request.turn_id)
+        {
+            return Err(PortError::new(
+                PortErrorKind::InvalidRequest,
+                "Agent-session request turns cannot be recoverably interrupted; cancel them instead",
+            ));
+        }
+        let wait_timeout = Duration::from_millis(request.wait_timeout_ms.unwrap_or(30_000));
+        self.coordinator
+            .interrupt_dialog_turn(&request.session_id, &request.turn_id, wait_timeout)
+            .await
+            .map_err(|error| {
+                PortError::new(
+                    match error {
+                        BitFunError::Validation(_) => PortErrorKind::InvalidRequest,
+                        BitFunError::NotFound(_) => PortErrorKind::NotFound,
+                        BitFunError::Timeout(_) => PortErrorKind::Timeout,
+                        _ => PortErrorKind::Backend,
+                    },
+                    error.to_string(),
+                )
+            })?;
+        Ok(bitfun_runtime_ports::AgentTurnInterruptionResult {
+            session_id: request.session_id,
+            turn_id: request.turn_id,
+            requested: true,
+        })
+    }
 }
 
 fn thread_goal_delivery_messages(reminders: Vec<ThreadGoalDeliveryReminder>) -> Vec<Message> {
@@ -2641,11 +3077,18 @@ mod tests {
         compression::{CompressionConfig, ContextCompressor},
         revert::{SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION},
         PromptCachePolicy, SessionContextStore, SessionManagerConfig,
+        TEST_MODEL_RESOLUTION_AI_CONFIG,
     };
     use crate::agentic::tools::registry::ToolRegistry;
     use crate::agentic::tools::{ToolPipeline, ToolStateManager};
+    use crate::infrastructure::ai::reasoning_catalog::reasoning_preset_runtime_fingerprint;
     use crate::infrastructure::PathManager;
-    use bitfun_runtime_ports::{AgentDialogPrependedReminder, AgentInputAttachment, PortErrorKind};
+    use crate::service::config::types::{
+        model_runtime_binding_fingerprint, AIConfig, AIModelConfig,
+    };
+    use bitfun_runtime_ports::{
+        AgentDialogPrependedReminder, AgentInputAttachment, PortErrorKind, ThreadGoalStatus,
+    };
     use tokio::sync::RwLock as TokioRwLock;
 
     #[test]
@@ -2659,6 +3102,17 @@ mod tests {
     }
 
     fn test_scheduler() -> (
+        Arc<DialogScheduler>,
+        Arc<SessionManager>,
+        Arc<EventQueue>,
+        tempfile::TempDir,
+    ) {
+        test_scheduler_with_persistence(false)
+    }
+
+    fn test_scheduler_with_persistence(
+        enable_persistence: bool,
+    ) -> (
         Arc<DialogScheduler>,
         Arc<SessionManager>,
         Arc<EventQueue>,
@@ -2678,7 +3132,7 @@ mod tests {
                 max_active_sessions: 100,
                 session_idle_timeout: Duration::from_secs(3600),
                 auto_save_interval: Duration::from_secs(300),
-                enable_persistence: false,
+                enable_persistence,
                 prompt_cache_policy: PromptCachePolicy::default(),
             },
         ));
@@ -2841,6 +3295,11 @@ mod tests {
             .await
             .expect("inject background Bash result");
 
+        let unrelated = scheduler
+            .round_injection_monitor()
+            .take_pending(session_id, "different-turn");
+        assert!(unrelated.is_empty());
+
         let pending = scheduler
             .round_injection_monitor()
             .take_pending(session_id, turn_id);
@@ -2861,25 +3320,185 @@ mod tests {
                 "agentic".to_string(),
                 SessionConfig {
                     workspace_path: Some(workspace.to_string_lossy().into_owned()),
+                    model_id: Some("model-original".to_string()),
                     ..Default::default()
                 },
             )
             .await
             .expect("create parent session");
 
-        scheduler
-            .deliver_background_result(
-                session_id.to_string(),
-                "external::opencode::agentic::generation-v1".to_string(),
-                None,
-                None,
-                None,
-                "Background Bash command completed".to_string(),
-                None,
-                None,
+        TEST_MODEL_RESOLUTION_AI_CONFIG
+            .scope(
+                AIConfig {
+                    models: vec![AIModelConfig {
+                        id: "model-original".to_string(),
+                        name: "model-original".to_string(),
+                        model_name: "model-original".to_string(),
+                        enabled: true,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                scheduler.deliver_background_result(
+                    session_id.to_string(),
+                    "external::opencode::agentic::generation-v1".to_string(),
+                    None,
+                    None,
+                    None,
+                    "Background Bash command completed".to_string(),
+                    None,
+                    None,
+                ),
             )
             .await
             .expect("lifecycle delivery must follow the persisted logical session route");
+    }
+
+    #[tokio::test]
+    async fn restored_interrupted_session_holds_agent_follow_up_queue() {
+        let (scheduler, session_manager, _, root) = test_scheduler_with_persistence(true);
+        let session_id = "evicted-interrupted-session";
+        let turn_id = "interrupted-turn";
+        let workspace = root.path().join("workspace");
+        let model_binding_fingerprint = model_runtime_binding_fingerprint(&AIModelConfig {
+            id: "model-original".to_string(),
+            name: "model-original".to_string(),
+            model_name: "model-original".to_string(),
+            enabled: true,
+            ..Default::default()
+        });
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        session_manager
+            .create_session_with_id(
+                Some(session_id.to_string()),
+                "Interrupted".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create session");
+        session_manager
+            .start_dialog_turn(
+                session_id,
+                "agentic".to_string(),
+                "finish this".to_string(),
+                Some(turn_id.to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": model_binding_fingerprint,
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": reasoning_preset_runtime_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("start turn");
+        session_manager
+            .mark_dialog_turn_interrupted(session_id, turn_id)
+            .await
+            .expect("interrupt turn");
+        session_manager
+            .update_session_state_for_turn_if_processing(session_id, turn_id, SessionState::Idle)
+            .await
+            .expect("settle session idle");
+        let storage_path = session_manager
+            .effective_session_storage_path(session_id)
+            .await
+            .expect("resolve persisted session storage path");
+        session_manager.evict_loaded_session_for_test(session_id);
+
+        scheduler
+            .restore_missing_session_before_admission(session_id, &storage_path)
+            .await
+            .expect("restore persisted session before admission")
+            .expect("persisted session should restore");
+        let mut queued_turn = standard_queued_turn("follow-up-turn");
+        queued_turn.policy = DialogSubmissionPolicy::for_source(DialogTriggerSource::AgentSession);
+        queued_turn.workspace_path = None;
+        let outcome = scheduler
+            .submit_queued_turn(
+                session_id.to_string(),
+                "follow-up-turn".to_string(),
+                queued_turn,
+                false,
+            )
+            .await
+            .expect("agent follow-up should be accepted behind the hold");
+
+        assert!(matches!(outcome, DialogSubmitOutcome::Queued { .. }));
+        assert_eq!(scheduler.queue_depth(session_id), 1);
+        assert!(session_manager
+            .latest_dialog_turn_holds_dispatch(session_id)
+            .await
+            .expect("hold should remain durable"));
+    }
+
+    #[tokio::test]
+    async fn running_thread_goal_delivery_targets_the_concrete_turn() {
+        let (scheduler, session_manager, _, root) = test_scheduler();
+        let session_id = "goal-parent-session";
+        let turn_id = "goal-parent-turn";
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        session_manager
+            .create_session_with_id(
+                Some(session_id.to_string()),
+                "Goal parent".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create parent session");
+        session_manager
+            .update_session_state(
+                session_id,
+                SessionState::Processing {
+                    current_turn_id: turn_id.to_string(),
+                    phase: ProcessingPhase::Thinking,
+                },
+            )
+            .await
+            .expect("mark goal turn active");
+
+        scheduler
+            .deliver_thread_goal_objective_updated(
+                session_id.to_string(),
+                "agentic".to_string(),
+                None,
+                None,
+                None,
+                ThreadGoal {
+                    goal_id: "goal-1".to_string(),
+                    session_id: session_id.to_string(),
+                    objective: "Finish the task".to_string(),
+                    status: ThreadGoalStatus::Active,
+                    token_budget: None,
+                    tokens_used: 0,
+                    time_used_seconds: 0,
+                    created_at: 1,
+                    updated_at: 2,
+                    auto_continuation_count: 0,
+                },
+            )
+            .await
+            .expect("inject goal update");
+
+        assert!(scheduler
+            .round_injection_monitor()
+            .take_pending(session_id, "different-turn")
+            .is_empty());
+        let pending = scheduler
+            .round_injection_monitor()
+            .take_pending(session_id, turn_id);
+        assert_eq!(pending.len(), 1);
     }
 
     fn standard_queued_turn(turn_id: &str) -> QueuedTurn {
@@ -2948,6 +3567,62 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_persistently_holds_later_queued_work() {
+        let (scheduler, session_manager, _, root) = test_scheduler_with_persistence(true);
+        let session_id = "interrupted-queue-hold";
+        let turn_id = "turn-interrupted";
+        let workspace = root.path().join("workspace-interrupted-hold");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        session_manager
+            .create_session_with_id(
+                Some(session_id.to_string()),
+                "Interrupted queue hold".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create session");
+        session_manager
+            .start_dialog_turn(
+                session_id,
+                "agentic".to_string(),
+                "original work".to_string(),
+                Some(turn_id.to_string()),
+                None,
+                None,
+            )
+            .await
+            .expect("start turn");
+        session_manager
+            .mark_dialog_turn_interrupted(session_id, turn_id)
+            .await
+            .expect("interrupt turn");
+        session_manager
+            .update_session_state_for_turn_if_processing(session_id, turn_id, SessionState::Idle)
+            .await
+            .expect("settle idle");
+        scheduler
+            .queues
+            .enqueue(
+                session_id,
+                standard_queued_turn("late-background-result"),
+                DialogQueuePriority::Low,
+            )
+            .expect("queue later work");
+
+        let started = scheduler
+            .try_start_next_queued(session_id)
+            .await
+            .expect("hold check should succeed");
+
+        assert!(started.is_none());
+        assert_eq!(scheduler.queue_depth(session_id), 1);
     }
 
     #[tokio::test]
@@ -3732,6 +4407,43 @@ mod tests {
         assert!(scheduler
             .active_turns
             .matches_turn(session_id, "turn-active"));
+    }
+
+    #[tokio::test]
+    async fn session_deletion_clears_injections_retained_for_an_interrupted_turn() {
+        let (scheduler, session_manager, _, root) = test_scheduler();
+        let session_id = "session-delete-interrupted-injections";
+        let storage = root.path().join("workspace-delete-interrupted-injections");
+        session_manager
+            .ensure_session_storage_path(session_id, &storage)
+            .expect("bind session storage");
+        scheduler.round_injection_buffer.push(
+            session_id,
+            target_background_delivery_injection_to_turn(
+                resolve_background_delivery_injection(
+                    BackgroundInjectionKind::BackgroundResult,
+                    "injection-1".to_string(),
+                    "retained result".to_string(),
+                    None,
+                    std::time::SystemTime::now(),
+                ),
+                "turn-interrupted".to_string(),
+            ),
+        );
+        assert_eq!(
+            scheduler.round_injection_buffer.pending_count(session_id),
+            1
+        );
+
+        let _permit = scheduler
+            .begin_session_deletion(session_id, &storage, Duration::ZERO)
+            .await
+            .expect("deletion maintenance should quiesce the idle session");
+
+        assert_eq!(
+            scheduler.round_injection_buffer.pending_count(session_id),
+            0
+        );
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -31,6 +31,12 @@ use crate::agentic::image_analysis::{
 use crate::agentic::round_preempt::RoundInjectionKind;
 use crate::agentic::session::{
     ContextCompressor, SessionManager, TokenAnchor, TokenAnchorInput, UserContextCacheIdentity,
+    INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY,
+    INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY,
+    INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY,
 };
 use crate::agentic::skill_agent_snapshot::build_skill_agent_tool_listing_sections_from_snapshot;
 use crate::agentic::tools::implementations::{SkillTool, TaskTool};
@@ -42,6 +48,7 @@ use crate::agentic::tools::{
 };
 use crate::agentic::WorkspaceBinding;
 use crate::infrastructure::ai::get_global_ai_client_factory;
+use crate::infrastructure::ai::reasoning_catalog::reasoning_preset_runtime_fingerprint;
 use crate::native_hooks::{self, NativeHookSessionFacts};
 use crate::service::config::get_global_config_service;
 use crate::service::config::types::{
@@ -64,6 +71,7 @@ use bitfun_agent_runtime::thread_goal_tools::ensure_thread_goal_tools;
 use bitfun_ai_adapters::ModelExchangeTraceConfig;
 use bitfun_core_types::SessionModelBindingPolicy;
 use bitfun_runtime_ports::{resolve_permission_mode, PermissionMode, PermissionModeLayers};
+use dashmap::DashMap;
 use log::{debug, error, info, trace, warn};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -71,6 +79,17 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
+
+fn execution_engine_owns_cancel_lifecycle(context: &HashMap<String, String>) -> bool {
+    !super::types::coordinator_owns_cancel_lifecycle(context)
+}
+
+fn initial_round_index(context: &std::collections::HashMap<String, String>) -> usize {
+    context
+        .get("initial_round_index")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0)
+}
 use tool_runtime::context::PrimaryModelFacts;
 
 fn ensure_primary_session_goal_tools(allowed_tools: &mut Vec<String>, is_subagent: bool) {
@@ -91,6 +110,25 @@ fn resolve_round_permission_mode(
             .with_turn(active_turn_mode.or(fixed_context_mode)),
     )
     .mode
+}
+
+pub(crate) fn restrict_recovered_permission_mode(
+    original: PermissionMode,
+    current: PermissionMode,
+) -> PermissionMode {
+    const fn rank(mode: PermissionMode) -> u8 {
+        match mode {
+            PermissionMode::Ask => 0,
+            PermissionMode::AutoApprove => 1,
+            PermissionMode::FullAccess => 2,
+        }
+    }
+
+    if rank(current) < rank(original) {
+        current
+    } else {
+        original
+    }
 }
 
 /// Execution engine configuration
@@ -482,6 +520,7 @@ pub struct ExecutionEngine {
     session_manager: Arc<SessionManager>,
     context_compressor: Arc<ContextCompressor>,
     config: ExecutionEngineConfig,
+    generation_messages: DashMap<(String, String), Vec<Message>>,
 }
 
 impl ExecutionEngine {
@@ -518,12 +557,17 @@ impl ExecutionEngine {
                 .unwrap_or(PermissionMode::Ask),
             Err(_) => PermissionMode::Ask,
         };
-        let resolved = resolve_round_permission_mode(
+        let current = resolve_round_permission_mode(
             active_turn_mode,
             fixed_context_mode,
             self.session_manager.session_permission_mode(session_id),
             global_default,
         );
+        let resolved = base
+            .get(INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY)
+            .and_then(|value| PermissionMode::parse(value))
+            .map(|original| restrict_recovered_permission_mode(original, current))
+            .unwrap_or(current);
         context_vars.insert(
             PERMISSION_MODE_CONTEXT_KEY.to_string(),
             resolved.as_str().to_string(),
@@ -544,7 +588,22 @@ impl ExecutionEngine {
             session_manager,
             context_compressor,
             config,
+            generation_messages: DashMap::new(),
         }
+    }
+
+    fn remember_generation_message(&self, session_id: &str, turn_id: &str, message: &Message) {
+        self.generation_messages
+            .entry((session_id.to_string(), turn_id.to_string()))
+            .or_default()
+            .push(message.clone());
+    }
+
+    pub(crate) fn take_generation_messages(&self, session_id: &str, turn_id: &str) -> Vec<Message> {
+        self.generation_messages
+            .remove(&(session_id.to_string(), turn_id.to_string()))
+            .map(|(_, messages)| messages)
+            .unwrap_or_default()
     }
 
     fn estimate_request_tokens_internal(
@@ -1067,6 +1126,160 @@ impl ExecutionEngine {
             .unwrap_or_else(|| "auto".to_string())
     }
 
+    fn resolve_model_id_for_turn_selection(
+        ai_config: &crate::service::config::types::AIConfig,
+        configured_model_id: &str,
+        frozen_model_id: Option<&str>,
+    ) -> BitFunResult<String> {
+        if let Some(frozen_model_id) = frozen_model_id
+            .map(str::trim)
+            .filter(|model_id| !model_id.is_empty())
+        {
+            return ai_config
+                .resolve_model_reference(frozen_model_id)
+                .ok_or_else(|| {
+                    BitFunError::Validation(format!(
+                        "Frozen dialog turn model contract is unavailable: {frozen_model_id}"
+                    ))
+                });
+        }
+
+        let resolved_configured_model_id =
+            Self::resolve_configured_model_id(ai_config, configured_model_id);
+        if configured_model_id == "auto"
+            || configured_model_id == "default"
+            || resolved_configured_model_id == "auto"
+        {
+            ai_config.resolve_model_selection("primary").ok_or_else(|| {
+                BitFunError::AIClient(
+                    "Auto dialog turn model could not resolve a concrete primary model".to_string(),
+                )
+            })
+        } else {
+            Ok(resolved_configured_model_id)
+        }
+    }
+
+    fn validate_frozen_reasoning_contract(
+        context: &ExecutionContext,
+        ai_client: &crate::infrastructure::ai::AIClient,
+    ) -> BitFunResult<()> {
+        let Some(expected_value) = context
+            .context
+            .get(INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY)
+        else {
+            return Ok(());
+        };
+        let expected = serde_json::from_str::<Option<String>>(expected_value).map_err(|error| {
+            BitFunError::Validation(format!(
+                "Frozen dialog turn reasoning contract is malformed: {error}"
+            ))
+        })?;
+        let actual_descriptor = ai_client
+            .selected_reasoning_preset()
+            .or_else(|| ai_client.model_reasoning_preset());
+        let actual = actual_descriptor.map(|preset| preset.id.as_str());
+        if actual != expected.as_deref() {
+            return Err(BitFunError::Validation(format!(
+                "Frozen dialog turn reasoning contract changed before execution: expected={:?}, actual={actual:?}",
+                expected.as_deref(),
+            )));
+        }
+        let expected_fingerprint = context
+            .context
+            .get(INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY)
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Frozen dialog turn reasoning contract has no runtime fingerprint".to_string(),
+                )
+            })?;
+        if reasoning_preset_runtime_fingerprint(actual_descriptor) != expected_fingerprint.as_str()
+        {
+            return Err(BitFunError::Validation(
+                "Frozen dialog turn reasoning contract changed before execution: runtime fingerprint mismatch"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn resolve_reasoning_selection_for_turn(
+        &self,
+        session_id: &str,
+        context: &ExecutionContext,
+    ) -> BitFunResult<Option<String>> {
+        if let Some(frozen_selection) = context
+            .context
+            .get(INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY)
+        {
+            return serde_json::from_str::<Option<String>>(frozen_selection).map_err(|error| {
+                BitFunError::Validation(format!(
+                    "Frozen dialog turn reasoning selection is malformed: {error}"
+                ))
+            });
+        }
+
+        self.session_manager
+            .reconcile_session_reasoning_preset_for_turn(session_id, "turn_resolution")
+            .await
+    }
+
+    pub(crate) fn is_frozen_reasoning_contract_error(error: &BitFunError) -> bool {
+        matches!(error, BitFunError::Validation(message) if message.starts_with("Frozen dialog turn reasoning contract changed before execution:"))
+    }
+
+    async fn validate_frozen_model_contract(context: &ExecutionContext) -> BitFunResult<()> {
+        let Some(expected_model_id) = context
+            .context
+            .get(INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY)
+        else {
+            return Ok(());
+        };
+        let expected_fingerprint = context
+            .context
+            .get(INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY)
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Frozen dialog turn model contract has no binding fingerprint".to_string(),
+                )
+            })?;
+        let ai_config = SessionManager::load_ai_config_for_model_resolution()
+            .await
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Frozen dialog turn model contract cannot be validated because AI configuration is unavailable"
+                        .to_string(),
+                )
+            })?;
+        let canonical_model_id = ai_config
+            .resolve_model_reference(expected_model_id)
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "Frozen dialog turn model contract is unavailable: {expected_model_id}"
+                ))
+            })?;
+        let model = ai_config
+            .models
+            .iter()
+            .find(|model| model.enabled && model.id == canonical_model_id)
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "Frozen dialog turn model contract is unavailable: {expected_model_id}"
+                ))
+            })?;
+        let actual_fingerprint = model_runtime_binding_fingerprint(model);
+        if actual_fingerprint != expected_fingerprint.as_str() {
+            return Err(BitFunError::Validation(format!(
+                "Frozen dialog turn model contract changed before execution: model_id={expected_model_id}"
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn is_frozen_model_contract_error(error: &BitFunError) -> bool {
+        matches!(error, BitFunError::Validation(message) if message.starts_with("Frozen dialog turn model contract"))
+    }
+
     async fn resolve_primary_model_context(
         model_id: &str,
         model_binding_policy: SessionModelBindingPolicy,
@@ -1511,17 +1724,16 @@ impl ExecutionEngine {
         workspace: Option<&WorkspaceBinding>,
         original_user_input: &str,
         turn_index: usize,
-    ) -> BitFunResult<String> {
-        let config_service = get_global_config_service().await.map_err(|e| {
-            BitFunError::AIClient(format!(
-                "Failed to get config service for model resolution: {}",
-                e
-            ))
-        })?;
-        let ai_config: crate::service::config::types::AIConfig = config_service
-            .get_config(Some("ai"))
+        frozen_model_id: Option<&str>,
+        frozen_model_binding_fingerprint: Option<&str>,
+    ) -> BitFunResult<(String, String)> {
+        let ai_config = SessionManager::load_ai_config_for_model_resolution()
             .await
-            .unwrap_or_default();
+            .ok_or_else(|| {
+                BitFunError::AIClient(
+                    "Failed to get config service for model resolution".to_string(),
+                )
+            })?;
         if matches!(
             session.config.model_binding_policy,
             SessionModelBindingPolicy::ApprovedImmutable
@@ -1564,7 +1776,7 @@ impl ExecutionEngine {
                     model_id
                 )));
             }
-            return Ok(model_id.to_string());
+            return Ok((model_id.to_string(), expected_fingerprint.to_string()));
         }
 
         let agent_registry = get_agent_registry();
@@ -1580,39 +1792,50 @@ impl ExecutionEngine {
             .filter(|model_id| !model_id.is_empty())
             .map(str::to_string)
             .unwrap_or(fallback_model_id.clone());
-        let resolved_configured_model_id =
-            Self::resolve_configured_model_id(&ai_config, &configured_model_id);
-
-        let model_id = if configured_model_id == "auto"
-            || configured_model_id == "default"
-            || resolved_configured_model_id == "auto"
+        let model_id = Self::resolve_model_id_for_turn_selection(
+            &ai_config,
+            &configured_model_id,
+            frozen_model_id,
+        )?;
+        let model = ai_config
+            .models
+            .iter()
+            .find(|model| model.enabled && model.id == model_id)
+            .ok_or_else(|| {
+                if frozen_model_id.is_some() {
+                    BitFunError::Validation(format!(
+                        "Frozen dialog turn model contract is unavailable: {model_id}"
+                    ))
+                } else {
+                    BitFunError::AIClient(format!(
+                        "Dialog turn model configuration is unavailable: {model_id}"
+                    ))
+                }
+            })?;
+        let model_binding_fingerprint = model_runtime_binding_fingerprint(model);
+        if frozen_model_binding_fingerprint
+            .is_some_and(|expected| expected != model_binding_fingerprint)
         {
-            let fallback_model = "primary";
-            let resolved_model_id = ai_config.resolve_model_selection(fallback_model);
+            return Err(BitFunError::Validation(format!(
+                "Frozen dialog turn model contract changed before execution: model_id={model_id}"
+            )));
+        }
+        if frozen_model_id.is_some() {
+            info!(
+                "Using frozen dialog turn model: session_id={}, turn_index={}, resolved_model_id={}",
+                session.session_id, turn_index, model_id
+            );
+        } else if configured_model_id == "auto" || configured_model_id == "default" {
+            info!(
+                "Auto model resolved without locking session: session_id={}, turn_index={}, user_input_chars={}, strategy=primary, resolved_model_id={}",
+                session.session_id,
+                turn_index,
+                original_user_input.chars().count(),
+                model_id
+            );
+        }
 
-            if let Some(resolved_model_id) = resolved_model_id {
-                info!(
-                    "Auto model resolved without locking session: session_id={}, turn_index={}, user_input_chars={}, strategy={}, resolved_model_id={}",
-                    session.session_id,
-                    turn_index,
-                    original_user_input.chars().count(),
-                    fallback_model,
-                    resolved_model_id
-                );
-
-                resolved_model_id
-            } else {
-                warn!(
-                    "Auto model strategy unresolved, keeping symbolic selector: session_id={}, strategy={}",
-                    session.session_id, fallback_model
-                );
-                fallback_model.to_string()
-            }
-        } else {
-            resolved_configured_model_id
-        };
-
-        Ok(model_id)
+        Ok((model_id, model_binding_fingerprint))
     }
 
     /// Omit from model request: UI-only verification frames and legacy auto desktop snapshots.
@@ -1622,6 +1845,11 @@ impl ExecutionEngine {
             Some(MessageSemanticKind::ComputerUseVerificationScreenshot)
                 | Some(MessageSemanticKind::ComputerUsePostActionSnapshot)
         )
+    }
+
+    fn is_stale_interrupted_continue(msg: &Message, current_turn_id: &str) -> bool {
+        msg.internal_reminder_kind() == Some(InternalReminderKind::InterruptedContinue)
+            && msg.metadata.turn_id.as_deref() != Some(current_turn_id)
     }
 
     /// True if this message would contribute at least one image to the model (before pruning).
@@ -1776,7 +2004,9 @@ impl ExecutionEngine {
                 prepended_reminders_injected = true;
             }
 
-            if Self::skip_message_for_model_send(msg) {
+            if Self::skip_message_for_model_send(msg)
+                || Self::is_stale_interrupted_continue(msg, current_turn_id)
+            {
                 continue;
             }
             let keep_this_message_images = attach_images && keep_image_messages.contains(&msg_idx);
@@ -2237,13 +2467,21 @@ impl ExecutionEngine {
             .get("original_user_input")
             .cloned()
             .unwrap_or_default();
-        let model_id = self
+        let (model_id, _) = self
             .resolve_model_id_for_turn(
                 session,
                 &context.agent_type,
                 context.workspace.as_ref(),
                 &original_user_input,
                 context.turn_index,
+                context
+                    .context
+                    .get(INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY)
+                    .map(String::as_str),
+                context
+                    .context
+                    .get(INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY)
+                    .map(String::as_str),
             )
             .await?;
 
@@ -2251,8 +2489,7 @@ impl ExecutionEngine {
             BitFunError::AIClient(format!("Failed to get AI client factory: {}", e))
         })?;
         let reasoning_preset = match self
-            .session_manager
-            .reconcile_session_reasoning_preset_for_turn(&session.session_id, "turn_resolution")
+            .resolve_reasoning_selection_for_turn(&session.session_id, context)
             .await
         {
             Ok(reasoning_preset) => reasoning_preset,
@@ -2284,12 +2521,27 @@ impl ExecutionEngine {
                 .get_client_resolved_with_reasoning_preset(&model_id, reasoning_preset.as_deref())
                 .await
         };
-        let ai_client = ai_client_result.map_err(|e| {
-            BitFunError::AIClient(format!(
-                "Failed to get AI client (model_id={}): {}",
-                model_id, e
-            ))
-        })?;
+        let ai_client = match ai_client_result {
+            Ok(ai_client) => ai_client,
+            Err(error) => {
+                if context
+                    .context
+                    .contains_key(INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY)
+                {
+                    // Re-check the frozen binding after a factory failure so a
+                    // config race is classified as recoverable contract drift,
+                    // while credentials/provider/client construction failures
+                    // remain ordinary execution failures.
+                    Self::validate_frozen_model_contract(context).await?;
+                }
+                return Err(BitFunError::AIClient(format!(
+                    "Failed to get AI client (model_id={}): {}",
+                    model_id, error
+                )));
+            }
+        };
+        Self::validate_frozen_model_contract(context).await?;
+        Self::validate_frozen_reasoning_contract(context, ai_client.as_ref())?;
 
         let primary_model_facts = Self::resolve_primary_model_context(
             &model_id,
@@ -3012,21 +3264,15 @@ impl ExecutionEngine {
         context: ExecutionContext,
     ) -> BitFunResult<ExecutionResult> {
         let start_time = std::time::Instant::now();
-        let initial_count = initial_messages.len();
-
         let dialog_turn_id = context.dialog_turn_id.clone();
+        self.generation_messages
+            .remove(&(context.session_id.clone(), dialog_turn_id.clone()));
 
         info!("Starting dialog turn: dialog_turn_id={}", dialog_turn_id);
 
         // Execute actual logic
         let result = self
-            .execute_dialog_turn_impl(
-                agent_type,
-                initial_messages,
-                context,
-                start_time,
-                initial_count,
-            )
+            .execute_dialog_turn_impl(agent_type, initial_messages, context, start_time)
             .await;
 
         // Cleanup cancellation token
@@ -3048,9 +3294,9 @@ impl ExecutionEngine {
         initial_messages: Vec<Message>,
         context: ExecutionContext,
         start_time: std::time::Instant,
-        initial_count: usize,
     ) -> BitFunResult<ExecutionResult> {
         let dialog_turn_id = context.dialog_turn_id.clone();
+        let initial_count = initial_messages.len();
 
         debug!(
             "Executing dialog turn implementation: dialog_turn_id={}",
@@ -3136,13 +3382,21 @@ impl ExecutionEngine {
             }
         }
 
-        let model_id = self
+        let (model_id, _) = self
             .resolve_model_id_for_turn(
                 &session,
                 &agent_type,
                 context.workspace.as_ref(),
                 &original_user_input,
                 context.turn_index,
+                context
+                    .context
+                    .get(INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY)
+                    .map(String::as_str),
+                context
+                    .context
+                    .get(INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY)
+                    .map(String::as_str),
             )
             .await?;
         info!(
@@ -3157,8 +3411,7 @@ impl ExecutionEngine {
 
         // Get AI client by model ID
         let reasoning_preset = match self
-            .session_manager
-            .reconcile_session_reasoning_preset_for_turn(&session.session_id, "turn_resolution")
+            .resolve_reasoning_selection_for_turn(&session.session_id, &context)
             .await
         {
             Ok(reasoning_preset) => reasoning_preset,
@@ -3190,12 +3443,23 @@ impl ExecutionEngine {
                 .get_client_resolved_with_reasoning_preset(&model_id, reasoning_preset.as_deref())
                 .await
         };
-        let ai_client = ai_client_result.map_err(|e| {
-            BitFunError::AIClient(format!(
-                "Failed to get AI client (model_id={}): {}",
-                model_id, e
-            ))
-        })?;
+        let ai_client = match ai_client_result {
+            Ok(ai_client) => ai_client,
+            Err(error) => {
+                if context
+                    .context
+                    .contains_key(INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY)
+                {
+                    Self::validate_frozen_model_contract(&context).await?;
+                }
+                return Err(BitFunError::AIClient(format!(
+                    "Failed to get AI client (model_id={}): {}",
+                    model_id, error
+                )));
+            }
+        };
+        Self::validate_frozen_model_contract(&context).await?;
+        Self::validate_frozen_reasoning_contract(&context, ai_client.as_ref())?;
 
         // Primary model vision capability (tools + system prompt appendix; also used below for API message stripping).
         let primary_model_facts = Self::resolve_primary_model_context(
@@ -3368,8 +3632,12 @@ impl ExecutionEngine {
         // Add System Prompt to the beginning of message list (only for this execution, not persisted)
         let mut messages = vec![turn_prompt_scaffold.system_prompt_message.clone()];
         messages.extend(initial_messages);
+        // Keep this generation's append-only transcript separate from the
+        // mutable request history. Context compression may replace `messages`
+        // wholesale, but durable recovered-Turn completion must still append
+        // every assistant/tool/injection message produced by this generation.
 
-        let mut round_index = 0;
+        let mut round_index = initial_round_index(&context.context);
         let mut completed_rounds = 0usize;
         let mut total_tools = 0;
         let mut last_partial_recovery_reason: Option<String> = None;
@@ -3947,6 +4215,11 @@ impl ExecutionEngine {
 
             // Add assistant message to history
             messages.push(round_result.assistant_message.clone());
+            self.remember_generation_message(
+                &context.session_id,
+                &context.dialog_turn_id,
+                &round_result.assistant_message,
+            );
 
             // Update the in-memory message caches immediately so subsequent rounds see it.
             if let Err(e) = self
@@ -3960,6 +4233,11 @@ impl ExecutionEngine {
             // Add tool result messages to history
             for tool_result_msg in round_result.tool_result_messages.iter() {
                 messages.push(tool_result_msg.clone());
+                self.remember_generation_message(
+                    &context.session_id,
+                    &context.dialog_turn_id,
+                    tool_result_msg,
+                );
 
                 // Update the in-memory message caches immediately so subsequent rounds see it.
                 if let Err(e) = self
@@ -3972,13 +4250,23 @@ impl ExecutionEngine {
             }
 
             #[cfg(feature = "agent-runtime")]
-            activate_conditional_instructions_after_round(
-                self.session_manager.as_ref(),
-                &context,
-                &round_result,
-                &mut messages,
-            )
-            .await;
+            {
+                let previous_message_count = messages.len();
+                activate_conditional_instructions_after_round(
+                    self.session_manager.as_ref(),
+                    &context,
+                    &round_result,
+                    &mut messages,
+                )
+                .await;
+                for message in &messages[previous_message_count..] {
+                    self.remember_generation_message(
+                        &context.session_id,
+                        &context.dialog_turn_id,
+                        message,
+                    );
+                }
+            }
 
             debug!(
                 "Updated round messages in memory: round_index={}, assistant + {} tool results",
@@ -4066,6 +4354,11 @@ impl ExecutionEngine {
                         )
                         .with_turn_id(context.dialog_turn_id.clone());
                         messages.push(user_msg.clone());
+                        self.remember_generation_message(
+                            &context.session_id,
+                            &context.dialog_turn_id,
+                            &user_msg,
+                        );
                         if let Err(e) = self
                             .session_manager
                             .add_message(&context.session_id, user_msg)
@@ -4122,6 +4415,11 @@ impl ExecutionEngine {
                     )
                     .with_turn_id(context.dialog_turn_id.clone());
                     messages.push(user_msg.clone());
+                    self.remember_generation_message(
+                        &context.session_id,
+                        &context.dialog_turn_id,
+                        &user_msg,
+                    );
                     if let Err(e) = self
                         .session_manager
                         .add_message(&context.session_id, user_msg)
@@ -4213,6 +4511,11 @@ impl ExecutionEngine {
                         }
                         .with_turn_id(context.dialog_turn_id.clone());
                         messages.push(user_msg.clone());
+                        self.remember_generation_message(
+                            &context.session_id,
+                            &context.dialog_turn_id,
+                            &user_msg,
+                        );
                         if let Err(e) = self
                             .session_manager
                             .add_message(&context.session_id, user_msg)
@@ -4277,6 +4580,11 @@ impl ExecutionEngine {
                                 )
                                 .with_turn_id(context.dialog_turn_id.clone());
                                 messages.push(user_msg.clone());
+                                self.remember_generation_message(
+                                    &context.session_id,
+                                    &context.dialog_turn_id,
+                                    &user_msg,
+                                );
                                 if let Err(e) = self
                                     .session_manager
                                     .add_message(&context.session_id, user_msg)
@@ -4349,6 +4657,11 @@ impl ExecutionEngine {
                             )
                             .with_turn_id(context.dialog_turn_id.clone());
                             messages.push(user_msg.clone());
+                            self.remember_generation_message(
+                                &context.session_id,
+                                &context.dialog_turn_id,
+                                &user_msg,
+                            );
                             if let Err(e) = self
                                 .session_manager
                                 .add_message(&context.session_id, user_msg)
@@ -4378,6 +4691,11 @@ impl ExecutionEngine {
                     )
                     .with_turn_id(context.dialog_turn_id.clone());
                     messages.push(user_msg.clone());
+                    self.remember_generation_message(
+                        &context.session_id,
+                        &context.dialog_turn_id,
+                        &user_msg,
+                    );
                     if let Err(e) = self
                         .session_manager
                         .add_message(&context.session_id, user_msg)
@@ -4412,7 +4730,9 @@ impl ExecutionEngine {
                     dialog_turn_id
                 );
 
-                if context.emit_lifecycle_events {
+                if context.emit_lifecycle_events
+                    && execution_engine_owns_cancel_lifecycle(&context.context)
+                {
                     self.emit_event(
                         AgenticEvent::DialogTurnCancelled {
                             session_id: context.session_id.clone(),
@@ -4549,6 +4869,11 @@ impl ExecutionEngine {
                             );
                         for anchor_message in finalize_cache_anchor_messages {
                             messages.push(anchor_message.clone());
+                            self.remember_generation_message(
+                                &context.session_id,
+                                &context.dialog_turn_id,
+                                &anchor_message,
+                            );
                             if let Err(e) = self
                                 .session_manager
                                 .add_message(&context.session_id, anchor_message)
@@ -4563,6 +4888,11 @@ impl ExecutionEngine {
                         last_usage = Some(usage);
                     }
                     messages.push(msg.clone());
+                    self.remember_generation_message(
+                        &context.session_id,
+                        &context.dialog_turn_id,
+                        &msg,
+                    );
                     if let Err(e) = self
                         .session_manager
                         .add_message(&context.session_id, msg)
@@ -4634,7 +4964,7 @@ impl ExecutionEngine {
                         total_rounds: completed_rounds,
                         total_tools,
                         duration_ms,
-                        partial_recovery_reason: last_partial_recovery_reason,
+                        partial_recovery_reason: last_partial_recovery_reason.clone(),
                         success: Some(success),
                         finish_reason: Some(effective_finish_reason.to_string()),
                         has_final_response: Some(has_final_response),
@@ -4662,30 +4992,35 @@ impl ExecutionEngine {
             warn!("Dialog turn completed but token stats not available");
         }
 
-        // Calculate newly generated messages
-        let safe_initial_count = initial_count.min(messages.len()); // Ensure no out-of-bounds
-        let new_messages = messages[safe_initial_count..].to_vec();
-
-        if safe_initial_count != initial_count {
-            warn!(
-                "initial_count ({}) exceeds messages length ({}), adjusted to {}",
-                initial_count,
-                messages.len(),
-                safe_initial_count
-            );
-        }
-
         Ok(ExecutionResult {
-            final_message: messages
-                .iter()
-                .rev()
-                .find(|message| message.role == MessageRole::Assistant)
-                .cloned()
+            final_message: self
+                .generation_messages
+                .get(&(context.session_id.clone(), context.dialog_turn_id.clone()))
+                .and_then(|generated| {
+                    generated
+                        .iter()
+                        .rev()
+                        .find(|message| message.role == MessageRole::Assistant)
+                        .cloned()
+                })
+                .or_else(|| {
+                    messages
+                        .iter()
+                        .rev()
+                        .find(|message| message.role == MessageRole::Assistant)
+                        .cloned()
+                })
                 .unwrap_or_else(|| Message::assistant(String::new())),
             total_rounds: completed_rounds,
             success,
-            new_messages,
+            new_messages: self
+                .take_generation_messages(&context.session_id, &context.dialog_turn_id),
             finish_reason,
+            total_tools,
+            duration_ms,
+            partial_recovery_reason: last_partial_recovery_reason,
+            effective_finish_reason: effective_finish_reason.to_string(),
+            has_final_response,
         })
     }
 
@@ -4773,6 +5108,46 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[test]
+    fn recovered_execution_starts_after_existing_model_rounds() {
+        let mut context = std::collections::HashMap::new();
+        context.insert("initial_round_index".to_string(), "3".to_string());
+
+        assert_eq!(super::initial_round_index(&context), 3);
+        assert_eq!(
+            super::initial_round_index(&std::collections::HashMap::new()),
+            0
+        );
+    }
+
+    #[test]
+    fn interrupted_continue_reminder_is_visible_only_to_its_own_turn() {
+        let reminder = Message::internal_reminder(
+            InternalReminderKind::InterruptedContinue,
+            "continue the interrupted work".to_string(),
+        )
+        .with_turn_id("turn-interrupted".to_string());
+
+        assert!(!ExecutionEngine::is_stale_interrupted_continue(
+            &reminder,
+            "turn-interrupted"
+        ));
+        assert!(ExecutionEngine::is_stale_interrupted_continue(
+            &reminder, "turn-new"
+        ));
+    }
+
+    #[test]
+    fn coordinator_owned_cancellation_suppresses_early_cancelled_event() {
+        let mut context = std::collections::HashMap::new();
+        assert!(super::execution_engine_owns_cancel_lifecycle(&context));
+        context.insert(
+            super::super::types::CANCEL_LIFECYCLE_OWNER_CONTEXT_KEY.to_string(),
+            "coordinator".to_string(),
+        );
+        assert!(!super::execution_engine_owns_cancel_lifecycle(&context));
+    }
 
     #[test]
     fn primary_session_tool_policy_restores_goal_tools_but_subagents_stay_scoped() {
@@ -5375,6 +5750,57 @@ mod tests {
             ExecutionEngine::resolve_configured_model_id(&ai_config, "fast"),
             "model-primary"
         );
+    }
+
+    #[test]
+    fn frozen_turn_model_wins_when_the_auto_default_changes() {
+        let mut ai_config = AIConfig {
+            models: vec![
+                build_model("model-original", "Original", "claude-sonnet-4.5"),
+                build_model("model-new-default", "New default", "gpt-5.4"),
+            ],
+            ..Default::default()
+        };
+        ai_config.default_models.primary = Some("model-new-default".to_string());
+
+        assert_eq!(
+            ExecutionEngine::resolve_model_id_for_turn_selection(
+                &ai_config,
+                "auto",
+                Some("model-original"),
+            )
+            .expect("the original resolved model remains available"),
+            "model-original"
+        );
+    }
+
+    #[test]
+    fn auto_turn_model_must_resolve_to_a_concrete_model_before_persistence() {
+        let ai_config = AIConfig::default();
+
+        let error = ExecutionEngine::resolve_model_id_for_turn_selection(&ai_config, "auto", None)
+            .expect_err("a symbolic selector cannot become the frozen Turn model");
+
+        assert!(error.to_string().contains("primary model"), "{error}");
+    }
+
+    #[test]
+    fn frozen_turn_model_must_still_be_available_for_recovery() {
+        let mut model = build_model("model-original", "Original", "claude-sonnet-4.5");
+        model.enabled = false;
+        let ai_config = AIConfig {
+            models: vec![model],
+            ..Default::default()
+        };
+
+        let error = ExecutionEngine::resolve_model_id_for_turn_selection(
+            &ai_config,
+            "auto",
+            Some("model-original"),
+        )
+        .expect_err("a disabled frozen model cannot execute another generation");
+
+        assert!(error.to_string().contains("unavailable"), "{error}");
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -4,7 +4,7 @@
 
 use super::model_exchange_trace::prepare_model_exchange_trace;
 use super::stream_processor::{StreamProcessOptions, StreamProcessor, StreamResult};
-use super::types::{FinishReason, RoundContext, RoundResult};
+use super::types::{coordinator_owns_cancel_lifecycle, FinishReason, RoundContext, RoundResult};
 use crate::agentic::core::{Message, ToolCall};
 use crate::agentic::events::{
     AgenticEvent, EventPriority, EventQueue, ModelRoundAttemptDiagnostic,
@@ -507,6 +507,9 @@ impl RoundExecutor {
                     StreamProcessOptions {
                         recover_partial_on_cancel: context.recover_partial_on_cancel,
                         allow_normal_tool_json_repair,
+                        suppress_cancel_lifecycle_event: coordinator_owns_cancel_lifecycle(
+                            &context.context_vars,
+                        ),
                         ..Default::default()
                     },
                 )

--- a/src/crates/assembly/core/src/agentic/execution/types.rs
+++ b/src/crates/assembly/core/src/agentic/execution/types.rs
@@ -124,4 +124,18 @@ pub struct ExecutionResult {
     pub new_messages: Vec<Message>,
     /// Why the execution finished
     pub finish_reason: FinishReason,
+    pub total_tools: usize,
+    pub duration_ms: u64,
+    pub partial_recovery_reason: Option<String>,
+    pub effective_finish_reason: String,
+    pub has_final_response: bool,
+}
+
+pub(crate) const CANCEL_LIFECYCLE_OWNER_CONTEXT_KEY: &str = "cancel_lifecycle_owner";
+
+pub(crate) fn coordinator_owns_cancel_lifecycle(context: &HashMap<String, String>) -> bool {
+    context
+        .get(CANCEL_LIFECYCLE_OWNER_CONTEXT_KEY)
+        .map(String::as_str)
+        == Some("coordinator")
 }

--- a/src/crates/assembly/core/src/agentic/memories/transcript.rs
+++ b/src/crates/assembly/core/src/agentic/memories/transcript.rs
@@ -365,6 +365,8 @@ mod tests {
             has_final_response: Some(true),
             error: None,
             error_detail: None,
+            recovery: None,
+            recovery_epoch: None,
             status: TurnStatus::Completed,
         }
     }

--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -488,6 +488,8 @@ pub struct PersistenceManager {
     fail_next_session_metadata_write: std::sync::Mutex<Option<String>>,
     #[cfg(test)]
     fail_next_session_metadata_rollback: std::sync::Mutex<Option<String>>,
+    #[cfg(test)]
+    fail_next_dialog_turn_write: std::sync::Mutex<Option<String>>,
 }
 
 impl PersistenceManager {
@@ -501,6 +503,8 @@ impl PersistenceManager {
             fail_next_session_metadata_write: std::sync::Mutex::new(None),
             #[cfg(test)]
             fail_next_session_metadata_rollback: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            fail_next_dialog_turn_write: std::sync::Mutex::new(None),
         })
     }
 
@@ -539,6 +543,14 @@ impl PersistenceManager {
             .fail_next_session_metadata_rollback
             .lock()
             .expect("session metadata rollback fault lock") = Some(session_id.to_string());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_dialog_turn_write_for_test(&self, session_id: &str) {
+        *self
+            .fail_next_dialog_turn_write
+            .lock()
+            .expect("dialog turn fault lock") = Some(session_id.to_string());
     }
 
     /// Resolve the on-disk sessions directory for `workspace_path`.
@@ -3007,6 +3019,17 @@ impl PersistenceManager {
         turn: &DialogTurnData,
     ) -> BitFunResult<()> {
         Self::validate_session_id(&turn.session_id)?;
+        #[cfg(test)]
+        {
+            let mut fault = self
+                .fail_next_dialog_turn_write
+                .lock()
+                .expect("dialog turn fault lock");
+            if fault.as_deref() == Some(turn.session_id.as_str()) {
+                *fault = None;
+                return Err(BitFunError::io("Injected dialog turn write failure"));
+            }
+        }
         let _session_write = self.lock_session_write_operation(workspace_path, &turn.session_id)?;
         let save_started_at = Instant::now();
         self.ensure_runtime_for_write(workspace_path).await?;

--- a/src/crates/assembly/core/src/agentic/session/revert.rs
+++ b/src/crates/assembly/core/src/agentic/session/revert.rs
@@ -249,6 +249,8 @@ mod tests {
             has_final_response: Some(true),
             error: None,
             error_detail: None,
+            recovery: None,
+            recovery_epoch: None,
             status: TurnStatus::Completed,
         }
     }

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -31,16 +31,20 @@ use crate::agentic::ConversationCoordinator;
 use crate::infrastructure::ai::get_global_ai_client_factory;
 use crate::infrastructure::ai::reasoning_catalog::{
     load_models_dev_reasoning_catalog_without_refresh, normalize_reasoning_preset_for_model,
+    project_model_reasoning_catalog, reasoning_preset_runtime_fingerprint,
+    resolve_default_reasoning_preset, resolve_reasoning_preset,
 };
+use crate::service::config::types::{model_runtime_binding_fingerprint, AIConfig};
 use crate::service::config::{
     get_app_language_code, get_global_config_service, short_model_user_language_instruction,
     subscribe_config_updates, ConfigUpdateEvent,
 };
 use crate::service::remote_ssh::workspace_state::LOCAL_WORKSPACE_SSH_HOST;
 use crate::service::session::{
-    DialogTurnData, DialogTurnKind, ModelRoundData, SessionContextUsage, SessionMemoryMode,
-    SessionMetadata, SessionRelationship, SessionStatus, TextItemData, ThinkingItemData,
-    ToolCallData, ToolItemData, ToolResultData, TranscriptLineRange, TurnStatus, UserMessageData,
+    DialogTurnData, DialogTurnKind, DialogTurnRecoveryData, DialogTurnRecoveryStatus,
+    ModelRoundData, SessionContextUsage, SessionMemoryMode, SessionMetadata, SessionRelationship,
+    SessionStatus, TextItemData, ThinkingItemData, ToolCallData, ToolItemData, ToolResultData,
+    TranscriptLineRange, TurnStatus, UserMessageData,
 };
 use crate::service::snapshot::{
     ensure_snapshot_manager_for_workspace, get_or_create_snapshot_manager,
@@ -72,7 +76,7 @@ use tokio::time;
 
 #[cfg(test)]
 tokio::task_local! {
-    static TEST_MODEL_RESOLUTION_AI_CONFIG: crate::service::config::types::AIConfig;
+    pub(crate) static TEST_MODEL_RESOLUTION_AI_CONFIG: crate::service::config::types::AIConfig;
 }
 
 /// Session manager configuration
@@ -104,6 +108,68 @@ pub struct MaterializedSessionReference {
     pub session_id: String,
     pub session_name: String,
     pub transcript: MaterializedSessionReferenceTranscript,
+}
+
+pub(crate) const INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY: &str = "resolved_permission_mode";
+pub(crate) const INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY: &str =
+    "runtime_resolved_model_id";
+pub(crate) const INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY: &str =
+    "runtime_model_binding_fingerprint";
+pub(crate) const INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY: &str = "runtime_reasoning_preset";
+pub(crate) const INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY: &str =
+    "runtime_reasoning_selection";
+pub(crate) const INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY: &str =
+    "runtime_reasoning_fingerprint";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TurnAdmissionSessionFacts {
+    model_id: Option<String>,
+    reasoning_preset: Option<String>,
+    permission_mode: Option<PermissionMode>,
+    agent_type: String,
+    enable_tools: bool,
+}
+
+impl TurnAdmissionSessionFacts {
+    pub(crate) fn from_session(session: &Session) -> Self {
+        Self {
+            model_id: session.config.model_id.clone(),
+            reasoning_preset: session.config.reasoning_preset.clone(),
+            permission_mode: session.config.permission_mode,
+            agent_type: session.agent_type.clone(),
+            enable_tools: session.config.enable_tools,
+        }
+    }
+
+    pub(crate) fn with_reasoning_preset(mut self, reasoning_preset: Option<String>) -> Self {
+        self.reasoning_preset = reasoning_preset;
+        self
+    }
+
+    fn matches(&self, session: &Session) -> bool {
+        self.model_id == session.config.model_id
+            && self.reasoning_preset == session.config.reasoning_preset
+            && self.permission_mode == session.config.permission_mode
+            && self.agent_type == session.agent_type
+            && self.enable_tools == session.config.enable_tools
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct InterruptedTurnRecoveryPlan {
+    pub session_id: String,
+    pub turn_id: String,
+    pub turn_index: usize,
+    pub agent_type: String,
+    pub execution_generation: u32,
+    pub resume_count: u32,
+    pub initial_round_index: usize,
+    pub resolved_permission_mode: PermissionMode,
+    pub resolved_model_id: String,
+    pub model_binding_fingerprint: String,
+    pub user_input: String,
+    pub messages: Vec<Message>,
+    pub user_message_metadata: Option<serde_json::Value>,
 }
 
 impl Default for SessionManagerConfig {
@@ -587,8 +653,7 @@ impl SessionManager {
             }))
     }
 
-    async fn load_ai_config_for_model_resolution() -> Option<crate::service::config::types::AIConfig>
-    {
+    pub(crate) async fn load_ai_config_for_model_resolution() -> Option<AIConfig> {
         #[cfg(test)]
         if let Ok(ai_config) = TEST_MODEL_RESOLUTION_AI_CONFIG.try_with(Clone::clone) {
             return Some(ai_config);
@@ -596,6 +661,67 @@ impl SessionManager {
 
         let config_service = get_global_config_service().await.ok()?;
         config_service.get_config(Some("ai")).await.ok()
+    }
+
+    pub(crate) async fn resolve_effective_reasoning_preset_for_turn(
+        resolved_model_id: &str,
+        selected_preset: Option<&str>,
+    ) -> BitFunResult<(Option<String>, String)> {
+        let ai_config = Self::load_ai_config_for_model_resolution()
+            .await
+            .ok_or_else(|| {
+                BitFunError::AIClient(
+                    "AI configuration is unavailable for reasoning preset resolution".to_string(),
+                )
+            })?;
+        Self::resolve_effective_reasoning_preset_from_config(
+            &ai_config,
+            resolved_model_id,
+            selected_preset,
+        )
+        .await
+    }
+
+    async fn resolve_effective_reasoning_preset_from_config(
+        ai_config: &AIConfig,
+        resolved_model_id: &str,
+        selected_preset: Option<&str>,
+    ) -> BitFunResult<(Option<String>, String)> {
+        let canonical_model_id = ai_config
+            .resolve_model_reference(resolved_model_id)
+            .ok_or_else(|| {
+                BitFunError::AIClient(format!(
+                    "Dialog turn model is unavailable for reasoning preset resolution: {resolved_model_id}"
+                ))
+            })?;
+        let model = ai_config
+            .models
+            .iter()
+            .find(|model| model.enabled && model.id == canonical_model_id)
+            .ok_or_else(|| {
+                BitFunError::AIClient(format!(
+                    "Dialog turn model configuration is unavailable: {canonical_model_id}"
+                ))
+            })?;
+        let models_dev = load_models_dev_reasoning_catalog_without_refresh().await;
+        let projection = project_model_reasoning_catalog(model, models_dev.catalog.as_deref());
+        let preset = match selected_preset
+            .map(str::trim)
+            .filter(|preset| !preset.is_empty())
+        {
+            Some(selected_preset) => resolve_reasoning_preset(&projection, selected_preset)
+                .ok_or_else(|| {
+                    BitFunError::Validation(format!(
+                        "Reasoning preset is unavailable for the dialog turn model: {selected_preset}"
+                    ))
+                })
+                .map(Some)?,
+            None => resolve_default_reasoning_preset(&projection),
+        };
+        Ok((
+            preset.map(|preset| preset.id.clone()),
+            reasoning_preset_runtime_fingerprint(preset),
+        ))
     }
 
     fn is_auto_model_selector(model_id: &str) -> bool {
@@ -5642,12 +5768,46 @@ impl SessionManager {
         // Reset session state to Idle
         // After application restart, previous Processing state is invalid and must be reset
         let previous_state_was_not_idle = !matches!(session.state, SessionState::Idle);
+        let mut interrupted_recovery_restored_turn = None;
         if previous_state_was_not_idle {
             let old_state = session.state.clone();
             session.state = SessionState::Idle;
+            should_persist_restored_session = true;
             debug!(
                 "Resetting session state during restore: session_id={}, state={:?} -> Idle",
                 session_id, old_state
+            );
+        }
+
+        // A process exit can happen after the recovering Turn write but before
+        // the Processing Session write, or after both. No execution survives
+        // restart, so normalize from the durable Turn fact independently of
+        // the stale Session state.
+        if let Some(turn) = persisted_turns.last_mut().filter(|turn| {
+            turn.status == TurnStatus::InProgress
+                && turn
+                    .recovery
+                    .as_ref()
+                    .is_some_and(|recovery| recovery.status == DialogTurnRecoveryStatus::Recovering)
+        }) {
+            let now = SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            turn.status = TurnStatus::Cancelled;
+            turn.finish_reason = Some("interrupted".to_string());
+            turn.end_time = Some(now);
+            turn.duration_ms = Some(now.saturating_sub(turn.start_time));
+            if let Some(recovery) = turn.recovery.as_mut() {
+                recovery.status = DialogTurnRecoveryStatus::Interrupted;
+                recovery.interrupted_at = Some(now);
+                turn.recovery_epoch = Some(recovery.execution_generation);
+            }
+            interrupted_recovery_restored_turn = Some(turn.clone());
+            should_persist_restored_session = true;
+            info!(
+                "Restored abandoned recovery generation as interrupted: session_id={}, turn_id={}",
+                session_id, turn.turn_id
             );
         }
 
@@ -5781,6 +5941,11 @@ impl SessionManager {
         // Complete all fallible restore migrations before publishing any runtime state.
         // A failed write keeps the session unloaded; restore-time recovery handles any
         // partial metadata/state update left by the existing multi-file persistence format.
+        if let Some(turn) = interrupted_recovery_restored_turn.as_ref() {
+            self.persistence_manager
+                .save_dialog_turn(session_storage_path, turn)
+                .await?;
+        }
         if should_persist_restored_session && self.should_persist_session_id(session_id) {
             self.persistence_manager
                 .save_session(session_storage_path, &session)
@@ -6792,6 +6957,57 @@ impl SessionManager {
         Ok(turn_id)
     }
 
+    /// Persist a Turn only if the execution-affecting Session settings still
+    /// match the snapshot used to resolve its model, permission, prompt, and
+    /// reasoning metadata. The validation and Turn append share one Session
+    /// mutation lock, so a concurrent settings write must retry admission.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn start_dialog_turn_with_prepended_messages_if_session_matches(
+        &self,
+        session_id: &str,
+        agent_type: String,
+        user_input: String,
+        turn_id: Option<String>,
+        image_contexts: Option<Vec<ImageContextData>>,
+        prepended_messages: Vec<Message>,
+        user_message_metadata: Option<serde_json::Value>,
+        expected: &TurnAdmissionSessionFacts,
+    ) -> BitFunResult<String> {
+        let user_message =
+            if let Some(images) = image_contexts.as_ref().filter(|v| !v.is_empty()).cloned() {
+                Message::user_multimodal(user_input.clone(), images)
+                    .with_semantic_kind(MessageSemanticKind::ActualUserInput)
+            } else {
+                Message::user(user_input.clone())
+                    .with_semantic_kind(MessageSemanticKind::ActualUserInput)
+            };
+        let mut context_messages = prepended_messages;
+        context_messages.push(user_message);
+
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+        let current = self
+            .get_session(session_id)
+            .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
+        if !expected.matches(&current) {
+            return Err(BitFunError::Validation(
+                "Session execution settings changed during turn admission; retry submission"
+                    .to_string(),
+            ));
+        }
+
+        self.start_persisted_turn_locked(
+            session_id,
+            DialogTurnKind::UserDialog,
+            Some(agent_type),
+            user_input,
+            turn_id,
+            context_messages,
+            ProcessingPhase::Starting,
+            user_message_metadata,
+        )
+        .await
+    }
+
     /// Start a new dialog turn when the model-visible user message has already
     /// been inserted into runtime context by the caller.
     ///
@@ -7013,7 +7229,14 @@ impl SessionManager {
             match msg.role {
                 MessageRole::Assistant => {
                     let round_index = rounds.len();
-                    let round_id = format!("{}-round-{}", turn_id, round_index);
+                    let round_id = msg
+                        .metadata
+                        .round_id
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|round_id| !round_id.is_empty())
+                        .map(str::to_string)
+                        .unwrap_or_else(|| format!("{}-round-{}", turn_id, round_index));
 
                     let mut text_items = Vec::new();
                     let mut thinking_items = Vec::new();
@@ -7308,6 +7531,7 @@ impl SessionManager {
             }
         }
         turn.status = TurnStatus::Completed;
+        turn.recovery = None;
         turn.duration_ms = Some(stats.duration_ms);
         turn.end_time = Some(completion_timestamp);
 
@@ -7333,6 +7557,235 @@ impl SessionManager {
         Ok(())
     }
 
+    fn append_generation_rounds(
+        turn: &mut DialogTurnData,
+        turn_id: &str,
+        new_messages: &[Message],
+        timestamp: u64,
+    ) -> usize {
+        let mut next_round_index = turn
+            .model_rounds
+            .iter()
+            .map(|round| round.round_index)
+            .max()
+            .map_or(0, |index| index.saturating_add(1));
+        let generated_rounds =
+            Self::build_model_rounds_from_messages(new_messages, turn_id, timestamp);
+        let generated_count = generated_rounds.len();
+        for mut round in generated_rounds {
+            if let Some(existing_index) = turn
+                .model_rounds
+                .iter()
+                .position(|existing| existing.id == round.id)
+            {
+                let existing = &turn.model_rounds[existing_index];
+                for text_item in &mut round.text_items {
+                    if let Some(previous) = existing
+                        .text_items
+                        .iter()
+                        .find(|item| item.id == text_item.id)
+                    {
+                        text_item.timestamp = previous.timestamp;
+                        text_item.is_markdown = previous.is_markdown;
+                        text_item.order_index = previous.order_index;
+                        text_item.is_subagent_item = previous.is_subagent_item;
+                        text_item.parent_task_tool_id = previous.parent_task_tool_id.clone();
+                        text_item.subagent_session_id = previous.subagent_session_id.clone();
+                        text_item.status = previous.status.clone().or(text_item.status.clone());
+                        text_item.attempt_id = previous.attempt_id.clone();
+                        text_item.attempt_index = previous.attempt_index;
+                    }
+                }
+                for thinking_item in &mut round.thinking_items {
+                    if let Some(previous) = existing
+                        .thinking_items
+                        .iter()
+                        .find(|item| item.id == thinking_item.id)
+                    {
+                        thinking_item.timestamp = previous.timestamp;
+                        thinking_item.order_index = previous.order_index;
+                        thinking_item.status =
+                            previous.status.clone().or(thinking_item.status.clone());
+                        thinking_item.is_subagent_item = previous.is_subagent_item;
+                        thinking_item.parent_task_tool_id = previous.parent_task_tool_id.clone();
+                        thinking_item.subagent_session_id = previous.subagent_session_id.clone();
+                        thinking_item.attempt_id = previous.attempt_id.clone();
+                        thinking_item.attempt_index = previous.attempt_index;
+                    }
+                }
+                for tool_item in &mut round.tool_items {
+                    if let Some(previous) = existing
+                        .tool_items
+                        .iter()
+                        .find(|item| item.id == tool_item.id)
+                    {
+                        tool_item.ai_intent = previous.ai_intent.clone();
+                        tool_item.start_time = previous.start_time;
+                        tool_item.end_time = previous.end_time.or(tool_item.end_time);
+                        tool_item.duration_ms = previous.duration_ms.or(tool_item.duration_ms);
+                        tool_item.queue_wait_ms = previous.queue_wait_ms;
+                        tool_item.preflight_ms = previous.preflight_ms;
+                        tool_item.confirmation_wait_ms = previous.confirmation_wait_ms;
+                        tool_item.execution_ms = previous.execution_ms;
+                        tool_item.order_index = previous.order_index;
+                        tool_item.is_subagent_item = previous.is_subagent_item;
+                        tool_item.parent_task_tool_id = previous.parent_task_tool_id.clone();
+                        tool_item.subagent_session_id = previous.subagent_session_id.clone();
+                        tool_item.subagent_dialog_turn_id =
+                            previous.subagent_dialog_turn_id.clone();
+                        tool_item.attempt_id = previous.attempt_id.clone();
+                        tool_item.attempt_index = previous.attempt_index;
+                        tool_item.subagent_model_id = previous.subagent_model_id.clone();
+                        tool_item.subagent_model_display_name =
+                            previous.subagent_model_display_name.clone();
+                        tool_item.status = previous.status.clone().or(tool_item.status.clone());
+                        tool_item.interruption_reason = previous.interruption_reason.clone();
+                    }
+                }
+                round.round_index = existing.round_index;
+                round.round_group_id = existing.round_group_id.clone();
+                round.timestamp = existing.timestamp;
+                round.start_time = existing.start_time;
+                round.end_time = existing.end_time.or(round.end_time);
+                round.duration_ms = existing.duration_ms.or(round.duration_ms);
+                round.provider_id = existing.provider_id.clone();
+                round.model_config_id = existing.model_config_id.clone();
+                round.effective_model_name = existing.effective_model_name.clone();
+                round.first_chunk_ms = existing.first_chunk_ms;
+                round.first_visible_output_ms = existing.first_visible_output_ms;
+                round.stream_duration_ms = existing.stream_duration_ms;
+                round.attempt_count = existing.attempt_count;
+                round.attempt_diagnostics = existing.attempt_diagnostics.clone();
+                round.failure_category = existing.failure_category.clone();
+                round.token_details = existing.token_details.clone();
+                if existing.status != "streaming" {
+                    round.status = existing.status.clone();
+                }
+                turn.model_rounds[existing_index] = round;
+            } else {
+                round.round_index = next_round_index;
+                next_round_index = next_round_index.saturating_add(1);
+                turn.model_rounds.push(round);
+            }
+        }
+        generated_count
+    }
+
+    /// Complete a reopened interrupted turn by appending only the messages
+    /// produced by the current execution generation.
+    pub async fn complete_recovered_dialog_turn(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        execution_generation: u32,
+        final_response: String,
+        new_messages: &[Message],
+        stats: TurnStats,
+    ) -> BitFunResult<()> {
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+        let workspace_path = self
+            .effective_session_storage_path(session_id)
+            .await
+            .ok_or_else(|| {
+                BitFunError::Validation(format!("Session workspace_path is missing: {session_id}"))
+            })?;
+        let turn_index = self
+            .sessions
+            .get(session_id)
+            .and_then(|session| session.dialog_turn_ids.iter().position(|id| id == turn_id))
+            .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {turn_id}")))?;
+        let mut turn = self
+            .persistence_manager
+            .load_dialog_turn(&workspace_path, session_id, turn_index)
+            .await?
+            .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {turn_id}")))?;
+
+        if turn.status == TurnStatus::Completed && turn.recovery.is_none() {
+            return Ok(());
+        }
+        let recovery = turn.recovery.as_ref().ok_or_else(|| {
+            BitFunError::Validation(format!(
+                "Recovered dialog turn has no recovery metadata: {turn_id}"
+            ))
+        })?;
+        if recovery.status != DialogTurnRecoveryStatus::Recovering
+            || recovery.execution_generation != execution_generation
+        {
+            return Err(BitFunError::Validation(format!(
+                "Recovered turn generation mismatch: expected={execution_generation}, actual={}",
+                recovery.execution_generation
+            )));
+        }
+
+        let completion_timestamp = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let first_round_index = turn
+            .model_rounds
+            .iter()
+            .map(|round| round.round_index)
+            .max()
+            .map_or(0, |index| index.saturating_add(1));
+        let appended_count =
+            Self::append_generation_rounds(&mut turn, turn_id, new_messages, completion_timestamp);
+        if appended_count == 0 && !final_response.trim().is_empty() {
+            turn.model_rounds.push(ModelRoundData {
+                id: format!("{turn_id}-round-{first_round_index}"),
+                turn_id: turn_id.to_string(),
+                round_index: first_round_index,
+                round_group_id: None,
+                timestamp: completion_timestamp,
+                text_items: vec![Self::make_text_item(
+                    &format!("{turn_id}-round-{first_round_index}-text-0"),
+                    &final_response,
+                    completion_timestamp,
+                    0,
+                )],
+                tool_items: Vec::new(),
+                thinking_items: Vec::new(),
+                start_time: completion_timestamp,
+                end_time: Some(completion_timestamp),
+                duration_ms: Some(0),
+                provider_id: None,
+                model_config_id: None,
+                effective_model_name: None,
+                first_chunk_ms: None,
+                first_visible_output_ms: None,
+                stream_duration_ms: None,
+                attempt_count: None,
+                attempt_diagnostics: vec![],
+                failure_category: None,
+                token_details: None,
+                status: "completed".to_string(),
+            });
+        }
+        turn.status = TurnStatus::Completed;
+        turn.recovery_epoch = Some(execution_generation);
+        turn.recovery = None;
+        turn.duration_ms = Some(stats.duration_ms);
+        turn.end_time = Some(completion_timestamp);
+
+        // A recovered generation is Runtime-owned, so its context snapshot is
+        // part of the completion commit. Persist it before the Completed Turn:
+        // a crash after the snapshot leaves a Recovering Turn that restore can
+        // safely normalize, while a Completed Turn never points at an older
+        // same-index snapshot that omits this generation's tool/results tail.
+        let context_messages = self.context_store.get_context_messages(session_id);
+        self.persistence_manager
+            .save_turn_context_snapshot(
+                &workspace_path,
+                session_id,
+                turn.turn_index,
+                &context_messages,
+            )
+            .await?;
+        self.persistence_manager
+            .save_dialog_turn(&workspace_path, &turn)
+            .await?;
+        Ok(())
+    }
+
     /// Mark a dialog turn as failed and persist it.
     /// Unlike `complete_dialog_turn`, this sets the state to `Failed` with an error message.
     pub async fn fail_dialog_turn(
@@ -7341,6 +7794,18 @@ impl SessionManager {
         turn_id: &str,
         error: String,
     ) -> BitFunResult<()> {
+        self.fail_dialog_turn_with_messages(session_id, turn_id, error, &[])
+            .await
+    }
+
+    pub(crate) async fn fail_dialog_turn_with_messages(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        error: String,
+        generation_messages: &[Message],
+    ) -> BitFunResult<()> {
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
         if !self.should_persist_session_id(session_id) {
             debug!(
                 "Skipping dialog turn persistence for transient session failure: session_id={}, turn_id={}, error={}",
@@ -7368,21 +7833,34 @@ impl SessionManager {
             .load_dialog_turn(&workspace_path, session_id, turn_index)
             .await?
             .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {}", turn_id)))?;
-
+        let recovered_generation = turn.recovery.is_some();
+        let now = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        Self::append_generation_rounds(&mut turn, turn_id, generation_messages, now);
         turn.status = TurnStatus::Error;
-        turn.end_time = Some(
-            SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
+        turn.recovery = None;
+        turn.end_time = Some(now);
 
-        self.persist_context_snapshot_for_turn_best_effort(
-            session_id,
-            turn.turn_index,
-            "turn_failed",
-        )
-        .await;
+        if recovered_generation {
+            let context_messages = self.context_store.get_context_messages(session_id);
+            self.persistence_manager
+                .save_turn_context_snapshot(
+                    &workspace_path,
+                    session_id,
+                    turn.turn_index,
+                    &context_messages,
+                )
+                .await?;
+        } else {
+            self.persist_context_snapshot_for_turn_best_effort(
+                session_id,
+                turn.turn_index,
+                "turn_failed",
+            )
+            .await;
+        }
         if self.should_persist_session_id(session_id) {
             self.persistence_manager
                 .save_dialog_turn(&workspace_path, &turn)
@@ -7403,6 +7881,17 @@ impl SessionManager {
     /// from a fully-completed one. Any partial assistant content that was
     /// already streamed is preserved in `model_rounds`.
     pub async fn cancel_dialog_turn(&self, session_id: &str, turn_id: &str) -> BitFunResult<()> {
+        self.cancel_dialog_turn_with_messages(session_id, turn_id, &[])
+            .await
+    }
+
+    pub(crate) async fn cancel_dialog_turn_with_messages(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        generation_messages: &[Message],
+    ) -> BitFunResult<()> {
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
         if !self.should_persist_session_id(session_id) {
             debug!(
                 "Skipping dialog turn persistence for transient session cancellation: session_id={}, turn_id={}",
@@ -7430,21 +7919,35 @@ impl SessionManager {
             .load_dialog_turn(&workspace_path, session_id, turn_index)
             .await?
             .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {}", turn_id)))?;
-
+        let recovered_generation = turn.recovery.is_some();
+        let now = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        Self::append_generation_rounds(&mut turn, turn_id, generation_messages, now);
         turn.status = TurnStatus::Cancelled;
-        turn.end_time = Some(
-            SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64,
-        );
+        turn.recovery = None;
+        turn.finish_reason = Some("cancelled".to_string());
+        turn.end_time = Some(now);
 
-        self.persist_context_snapshot_for_turn_best_effort(
-            session_id,
-            turn.turn_index,
-            "turn_cancelled",
-        )
-        .await;
+        if recovered_generation {
+            let context_messages = self.context_store.get_context_messages(session_id);
+            self.persistence_manager
+                .save_turn_context_snapshot(
+                    &workspace_path,
+                    session_id,
+                    turn.turn_index,
+                    &context_messages,
+                )
+                .await?;
+        } else {
+            self.persist_context_snapshot_for_turn_best_effort(
+                session_id,
+                turn.turn_index,
+                "turn_cancelled",
+            )
+            .await;
+        }
 
         self.persistence_manager
             .save_dialog_turn(&workspace_path, &turn)
@@ -7456,6 +7959,555 @@ impl SessionManager {
         );
 
         Ok(())
+    }
+
+    /// Persist a settled, intentionally interrupted user turn without adding a
+    /// new persisted enum variant that older builds cannot deserialize.
+    pub async fn mark_dialog_turn_interrupted(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+    ) -> BitFunResult<DialogTurnRecoveryData> {
+        self.mark_dialog_turn_interrupted_with_messages(session_id, turn_id, &[])
+            .await
+    }
+
+    pub(crate) async fn mark_dialog_turn_interrupted_with_messages(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        generation_messages: &[Message],
+    ) -> BitFunResult<DialogTurnRecoveryData> {
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+        if !self.should_persist_session_id(session_id) {
+            return Err(BitFunError::Validation(
+                "Recoverable interruption is unavailable for transient sessions".to_string(),
+            ));
+        }
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
+        let turn_index = session
+            .dialog_turn_ids
+            .len()
+            .checked_sub(1)
+            .filter(|index| session.dialog_turn_ids[*index] == turn_id)
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "Only the latest dialog turn can be interrupted: {turn_id}"
+                ))
+            })?;
+        let workspace_path = self
+            .effective_storage_path_for_config(&session.config)
+            .await
+            .ok_or_else(|| {
+                BitFunError::Validation(format!("Session workspace_path is missing: {session_id}"))
+            })?;
+        let mut turn = self
+            .persistence_manager
+            .load_dialog_turn(&workspace_path, session_id, turn_index)
+            .await?
+            .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {turn_id}")))?;
+        if turn.kind != DialogTurnKind::UserDialog {
+            return Err(BitFunError::Validation(
+                "Only a user dialog turn can be interrupted".to_string(),
+            ));
+        }
+        if turn
+            .user_message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("acp_transport"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+        {
+            return Err(BitFunError::Validation(
+                "Recoverable interruption is unavailable for ACP turns".to_string(),
+            ));
+        }
+        if let Some(recovery) = turn
+            .recovery
+            .as_ref()
+            .filter(|recovery| recovery.status == DialogTurnRecoveryStatus::Interrupted)
+            .cloned()
+        {
+            if turn.recovery_epoch != Some(recovery.execution_generation) {
+                turn.recovery_epoch = Some(recovery.execution_generation);
+                self.persistence_manager
+                    .save_dialog_turn(&workspace_path, &turn)
+                    .await?;
+            }
+            return Ok(recovery);
+        }
+        if turn.status != TurnStatus::InProgress {
+            return Err(BitFunError::Validation(format!(
+                "Dialog turn is not running: {turn_id}"
+            )));
+        }
+
+        // Recovery is offered only when the exact settled model context is
+        // durable. If this write fails, the coordinator falls back to an
+        // ordinary non-recoverable cancellation rather than exposing a broken
+        // continue button.
+        let context_messages = self.context_store.get_context_messages(session_id);
+        self.persistence_manager
+            .save_turn_context_snapshot(&workspace_path, session_id, turn_index, &context_messages)
+            .await?;
+        let now = SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let recovery = match turn.recovery.take() {
+            Some(mut recovery) => {
+                recovery.status = DialogTurnRecoveryStatus::Interrupted;
+                recovery.interrupted_at = Some(now);
+                recovery
+            }
+            None => DialogTurnRecoveryData {
+                status: DialogTurnRecoveryStatus::Interrupted,
+                execution_generation: 0,
+                resume_count: 0,
+                interrupted_at: Some(now),
+                model_id: session.config.model_id.clone(),
+            },
+        };
+        Self::append_generation_rounds(&mut turn, turn_id, generation_messages, now);
+        turn.status = TurnStatus::Cancelled;
+        turn.finish_reason = Some("interrupted".to_string());
+        turn.end_time = Some(now);
+        turn.duration_ms = Some(now.saturating_sub(turn.start_time));
+        turn.recovery = Some(recovery.clone());
+        turn.recovery_epoch = Some(recovery.execution_generation);
+        self.persistence_manager
+            .save_dialog_turn(&workspace_path, &turn)
+            .await?;
+        Ok(recovery)
+    }
+
+    /// Reopen the latest settled interrupted user turn from its exact context
+    /// snapshot. This does not run prompt-submit hooks or append a user Turn.
+    pub(crate) async fn reopen_interrupted_dialog_turn(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        expected_execution_generation: u32,
+    ) -> BitFunResult<InterruptedTurnRecoveryPlan> {
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| BitFunError::NotFound(format!("Session not found: {session_id}")))?;
+        let turn_index = session
+            .dialog_turn_ids
+            .len()
+            .checked_sub(1)
+            .filter(|index| session.dialog_turn_ids[*index] == turn_id)
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "Only the latest dialog turn can be recovered: {turn_id}"
+                ))
+            })?;
+        let workspace_path = self
+            .effective_storage_path_for_config(&session.config)
+            .await
+            .ok_or_else(|| {
+                BitFunError::Validation(format!("Session workspace_path is missing: {session_id}"))
+            })?;
+        let mut turn = self
+            .persistence_manager
+            .load_dialog_turn(&workspace_path, session_id, turn_index)
+            .await?
+            .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {turn_id}")))?;
+        let original_turn = turn.clone();
+        let recovery = turn.recovery.as_ref().ok_or_else(|| {
+            BitFunError::Validation(format!("Dialog turn has no recovery metadata: {turn_id}"))
+        })?;
+        if recovery.status != DialogTurnRecoveryStatus::Interrupted
+            || recovery.execution_generation != expected_execution_generation
+        {
+            return Err(BitFunError::Validation(format!(
+                "Interrupted turn generation mismatch: expected={}, actual={}",
+                expected_execution_generation, recovery.execution_generation
+            )));
+        }
+        if recovery.model_id != session.config.model_id {
+            return Err(BitFunError::Validation(
+                "The session model changed after interruption; start a new turn instead"
+                    .to_string(),
+            ));
+        }
+        if turn
+            .agent_type
+            .as_deref()
+            .is_some_and(|agent_type| agent_type != session.agent_type)
+        {
+            return Err(BitFunError::Validation(
+                "The session agent mode changed after interruption; start a new turn instead"
+                    .to_string(),
+            ));
+        }
+        if turn.kind != DialogTurnKind::UserDialog || turn.status != TurnStatus::Cancelled {
+            return Err(BitFunError::Validation(format!(
+                "Dialog turn is not recoverably interrupted: {turn_id}"
+            )));
+        }
+        if turn
+            .user_message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("acp_transport"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+        {
+            return Err(BitFunError::Validation(
+                "Interrupted ACP turns cannot be recovered through the native runtime".to_string(),
+            ));
+        }
+        if !matches!(session.state, SessionState::Idle) {
+            return Err(BitFunError::Validation(format!(
+                "Session must be idle before recovering turn: {turn_id}"
+            )));
+        }
+        let mut messages = self
+            .persistence_manager
+            .load_turn_context_snapshot(&workspace_path, session_id, turn_index)
+            .await?
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "Context snapshot is unavailable for interrupted turn: {turn_id}"
+                ))
+            })?;
+        messages.retain(|message| {
+            message.internal_reminder_kind() != Some(InternalReminderKind::InterruptedContinue)
+        });
+        messages.push(
+            Message::internal_reminder(
+                InternalReminderKind::InterruptedContinue,
+                "Your previous work was interrupted by the user. Continue the same task from the last safe context boundary. Do not repeat completed work or assume that an interrupted tool call had no side effects; verify uncertain external state before acting again.",
+            )
+            .with_turn_id(turn_id.to_string()),
+        );
+
+        let next_generation = recovery.execution_generation.saturating_add(1);
+        let next_resume_count = recovery.resume_count.saturating_add(1);
+        turn.status = TurnStatus::InProgress;
+        turn.finish_reason = None;
+        turn.end_time = None;
+        turn.duration_ms = None;
+        turn.error = None;
+        turn.error_detail = None;
+        turn.recovery = Some(DialogTurnRecoveryData {
+            status: DialogTurnRecoveryStatus::Recovering,
+            execution_generation: next_generation,
+            resume_count: next_resume_count,
+            interrupted_at: recovery.interrupted_at,
+            model_id: recovery.model_id.clone(),
+        });
+        turn.recovery_epoch = Some(next_generation);
+        let initial_round_index = turn
+            .model_rounds
+            .iter()
+            .map(|round| round.round_index)
+            .max()
+            .map_or(0, |index| index.saturating_add(1));
+        let agent_type = turn
+            .agent_type
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                BitFunError::Validation(format!("Interrupted turn has no agent type: {turn_id}"))
+            })?;
+        let user_message_metadata = turn.user_message.metadata.clone();
+        let resolved_permission_mode = user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY))
+            .and_then(serde_json::Value::as_str)
+            .and_then(PermissionMode::parse)
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Interrupted turn has no frozen permission mode; start a new turn instead"
+                        .to_string(),
+                )
+            })?;
+        let resolved_model_id = user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|model_id| !model_id.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Interrupted turn has no frozen resolved model; start a new turn instead"
+                        .to_string(),
+                )
+            })?;
+        let expected_model_binding_fingerprint = user_message_metadata
+            .as_ref()
+            .and_then(|metadata| {
+                metadata.get(INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY)
+            })
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|fingerprint| !fingerprint.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Interrupted turn has no frozen model binding; start a new turn instead"
+                        .to_string(),
+                )
+            })?;
+        let ai_config = Self::load_ai_config_for_model_resolution()
+            .await
+            .ok_or_else(|| {
+                BitFunError::AIClient(
+                    "AI configuration is unavailable; retry interrupted turn recovery".to_string(),
+                )
+            })?;
+        let canonical_model_id = ai_config
+            .resolve_model_reference(&resolved_model_id)
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "The interrupted turn model is unavailable: {resolved_model_id}"
+                ))
+            })?;
+        let model = ai_config
+            .models
+            .iter()
+            .find(|model| model.enabled && model.id == canonical_model_id)
+            .ok_or_else(|| {
+                BitFunError::Validation(format!(
+                    "The interrupted turn model is unavailable: {resolved_model_id}"
+                ))
+            })?;
+        if model_runtime_binding_fingerprint(model) != expected_model_binding_fingerprint {
+            return Err(BitFunError::Validation(format!(
+                "The interrupted turn model binding changed after interruption: {resolved_model_id}"
+            )));
+        }
+        let resolved_reasoning_preset = match user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY))
+        {
+            Some(serde_json::Value::Null) => None,
+            Some(serde_json::Value::String(value)) => value
+                .trim()
+                .is_empty()
+                .then_some(None)
+                .unwrap_or_else(|| Some(value.trim().to_string())),
+            _ => {
+                return Err(BitFunError::Validation(
+                    "Interrupted turn has no frozen reasoning preset; start a new turn instead"
+                        .to_string(),
+                ))
+            }
+        };
+        let expected_reasoning_fingerprint = user_message_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|fingerprint| !fingerprint.is_empty())
+            .ok_or_else(|| {
+                BitFunError::Validation(
+                    "Interrupted turn has no frozen reasoning fingerprint; start a new turn instead"
+                        .to_string(),
+                )
+            })?;
+        let reasoning_selection =
+            match user_message_metadata.as_ref().and_then(|metadata| {
+                metadata.get(INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY)
+            }) {
+                Some(serde_json::Value::Null) => None,
+                Some(serde_json::Value::String(value)) => value
+                    .trim()
+                    .is_empty()
+                    .then_some(None)
+                    .unwrap_or_else(|| Some(value.trim().to_string())),
+                _ => return Err(BitFunError::Validation(
+                    "Interrupted turn has no frozen reasoning selection; start a new turn instead"
+                        .to_string(),
+                )),
+            };
+        if reasoning_selection != session.config.reasoning_preset {
+            return Err(BitFunError::Validation(
+                "The session reasoning preset changed after interruption; start a new turn instead"
+                    .to_string(),
+            ));
+        }
+        let (current_resolved_reasoning_preset, current_reasoning_fingerprint) =
+            Self::resolve_effective_reasoning_preset_from_config(
+                &ai_config,
+                &resolved_model_id,
+                reasoning_selection.as_deref(),
+            )
+            .await?;
+        if current_resolved_reasoning_preset != resolved_reasoning_preset {
+            return Err(BitFunError::Validation(
+                "The dialog turn reasoning contract changed after interruption; start a new turn instead"
+                    .to_string(),
+            ));
+        }
+        if current_reasoning_fingerprint != expected_reasoning_fingerprint {
+            return Err(BitFunError::Validation(
+                "The dialog turn reasoning runtime contract changed after interruption; start a new turn instead"
+                    .to_string(),
+            ));
+        }
+        let user_input = turn.user_message.content.clone();
+
+        let mut updated_session = session.clone();
+        updated_session.state = SessionState::Processing {
+            current_turn_id: turn_id.to_string(),
+            phase: ProcessingPhase::Starting,
+        };
+        let now = SystemTime::now();
+        updated_session.updated_at = now;
+        updated_session.last_activity_at = now;
+
+        self.persistence_manager
+            .save_turn_context_snapshot(&workspace_path, session_id, turn_index, &messages)
+            .await?;
+        if let Err(error) = self
+            .persistence_manager
+            .save_dialog_turn(&workspace_path, &turn)
+            .await
+        {
+            if let Err(rollback_error) = self
+                .persistence_manager
+                .save_dialog_turn(&workspace_path, &original_turn)
+                .await
+            {
+                return Err(BitFunError::session(format!(
+                    "Recovery turn persistence failed and rollback did not complete: session_id={session_id}, turn_id={turn_id}, error={error}, rollback_error={rollback_error}"
+                )));
+            }
+            return Err(error);
+        }
+        if let Err(error) = self
+            .persistence_manager
+            .save_session(&workspace_path, &updated_session)
+            .await
+        {
+            let session_rollback = self
+                .persistence_manager
+                .save_session(&workspace_path, &session)
+                .await;
+            let turn_rollback = self
+                .persistence_manager
+                .save_dialog_turn(&workspace_path, &original_turn)
+                .await;
+            if session_rollback.is_err() || turn_rollback.is_err() {
+                return Err(BitFunError::session(format!(
+                    "Recovery persistence failed and rollback did not complete: session_id={session_id}, turn_id={turn_id}, error={error}, session_rollback_error={:?}, turn_rollback_error={:?}",
+                    session_rollback.err(),
+                    turn_rollback.err(),
+                )));
+            }
+            return Err(error);
+        }
+
+        self.sessions
+            .insert(session_id.to_string(), updated_session);
+        self.context_store
+            .replace_context(session_id, messages.clone());
+
+        Ok(InterruptedTurnRecoveryPlan {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            turn_index,
+            agent_type,
+            execution_generation: next_generation,
+            resume_count: next_resume_count,
+            initial_round_index,
+            resolved_permission_mode,
+            resolved_model_id,
+            model_binding_fingerprint: expected_model_binding_fingerprint,
+            user_input,
+            messages,
+            user_message_metadata,
+        })
+    }
+
+    pub(crate) async fn latest_dialog_turn_holds_dispatch(
+        &self,
+        session_id: &str,
+    ) -> BitFunResult<bool> {
+        if !self.should_persist_session_id(session_id) {
+            return Ok(false);
+        }
+        let Some(session) = self.get_session(session_id) else {
+            return Ok(false);
+        };
+        let Some(turn_index) = session.dialog_turn_ids.len().checked_sub(1) else {
+            return Ok(false);
+        };
+        let Some(workspace_path) = self
+            .effective_storage_path_for_config(&session.config)
+            .await
+        else {
+            return Ok(false);
+        };
+        let Some(turn) = self
+            .persistence_manager
+            .load_dialog_turn(&workspace_path, session_id, turn_index)
+            .await?
+        else {
+            return Ok(false);
+        };
+        Ok(turn.status == TurnStatus::Cancelled
+            && turn
+                .recovery
+                .as_ref()
+                .is_some_and(|recovery| recovery.status == DialogTurnRecoveryStatus::Interrupted))
+    }
+
+    pub(crate) async fn abandon_interrupted_dialog_turn(
+        &self,
+        session_id: &str,
+        expected_turn_id: Option<&str>,
+    ) -> BitFunResult<Option<String>> {
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+        let Some(session) = self.get_session(session_id) else {
+            return Ok(None);
+        };
+        let turn_index = match expected_turn_id {
+            Some(expected) => session
+                .dialog_turn_ids
+                .iter()
+                .position(|turn_id| turn_id == expected),
+            None => session.dialog_turn_ids.len().checked_sub(1),
+        };
+        let Some(turn_index) = turn_index else {
+            return Ok(None);
+        };
+        let Some(workspace_path) = self
+            .effective_storage_path_for_config(&session.config)
+            .await
+        else {
+            return Ok(None);
+        };
+        let Some(mut turn) = self
+            .persistence_manager
+            .load_dialog_turn(&workspace_path, session_id, turn_index)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if turn.status != TurnStatus::Cancelled
+            || !turn
+                .recovery
+                .as_ref()
+                .is_some_and(|recovery| recovery.status == DialogTurnRecoveryStatus::Interrupted)
+        {
+            return Ok(None);
+        }
+        turn.recovery = None;
+        turn.finish_reason = Some("cancelled".to_string());
+        let turn_id = turn.turn_id.clone();
+        self.persistence_manager
+            .save_dialog_turn(&workspace_path, &turn)
+            .await?;
+        Ok(Some(turn_id))
     }
 
     /// Complete a maintenance turn and persist its synthetic model round payload.
@@ -8259,12 +9311,12 @@ mod tests {
     use super::{
         should_auto_migrate_session_model, CoreSessionStorePort, PermissionMode,
         SessionExecutionBindingError, SessionExecutionBindingUpdate, SessionManager,
-        SessionManagerConfig, TEST_MODEL_RESOLUTION_AI_CONFIG,
+        SessionManagerConfig, TurnAdmissionSessionFacts, TEST_MODEL_RESOLUTION_AI_CONFIG,
     };
     use crate::agentic::core::{
-        CompressionState, Message, MessageContent, MessageRole, ProcessingPhase, Session,
-        SessionAgentRouteOwner, SessionConfig, SessionModelBindingPolicy, SessionState, ToolCall,
-        ToolResult,
+        CompressionState, Message, MessageContent, MessageRole, MessageSemanticKind,
+        ProcessingPhase, Session, SessionAgentRouteOwner, SessionConfig, SessionModelBindingPolicy,
+        SessionState, ToolCall, ToolResult, TurnStats,
     };
     use crate::agentic::persistence::PersistenceManager;
     use crate::agentic::session::{
@@ -8273,15 +9325,22 @@ mod tests {
         UserContextCacheIdentity,
     };
     use crate::agentic::skill_agent_snapshot::{SkillSnapshotEntry, TurnSkillAgentSnapshot};
+    use crate::infrastructure::ai::reasoning_catalog::{
+        project_model_reasoning_catalog as project_test_model_reasoning_catalog,
+        reasoning_preset_runtime_fingerprint as test_reasoning_preset_runtime_fingerprint,
+        resolve_default_reasoning_preset as resolve_test_default_reasoning_preset,
+        resolve_reasoning_preset as resolve_test_reasoning_preset,
+    };
     use crate::infrastructure::PathManager;
     use crate::service::config::types::{
+        model_runtime_binding_fingerprint as service_model_runtime_binding_fingerprint,
         AIConfig as ServiceAIConfig, AIModelConfig as ServiceAIModelConfig,
     };
     use crate::service::session::{
-        DialogTurnData, DialogTurnKind, ModelRoundData, SessionContextUsage,
-        SessionContextUsageSource, SessionKind, SessionMetadata, SessionRelationship,
-        SessionRelationshipKind, ToolCallData, ToolItemData, ToolResultData, TurnStatus,
-        UserMessageData,
+        DialogTurnData, DialogTurnKind, DialogTurnRecoveryStatus, ModelRoundData,
+        SessionContextUsage, SessionContextUsageSource, SessionKind, SessionMetadata,
+        SessionRelationship, SessionRelationshipKind, ToolCallData, ToolItemData, ToolResultData,
+        TurnStatus, UserMessageData,
     };
     use crate::util::errors::BitFunError;
     use bitfun_core_types::{
@@ -8465,6 +9524,49 @@ mod tests {
         )
     }
 
+    async fn reopen_interrupted_turn_for_test(
+        manager: &SessionManager,
+        session_id: &str,
+        turn_id: &str,
+        expected_generation: u32,
+    ) -> crate::util::errors::BitFunResult<super::InterruptedTurnRecoveryPlan> {
+        TEST_MODEL_RESOLUTION_AI_CONFIG
+            .scope(
+                ServiceAIConfig {
+                    models: vec![configured_reasoning_model("model-original")],
+                    ..Default::default()
+                },
+                manager.reopen_interrupted_dialog_turn(session_id, turn_id, expected_generation),
+            )
+            .await
+    }
+
+    fn interrupted_turn_test_model_fingerprint() -> String {
+        service_model_runtime_binding_fingerprint(&configured_reasoning_model("model-original"))
+    }
+
+    fn interrupted_turn_test_reasoning_fingerprint(selected_preset: Option<&str>) -> String {
+        let model = configured_reasoning_model("model-original");
+        let projection = project_test_model_reasoning_catalog(&model, None);
+        let preset = selected_preset
+            .and_then(|preset_id| resolve_test_reasoning_preset(&projection, preset_id))
+            .or_else(|| {
+                selected_preset
+                    .is_none()
+                    .then(|| resolve_test_default_reasoning_preset(&projection))
+                    .flatten()
+            });
+        test_reasoning_preset_runtime_fingerprint(preset)
+    }
+
+    fn interrupted_turn_test_auto_reasoning_fingerprint(default_preset: &str) -> String {
+        let model = reasoning_model_with_default("model-original", default_preset);
+        let projection = project_test_model_reasoning_catalog(&model, None);
+        test_reasoning_preset_runtime_fingerprint(resolve_test_default_reasoning_preset(
+            &projection,
+        ))
+    }
+
     fn test_manager_with_config(
         persistence_manager: Arc<PersistenceManager>,
         config: SessionManagerConfig,
@@ -8544,6 +9646,954 @@ mod tests {
             .expect("metadata should load")
             .expect("metadata should exist");
         assert_eq!(metadata.current_context_usage, Some(usage));
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_reopens_same_turn_from_snapshot_with_generation_cas() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Recovery".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish the task".to_string(),
+                Some("turn-1".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .add_message(
+                &session.session_id,
+                Message::assistant("safe completed fragment".to_string())
+                    .with_turn_id(turn_id.clone())
+                    .with_round_id("round-0".to_string()),
+            )
+            .await
+            .expect("safe boundary should persist");
+
+        let interrupted = manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        assert_eq!(interrupted.execution_generation, 0);
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+        manager
+            .update_session_permission_mode(&session.session_id, Some(PermissionMode::FullAccess))
+            .await
+            .expect("session permission should change after interruption");
+
+        let plan = reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+            .await
+            .expect("same generation should recover");
+
+        assert_eq!(plan.turn_id, turn_id);
+        assert_eq!(plan.turn_index, 0);
+        assert_eq!(plan.execution_generation, 1);
+        assert_eq!(plan.resume_count, 1);
+        assert_eq!(plan.initial_round_index, 0);
+        assert_eq!(plan.resolved_permission_mode, PermissionMode::Ask);
+        assert_eq!(plan.resolved_model_id, "model-original");
+        assert_eq!(
+            plan.messages
+                .iter()
+                .filter(|message| {
+                    message.metadata.semantic_kind == Some(MessageSemanticKind::ActualUserInput)
+                })
+                .count(),
+            1,
+            "recovery must not duplicate the original user message"
+        );
+        assert!(plan.messages.iter().any(|message| {
+            message
+                .content
+                .to_string()
+                .contains("previous work was interrupted")
+        }));
+
+        let duplicate =
+            reopen_interrupted_turn_for_test(&manager, &session.session_id, &plan.turn_id, 0)
+                .await
+                .expect_err("stale generation must be rejected");
+        assert!(duplicate.to_string().contains("generation"), "{duplicate}");
+
+        manager
+            .cancel_dialog_turn(&session.session_id, &plan.turn_id)
+            .await
+            .expect("ordinary cancellation should settle recovered work");
+        let persisted = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert!(
+            persisted.recovery.is_none(),
+            "ordinary cancellation must remove the recoverable state"
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_recovery_does_not_narrow_its_frozen_permission_mode() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Recovery permission".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    permission_mode: Some(PermissionMode::FullAccess),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish with the original permission".to_string(),
+                Some("turn-permission".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "full_access",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+        manager
+            .update_session_permission_mode(&session.session_id, Some(PermissionMode::Ask))
+            .await
+            .expect("session permission should change after interruption");
+
+        let plan = reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+            .await
+            .expect("turn should keep its original permission contract");
+        assert_eq!(plan.resolved_permission_mode, PermissionMode::FullAccess);
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_recovery_rejects_a_changed_reasoning_preset() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Recovery reasoning preset".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    reasoning_preset: Some("high".to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "continue with one reasoning contract".to_string(),
+                Some("turn-reasoning".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": "high",
+                    "runtime_reasoning_selection": "high",
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(Some("high"))
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should remain loaded")
+            .config
+            .reasoning_preset = Some("low".to_string());
+
+        let error = reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+            .await
+            .expect_err("same Turn must not silently change reasoning preset");
+
+        assert!(error.to_string().contains("reasoning preset"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_recovery_rejects_a_changed_auto_reasoning_default() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Recovery auto reasoning".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    model_id: Some("model-original".to_string()),
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "continue with the original auto reasoning default".to_string(),
+                Some("turn-auto-reasoning".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": service_model_runtime_binding_fingerprint(
+                        &reasoning_model_with_default("model-original", "low")
+                    ),
+                    "runtime_reasoning_preset": "high",
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_auto_reasoning_fingerprint("high")
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+
+        let error = TEST_MODEL_RESOLUTION_AI_CONFIG
+            .scope(
+                ServiceAIConfig {
+                    models: vec![reasoning_model_with_default("model-original", "low")],
+                    ..Default::default()
+                },
+                manager.reopen_interrupted_dialog_turn(&session.session_id, &turn_id, 0),
+            )
+            .await
+            .expect_err("Auto must not resolve to a different preset for the same Turn");
+
+        assert!(error.to_string().contains("reasoning contract"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn interrupted_turn_recovery_rejects_a_changed_model_binding() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Recovery model binding".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    model_id: Some("model-original".to_string()),
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "continue with the original model binding".to_string(),
+                Some("turn-model-binding".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+
+        let mut changed_model = configured_reasoning_model("model-original");
+        changed_model.model_name = "provider-model-v2".to_string();
+        let error = TEST_MODEL_RESOLUTION_AI_CONFIG
+            .scope(
+                ServiceAIConfig {
+                    models: vec![changed_model],
+                    ..Default::default()
+                },
+                manager.reopen_interrupted_dialog_turn(&session.session_id, &turn_id, 0),
+            )
+            .await
+            .expect_err("same model ID must not silently change its runtime binding");
+
+        assert!(error.to_string().contains("model binding"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn dialog_turn_admission_rejects_a_concurrent_session_model_change() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Turn admission CAS".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    model_id: Some("model-original".to_string()),
+                    reasoning_preset: Some("high".to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let expected = TurnAdmissionSessionFacts::from_session(&session);
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should remain loaded")
+            .config
+            .model_id = Some("model-updated".to_string());
+
+        let error = manager
+            .start_dialog_turn_with_prepended_messages_if_session_matches(
+                &session.session_id,
+                "agentic".to_string(),
+                "must retry admission".to_string(),
+                Some("turn-admission-race".to_string()),
+                None,
+                Vec::new(),
+                Some(serde_json::json!({"runtime_resolved_model_id": "model-original"})),
+                &expected,
+            )
+            .await
+            .expect_err("a concurrent settings update must invalidate admission");
+
+        assert!(error.to_string().contains("changed during turn admission"));
+        assert_eq!(manager.get_turn_count(&session.session_id), 0);
+    }
+
+    #[tokio::test]
+    async fn recovery_persistence_failure_keeps_memory_and_disk_interrupted() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Recovery rollback".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish the task".to_string(),
+                Some("turn-rollback".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+
+        persistence_manager.fail_next_session_state_write_for_test(&session.session_id);
+        reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+            .await
+            .expect_err("injected session write must reject recovery");
+
+        let active = manager
+            .get_session(&session.session_id)
+            .expect("session should remain active");
+        assert!(matches!(active.state, SessionState::Idle));
+        let persisted_session = persistence_manager
+            .load_session(workspace.path(), &session.session_id)
+            .await
+            .expect("session should reload");
+        assert!(matches!(persisted_session.state, SessionState::Idle));
+        let persisted_turn = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert_eq!(persisted_turn.status, TurnStatus::Cancelled);
+        assert_eq!(
+            persisted_turn
+                .recovery
+                .as_ref()
+                .map(|recovery| recovery.status),
+            Some(DialogTurnRecoveryStatus::Interrupted),
+        );
+
+        let plan = reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+            .await
+            .expect("retry should reopen after rollback");
+        persistence_manager.fail_next_dialog_turn_write_for_test(&session.session_id);
+        manager
+            .complete_recovered_dialog_turn(
+                &session.session_id,
+                &turn_id,
+                plan.execution_generation,
+                "completion that cannot persist".to_string(),
+                &[],
+                TurnStats {
+                    total_rounds: 1,
+                    total_tools: 0,
+                    total_tokens: 0,
+                    duration_ms: 1,
+                },
+            )
+            .await
+            .expect_err("injected recovered completion write must fail");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("failed recovered completion should return to interruption");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("fallback interruption should settle idle");
+        let persisted_turn = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert_eq!(persisted_turn.status, TurnStatus::Cancelled);
+        assert_eq!(
+            persisted_turn.recovery_epoch,
+            Some(plan.execution_generation)
+        );
+        assert_eq!(
+            persisted_turn
+                .recovery
+                .as_ref()
+                .map(|recovery| (recovery.status, recovery.execution_generation)),
+            Some((
+                DialogTurnRecoveryStatus::Interrupted,
+                plan.execution_generation
+            )),
+        );
+    }
+
+    #[tokio::test]
+    async fn recovered_completion_appends_rounds_after_the_existing_history() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Recovery append".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish the task".to_string(),
+                Some("turn-append".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        let mut persisted_turn = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        persisted_turn.model_rounds = SessionManager::build_model_rounds_from_messages(
+            &[Message::assistant("before interruption".to_string())
+                .with_turn_id(turn_id.clone())
+                .with_round_id("round-before".to_string())],
+            &turn_id,
+            1,
+        );
+        persistence_manager
+            .save_dialog_turn(workspace.path(), &persisted_turn)
+            .await
+            .expect("existing round should persist");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+        let plan = reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+            .await
+            .expect("turn should reopen");
+
+        manager
+            .complete_recovered_dialog_turn(
+                &session.session_id,
+                &turn_id,
+                plan.execution_generation,
+                "after recovery".to_string(),
+                &[Message::assistant("after recovery".to_string())
+                    .with_turn_id(turn_id.clone())
+                    .with_round_id("round-after".to_string())],
+                TurnStats {
+                    total_rounds: 1,
+                    total_tools: 0,
+                    total_tokens: 0,
+                    duration_ms: 1,
+                },
+            )
+            .await
+            .expect("recovered completion should persist");
+
+        let completed = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert_eq!(completed.model_rounds.len(), 2);
+        assert_eq!(completed.model_rounds[0].round_index, 0);
+        assert_eq!(completed.model_rounds[1].round_index, 1);
+        assert_eq!(
+            completed.model_rounds[1].text_items[0].content,
+            "after recovery"
+        );
+        assert!(completed.recovery.is_none());
+        assert_eq!(completed.recovery_epoch, Some(plan.execution_generation));
+    }
+
+    #[tokio::test]
+    async fn repeated_interruption_persists_recovered_generation_rounds() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Repeated recovery".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "continue through two interruptions".to_string(),
+                Some("turn-repeat-interruption".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("first generation should interrupt");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+        let first_recovery =
+            reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+                .await
+                .expect("first recovery should reopen");
+
+        let assistant = Message::assistant_with_tools(
+            String::new(),
+            vec![ToolCall {
+                tool_id: "tool-recovered".to_string(),
+                tool_name: "Read".to_string(),
+                arguments: json!({"path": "README.md"}),
+                raw_arguments: None,
+                is_error: false,
+                parse_error: None,
+                recovered_from_truncation: false,
+                repair_kind: Default::default(),
+            }],
+        )
+        .with_turn_id(turn_id.clone())
+        .with_round_id("recovered-round".to_string());
+        let tool_result = Message::tool_result(ToolResult {
+            tool_id: "tool-recovered".to_string(),
+            tool_name: "Read".to_string(),
+            effective_tool_name: None,
+            result: json!({"content": "safe boundary"}),
+            result_for_assistant: Some("safe boundary".to_string()),
+            is_error: false,
+            duration_ms: Some(1),
+            image_attachments: None,
+        })
+        .with_turn_id(turn_id.clone())
+        .with_round_id("recovered-round".to_string());
+        manager
+            .mark_dialog_turn_interrupted_with_messages(
+                &session.session_id,
+                &turn_id,
+                &[assistant, tool_result],
+            )
+            .await
+            .expect("recovered generation should interrupt durably");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle again");
+
+        let persisted = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert_eq!(persisted.model_rounds.len(), 1);
+        assert_eq!(persisted.model_rounds[0].round_index, 0);
+        assert_eq!(
+            persisted.model_rounds[0].tool_items[0]
+                .tool_result
+                .as_ref()
+                .map(|result| result.success),
+            Some(true),
+        );
+        let next_recovery = reopen_interrupted_turn_for_test(
+            &manager,
+            &session.session_id,
+            &turn_id,
+            first_recovery.execution_generation,
+        )
+        .await
+        .expect("second recovery should reopen after appended history");
+        assert_eq!(next_recovery.initial_round_index, 1);
+    }
+
+    #[tokio::test]
+    async fn first_interruption_merges_a_partially_persisted_round_prefix() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Interrupted merge".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "merge frontend and runtime rounds".to_string(),
+                Some("turn-prefix-merge".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        let persisted_prefix = Message::assistant("frontend prefix".to_string())
+            .with_turn_id(turn_id.clone())
+            .with_round_id("round-shared".to_string());
+        let mut persisted_turn = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        persisted_turn.model_rounds =
+            SessionManager::build_model_rounds_from_messages(&[persisted_prefix], &turn_id, 1);
+        persistence_manager
+            .save_dialog_turn(workspace.path(), &persisted_turn)
+            .await
+            .expect("frontend prefix should persist");
+
+        let runtime_rounds = [
+            Message::assistant("runtime authoritative prefix".to_string())
+                .with_turn_id(turn_id.clone())
+                .with_round_id("round-shared".to_string()),
+            Message::assistant("runtime missing tail".to_string())
+                .with_turn_id(turn_id.clone())
+                .with_round_id("round-tail".to_string()),
+        ];
+        manager
+            .mark_dialog_turn_interrupted_with_messages(
+                &session.session_id,
+                &turn_id,
+                &runtime_rounds,
+            )
+            .await
+            .expect("interruption should merge the runtime journal");
+
+        let persisted = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert_eq!(persisted.model_rounds.len(), 2);
+        assert_eq!(persisted.model_rounds[0].id, "round-shared");
+        assert_eq!(persisted.model_rounds[0].round_index, 0);
+        assert_eq!(
+            persisted.model_rounds[0].text_items[0].content,
+            "runtime authoritative prefix"
+        );
+        assert_eq!(persisted.model_rounds[1].id, "round-tail");
+        assert_eq!(persisted.model_rounds[1].round_index, 1);
+    }
+
+    #[tokio::test]
+    async fn restore_reopens_a_recovering_turn_when_the_session_write_was_lost() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Recovery restart".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    model_id: Some("auto".to_string()),
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish after restart".to_string(),
+                Some("turn-restart".to_string()),
+                None,
+                Some(serde_json::json!({
+                    "resolved_permission_mode": "ask",
+                    "runtime_resolved_model_id": "model-original",
+                    "runtime_model_binding_fingerprint": interrupted_turn_test_model_fingerprint(),
+                    "runtime_reasoning_preset": null,
+                    "runtime_reasoning_selection": null,
+                    "runtime_reasoning_fingerprint": interrupted_turn_test_reasoning_fingerprint(None)
+                })),
+            )
+            .await
+            .expect("turn should start");
+        manager
+            .mark_dialog_turn_interrupted(&session.session_id, &turn_id)
+            .await
+            .expect("turn should become interrupted");
+        manager
+            .update_session_state_for_turn_if_processing(
+                &session.session_id,
+                &turn_id,
+                SessionState::Idle,
+            )
+            .await
+            .expect("session should settle idle");
+        let first_recovery =
+            reopen_interrupted_turn_for_test(&manager, &session.session_id, &turn_id, 0)
+                .await
+                .expect("turn should start recovering");
+        assert_eq!(first_recovery.execution_generation, 1);
+
+        // Simulate a crash after the recovering Turn rename but before the
+        // Processing Session rename. The older Idle Session file must not hide
+        // the abandoned execution generation forever.
+        let mut stale_session = persistence_manager
+            .load_session(workspace.path(), &session.session_id)
+            .await
+            .expect("persisted session should load");
+        stale_session.state = SessionState::Idle;
+        persistence_manager
+            .save_session(workspace.path(), &stale_session)
+            .await
+            .expect("stale idle session should persist");
+        manager.evict_loaded_session_for_test(&session.session_id);
+        drop(manager);
+
+        let restored_manager = test_manager(persistence_manager.clone());
+        let (restored_session, restored_turns) = restored_manager
+            .restore_session_with_turns(workspace.path(), &session.session_id)
+            .await
+            .expect("restart should restore the session");
+
+        assert!(matches!(restored_session.state, SessionState::Idle));
+        let restored_turn = restored_turns.last().expect("latest turn should restore");
+        assert_eq!(restored_turn.status, TurnStatus::Cancelled);
+        assert_eq!(
+            restored_turn
+                .recovery
+                .as_ref()
+                .map(|recovery| (recovery.status, recovery.execution_generation)),
+            Some((DialogTurnRecoveryStatus::Interrupted, 1)),
+        );
+
+        let second_recovery =
+            reopen_interrupted_turn_for_test(&restored_manager, &session.session_id, &turn_id, 1)
+                .await
+                .expect("the interrupted generation should remain recoverable");
+        assert_eq!(second_recovery.execution_generation, 2);
     }
 
     #[tokio::test]
@@ -10607,6 +12657,30 @@ mod tests {
                     ..Default::default()
                 }],
                 ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn reasoning_model_with_default(id: &str, default_preset: &str) -> ServiceAIModelConfig {
+        ServiceAIModelConfig {
+            id: id.to_string(),
+            name: id.to_string(),
+            model_name: id.to_string(),
+            enabled: true,
+            reasoning: Some(ReasoningConfig {
+                catalog: ReasoningCatalogBinding::Disabled,
+                default_preset: Some(default_preset.to_string()),
+                presets: ["low", "high"]
+                    .into_iter()
+                    .map(|preset_id| ReasoningPreset {
+                        id: preset_id.to_string(),
+                        actions: vec![ReasoningPresetAction::Effort {
+                            value: preset_id.to_string(),
+                        }],
+                        ..Default::default()
+                    })
+                    .collect(),
             }),
             ..Default::default()
         }

--- a/src/crates/assembly/core/src/infrastructure/ai/reasoning_catalog.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/reasoning_catalog.rs
@@ -8,14 +8,14 @@ use bitfun_ai_adapters::models_dev::{
     project_reasoning_catalog_with_limit_and_auto_binding, ModelsDevCatalog,
 };
 #[cfg(feature = "model-catalog")]
+use bitfun_core_types::ReasoningCatalogProjectionRequest;
+#[cfg(feature = "model-catalog")]
 use bitfun_core_types::{
     ModelsDevCatalogSource, ModelsDevCatalogStatus, ModelsDevRefreshResult, ModelsDevRefreshStatus,
 };
 use bitfun_core_types::{
     ReasoningCatalogBinding, ReasoningCatalogProjection, ReasoningPresetDescriptor,
 };
-#[cfg(feature = "model-catalog")]
-use bitfun_core_types::ReasoningCatalogProjectionRequest;
 #[cfg(feature = "model-catalog")]
 use bitfun_events::{AIModelCatalogUpdatedEvent, AI_MODEL_CATALOG_UPDATED_EVENT};
 #[cfg(feature = "model-catalog")]
@@ -24,6 +24,7 @@ use bitfun_services_integrations::models_dev::{
 };
 #[cfg(feature = "model-catalog")]
 use log::debug;
+use sha2::{Digest, Sha256};
 
 use crate::infrastructure::ai::provider_catalog::trusted_models_dev_binding;
 use crate::infrastructure::ai::AIClient;
@@ -349,6 +350,22 @@ pub(crate) fn resolve_reasoning_preset<'a>(
         .find(|preset| preset.id == preset_id)
 }
 
+pub(crate) fn reasoning_preset_runtime_fingerprint(
+    preset: Option<&ReasoningPresetDescriptor>,
+) -> String {
+    let value = preset.map_or(serde_json::Value::Null, |preset| {
+        serde_json::json!({
+            "id": preset.id,
+            "actions": preset.actions,
+            "source": preset.source,
+            "execution_provider": preset.execution_provider,
+            "execution_model": preset.execution_model,
+        })
+    });
+    let encoded = serde_json::to_vec(&value).unwrap_or_default();
+    format!("{:x}", Sha256::digest(encoded))
+}
+
 /// Normalizes a session-scoped reasoning preset against one concrete model.
 ///
 /// `None` is the canonical Auto state. A configured preset can always be
@@ -428,17 +445,44 @@ pub(crate) fn apply_selected_reasoning_preset(
 mod tests {
     use bitfun_core_types::{
         ReasoningCatalogBinding, ReasoningCatalogProjectionRequest, ReasoningConfig,
-        ReasoningPreset, ReasoningPresetAction, ReasoningPresetSource,
+        ReasoningPreset, ReasoningPresetAction, ReasoningPresetDescriptor, ReasoningPresetSource,
     };
 
     use super::{
         apply_default_reasoning_preset, apply_selected_reasoning_preset,
         normalize_reasoning_preset_for_model, project_model_reasoning_catalog,
-        resolve_default_reasoning_preset, resolve_reasoning_preset, ModelsDevCatalog,
+        reasoning_preset_runtime_fingerprint, resolve_default_reasoning_preset,
+        resolve_reasoning_preset, ModelsDevCatalog,
     };
     use crate::infrastructure::ai::AIClient;
     use crate::service::config::types::AIModelConfig;
     use crate::util::types::AIConfig;
+
+    #[test]
+    fn runtime_fingerprint_detects_same_id_action_drift() {
+        let preset = ReasoningPresetDescriptor {
+            id: "high".to_string(),
+            label: "High".to_string(),
+            order: 1,
+            actions: vec![ReasoningPresetAction::Effort {
+                value: "high".to_string(),
+            }],
+            source: ReasoningPresetSource::ModelsDev,
+            execution_provider: Some("openai".to_string()),
+            execution_model: Some("model-v1".to_string()),
+        };
+        let mut changed = preset.clone();
+        changed.actions = vec![ReasoningPresetAction::BudgetTokens { value: 32_000 }];
+
+        assert_ne!(
+            reasoning_preset_runtime_fingerprint(Some(&preset)),
+            reasoning_preset_runtime_fingerprint(Some(&changed)),
+        );
+        assert_ne!(
+            reasoning_preset_runtime_fingerprint(None),
+            reasoning_preset_runtime_fingerprint(Some(&preset)),
+        );
+    }
 
     fn catalog() -> ModelsDevCatalog {
         ModelsDevCatalog::parse_str(

--- a/src/crates/assembly/core/src/product_runtime.rs
+++ b/src/crates/assembly/core/src/product_runtime.rs
@@ -46,11 +46,19 @@ use crate::agentic::events::EventQueue;
 use crate::agentic::keyed_lock::KeyedAsyncLockGuard;
 use crate::agentic::persistence::session_branch::SessionBranchRequest;
 use crate::agentic::persistence::{PersistenceManager, SessionMetadataPage};
-use crate::agentic::session::{CoreSessionStorePort, PromptCacheScope};
+use crate::agentic::session::{
+    CoreSessionStorePort, PromptCacheScope,
+    INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY,
+    INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY,
+    INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY,
+    INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY,
+};
 use crate::agentic::tools::implementations::skills::SkillRegistry;
 use crate::service::session::{
     DialogTurnData, SessionMetadata, SessionTranscriptExport, SessionTranscriptExportOptions,
-    SessionTurnCatalog, SessionTurnWindowResponse,
+    SessionTurnCatalog, SessionTurnWindowResponse, TurnStatus,
 };
 use crate::service::session_usage::{
     generate_session_usage_report_from_storage_path, SessionUsageReport,
@@ -65,6 +73,60 @@ use crate::util::errors::{BitFunError, BitFunResult};
 
 pub use bitfun_product_capabilities::ProductRuntimeAssembly as CoreProductRuntimeAssembly;
 pub use runtime_services::{build_local_runtime_services, CoreRuntimeServicesProvider};
+
+fn projected_turn_save_would_overwrite_runtime_state(
+    persisted: &DialogTurnData,
+    projected: &DialogTurnData,
+) -> bool {
+    persisted.recovery.is_some()
+        || persisted.recovery_epoch.is_some()
+        || projected.recovery.is_some()
+        || projected.recovery_epoch.is_some()
+        || (matches!(
+            persisted.status,
+            TurnStatus::Completed | TurnStatus::Cancelled | TurnStatus::Error
+        ) && projected.status == TurnStatus::InProgress)
+}
+
+fn merge_runtime_owned_turn_facts(
+    persisted: &DialogTurnData,
+    projected: &DialogTurnData,
+) -> DialogTurnData {
+    let mut merged = projected.clone();
+    merged.agent_type = persisted.agent_type.clone();
+
+    let Some(persisted_metadata) = persisted
+        .user_message
+        .metadata
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+    else {
+        return merged;
+    };
+    let projected_metadata = merged
+        .user_message
+        .metadata
+        .get_or_insert_with(|| serde_json::json!({}));
+    if !projected_metadata.is_object() {
+        *projected_metadata = serde_json::json!({});
+    }
+    let target = projected_metadata
+        .as_object_mut()
+        .expect("projected metadata was normalized to an object");
+    for key in [
+        INTERRUPTED_TURN_PERMISSION_MODE_METADATA_KEY,
+        INTERRUPTED_TURN_RESOLVED_MODEL_ID_METADATA_KEY,
+        INTERRUPTED_TURN_MODEL_BINDING_FINGERPRINT_METADATA_KEY,
+        INTERRUPTED_TURN_REASONING_PRESET_METADATA_KEY,
+        INTERRUPTED_TURN_REASONING_SELECTION_METADATA_KEY,
+        INTERRUPTED_TURN_REASONING_FINGERPRINT_METADATA_KEY,
+    ] {
+        if let Some(value) = persisted_metadata.get(key) {
+            target.insert(key.to_string(), value.clone());
+        }
+    }
+    merged
+}
 
 struct ProductEventQueueDrain {
     task: tokio::task::JoinHandle<()>,
@@ -1297,8 +1359,26 @@ impl CoreAgentRuntimeCompatibility {
                 permit.session_id, turn.turn_index, turn.turn_id
             )));
         }
+        let mut projected = turn.clone();
+        if let Some(persisted) = self
+            .persistence
+            .load_dialog_turn(&permit.storage_path, &permit.session_id, turn.turn_index)
+            .await?
+        {
+            if projected_turn_save_would_overwrite_runtime_state(&persisted, turn) {
+                log::debug!(
+                    "Ignoring stale projected Turn save owned by the runtime: session_id={}, turn_id={}, persisted_status={:?}, projected_status={:?}",
+                    permit.session_id,
+                    turn.turn_id,
+                    persisted.status,
+                    turn.status
+                );
+                return Ok(());
+            }
+            projected = merge_runtime_owned_turn_facts(&persisted, turn);
+        }
         self.persistence
-            .save_dialog_turn(&permit.storage_path, turn)
+            .save_dialog_turn(&permit.storage_path, &projected)
             .await
     }
 
@@ -1938,11 +2018,12 @@ mod tests {
     use super::CoreProductAgentEventSource;
     use super::{
         build_session_lineage_snapshot, generate_core_session_usage_report,
-        get_snapshot_manager_for_workspace, latest_persisted_turn_id, runtime_lineage_snapshot,
-        runtime_port_error, validate_latest_turn_fork_scope, validate_persisted_session_id,
-        CoreAgentRuntimeCompatibility, CoreLocalWorkspaceSnapshot, CoreProductAgentRuntime,
-        CoreProductEventQueueOwner, CoreSessionOperationsPort, SESSION_PROVIDER_ACP,
-        SESSION_PROVIDER_METADATA_KEY,
+        get_snapshot_manager_for_workspace, latest_persisted_turn_id,
+        merge_runtime_owned_turn_facts, projected_turn_save_would_overwrite_runtime_state,
+        runtime_lineage_snapshot, runtime_port_error, validate_latest_turn_fork_scope,
+        validate_persisted_session_id, CoreAgentRuntimeCompatibility, CoreLocalWorkspaceSnapshot,
+        CoreProductAgentRuntime, CoreProductEventQueueOwner, CoreSessionOperationsPort,
+        SESSION_PROVIDER_ACP, SESSION_PROVIDER_METADATA_KEY,
     };
     use crate::agentic::coordination::{ConversationCoordinator, DialogScheduler};
     use crate::agentic::events::{EventQueue, EventQueueConfig, EventRouter};
@@ -1958,7 +2039,10 @@ mod tests {
     use crate::agentic::tools::registry::ToolRegistry;
     use crate::agentic::tools::{ToolPipeline, ToolStateManager};
     use crate::infrastructure::PathManager;
-    use crate::service::session::{DialogTurnData, SessionMetadata, UserMessageData};
+    use crate::service::session::{
+        DialogTurnData, DialogTurnRecoveryData, DialogTurnRecoveryStatus, SessionMetadata,
+        TurnStatus, UserMessageData,
+    };
     use crate::service::session_usage::UsageTokenSource;
     use crate::service::snapshot::manager::clear_snapshot_manager_for_test;
     use crate::service::token_usage::TokenUsageService;
@@ -2003,6 +2087,103 @@ mod tests {
             clear_snapshot_manager_for_test(&self.path);
             let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn stale_projected_turn_saves_cannot_overwrite_runtime_recovery_state() {
+        let mut persisted = DialogTurnData::new(
+            "turn-1".to_string(),
+            0,
+            "session-1".to_string(),
+            UserMessageData {
+                id: "user-1".to_string(),
+                content: "continue".to_string(),
+                timestamp: 1,
+                metadata: None,
+            },
+        );
+        let projected = persisted.clone();
+        persisted.status = TurnStatus::Cancelled;
+        persisted.recovery = Some(DialogTurnRecoveryData {
+            status: DialogTurnRecoveryStatus::Interrupted,
+            execution_generation: 0,
+            resume_count: 0,
+            interrupted_at: Some(2),
+            model_id: Some("model-a".to_string()),
+        });
+        persisted.recovery_epoch = Some(0);
+        assert!(projected_turn_save_would_overwrite_runtime_state(
+            &persisted, &projected
+        ));
+
+        let mut completed = persisted.clone();
+        completed.status = TurnStatus::Completed;
+        completed.recovery = None;
+        assert!(projected_turn_save_would_overwrite_runtime_state(
+            &completed, &projected
+        ));
+
+        let mut projected_with_recovery = projected.clone();
+        projected_with_recovery.recovery = persisted.recovery.clone();
+        assert!(projected_turn_save_would_overwrite_runtime_state(
+            &projected,
+            &projected_with_recovery
+        ));
+        assert!(!projected_turn_save_would_overwrite_runtime_state(
+            &projected, &projected
+        ));
+    }
+
+    #[test]
+    fn projected_turn_saves_preserve_runtime_execution_contract() {
+        let mut persisted = DialogTurnData::new(
+            "turn-1".to_string(),
+            0,
+            "session-1".to_string(),
+            UserMessageData {
+                id: "user-1".to_string(),
+                content: "continue".to_string(),
+                timestamp: 1,
+                metadata: Some(serde_json::json!({
+                    "runtime_resolved_model_id": "model-a",
+                    "runtime_model_binding_fingerprint": "binding-a",
+                    "runtime_reasoning_preset": "high",
+                    "runtime_reasoning_selection": "high",
+                    "runtime_reasoning_fingerprint": "reasoning-a",
+                    "resolved_permission_mode": "ask",
+                })),
+            },
+        );
+        persisted.agent_type = Some("runtime-agent".to_string());
+        let mut projected = persisted.clone();
+        projected.agent_type = Some("stale-agent".to_string());
+        projected.user_message.metadata = Some(serde_json::json!({
+            "canvas_context": { "node": "selected" }
+        }));
+
+        let merged = merge_runtime_owned_turn_facts(&persisted, &projected);
+        let metadata = merged
+            .user_message
+            .metadata
+            .and_then(|value| value.as_object().cloned())
+            .expect("merged metadata");
+        assert_eq!(merged.agent_type.as_deref(), Some("runtime-agent"));
+        assert_eq!(
+            metadata.get("runtime_resolved_model_id"),
+            Some(&serde_json::json!("model-a"))
+        );
+        assert_eq!(
+            metadata.get("runtime_reasoning_fingerprint"),
+            Some(&serde_json::json!("reasoning-a"))
+        );
+        assert_eq!(
+            metadata.get("resolved_permission_mode"),
+            Some(&serde_json::json!("ask"))
+        );
+        assert_eq!(
+            metadata.get("canvas_context"),
+            Some(&serde_json::json!({ "node": "selected" }))
+        );
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/service/session_usage/service.rs
+++ b/src/crates/assembly/core/src/service/session_usage/service.rs
@@ -2794,6 +2794,8 @@ mod tests {
             has_final_response: None,
             error: None,
             error_detail: None,
+            recovery: None,
+            recovery_epoch: None,
             status: TurnStatus::Completed,
         }
     }

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -3036,6 +3036,8 @@ mod tests {
             has_final_response: None,
             error: None,
             error_detail: None,
+            recovery: None,
+            recovery_epoch: None,
             status,
         }
     }

--- a/src/crates/contracts/events/src/agentic.rs
+++ b/src/crates/contracts/events/src/agentic.rs
@@ -188,6 +188,19 @@ pub enum AgenticEvent {
         turn_id: String,
     },
 
+    DialogTurnInterrupted {
+        session_id: String,
+        turn_id: String,
+        execution_generation: u32,
+        model_id: Option<String>,
+    },
+
+    DialogTurnRecovered {
+        session_id: String,
+        turn_id: String,
+        execution_generation: u32,
+    },
+
     DialogTurnFailed {
         session_id: String,
         turn_id: String,
@@ -629,6 +642,8 @@ impl AgenticEvent {
             | Self::ContextCompressionFailed { session_id, .. }
             | Self::ThreadGoalUpdated { session_id, .. }
             | Self::DialogTurnCancelled { session_id, .. }
+            | Self::DialogTurnInterrupted { session_id, .. }
+            | Self::DialogTurnRecovered { session_id, .. }
             | Self::DialogTurnFailed { session_id, .. }
             | Self::ModelRoundStarted { session_id, .. }
             | Self::ModelRoundAttemptSuperseded { session_id, .. }
@@ -650,6 +665,8 @@ impl AgenticEvent {
             Self::DialogTurnStarted { turn_id, .. }
             | Self::DialogTurnCompleted { turn_id, .. }
             | Self::DialogTurnCancelled { turn_id, .. }
+            | Self::DialogTurnInterrupted { turn_id, .. }
+            | Self::DialogTurnRecovered { turn_id, .. }
             | Self::DialogTurnFailed { turn_id, .. }
             | Self::TokenUsageUpdated { turn_id, .. }
             | Self::ContextCompressionStarted { turn_id, .. }
@@ -673,6 +690,10 @@ impl AgenticEvent {
             Self::SystemError { .. }
             | Self::DialogTurnFailed { .. }
             | Self::DialogTurnCancelled { .. } => AgenticEventPriority::Critical,
+
+            Self::DialogTurnInterrupted { .. } | Self::DialogTurnRecovered { .. } => {
+                AgenticEventPriority::Critical
+            }
 
             Self::SessionStateChanged { .. }
             | Self::SessionHistoryChanged { .. }

--- a/src/crates/contracts/events/src/frontend_projection.rs
+++ b/src/crates/contracts/events/src/frontend_projection.rs
@@ -239,6 +239,32 @@ pub fn project_agentic_frontend_event(event: AgenticEvent) -> Option<AgenticFron
                 "turnId": turn_id,
             }),
         )),
+        AgenticEvent::DialogTurnInterrupted {
+            session_id,
+            turn_id,
+            execution_generation,
+            model_id,
+        } => Some(AgenticFrontendEvent::new(
+            "agentic://dialog-turn-interrupted",
+            json!({
+                "sessionId": session_id,
+                "turnId": turn_id,
+                "executionGeneration": execution_generation,
+                "modelId": model_id,
+            }),
+        )),
+        AgenticEvent::DialogTurnRecovered {
+            session_id,
+            turn_id,
+            execution_generation,
+        } => Some(AgenticFrontendEvent::new(
+            "agentic://dialog-turn-recovered",
+            json!({
+                "sessionId": session_id,
+                "turnId": turn_id,
+                "executionGeneration": execution_generation,
+            }),
+        )),
         AgenticEvent::DialogTurnFailed {
             session_id,
             turn_id,
@@ -580,6 +606,29 @@ mod tests {
 
         assert_eq!(projected.event_name, "agentic://dialog-turn-completed");
         assert_eq!(projected.payload["durationMs"], 21_206);
+    }
+
+    #[test]
+    fn interrupted_turn_lifecycle_projects_generation() {
+        let interrupted = project_agentic_frontend_event(AgenticEvent::DialogTurnInterrupted {
+            session_id: "session-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            execution_generation: 2,
+            model_id: Some("model-a".to_string()),
+        })
+        .expect("interrupted event should project");
+        let recovered = project_agentic_frontend_event(AgenticEvent::DialogTurnRecovered {
+            session_id: "session-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            execution_generation: 3,
+        })
+        .expect("recovered event should project");
+
+        assert_eq!(interrupted.event_name, "agentic://dialog-turn-interrupted");
+        assert_eq!(interrupted.payload["executionGeneration"], 2);
+        assert_eq!(interrupted.payload["modelId"], "model-a");
+        assert_eq!(recovered.event_name, "agentic://dialog-turn-recovered");
+        assert_eq!(recovered.payload["executionGeneration"], 3);
     }
 
     #[test]

--- a/src/crates/contracts/runtime-ports/src/agent_api.rs
+++ b/src/crates/contracts/runtime-ports/src/agent_api.rs
@@ -580,6 +580,32 @@ pub struct AgentDialogTurnRequest {
     pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
+/// Recover one settled interrupted user dialog without creating a new Turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct AgentDialogTurnRecoveryRequest {
+    pub session_id: String,
+    pub turn_id: String,
+    /// Compare-and-set generation observed by the caller.
+    pub execution_generation: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct AgentDialogTurnRecoveryOutcome {
+    pub session_id: String,
+    pub turn_id: String,
+    pub execution_generation: u32,
+}
+
 /// Steering request for one exact running dialog turn.
 ///
 /// Carries the same payload shape as a turn submission: a mid-turn steering
@@ -762,6 +788,7 @@ pub fn should_suppress_agent_session_cancelled_reply(
 pub enum DialogTurnOutcomeKind {
     Completed,
     Cancelled,
+    Interrupted,
     Failed,
 }
 
@@ -769,7 +796,8 @@ pub const fn should_skip_agent_session_reply(
     outcome_kind: DialogTurnOutcomeKind,
     suppressed_cancelled_reply: bool,
 ) -> bool {
-    matches!(outcome_kind, DialogTurnOutcomeKind::Cancelled) && suppressed_cancelled_reply
+    matches!(outcome_kind, DialogTurnOutcomeKind::Interrupted)
+        || matches!(outcome_kind, DialogTurnOutcomeKind::Cancelled) && suppressed_cancelled_reply
 }
 
 /// Source session route used when an agent-session request should reply to the
@@ -1696,6 +1724,16 @@ pub trait AgentDialogTurnPort: Send + Sync {
             "dialog turn steering is not supported by this provider",
         ))
     }
+
+    async fn recover_interrupted_turn(
+        &self,
+        _request: AgentDialogTurnRecoveryRequest,
+    ) -> PortResult<AgentDialogTurnRecoveryOutcome> {
+        Err(PortError::new(
+            PortErrorKind::NotAvailable,
+            "interrupted dialog turn recovery is not supported by this provider",
+        ))
+    }
 }
 
 #[async_trait::async_trait]
@@ -1761,12 +1799,44 @@ pub struct AgentTurnCancellationResult {
     pub requested: bool,
 }
 
+/// Request an intentional, recoverable interruption of one active Turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTurnInterruptionRequest {
+    pub session_id: String,
+    pub turn_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<AgentSubmissionSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTurnInterruptionResult {
+    pub session_id: String,
+    pub turn_id: String,
+    pub requested: bool,
+}
+
 #[async_trait::async_trait]
 pub trait AgentTurnCancellationPort: Send + Sync {
     async fn cancel_turn(
         &self,
         request: AgentTurnCancellationRequest,
     ) -> PortResult<AgentTurnCancellationResult>;
+
+    async fn interrupt_turn(
+        &self,
+        _request: AgentTurnInterruptionRequest,
+    ) -> PortResult<AgentTurnInterruptionResult> {
+        Err(PortError::new(
+            PortErrorKind::NotAvailable,
+            "recoverable interruption is not supported by this provider",
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2985,6 +3055,32 @@ mod tests {
         }))
         .expect("deserialize legacy cancel request");
         assert!(legacy.cancel_descendants);
+    }
+
+    #[test]
+    fn interrupted_turn_requests_are_typed_and_generation_scoped() {
+        let interrupt = AgentTurnInterruptionRequest {
+            session_id: "session_1".to_string(),
+            turn_id: "turn_1".to_string(),
+            source: Some(AgentSubmissionSource::DesktopUi),
+            wait_timeout_ms: Some(30_000),
+        };
+        let recover = AgentDialogTurnRecoveryRequest {
+            session_id: "session_1".to_string(),
+            turn_id: "turn_1".to_string(),
+            execution_generation: 1,
+            workspace_path: Some("/workspace/project".to_string()),
+            remote_connection_id: None,
+            remote_ssh_host: None,
+        };
+
+        let interrupt_json = serde_json::to_value(interrupt).expect("serialize interruption");
+        let recover_json = serde_json::to_value(recover).expect("serialize recovery");
+
+        assert_eq!(interrupt_json["turnId"], "turn_1");
+        assert_eq!(interrupt_json["source"], "desktop_ui");
+        assert_eq!(recover_json["executionGeneration"], 1);
+        assert_eq!(recover_json["workspacePath"], "/workspace/project");
     }
 
     #[test]

--- a/src/crates/execution/agent-runtime/src/event_queue.rs
+++ b/src/crates/execution/agent-runtime/src/event_queue.rs
@@ -11,7 +11,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, RwLock as StdRwLock, Weak,
 };
-use tokio::sync::{broadcast, Mutex, Notify};
+use tokio::sync::{broadcast, oneshot, Mutex, Notify};
 
 const MIN_EVENT_BROADCAST_BUFFER: usize = 1024;
 // Session-scoped protocol consumers can pause while servicing an RPC. Keep a
@@ -107,6 +107,100 @@ pub struct QueueStats {
     pub total_processed: u64,
 }
 
+/// Completion handle for an event that must enter the legacy dequeue stream
+/// before a producer may publish dependent events.
+pub struct LegacyDequeueAck {
+    receiver: oneshot::Receiver<()>,
+}
+
+impl LegacyDequeueAck {
+    pub async fn wait(self) -> EventBusResult<()> {
+        self.receiver
+            .await
+            .map_err(|_| crate::event_bus::EventBusError::subscriber("legacy dequeue fence closed"))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LegacyQueuePolicy {
+    BestEffort,
+    RequireImmediateAck,
+    AuthoritativeControl,
+}
+
+fn interrupted_control_identity(event: &AgenticEvent) -> Option<(&str, &str, u32)> {
+    match event {
+        AgenticEvent::DialogTurnInterrupted {
+            session_id,
+            turn_id,
+            execution_generation,
+            ..
+        }
+        | AgenticEvent::DialogTurnRecovered {
+            session_id,
+            turn_id,
+            execution_generation,
+        } => Some((session_id, turn_id, *execution_generation)),
+        _ => None,
+    }
+}
+
+fn authoritative_control_supersedes(authoritative: &AgenticEvent, pending: &AgenticEvent) -> bool {
+    let AgenticEvent::DialogTurnInterrupted {
+        session_id,
+        turn_id,
+        execution_generation,
+        ..
+    } = authoritative
+    else {
+        return false;
+    };
+    interrupted_control_identity(pending).is_some_and(
+        |(pending_session_id, pending_turn_id, pending_generation)| {
+            pending_session_id == session_id
+                && (pending_turn_id != turn_id || pending_generation <= *execution_generation)
+        },
+    )
+}
+
+fn authoritative_control_is_stale(authoritative: &AgenticEvent, pending: &AgenticEvent) -> bool {
+    let Some((session_id, turn_id, execution_generation)) =
+        interrupted_control_identity(authoritative)
+    else {
+        return false;
+    };
+    interrupted_control_identity(pending).is_some_and(
+        |(pending_session_id, pending_turn_id, pending_generation)| {
+            pending_session_id == session_id
+                && pending_turn_id == turn_id
+                && pending_generation > execution_generation
+        },
+    )
+}
+
+fn is_reclaimable_stream_data(authoritative: &AgenticEvent, pending: &AgenticEvent) -> bool {
+    let AgenticEvent::DialogTurnInterrupted {
+        session_id,
+        turn_id,
+        ..
+    } = authoritative
+    else {
+        return false;
+    };
+    matches!(
+        pending,
+        AgenticEvent::TextChunk {
+            session_id: pending_session_id,
+            turn_id: pending_turn_id,
+            ..
+        } | AgenticEvent::ThinkingChunk {
+            session_id: pending_session_id,
+            turn_id: pending_turn_id,
+            ..
+        } if pending_session_id == session_id && pending_turn_id == turn_id
+    )
+}
+
 /// Event queue
 ///
 /// Core functionality:
@@ -119,6 +213,10 @@ pub struct EventQueue {
 
     /// Notifier (used to wake up waiting consumers)
     notify: Arc<Notify>,
+
+    /// One-shot acknowledgements completed when a fenced event is removed
+    /// from the legacy priority queue into a concrete delivery batch.
+    legacy_dequeue_acks: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
 
     /// Broadcast stream for non-consuming subscribers.
     broadcast_tx: broadcast::Sender<EventEnvelope>,
@@ -148,6 +246,7 @@ impl EventQueue {
         Self {
             queue: Arc::new(Mutex::new(BinaryHeap::new())),
             notify: Arc::new(Notify::new()),
+            legacy_dequeue_acks: Arc::new(Mutex::new(HashMap::new())),
             broadcast_tx,
             session_broadcasts: Arc::new(StdRwLock::new(HashMap::new())),
             has_session_broadcasts: Arc::new(AtomicBool::new(false)),
@@ -162,22 +261,173 @@ impl EventQueue {
         event: AgenticEvent,
         priority: Option<EventPriority>,
     ) -> EventBusResult<String> {
+        self.enqueue_internal(event, priority, LegacyQueuePolicy::BestEffort)
+            .await
+            .map(|(event_id, _)| event_id)
+    }
+
+    /// Enqueue an ordering fence into the legacy dequeue stream.
+    ///
+    /// Unlike ordinary events, a fence fails closed when the legacy queue is
+    /// full. Awaiting the returned acknowledgement guarantees that the fence
+    /// is already part of the current delivery batch, so later higher-priority
+    /// events cannot overtake it in the priority heap.
+    pub async fn enqueue_with_legacy_dequeue_ack(
+        &self,
+        event: AgenticEvent,
+        priority: Option<EventPriority>,
+    ) -> EventBusResult<(String, LegacyDequeueAck)> {
+        let (event_id, ack) = self
+            .enqueue_internal(event, priority, LegacyQueuePolicy::RequireImmediateAck)
+            .await?;
+        Ok((
+            event_id,
+            ack.expect("legacy dequeue acknowledgement requested"),
+        ))
+    }
+
+    /// Enqueue an authoritative control event without allowing the bounded
+    /// best-effort data budget to discard or block it. The queue first
+    /// coalesces older session recovery controls and reclaims same-turn stream
+    /// chunks. A separate bounded reserve protects unrelated lifecycle events.
+    ///
+    /// Broadcast happens only after legacy storage succeeds, keeping the
+    /// Desktop WebView and non-consuming subscribers on the same lifecycle.
+    pub async fn enqueue_with_guaranteed_legacy_storage(
+        &self,
+        event: AgenticEvent,
+        priority: Option<EventPriority>,
+    ) -> EventBusResult<String> {
+        self.enqueue_internal(event, priority, LegacyQueuePolicy::AuthoritativeControl)
+            .await
+            .map(|(event_id, _)| event_id)
+    }
+
+    async fn enqueue_internal(
+        &self,
+        event: AgenticEvent,
+        priority: Option<EventPriority>,
+        legacy_policy: LegacyQueuePolicy,
+    ) -> EventBusResult<(String, Option<LegacyDequeueAck>)> {
         let priority = priority.unwrap_or_else(|| event.default_priority());
         let envelope = EventEnvelope::new(event, priority);
         let event_id = envelope.id.clone();
+        let require_legacy_ack = matches!(legacy_policy, LegacyQueuePolicy::RequireImmediateAck);
+        let (mut ack_sender, ack) = if require_legacy_ack {
+            let (sender, receiver) = oneshot::channel();
+            (Some(sender), Some(LegacyDequeueAck { receiver }))
+        } else {
+            (None, None)
+        };
 
         let (queue_len, queued) = {
             let mut queue = self.queue.lock().await;
-            if queue.len() >= self.config.max_queue_size {
-                warn!(
-                    "Event queue full, skipping legacy queue storage: event_id={}",
-                    event_id
-                );
-                (queue.len(), false)
-            } else {
-                queue.push(std::cmp::Reverse(envelope.clone()));
-                (queue.len(), true)
+            if matches!(legacy_policy, LegacyQueuePolicy::AuthoritativeControl) {
+                if let Some(pending) = queue
+                    .iter()
+                    .map(|std::cmp::Reverse(pending)| pending)
+                    .find(|pending| authoritative_control_is_stale(&envelope.event, &pending.event))
+                {
+                    return Ok((pending.id.clone(), None));
+                }
+                let mut retained = BinaryHeap::with_capacity(queue.len());
+                let mut removed_ids = Vec::new();
+                while let Some(std::cmp::Reverse(pending)) = queue.pop() {
+                    if authoritative_control_supersedes(&envelope.event, &pending.event) {
+                        removed_ids.push(pending.id);
+                    } else {
+                        retained.push(std::cmp::Reverse(pending));
+                    }
+                }
+                *queue = retained;
+
+                if queue.len() >= self.config.max_queue_size {
+                    let reclaim_id = queue
+                        .iter()
+                        .map(|std::cmp::Reverse(pending)| pending)
+                        .filter(|pending| {
+                            is_reclaimable_stream_data(&envelope.event, &pending.event)
+                        })
+                        .max()
+                        .map(|pending| pending.id.clone());
+                    if let Some(reclaim_id) = reclaim_id {
+                        queue.retain(|std::cmp::Reverse(pending)| pending.id != reclaim_id);
+                        warn!(
+                            "Event queue full, reclaiming same-turn legacy stream data for authoritative control: event_id={}, reclaimed_event_id={}",
+                            event_id, reclaim_id
+                        );
+                        removed_ids.push(reclaim_id);
+                    }
+                }
+
+                let control_reserve = self.config.max_queue_size.max(1);
+                let mut pending_controls = queue
+                    .iter()
+                    .filter(|std::cmp::Reverse(pending)| {
+                        matches!(pending.event, AgenticEvent::DialogTurnInterrupted { .. })
+                    })
+                    .count();
+                while queue.len() >= self.config.max_queue_size
+                    && pending_controls >= control_reserve
+                {
+                    let oldest_control_id = queue
+                        .iter()
+                        .map(|std::cmp::Reverse(pending)| pending)
+                        .filter(|pending| {
+                            matches!(pending.event, AgenticEvent::DialogTurnInterrupted { .. })
+                        })
+                        .min_by_key(|pending| pending.timestamp)
+                        .map(|pending| pending.id.clone());
+                    let Some(oldest_control_id) = oldest_control_id else {
+                        break;
+                    };
+                    queue.retain(|std::cmp::Reverse(pending)| pending.id != oldest_control_id);
+                    removed_ids.push(oldest_control_id);
+                    pending_controls -= 1;
+                }
+
+                if !removed_ids.is_empty() {
+                    let mut acknowledgements = self.legacy_dequeue_acks.lock().await;
+                    for removed_id in removed_ids {
+                        acknowledgements.remove(&removed_id);
+                    }
+                }
             }
+            let queued = if queue.len() >= self.config.max_queue_size {
+                match legacy_policy {
+                    LegacyQueuePolicy::RequireImmediateAck => {
+                        return Err(crate::event_bus::EventBusError::subscriber(
+                            "legacy event queue is full",
+                        ));
+                    }
+                    LegacyQueuePolicy::AuthoritativeControl => {
+                        warn!(
+                            "Event queue data capacity full, using bounded authoritative legacy control reserve: event_id={}, reserve_limit={}",
+                            event_id, self.config.max_queue_size.max(1)
+                        );
+                        true
+                    }
+                    LegacyQueuePolicy::BestEffort => {
+                        warn!(
+                            "Event queue full, skipping legacy queue storage: event_id={}",
+                            event_id
+                        );
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+            if queued {
+                if let Some(sender) = ack_sender.take() {
+                    self.legacy_dequeue_acks
+                        .lock()
+                        .await
+                        .insert(event_id.clone(), sender);
+                }
+                queue.push(std::cmp::Reverse(envelope.clone()));
+            }
+            (queue.len(), queued)
         };
 
         // Broadcast delivery is authoritative for non-consuming runtime
@@ -216,7 +466,7 @@ impl EventQueue {
             priority
         );
 
-        Ok(event_id)
+        Ok((event_id, ack))
     }
 
     /// Dequeue batch of events
@@ -233,6 +483,15 @@ impl EventQueue {
         }
         let remaining_queue_len = queue.len();
         drop(queue);
+
+        if !batch.is_empty() {
+            let mut acknowledgements = self.legacy_dequeue_acks.lock().await;
+            for envelope in &batch {
+                if let Some(sender) = acknowledgements.remove(&envelope.id) {
+                    let _ = sender.send(());
+                }
+            }
+        }
 
         if let Some((max_age_ms, event_id, priority)) = batch
             .iter()
@@ -335,19 +594,29 @@ impl EventQueue {
     /// Clear all events for a session
     pub async fn clear_session(&self, session_id: &str) -> EventBusResult<()> {
         // Remove all events for this session from the queue
-        let queue_len = {
+        let (queue_len, removed_ids) = {
             let mut queue = self.queue.lock().await;
             let mut new_queue = BinaryHeap::new();
+            let mut removed_ids = Vec::new();
 
             while let Some(std::cmp::Reverse(envelope)) = queue.pop() {
                 if envelope.event.session_id() != Some(session_id) {
                     new_queue.push(std::cmp::Reverse(envelope));
+                } else {
+                    removed_ids.push(envelope.id);
                 }
             }
 
             *queue = new_queue;
-            queue.len() // Get size before releasing queue lock
+            (queue.len(), removed_ids)
         };
+
+        if !removed_ids.is_empty() {
+            let mut acknowledgements = self.legacy_dequeue_acks.lock().await;
+            for removed_id in removed_ids {
+                acknowledgements.remove(&removed_id);
+            }
+        }
 
         // Update statistics: use the size obtained earlier
         {
@@ -391,8 +660,372 @@ impl StreamEventSink for EventQueue {
 #[cfg(test)]
 mod tests {
     use super::{EventQueue, EventQueueConfig};
-    use bitfun_events::AgenticEvent;
+    use bitfun_events::{AgenticEvent, AgenticEventPriority};
     use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn legacy_dequeue_ack_separates_later_high_priority_events() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 8,
+            batch_size: 8,
+        });
+        queue
+            .enqueue(
+                AgenticEvent::SessionStateChanged {
+                    session_id: "session".to_string(),
+                    new_state: "old-data".to_string(),
+                },
+                Some(AgenticEventPriority::Normal),
+            )
+            .await
+            .expect("old event should enqueue");
+        let (_, acknowledgement) = queue
+            .enqueue_with_legacy_dequeue_ack(
+                AgenticEvent::DialogTurnRecovered {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                },
+                Some(AgenticEventPriority::Normal),
+            )
+            .await
+            .expect("fence should enqueue");
+        let mut acknowledgement = Box::pin(acknowledgement.wait());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1), &mut acknowledgement)
+                .await
+                .is_err(),
+            "fence must not acknowledge before dequeue"
+        );
+
+        let batch = queue.dequeue_configured_batch().await;
+        acknowledgement
+            .await
+            .expect("fence should acknowledge its delivery batch");
+        assert_eq!(batch.len(), 2);
+        assert!(matches!(
+            &batch[0].event,
+            AgenticEvent::SessionStateChanged { new_state, .. } if new_state == "old-data"
+        ));
+        assert!(matches!(
+            &batch[1].event,
+            AgenticEvent::DialogTurnRecovered {
+                execution_generation: 1,
+                ..
+            }
+        ));
+
+        queue
+            .enqueue(
+                AgenticEvent::DialogTurnCancelled {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                },
+                Some(AgenticEventPriority::Critical),
+            )
+            .await
+            .expect("later event should enqueue");
+        let next_batch = queue.dequeue_configured_batch().await;
+        assert!(matches!(
+            &next_batch[0].event,
+            AgenticEvent::DialogTurnCancelled { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn legacy_dequeue_fence_fails_before_broadcast_when_queue_is_full() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 1,
+            batch_size: 1,
+        });
+        let mut events = queue.subscribe();
+        queue
+            .enqueue(
+                AgenticEvent::TextChunk {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    round_id: "round".to_string(),
+                    attempt_id: None,
+                    attempt_index: None,
+                    text: "occupied".to_string(),
+                },
+                None,
+            )
+            .await
+            .expect("first event should enqueue");
+        events.recv().await.expect("first broadcast should arrive");
+
+        let result = queue
+            .enqueue_with_legacy_dequeue_ack(
+                AgenticEvent::DialogTurnRecovered {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                },
+                Some(AgenticEventPriority::Normal),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1), events.recv())
+                .await
+                .is_err(),
+            "a rejected fence must not be broadcast as recovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn authoritative_legacy_control_bypasses_data_capacity_without_losing_delivery() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 1,
+            batch_size: 1,
+        });
+        let mut events = queue.subscribe();
+        queue
+            .enqueue(
+                AgenticEvent::TextChunk {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    round_id: "round".to_string(),
+                    attempt_id: None,
+                    attempt_index: None,
+                    text: "occupied".to_string(),
+                },
+                None,
+            )
+            .await
+            .expect("first event should enqueue");
+        events.recv().await.expect("first broadcast should arrive");
+
+        tokio::time::timeout(
+            Duration::from_millis(10),
+            queue.enqueue_with_guaranteed_legacy_storage(
+                AgenticEvent::DialogTurnInterrupted {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                    model_id: Some("model".to_string()),
+                },
+                Some(AgenticEventPriority::Critical),
+            ),
+        )
+        .await
+        .expect("authoritative control event must not wait for data capacity")
+        .expect("authoritative control event should enqueue");
+        assert_eq!(
+            queue.len().await,
+            1,
+            "authoritative control should reclaim lower-priority data capacity"
+        );
+        assert!(matches!(
+            events
+                .recv()
+                .await
+                .expect("authoritative broadcast should arrive")
+                .event,
+            AgenticEvent::DialogTurnInterrupted { .. }
+        ));
+
+        queue
+            .enqueue_with_guaranteed_legacy_storage(
+                AgenticEvent::DialogTurnInterrupted {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 2,
+                    model_id: Some("model".to_string()),
+                },
+                Some(AgenticEventPriority::Critical),
+            )
+            .await
+            .expect("newer authoritative control event should enqueue");
+        events
+            .recv()
+            .await
+            .expect("newer authoritative broadcast should arrive");
+        assert_eq!(
+            queue.len().await,
+            1,
+            "a newer generation must replace the queued control event for the same turn"
+        );
+
+        queue
+            .enqueue_with_guaranteed_legacy_storage(
+                AgenticEvent::DialogTurnInterrupted {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                    model_id: Some("model".to_string()),
+                },
+                Some(AgenticEventPriority::Critical),
+            )
+            .await
+            .expect("stale authoritative control should be ignored idempotently");
+        assert_eq!(queue.len().await, 1);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1), events.recv())
+                .await
+                .is_err(),
+            "a stale generation must not be broadcast"
+        );
+
+        let delivered = queue.dequeue_configured_batch().await;
+        assert!(matches!(
+            &delivered[0].event,
+            AgenticEvent::DialogTurnInterrupted {
+                execution_generation: 2,
+                ..
+            }
+        ));
+        assert!(queue.dequeue_configured_batch().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn authoritative_control_preserves_unrelated_lifecycle_events() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 1,
+            batch_size: 1,
+        });
+        queue
+            .enqueue(
+                AgenticEvent::SessionStateChanged {
+                    session_id: "other-session".to_string(),
+                    new_state: "idle".to_string(),
+                },
+                None,
+            )
+            .await
+            .expect("lifecycle event should enqueue");
+        queue
+            .enqueue_with_guaranteed_legacy_storage(
+                AgenticEvent::DialogTurnInterrupted {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                    model_id: Some("model".to_string()),
+                },
+                Some(AgenticEventPriority::Critical),
+            )
+            .await
+            .expect("authoritative control should use its reserve");
+
+        assert_eq!(queue.len().await, 2);
+        assert!(matches!(
+            queue.dequeue_configured_batch().await[0].event,
+            AgenticEvent::DialogTurnInterrupted { .. }
+        ));
+        assert!(matches!(
+            queue.dequeue_configured_batch().await[0].event,
+            AgenticEvent::SessionStateChanged { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn authoritative_control_reserve_is_bounded_across_distinct_turns() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 1,
+            batch_size: 1,
+        });
+        for index in 0..3 {
+            queue
+                .enqueue_with_guaranteed_legacy_storage(
+                    AgenticEvent::DialogTurnInterrupted {
+                        session_id: format!("session-{index}"),
+                        turn_id: format!("turn-{index}"),
+                        execution_generation: 1,
+                        model_id: Some("model".to_string()),
+                    },
+                    Some(AgenticEventPriority::Critical),
+                )
+                .await
+                .expect("authoritative control should remain bounded");
+            assert_eq!(queue.len().await, 1);
+        }
+
+        let delivered = queue.dequeue_configured_batch().await;
+        assert!(matches!(
+            &delivered[0].event,
+            AgenticEvent::DialogTurnInterrupted {
+                session_id,
+                turn_id,
+                ..
+            } if session_id == "session-2" && turn_id == "turn-2"
+        ));
+    }
+
+    #[tokio::test]
+    async fn authoritative_interruption_replaces_the_same_turn_recovery_fence() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 1,
+            batch_size: 1,
+        });
+        let (_, recovery_ack) = queue
+            .enqueue_with_legacy_dequeue_ack(
+                AgenticEvent::DialogTurnRecovered {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                },
+                Some(AgenticEventPriority::Normal),
+            )
+            .await
+            .expect("recovery fence should enqueue");
+
+        queue
+            .enqueue_with_guaranteed_legacy_storage(
+                AgenticEvent::DialogTurnInterrupted {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                    model_id: Some("model".to_string()),
+                },
+                Some(AgenticEventPriority::Critical),
+            )
+            .await
+            .expect("authoritative interruption should replace its recovery fence");
+
+        assert_eq!(queue.len().await, 1);
+        tokio::time::timeout(Duration::from_millis(10), recovery_ack.wait())
+            .await
+            .expect("superseded fence acknowledgement should close promptly")
+            .expect_err("a superseded fence must not acknowledge delivery");
+        let delivered = queue.dequeue_configured_batch().await;
+        assert!(matches!(
+            &delivered[0].event,
+            AgenticEvent::DialogTurnInterrupted { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn clearing_a_session_closes_its_pending_recovery_fence() {
+        let queue = EventQueue::new(EventQueueConfig {
+            max_queue_size: 1,
+            batch_size: 1,
+        });
+        let (_, recovery_ack) = queue
+            .enqueue_with_legacy_dequeue_ack(
+                AgenticEvent::DialogTurnRecovered {
+                    session_id: "session".to_string(),
+                    turn_id: "turn".to_string(),
+                    execution_generation: 1,
+                },
+                Some(AgenticEventPriority::Normal),
+            )
+            .await
+            .expect("recovery fence should enqueue");
+
+        queue
+            .clear_session("session")
+            .await
+            .expect("session events should clear");
+
+        assert!(queue.is_empty().await);
+        tokio::time::timeout(Duration::from_millis(10), recovery_ack.wait())
+            .await
+            .expect("cleared fence acknowledgement should close promptly")
+            .expect_err("a cleared fence must not acknowledge delivery");
+    }
 
     #[tokio::test]
     async fn full_legacy_queue_does_not_drop_broadcast_delivery() {

--- a/src/crates/execution/agent-runtime/src/events.rs
+++ b/src/crates/execution/agent-runtime/src/events.rs
@@ -47,6 +47,7 @@ pub const fn turn_outcome_status_kind(status: TurnOutcomeStatus) -> DialogTurnOu
     match status {
         TurnOutcomeStatus::Completed => DialogTurnOutcomeKind::Completed,
         TurnOutcomeStatus::Cancelled => DialogTurnOutcomeKind::Cancelled,
+        TurnOutcomeStatus::Interrupted => DialogTurnOutcomeKind::Interrupted,
         TurnOutcomeStatus::Failed => DialogTurnOutcomeKind::Failed,
     }
 }

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -11,8 +11,9 @@ use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
 use bitfun_harness::HarnessRegistry;
 use bitfun_runtime_ports::{
     AgentBackgroundResultRequest, AgentDialogSteerRequest, AgentDialogTurnPort,
-    AgentDialogTurnRequest, AgentInputAttachment, AgentInteractionResponsePort,
-    AgentLifecycleDeliveryPort, AgentLocalCommandTurnPort, AgentLocalCommandTurnRecordRequest,
+    AgentDialogTurnRecoveryOutcome, AgentDialogTurnRecoveryRequest, AgentDialogTurnRequest,
+    AgentInputAttachment, AgentInteractionResponsePort, AgentLifecycleDeliveryPort,
+    AgentLocalCommandTurnPort, AgentLocalCommandTurnRecordRequest,
     AgentLocalCommandTurnRecordResult, AgentMessageWorkspaceReferencesRequest,
     AgentSessionArchiveRequest, AgentSessionArchiveStateRequest, AgentSessionClosePort,
     AgentSessionCompactionPort, AgentSessionCompactionRequest, AgentSessionCompactionResult,
@@ -31,14 +32,14 @@ use bitfun_runtime_ports::{
     AgentThreadGoalCreateRequest, AgentThreadGoalDeliveryRequest, AgentThreadGoalGetRequest,
     AgentThreadGoalManagementPort, AgentThreadGoalUpdateStatusRequest,
     AgentTransientSessionDiscardRequest, AgentTurnCancellationPort, AgentTurnCancellationRequest,
-    AgentTurnCancellationResult, AgentTurnSettlementPort, AgentTurnSettlementRequest,
-    AgentUserAnswersRequest, AgentUserShellCommandPort, AgentUserShellCommandRequest,
-    AgentUserShellCommandResult, AgentWorkspaceReference, AgentWorkspaceReferencePort,
-    AgentWorkspaceReferenceSearchRequest, AgentWorkspaceReferenceSearchResult, DialogSteerOutcome,
-    DialogSubmitOutcome, PermissionAuditRecord, PermissionGrant, PermissionGrantKey,
-    PluginRuntimeBinding, PortError, PortErrorKind, PortResult, RuntimeEventEnvelope,
-    SessionTranscript, SessionTranscriptReader, SessionTranscriptRequest, ThreadGoal,
-    WorkspaceDiffSnapshot,
+    AgentTurnCancellationResult, AgentTurnInterruptionRequest, AgentTurnInterruptionResult,
+    AgentTurnSettlementPort, AgentTurnSettlementRequest, AgentUserAnswersRequest,
+    AgentUserShellCommandPort, AgentUserShellCommandRequest, AgentUserShellCommandResult,
+    AgentWorkspaceReference, AgentWorkspaceReferencePort, AgentWorkspaceReferenceSearchRequest,
+    AgentWorkspaceReferenceSearchResult, DialogSteerOutcome, DialogSubmitOutcome,
+    PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PluginRuntimeBinding, PortError,
+    PortErrorKind, PortResult, RuntimeEventEnvelope, SessionTranscript, SessionTranscriptReader,
+    SessionTranscriptRequest, ThreadGoal, WorkspaceDiffSnapshot,
 };
 use bitfun_runtime_services::RuntimeServices;
 
@@ -1502,6 +1503,33 @@ impl AgentRuntime {
         Ok(outcome)
     }
 
+    pub async fn recover_interrupted_turn(
+        &self,
+        request: AgentDialogTurnRecoveryRequest,
+    ) -> Result<AgentDialogTurnRecoveryOutcome, RuntimeError> {
+        let requested_session_id = request.session_id.clone();
+        let requested_turn_id = request.turn_id.clone();
+        let dialog_turn = self
+            .dialog_turn
+            .as_ref()
+            .ok_or(RuntimeError::MissingDialogTurnPort)?;
+        let outcome = dialog_turn
+            .recover_interrupted_turn(request)
+            .await
+            .map_err(RuntimeError::from)?;
+        if outcome.session_id != requested_session_id || outcome.turn_id != requested_turn_id {
+            return Err(PortError::new(
+                PortErrorKind::Backend,
+                format!(
+                    "agent dialog recovery provider returned session_id '{}' and turn_id '{}' for requested session_id '{}' and turn_id '{}'",
+                    outcome.session_id, outcome.turn_id, requested_session_id, requested_turn_id
+                ),
+            )
+            .into());
+        }
+        Ok(outcome)
+    }
+
     pub async fn deliver_background_result(
         &self,
         request: AgentBackgroundResultRequest,
@@ -1592,6 +1620,20 @@ impl AgentRuntime {
             .ok_or(RuntimeError::MissingCancellationPort)?;
         cancellation
             .cancel_turn(request)
+            .await
+            .map_err(RuntimeError::from)
+    }
+
+    pub async fn interrupt_turn(
+        &self,
+        request: AgentTurnInterruptionRequest,
+    ) -> Result<AgentTurnInterruptionResult, RuntimeError> {
+        let cancellation = self
+            .cancellation
+            .as_ref()
+            .ok_or(RuntimeError::MissingCancellationPort)?;
+        cancellation
+            .interrupt_turn(request)
             .await
             .map_err(RuntimeError::from)
     }
@@ -1757,6 +1799,7 @@ mod tests {
         exact_session_result_id: Mutex<Option<String>>,
         submitted_messages: Mutex<Vec<AgentSubmissionRequest>>,
         cancelled_turns: Mutex<Vec<AgentTurnCancellationRequest>>,
+        interrupted_turns: Mutex<Vec<AgentTurnInterruptionRequest>>,
         compaction_requests: Mutex<Vec<AgentSessionCompactionRequest>>,
         before_turn_fork_requests: Mutex<Vec<AgentSessionForkBeforeTurnRequest>>,
         listed_sessions: Mutex<Vec<AgentSessionListRequest>>,
@@ -2283,6 +2326,18 @@ mod tests {
                 requested: true,
             })
         }
+
+        async fn interrupt_turn(
+            &self,
+            request: AgentTurnInterruptionRequest,
+        ) -> PortResult<AgentTurnInterruptionResult> {
+            self.interrupted_turns.lock().unwrap().push(request.clone());
+            Ok(AgentTurnInterruptionResult {
+                session_id: request.session_id,
+                turn_id: request.turn_id,
+                requested: true,
+            })
+        }
     }
 
     #[derive(Debug, Default)]
@@ -2696,6 +2751,30 @@ mod tests {
                 .as_deref(),
             Some("requester_session")
         );
+    }
+
+    #[tokio::test]
+    async fn interrupt_turn_delegates_to_cancellation_owner() {
+        let ports = Arc::new(FakeAgentRuntimePorts::default());
+        let runtime = AgentRuntimeBuilder::new()
+            .with_submission_port(ports.clone())
+            .with_cancellation_port(ports.clone())
+            .build()
+            .expect("runtime");
+
+        let result = runtime
+            .interrupt_turn(AgentTurnInterruptionRequest {
+                session_id: "session_1".to_string(),
+                turn_id: "turn_1".to_string(),
+                source: Some(AgentSubmissionSource::DesktopUi),
+                wait_timeout_ms: Some(30_000),
+            })
+            .await
+            .expect("interrupt");
+
+        assert!(result.requested);
+        assert_eq!(result.turn_id, "turn_1");
+        assert_eq!(ports.interrupted_turns.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -3378,6 +3457,54 @@ mod tests {
             dialog_turns.requests.lock().unwrap()[0].attachments[0].kind,
             "remote_image"
         );
+    }
+
+    #[tokio::test]
+    async fn recover_interrupted_turn_delegates_and_validates_identity() {
+        #[derive(Debug)]
+        struct RecoveryPort;
+
+        #[async_trait::async_trait]
+        impl bitfun_runtime_ports::AgentDialogTurnPort for RecoveryPort {
+            async fn submit_dialog_turn(
+                &self,
+                _request: AgentDialogTurnRequest,
+            ) -> PortResult<DialogSubmitOutcome> {
+                unreachable!("recovery must not submit a new turn")
+            }
+
+            async fn recover_interrupted_turn(
+                &self,
+                request: AgentDialogTurnRecoveryRequest,
+            ) -> PortResult<AgentDialogTurnRecoveryOutcome> {
+                Ok(AgentDialogTurnRecoveryOutcome {
+                    session_id: request.session_id,
+                    turn_id: request.turn_id,
+                    execution_generation: request.execution_generation + 1,
+                })
+            }
+        }
+
+        let runtime = AgentRuntimeBuilder::new()
+            .with_submission_port(Arc::new(FakeAgentRuntimePorts::default()))
+            .with_dialog_turn_port(Arc::new(RecoveryPort))
+            .build()
+            .expect("runtime");
+        let result = runtime
+            .recover_interrupted_turn(AgentDialogTurnRecoveryRequest {
+                session_id: "session_1".to_string(),
+                turn_id: "turn_1".to_string(),
+                execution_generation: 0,
+                workspace_path: Some("/workspace/project".to_string()),
+                remote_connection_id: None,
+                remote_ssh_host: None,
+            })
+            .await
+            .expect("recover");
+
+        assert_eq!(result.session_id, "session_1");
+        assert_eq!(result.turn_id, "turn_1");
+        assert_eq!(result.execution_generation, 1);
     }
 
     #[tokio::test]

--- a/src/crates/execution/agent-runtime/src/scheduler.rs
+++ b/src/crates/execution/agent-runtime/src/scheduler.rs
@@ -164,6 +164,12 @@ impl ActiveDialogTurnStore {
             .is_some_and(|turn| turn.turn_id() == turn_id)
     }
 
+    pub fn matches_agent_session_request(&self, session_id: &str, turn_id: &str) -> bool {
+        self.inner
+            .get(session_id)
+            .is_some_and(|turn| turn.turn_id() == turn_id && turn.is_agent_session_request())
+    }
+
     pub fn suppression_key_for_requester(
         &self,
         target_session_id: &str,
@@ -592,6 +598,17 @@ impl SessionRoundInjectionBuffer {
         taken
     }
 
+    /// Drop injections whose target was only "whatever turn is currently
+    /// running" while retaining messages explicitly bound to a Turn. An
+    /// interrupted Turn may resume later, but an unscoped injection must not
+    /// leak into a different Turn if the user abandons it.
+    pub fn discard_current_running(&self, session_id: &str) {
+        let Some(mut entry) = self.inner.get_mut(session_id) else {
+            return;
+        };
+        entry.retain(|message| matches!(message.target, RoundInjectionTarget::ExactTurn(_)));
+    }
+
     pub fn remove_by_id(&self, session_id: &str, injection_id: &str) -> Option<RoundInjection> {
         let mut entry = self.inner.get_mut(session_id)?;
         let index = entry
@@ -706,6 +723,14 @@ pub fn resolve_background_delivery_injection(
     }
 }
 
+pub fn target_background_delivery_injection_to_turn(
+    mut injection: RoundInjection,
+    turn_id: String,
+) -> RoundInjection {
+    injection.target = RoundInjectionTarget::ExactTurn(turn_id);
+    injection
+}
+
 pub fn resolve_background_delivery_injection_for_turn(
     kind: BackgroundInjectionKind,
     injection_id: String,
@@ -714,15 +739,16 @@ pub fn resolve_background_delivery_injection_for_turn(
     created_at: SystemTime,
     turn_id: String,
 ) -> RoundInjection {
-    let mut injection = resolve_background_delivery_injection(
-        kind,
-        injection_id,
-        content,
-        display_content,
-        created_at,
-    );
-    injection.target = RoundInjectionTarget::ExactTurn(turn_id);
-    injection
+    target_background_delivery_injection_to_turn(
+        resolve_background_delivery_injection(
+            kind,
+            injection_id,
+            content,
+            display_content,
+            created_at,
+        ),
+        turn_id,
+    )
 }
 
 pub fn is_background_result_injection(kind: RoundInjectionKind) -> bool {
@@ -739,6 +765,11 @@ pub enum TurnOutcome {
     },
     /// Turn was cancelled by user.
     Cancelled { turn_id: String },
+    /// Turn was intentionally interrupted and may be recovered in place.
+    Interrupted {
+        turn_id: String,
+        execution_generation: u32,
+    },
     /// Turn failed with an error.
     Failed { turn_id: String, error: String },
 }
@@ -746,6 +777,7 @@ pub enum TurnOutcome {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TurnOutcomeQueueAction {
     DispatchNext,
+    HoldQueue,
     ClearQueue,
 }
 
@@ -753,6 +785,7 @@ pub enum TurnOutcomeQueueAction {
 pub enum TurnOutcomeStatus {
     Completed,
     Cancelled,
+    Interrupted,
     Failed,
 }
 
@@ -761,6 +794,7 @@ impl TurnOutcomeStatus {
         match self {
             Self::Completed => "completed",
             Self::Cancelled => "cancelled",
+            Self::Interrupted => "interrupted",
             Self::Failed => "failed",
         }
     }
@@ -777,6 +811,7 @@ impl TurnOutcome {
         match self {
             Self::Completed { turn_id, .. }
             | Self::Cancelled { turn_id }
+            | Self::Interrupted { turn_id, .. }
             | Self::Failed { turn_id, .. } => turn_id,
         }
     }
@@ -785,6 +820,7 @@ impl TurnOutcome {
         match self {
             Self::Completed { .. } => TurnOutcomeStatus::Completed,
             Self::Cancelled { .. } => TurnOutcomeStatus::Cancelled,
+            Self::Interrupted { .. } => TurnOutcomeStatus::Interrupted,
             Self::Failed { .. } => TurnOutcomeStatus::Failed,
         }
     }
@@ -806,6 +842,10 @@ impl TurnOutcome {
                 "The target session cancelled this request before producing a final answer."
                     .to_string()
             }
+            Self::Interrupted { .. } => {
+                "The target session interrupted this request before producing a final answer."
+                    .to_string()
+            }
             Self::Failed { error, .. } => {
                 format!("The target session failed to complete this request.\nError: {error}")
             }
@@ -815,6 +855,7 @@ impl TurnOutcome {
     pub fn queue_action(&self) -> TurnOutcomeQueueAction {
         match self {
             Self::Completed { .. } | Self::Cancelled { .. } => TurnOutcomeQueueAction::DispatchNext,
+            Self::Interrupted { .. } => TurnOutcomeQueueAction::HoldQueue,
             Self::Failed { .. } => TurnOutcomeQueueAction::ClearQueue,
         }
     }
@@ -824,6 +865,7 @@ impl TurnOutcome {
 pub enum GoalContinuationAfterTurnAction {
     SkipNoActiveTurn,
     AbortForCancelled,
+    AbortForInterrupted,
     Evaluate { turn_completed: bool },
 }
 
@@ -878,6 +920,7 @@ pub fn resolve_turn_outcome_lifecycle_plan(
     } else {
         match status {
             TurnOutcomeStatus::Cancelled => GoalContinuationAfterTurnAction::AbortForCancelled,
+            TurnOutcomeStatus::Interrupted => GoalContinuationAfterTurnAction::AbortForInterrupted,
             TurnOutcomeStatus::Completed => GoalContinuationAfterTurnAction::Evaluate {
                 turn_completed: true,
             },
@@ -890,7 +933,10 @@ pub fn resolve_turn_outcome_lifecycle_plan(
     TurnOutcomeLifecyclePlan {
         status,
         queue_action: outcome.queue_action(),
-        drain_finished_turn_injections: true,
+        // Interrupted is a resumable generation of the same Turn. Steering
+        // and background results already accepted for that Turn remain valid
+        // until the user either resumes it or explicitly abandons it.
+        drain_finished_turn_injections: status != TurnOutcomeStatus::Interrupted,
         goal_continuation,
     }
 }
@@ -1068,6 +1114,63 @@ mod tests {
         );
         assert!(plan.dispatch_next());
         assert!(!plan.clear_queue());
+    }
+
+    #[test]
+    fn outcome_lifecycle_holds_queue_for_interrupted_turn() {
+        let outcome = TurnOutcome::Interrupted {
+            turn_id: "turn_1".to_string(),
+            execution_generation: 1,
+        };
+
+        let plan = resolve_turn_outcome_lifecycle_plan(&outcome, true);
+
+        assert_eq!(plan.status, TurnOutcomeStatus::Interrupted);
+        assert_eq!(plan.queue_action, TurnOutcomeQueueAction::HoldQueue);
+        assert!(
+            !plan.drain_finished_turn_injections,
+            "same-turn injections must survive until recovery or explicit abandonment"
+        );
+        assert_eq!(
+            plan.goal_continuation,
+            GoalContinuationAfterTurnAction::AbortForInterrupted
+        );
+        assert!(!plan.dispatch_next());
+        assert!(!plan.clear_queue());
+    }
+
+    #[test]
+    fn interrupted_turn_discards_only_unscoped_current_turn_injections() {
+        let buffer = SessionRoundInjectionBuffer::default();
+        buffer.push(
+            "session-1",
+            resolve_background_delivery_injection(
+                BackgroundInjectionKind::ThreadGoalObjectiveUpdated,
+                "current".to_string(),
+                "current-only".to_string(),
+                None,
+                SystemTime::now(),
+            ),
+        );
+        buffer.push(
+            "session-1",
+            target_background_delivery_injection_to_turn(
+                resolve_background_delivery_injection(
+                    BackgroundInjectionKind::BackgroundResult,
+                    "exact".to_string(),
+                    "resume-me".to_string(),
+                    None,
+                    SystemTime::now(),
+                ),
+                "turn-1".to_string(),
+            ),
+        );
+
+        buffer.discard_current_running("session-1");
+
+        assert!(buffer.has_pending_for_turn("session-1", "turn-1"));
+        assert!(!buffer.has_pending_for_turn("session-1", "turn-2"));
+        assert_eq!(buffer.pending_count("session-1"), 1);
     }
 
     #[test]

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -64,7 +64,8 @@ pub use bitfun_harness::{
 };
 pub use bitfun_runtime_ports::{
     AgentBackgroundResultRequest, AgentContextReloadPort, AgentDialogSteerRequest,
-    AgentDialogTurnExecution, AgentDialogTurnPort, AgentDialogTurnRequest, AgentInputAttachment,
+    AgentDialogTurnExecution, AgentDialogTurnPort, AgentDialogTurnRecoveryOutcome,
+    AgentDialogTurnRecoveryRequest, AgentDialogTurnRequest, AgentInputAttachment,
     AgentInteractionResponsePort, AgentLifecycleDeliveryPort, AgentLocalCommandTurnPort,
     AgentLocalCommandTurnRecordRequest, AgentLocalCommandTurnRecordResult,
     AgentMessageWorkspaceReferencesRequest, AgentSessionArchiveRequest,
@@ -86,18 +87,18 @@ pub use bitfun_runtime_ports::{
     AgentThreadGoalCreateRequest, AgentThreadGoalDeliveryRequest, AgentThreadGoalGetRequest,
     AgentThreadGoalManagementPort, AgentThreadGoalUpdateStatusRequest,
     AgentTransientSessionDiscardRequest, AgentTurnCancellationPort, AgentTurnCancellationRequest,
-    AgentTurnCancellationResult, AgentTurnSettlementPort, AgentTurnSettlementRequest,
-    AgentUserAnswersRequest, AgentUserShellCommandPort, AgentUserShellCommandRequest,
-    AgentUserShellCommandResult, AgentWorkspaceReference, AgentWorkspaceReferenceKind,
-    AgentWorkspaceReferencePort, AgentWorkspaceReferenceSearchEntry,
-    AgentWorkspaceReferenceSearchRequest, AgentWorkspaceReferenceSearchResult,
-    AgentWorkspaceReferenceSourceRange, ClockPort, DialogSteerOutcome, DialogSubmissionPolicy,
-    DialogSubmitOutcome, FileSystemPort, GitPort, McpCatalogPort, NetworkPort,
-    PermissionAuditRecord, PermissionDelegationContext, PermissionGrant, PermissionGrantKey,
-    PermissionReply, PermissionReplySource, PermissionRequest, PermissionRequestEvent,
-    PermissionRequestSource, PermissionRequestSourceKind, PortError, PortErrorKind, PortResult,
-    RemoteAssistantWorkspaceFacts, RemoteCapabilityPort, RemoteConnectionPort,
-    RemoteProjectionPort, RemoteRecentWorkspaceFacts, RemoteWorkspaceFacts,
+    AgentTurnCancellationResult, AgentTurnInterruptionRequest, AgentTurnInterruptionResult,
+    AgentTurnSettlementPort, AgentTurnSettlementRequest, AgentUserAnswersRequest,
+    AgentUserShellCommandPort, AgentUserShellCommandRequest, AgentUserShellCommandResult,
+    AgentWorkspaceReference, AgentWorkspaceReferenceKind, AgentWorkspaceReferencePort,
+    AgentWorkspaceReferenceSearchEntry, AgentWorkspaceReferenceSearchRequest,
+    AgentWorkspaceReferenceSearchResult, AgentWorkspaceReferenceSourceRange, ClockPort,
+    DialogSteerOutcome, DialogSubmissionPolicy, DialogSubmitOutcome, FileSystemPort, GitPort,
+    McpCatalogPort, NetworkPort, PermissionAuditRecord, PermissionDelegationContext,
+    PermissionGrant, PermissionGrantKey, PermissionReply, PermissionReplySource, PermissionRequest,
+    PermissionRequestEvent, PermissionRequestSource, PermissionRequestSourceKind, PortError,
+    PortErrorKind, PortResult, RemoteAssistantWorkspaceFacts, RemoteCapabilityPort,
+    RemoteConnectionPort, RemoteProjectionPort, RemoteRecentWorkspaceFacts, RemoteWorkspaceFacts,
     RemoteWorkspaceFileRuntimeHost, RemoteWorkspaceKind, RemoteWorkspacePort,
     RemoteWorkspaceRuntimeHost, RemoteWorkspaceUpdate, RuntimeEventEnvelope, RuntimeEventSink,
     RuntimeEventType, RuntimeServiceCapability, RuntimeServicePort, SessionStorageKind,
@@ -666,6 +667,13 @@ impl AgentRuntime {
         self.inner.steer_dialog_turn(request).await
     }
 
+    pub async fn recover_interrupted_turn(
+        &self,
+        request: AgentDialogTurnRecoveryRequest,
+    ) -> Result<AgentDialogTurnRecoveryOutcome, RuntimeError> {
+        self.inner.recover_interrupted_turn(request).await
+    }
+
     pub async fn deliver_background_result(
         &self,
         request: AgentBackgroundResultRequest,
@@ -713,6 +721,13 @@ impl AgentRuntime {
         request: AgentTurnCancellationRequest,
     ) -> Result<AgentTurnCancellationResult, RuntimeError> {
         self.inner.cancel_turn(request).await
+    }
+
+    pub async fn interrupt_turn(
+        &self,
+        request: AgentTurnInterruptionRequest,
+    ) -> Result<AgentTurnInterruptionResult, RuntimeError> {
+        self.inner.interrupt_turn(request).await
     }
 
     pub async fn cancel_lineage_session(

--- a/src/crates/execution/agent-runtime/tests/agent_session_contracts/scheduler_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/agent_session_contracts/scheduler_contracts.rs
@@ -12,9 +12,9 @@ use bitfun_agent_runtime::scheduler::{
 };
 use bitfun_runtime_ports::{
     AgentInputAttachment, AgentSessionReplyRoute, DialogQueuePriority, DialogSessionStateFact,
-    DialogSteerOutcome,
-    DialogSubmissionPolicy, DialogTriggerSource, RoundInjection, RoundInjectionKind,
-    RoundInjectionTarget, RoundInjectionToolPreemption, ThreadGoal, ThreadGoalStatus,
+    DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource, RoundInjection,
+    RoundInjectionKind, RoundInjectionTarget, RoundInjectionToolPreemption, ThreadGoal,
+    ThreadGoalStatus,
 };
 use std::sync::Arc;
 use std::time::SystemTime;

--- a/src/crates/execution/agent-stream/src/lib.rs
+++ b/src/crates/execution/agent-stream/src/lib.rs
@@ -290,6 +290,9 @@ impl StreamProcessError {
 #[derive(Debug, Clone, Default)]
 pub struct StreamProcessOptions {
     pub recover_partial_on_cancel: bool,
+    /// Suppress the stream-owned terminal cancellation event when a higher
+    /// layer owns the authoritative cancellation lifecycle.
+    pub suppress_cancel_lifecycle_event: bool,
     /// Allow broad JSON repair for non-Write tools, but only after a provider
     /// confirms a normal tool-use completion.
     pub allow_normal_tool_json_repair: bool,
@@ -333,6 +336,7 @@ struct StreamContext {
     /// output token limit (e.g. "length", "max_tokens", "MAX_TOKENS").
     token_limit_finish_reason: Option<String>,
     allow_normal_tool_json_repair: bool,
+    suppress_cancel_lifecycle_event: bool,
 }
 
 impl StreamContext {
@@ -371,6 +375,7 @@ impl StreamContext {
             partial_recovery_reason: None,
             token_limit_finish_reason: None,
             allow_normal_tool_json_repair: options.allow_normal_tool_json_repair,
+            suppress_cancel_lifecycle_event: options.suppress_cancel_lifecycle_event,
         }
     }
 
@@ -512,6 +517,7 @@ struct GracefulShutdownInput {
     attempt_index: u32,
     tool_calls: Vec<ToolCall>,
     reason: String,
+    suppress_cancel_lifecycle_event: bool,
 }
 
 impl StreamProcessor {
@@ -607,6 +613,7 @@ impl StreamProcessor {
             attempt_index: ctx.attempt_index,
             tool_calls: ctx.tool_calls.clone(),
             reason,
+            suppress_cancel_lifecycle_event: ctx.suppress_cancel_lifecycle_event,
         })
         .await;
     }
@@ -621,6 +628,7 @@ impl StreamProcessor {
             attempt_index,
             tool_calls,
             reason,
+            suppress_cancel_lifecycle_event,
         } = input;
         debug!(
             "Starting graceful shutdown: session_id={}, reason={}",
@@ -679,7 +687,7 @@ impl StreamProcessor {
         }
 
         // 2. Send dialog turn status update (if tools were cleaned up)
-        if tool_call_count > 0 {
+        if tool_call_count > 0 && !(is_user_cancellation && suppress_cancel_lifecycle_event) {
             let event = if is_user_cancellation {
                 AgenticEvent::DialogTurnCancelled {
                     session_id: session_id.clone(),
@@ -1324,6 +1332,7 @@ mod tests {
                     repair_kind: Default::default(),
                 }],
                 reason: "User cancelled stream processing".to_string(),
+                suppress_cancel_lifecycle_event: false,
             })
             .await;
 
@@ -1340,6 +1349,44 @@ mod tests {
             &events[1],
             AgenticEvent::DialogTurnCancelled { session_id, turn_id }
                 if session_id == "session_1" && turn_id == "turn_1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_suppresses_turn_cancellation_for_coordinator_owned_lifecycle() {
+        let sink = Arc::new(RecordingEventSink::default());
+        let processor = StreamProcessor::new(sink.clone());
+
+        processor
+            .graceful_shutdown(GracefulShutdownInput {
+                session_id: "session_1".to_string(),
+                turn_id: "turn_1".to_string(),
+                round_id: "round_1".to_string(),
+                attempt_id: "attempt_1".to_string(),
+                attempt_index: 1,
+                tool_calls: vec![ToolCall {
+                    tool_id: "tool_1".to_string(),
+                    tool_name: "Read".to_string(),
+                    arguments: json!({}),
+                    raw_arguments: None,
+                    is_error: false,
+                    parse_error: None,
+                    recovered_from_truncation: false,
+                    repair_kind: Default::default(),
+                }],
+                reason: "User cancelled stream processing".to_string(),
+                suppress_cancel_lifecycle_event: true,
+            })
+            .await;
+
+        let events = sink.events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::Cancelled { identity, .. },
+                ..
+            } if identity.tool_id == "tool_1"
         ));
     }
 

--- a/src/crates/services/services-core/src/session/types.rs
+++ b/src/crates/services/services-core/src/session/types.rs
@@ -532,6 +532,20 @@ pub struct DialogTurnData {
     )]
     pub error_detail: Option<AiErrorDetail>,
 
+    /// Additive recovery lifecycle for an intentionally interrupted user turn.
+    ///
+    /// `TurnStatus` remains backward-compatible (`cancelled` while interrupted)
+    /// so older builds can still load the turn and simply treat it as terminal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<DialogTurnRecoveryData>,
+
+    /// Monotonic tombstone proving that the Runtime has owned persistence for
+    /// this turn. It remains after recovery settles so a delayed whole-turn UI
+    /// projection from an older execution generation cannot overwrite the
+    /// authoritative terminal payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery_epoch: Option<u32>,
+
     /// Turn status
     pub status: TurnStatus,
 }
@@ -999,6 +1013,29 @@ fn default_transcript_line_range() -> TranscriptLineRange {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DialogTurnRecoveryStatus {
+    Interrupted,
+    Recovering,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DialogTurnRecoveryData {
+    pub status: DialogTurnRecoveryStatus,
+    /// Generation zero is the original execution; each recovery increments it.
+    pub execution_generation: u32,
+    #[serde(default)]
+    pub resume_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interrupted_at: Option<u64>,
+    /// Model binding captured at interruption. Recovery rejects a model switch
+    /// instead of silently continuing one turn under a different model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+}
+
 /// Turn status
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -1162,6 +1199,8 @@ impl DialogTurnData {
             has_final_response: None,
             error: None,
             error_detail: None,
+            recovery: None,
+            recovery_epoch: None,
             status: TurnStatus::InProgress,
         }
     }
@@ -1190,9 +1229,10 @@ impl DialogTurnData {
 #[cfg(test)]
 mod tests {
     use super::{
-        DialogTurnData, DialogTurnKind, ModelRoundData, SessionMemoryMode, SessionMetadata,
-        SessionRelationship, SessionRelationshipKind, SessionTurnWindowResponse, TextItemData,
-        ThinkingItemData, ToolItemData, UserMessageData,
+        DialogTurnData, DialogTurnKind, DialogTurnRecoveryData, DialogTurnRecoveryStatus,
+        ModelRoundData, SessionMemoryMode, SessionMetadata, SessionRelationship,
+        SessionRelationshipKind, SessionTurnWindowResponse, TextItemData, ThinkingItemData,
+        ToolItemData, UserMessageData,
     };
     use bitfun_core_types::{SessionContinuationPolicy, SessionKind};
 
@@ -1217,6 +1257,41 @@ mod tests {
             serde_json::from_value(payload).expect("legacy payload should deserialize");
 
         assert_eq!(turn.kind, DialogTurnKind::UserDialog);
+        assert!(turn.recovery.is_none());
+    }
+
+    #[test]
+    fn interrupted_turn_recovery_metadata_is_additive_and_generation_scoped() {
+        let mut turn = DialogTurnData::new(
+            "turn-1".to_string(),
+            0,
+            "session-1".to_string(),
+            UserMessageData {
+                id: "user-1".to_string(),
+                content: "hello".to_string(),
+                timestamp: 1,
+                metadata: None,
+            },
+        );
+        turn.recovery = Some(DialogTurnRecoveryData {
+            status: DialogTurnRecoveryStatus::Interrupted,
+            execution_generation: 2,
+            resume_count: 2,
+            interrupted_at: Some(42),
+            model_id: Some("model-a".to_string()),
+        });
+
+        let serialized = serde_json::to_value(&turn).expect("serialize interrupted turn");
+        assert_eq!(serialized["status"], "inprogress");
+        assert_eq!(serialized["recovery"]["status"], "interrupted");
+        assert_eq!(serialized["recovery"]["executionGeneration"], 2);
+        assert_eq!(serialized["recovery"]["resumeCount"], 2);
+        assert_eq!(serialized["recovery"]["interruptedAt"], 42);
+        assert_eq!(serialized["recovery"]["modelId"], "model-a");
+
+        let restored: DialogTurnData =
+            serde_json::from_value(serialized).expect("restore interrupted turn");
+        assert_eq!(restored.recovery, turn.recovery);
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/components/ChatInput.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInput.appearance.ts
@@ -55,7 +55,7 @@ export const chatInputAppearanceDescriptor: AppearanceSurfaceDescriptor = {
     { id: 'target', attribute: 'data-bf-target', values: ['main', 'btw'] },
     { id: 'command', attribute: 'data-bf-command', values: ['actions', 'all', 'skills', 'modes'] },
     { id: 'commandItemKind', attribute: 'data-bf-command-item-kind', values: ['action', 'mode', 'skill', 'mcp'] },
-    { id: 'action', attribute: 'data-bf-action', values: ['cancel', 'retry', 'send', 'split'] },
+    { id: 'action', attribute: 'data-bf-action', values: ['cancel', 'continue-interrupted', 'retry', 'send', 'split'] },
     { id: 'boostItemKind', attribute: 'data-bf-boost-item-kind', values: ['mode', 'context', 'skill', 'manage'] },
   ],
   states: [

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -7,7 +7,7 @@ import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo, u
 import { createPortal } from 'react-dom';
 import path from 'path-browserify';
 import { useTranslation } from 'react-i18next';
-import { ArrowUp, BotMessageSquare, Image, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus, Star } from 'lucide-react';
+import { ArrowUp, BotMessageSquare, Image, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus, Star, Play } from 'lucide-react';
 import { ContextDropZone, useContextStore } from '../../shared/context-system';
 import { useActiveSessionState } from '@/flow_chat/hooks';
 import {
@@ -87,6 +87,7 @@ import { ThreadGoalDialogs } from './thread-goal/ThreadGoalDialogs';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { FlowChatManager } from '@/flow_chat/services/FlowChatManager';
+import { interruptedTurnRecoveryGate } from '@/flow_chat/services/interruptedTurnRecoveryGate';
 import {
   getDeepReviewLaunchErrorMessage,
 } from '../services/DeepReviewService';
@@ -181,6 +182,8 @@ import {
 } from '../utils/tokenUsageDisplay';
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import type { SessionPermissionMode } from '@/infrastructure/api/service-api/AgentAPI';
+import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
+import { selectInterruptedTurnRecovery } from '../utils/interruptedTurnRecovery';
 import {
   chatInputPermissionMode,
   permissionModeFromConfig,
@@ -4236,10 +4239,73 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     publishSessionModeSelection,
     reportModeSelectionFailure,
   );
-  
+
+  const interruptedTurnRecovery = useMemo(
+    () => selectInterruptedTurnRecovery(effectiveTargetSession, {
+      draft: inputState.value,
+      hasComposerAttachments: contexts.length > 0,
+      executionIdle:
+        derivedState?.sendButtonMode === 'send'
+        && !caps.transferInFlight,
+      desktopRuntime: isTauriRuntime(),
+      peerMode: isPeerDeviceModeActive(),
+      acpSession: Boolean(acpSessionForInput || isAcpTargetSession),
+      modeChangePending: isModeChangePending,
+      modelChangePending: isModelSwitching,
+    }),
+    [
+      acpSessionForInput,
+      caps.transferInFlight,
+      contexts.length,
+      derivedState?.sendButtonMode,
+      effectiveTargetSession,
+      inputState.value,
+      isAcpTargetSession,
+      isModeChangePending,
+      isModelSwitching,
+    ],
+  );
+  useSyncExternalStore(
+    interruptedTurnRecoveryGate.subscribe,
+    interruptedTurnRecoveryGate.getSnapshot,
+    interruptedTurnRecoveryGate.getSnapshot,
+  );
+  const isInterruptedTurnRecoveryInFlight =
+    interruptedTurnRecoveryGate.isSessionInFlight(effectiveTargetSessionId);
+
+  const handleRecoverInterruptedTurn = useCallback(async () => {
+    const candidate = interruptedTurnRecovery;
+    if (!candidate || !interruptedTurnRecoveryGate.tryBegin(candidate)) return;
+    try {
+      await agentAPI.recoverInterruptedDialogTurn({
+        sessionId: candidate.sessionId,
+        dialogTurnId: candidate.turnId,
+        executionGeneration: candidate.executionGeneration,
+        workspacePath:
+          effectiveTargetSession?.projectWorkspacePath
+          || effectiveTargetSession?.workspacePath
+          || effectiveTargetSession?.config.projectWorkspacePath
+          || effectiveTargetSession?.config.workspacePath,
+      });
+    } catch (error) {
+      log.error('Failed to recover interrupted dialog turn', {
+        sessionId: candidate.sessionId,
+        turnId: candidate.turnId,
+        error,
+      });
+      notificationService.error(t('input.continueInterruptedFailed'));
+      interruptedTurnRecoveryGate.clearExact(candidate);
+    }
+  }, [
+    effectiveTargetSession,
+    interruptedTurnRecovery,
+    t,
+  ]);
+
   const handleSendOrCancel = useCallback(async (messageOverride?: string) => {
     if (!derivedState) return;
     if (caps.transferInFlight) return;
+    if (isInterruptedTurnRecoveryInFlight) return;
     
     const { sendButtonMode } = derivedState;
     const draftTrimmed = (messageOverride ?? inputState.value).trim();
@@ -4451,6 +4517,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     isModelSwitching,
     isModeChangePending,
     caps.transferInFlight,
+    isInterruptedTurnRecoveryInFlight,
     inputState.value,
     derivedState,
     dispatchInput,
@@ -4498,10 +4565,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     );
   }, [canSwitchModes, selectableCodeModes, slashCommandState.query]);
 
-  publishModeSelectionRef.current = publishModeSelection;
-  requestModeChangeRef.current = requestSessionModeChange;
-
   const requestModeChange = useCallback((modeId: string) => {
+    if (isInterruptedTurnRecoveryInFlight) {
+      dispatchMode({ type: 'CLOSE_DROPDOWN' });
+      return;
+    }
     if (!canSwitchModes) {
       dispatchMode({ type: 'CLOSE_DROPDOWN' });
       return;
@@ -4519,7 +4587,17 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
     requestSessionModeChange(modeId);
     dispatchMode({ type: 'CLOSE_DROPDOWN' });
-  }, [canSwitchModes, currentMode, effectiveTargetSessionId, requestSessionModeChange, switchableModes]);
+  }, [
+    canSwitchModes,
+    currentMode,
+    effectiveTargetSessionId,
+    isInterruptedTurnRecoveryInFlight,
+    requestSessionModeChange,
+    switchableModes,
+  ]);
+
+  publishModeSelectionRef.current = publishModeSelection;
+  requestModeChangeRef.current = requestModeChange;
 
   const toggleDefaultMode = useCallback(async (modeId: string, modeName: string) => {
     const previousDefaultModeId = userDefaultModeId;
@@ -5286,6 +5364,31 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     if (!derivedState) return <span className="bitfun-chat-input__send-action" data-bf-component="chat-input" data-bf-part="sendButton" data-bf-action="send" data-bf-state="disabled"><IconButton className="bitfun-chat-input__send-button" disabled size="small"><ArrowUp size={11} /></IconButton></span>;
 
     const { sendButtonMode, hasQueuedInput } = derivedState;
+
+    if (interruptedTurnRecovery) {
+      return (
+        <span
+          className="bitfun-chat-input__send-action"
+          data-bf-component="chat-input"
+          data-bf-part="sendButton"
+          data-bf-action="continue-interrupted"
+          data-bf-state={isInterruptedTurnRecoveryInFlight ? 'disabled' : undefined}
+        >
+          <IconButton
+            className="bitfun-chat-input__send-button"
+            onClick={() => void handleRecoverInterruptedTurn()}
+            disabled={isInterruptedTurnRecoveryInFlight}
+            data-testid="chat-input-continue-interrupted-btn"
+            tooltip={t('input.continueInterrupted')}
+            size="small"
+          >
+            {isInterruptedTurnRecoveryInFlight
+              ? <Loader2 size={11} className="bitfun-spin" />
+              : <Play size={11} fill="currentColor" />}
+          </IconButton>
+        </span>
+      );
+    }
     
     if (sendButtonMode === 'cancel') {
       return (
@@ -5374,6 +5477,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       <ContextDropZone
         acceptedTypes={['file', 'directory', 'image', 'code-snippet', 'mermaid-diagram']}
         className="bitfun-chat-input-drop-zone"
+        disabled={isInterruptedTurnRecoveryInFlight}
         onContextAdded={(context) => {
           if (context.type === 'image' && currentImageCount >= CHAT_INPUT_CONFIG.image.maxCount) {
             notificationService.warning(t('input.maxImagesWarning', { count: CHAT_INPUT_CONFIG.image.maxCount }), { duration: 3000 });
@@ -5513,7 +5617,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 onCompositionStart={handleImeCompositionStart}
                 onCompositionEnd={handleImeCompositionEnd}
                 placeholder=""
-                disabled={caps.transferInFlight}
+                disabled={caps.transferInFlight || isInterruptedTurnRecoveryInFlight}
                 contexts={contexts}
                 onRemoveContext={removeContext}
                 onMentionStateChange={setMentionState}
@@ -5913,8 +6017,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                           aria-label={t('chatInput.resetToAgentic')}
                           onClick={e => {
                             e.stopPropagation();
-                            requestSessionModeChange('agentic');
-                            dispatchMode({ type: 'CLOSE_DROPDOWN' });
+                            requestModeChange('agentic');
                           }}
                         >
                           <X size={12} strokeWidth={2.5} />
@@ -6226,11 +6329,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                     externalSelection={dispatchModelSelection}
                     modeDefaultModelId={targetModeInfo?.model}
                     persistSharedModeDefault={Boolean(targetModeInfo && targetModeInfo.source !== 'external')}
+                    disabled={isInterruptedTurnRecoveryInFlight}
                   />
                   </div>
                 ) : null}
 
-                {!caps.transferInFlight ? (
+                {!caps.transferInFlight && !isInterruptedTurnRecoveryInFlight ? (
                   <ComposerVoiceInputButton controller={voiceInput} />
                 ) : null}
                 {voiceInput.phase === 'idle' ? renderActionButton() : null}

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -105,6 +105,8 @@ interface ModelSelectorProps {
   modeDefaultModelId?: string;
   /** Whether a selection also changes BitFun's shared built-in mode default. */
   persistSharedModeDefault?: boolean;
+  /** Whether lifecycle ownership currently prevents Session setting changes. */
+  disabled?: boolean;
 }
 
 interface ModelInfo {
@@ -233,6 +235,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   externalSelection,
   modeDefaultModelId,
   persistSharedModeDefault = true,
+  disabled = false,
 }) => {
   const { t } = useTranslation('flow-chat');
   const [allModels, setAllModels] = useState<AIModelConfig[]>([]);
@@ -718,7 +721,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   }, [defaultModels, modelCatalog]);
   
   const handleSelectModel = useCallback(async (modelId: string) => {
-    if (loading || reasoningLoading) return;
+    if (disabled || loading || reasoningLoading) return;
 
     if (portalDropdownRef.current?.contains(document.activeElement)) {
       triggerRef.current?.focus();
@@ -824,6 +827,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     acpClientId,
     currentMode,
     defaultModels,
+    disabled,
     externalSelection,
     isAcpSession,
     loading,
@@ -837,7 +841,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   const handleSelectReasoningPreset = useCallback(async (presetId: string | null) => {
     if (
-      loading
+      disabled
+      || loading
       || reasoningLoading
       || !sessionId
       || !concreteModelId
@@ -892,6 +897,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     concreteModelId,
     currentNativeModelId,
     currentReasoningProjection,
+    disabled,
     loading,
     reasoningLoading,
     sessionId,
@@ -900,7 +906,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   ]);
 
   const handleSetAcpFastMode = useCallback(async (enabled: boolean) => {
-    if (loading || !acpFastMode || !acpClientId || !sessionId) return;
+    if (disabled || loading || !acpFastMode || !acpClientId || !sessionId) return;
     const value = buildAcpFastModeValue(acpFastMode.option, enabled);
     if (!value) return;
 
@@ -930,12 +936,13 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     activeSession?.workspacePath,
     acpClientId,
     acpFastMode,
+    disabled,
     loading,
     sessionId,
   ]);
 
   const handleSelectAcpReasoning = useCallback(async (presetId: string | null) => {
-    if (loading || !presetId || !acpReasoning || !acpClientId || !sessionId) return;
+    if (disabled || loading || !presetId || !acpReasoning || !acpClientId || !sessionId) return;
     setReasoningLoading(true);
     try {
       const options = await ACPClientAPI.setSessionConfigOption({
@@ -963,6 +970,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     activeSession?.workspacePath,
     acpClientId,
     acpReasoning,
+    disabled,
     loading,
     sessionId,
     t,
@@ -1121,7 +1129,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
               }
               setDropdownOpen(nextOpen);
             }}
-            disabled={loading || externalSelection.disabled}
+            disabled={disabled || loading || externalSelection.disabled}
           >
             <span className="bitfun-model-selector__name">
               {getModelDisplayLabel(externalCurrentModel, externalCurrentModelId)}
@@ -1136,7 +1144,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             selectedPreset={externalSelection.selectedReasoningPreset === 'auto'
               ? undefined
               : externalSelection.selectedReasoningPreset}
-            disabled={externalSelection.disabled}
+            disabled={disabled || externalSelection.disabled}
             loading={false}
             dropdownPlacement={dropdownPlacement}
             onSelect={externalSelection.onSelectReasoningPreset}
@@ -1256,7 +1264,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 void loadAcpOptions();
               }
             }}
-            disabled={loading}
+            disabled={disabled || loading}
            data-bf-component="model-selector" data-bf-part="trigger" data-bf-state={dropdownOpen ? 'open' : undefined}>
             <span className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
               {acpModeOnly ? acpModeLabel : getModelDisplayLabel(acpCurrentModel, currentAcpModelId)}
@@ -1277,7 +1285,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           <ReasoningPresetSelector
             projection={acpReasoning.projection}
             selectedPreset={acpReasoning.selectedPreset}
-            disabled={loading}
+            disabled={disabled || loading}
             loading={reasoningLoading}
             dropdownPlacement={dropdownPlacement}
             onSelect={handleSelectAcpReasoning}
@@ -1476,7 +1484,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             }
             setDropdownOpen(nextOpen);
           }}
-          disabled={loading || reasoningLoading}
+          disabled={disabled || loading || reasoningLoading}
          data-bf-component="model-selector" data-bf-part="trigger" data-bf-state={dropdownOpen ? 'open' : undefined}>
           <span className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
             {getModelDisplayLabel(currentModel, t('modelSelector.autoModel'))}
@@ -1489,7 +1497,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         <ReasoningPresetSelector
           projection={currentReasoningProjection}
           selectedPreset={selectedReasoningPreset}
-          disabled={loading}
+          disabled={disabled || loading}
           loading={reasoningLoading}
           dropdownPlacement={dropdownPlacement}
           onSelect={handleSelectReasoningPreset}

--- a/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
@@ -12,7 +12,7 @@
  *   deduped via `steeringId`.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Pencil,
@@ -29,6 +29,7 @@ import { stateMachineManager } from '../state-machine';
 import { FlowChatStore } from '../store/FlowChatStore';
 import { pendingQueueManager } from '../services/flow-chat-manager/PendingQueueModule';
 import { FlowChatManager } from '../services/FlowChatManager';
+import { interruptedTurnRecoveryGate } from '../services/interruptedTurnRecoveryGate';
 import { insertSteeringItemIfAbsent } from '../services/flow-chat-manager/EventHandlerModule';
 import { notificationService } from '../../shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
@@ -45,6 +46,12 @@ interface PendingQueuePanelProps {
 
 export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelProps): JSX.Element | null {
   const { t } = useTranslation('flow-chat');
+  useSyncExternalStore(
+    interruptedTurnRecoveryGate.subscribe,
+    interruptedTurnRecoveryGate.getSnapshot,
+    interruptedTurnRecoveryGate.getSnapshot,
+  );
+  const recoveryInFlight = interruptedTurnRecoveryGate.isSessionInFlight(sessionId);
   const [items, setItems] = useState<QueuedMessage[]>(() =>
     sessionId ? pendingQueueManager.list(sessionId) : [],
   );
@@ -121,7 +128,7 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
 
   const handleSendNow = useCallback(
     async (item: QueuedMessage) => {
-      if (!sessionId) return;
+      if (!sessionId || recoveryInFlight) return;
       const machine = stateMachineManager.get(sessionId);
       const dialogTurnId = machine?.getContext().currentDialogTurnId ?? null;
 
@@ -180,13 +187,15 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
           log.warn('Send now item is no longer queued', { sessionId, itemId: item.id });
           return;
         }
-        await FlowChatManager.getInstance().drainPendingQueueForSession(sessionId);
+        await FlowChatManager.getInstance().drainPendingQueueForSession(sessionId, {
+          allowInterruptedRecoveryAbandon: true,
+        });
       } catch (err) {
         log.error('Send now fallback failed', { sessionId, itemId: item.id, err });
         notificationService.error(t('pendingQueue.errors.sendNowFailed'), { duration: 4000 });
       }
     },
-    [isAcpSession, sessionId, t],
+    [isAcpSession, recoveryInFlight, sessionId, t],
   );
 
   const visibleItems = useMemo(() => items, [items]);
@@ -358,7 +367,7 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
                         data-bf-part="action"
                         size="small"
                         className="bitfun-pending-queue-panel__btn bitfun-pending-queue-panel__btn--primary"
-                        disabled={isSending}
+                        disabled={isSending || recoveryInFlight}
                         onClick={() => {
                           void handleSendNow(item);
                         }}

--- a/src/web-ui/src/flow_chat/services/AgenticEventListener.ts
+++ b/src/web-ui/src/flow_chat/services/AgenticEventListener.ts
@@ -24,6 +24,7 @@ import type {
   DeepReviewQueueStateChangedEvent,
   AcpContextUsageUpdatedEvent,
   OpenBuiltInBrowserEvent,
+  InterruptedDialogTurnEvent,
 } from '@/infrastructure/api/service-api/AgentAPI';
 import { createLogger } from '@/shared/utils/logger';
 
@@ -48,6 +49,8 @@ export interface AgenticEventCallbacks {
   onDialogTurnCompleted?: (event: AgenticEvent) => void;
   onDialogTurnFailed?: (event: AgenticEvent) => void;
   onDialogTurnCancelled?: (event: AgenticEvent) => void;
+  onDialogTurnInterrupted?: (event: InterruptedDialogTurnEvent) => void;
+  onDialogTurnRecovered?: (event: InterruptedDialogTurnEvent) => void;
   onTokenUsageUpdated?: (event: AgenticEvent) => void;
   onAcpContextUsageUpdated?: (event: AcpContextUsageUpdatedEvent) => void;
   onContextCompressionStarted?: (event: AgenticEvent) => void;
@@ -200,6 +203,22 @@ export class AgenticEventListener {
         const unlisten = agentAPI.onDialogTurnCancelled((event) => {
           logger.debug('Dialog turn cancelled:', event);
           callbacks.onDialogTurnCancelled?.(event);
+        });
+        this.unlistenFunctions.push(unlisten);
+      }
+
+      if (callbacks.onDialogTurnInterrupted) {
+        const unlisten = agentAPI.onDialogTurnInterrupted((event) => {
+          logger.debug('Dialog turn interrupted:', event);
+          callbacks.onDialogTurnInterrupted?.(event);
+        });
+        this.unlistenFunctions.push(unlisten);
+      }
+
+      if (callbacks.onDialogTurnRecovered) {
+        const unlisten = agentAPI.onDialogTurnRecovered((event) => {
+          logger.debug('Dialog turn recovered:', event);
+          callbacks.onDialogTurnRecovered?.(event);
         });
         this.unlistenFunctions.push(unlisten);
       }
@@ -367,6 +386,12 @@ export class AgenticEventListener {
         break;
       case 'agentic://dialog-turn-cancelled':
         callbacks.onDialogTurnCancelled?.(payload as AgenticEvent);
+        break;
+      case 'agentic://dialog-turn-interrupted':
+        callbacks.onDialogTurnInterrupted?.(payload as unknown as InterruptedDialogTurnEvent);
+        break;
+      case 'agentic://dialog-turn-recovered':
+        callbacks.onDialogTurnRecovered?.(payload as unknown as InterruptedDialogTurnEvent);
         break;
       case 'agentic://token-usage-updated':
         callbacks.onTokenUsageUpdated?.(payload as AgenticEvent);

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -112,8 +112,11 @@ export class FlowChatManager {
   }
 
   /** Public hook used by the queue panel "send now" fallback to drain head item. */
-  async drainPendingQueueForSession(sessionId: string): Promise<void> {
-    return drainPendingQueue(this.context, sessionId);
+  async drainPendingQueueForSession(
+    sessionId: string,
+    options?: { allowInterruptedRecoveryAbandon?: boolean },
+  ): Promise<void> {
+    return drainPendingQueue(this.context, sessionId, options);
   }
 
   public static getInstance(): FlowChatManager {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -5,6 +5,7 @@ import {
   handleSessionStateChanged,
   insertSteeringItemIfAbsent,
   isAppWindowFocused,
+  projectDialogTurnRecovered,
   shouldProcessEvent,
 } from './EventHandlerModule';
 import { stateMachineManager } from '../../state-machine';
@@ -18,6 +19,7 @@ import { notificationService } from '../../../shared/notification-system/service
 import type { DialogTurn, FlowToolItem, FlowUserSteeringItem, ModelRound, Session } from '../../types/flow-chat';
 import type { FlowChatContext } from './types';
 import { markOptimisticDispatchTurnMetadata } from '@/features/dispatch/optimisticDispatchTurn';
+import { interruptedTurnRecoveryGate } from '../interruptedTurnRecoveryGate';
 
 const { handleCompressionCompleted, handleTokenUsageUpdate } = __test_only__;
 
@@ -32,6 +34,339 @@ vi.mock('../../../shared/notification-system/services/NotificationService', () =
 describe('isAppWindowFocused', () => {
   it('returns true when no document is available', () => {
     expect(isAppWindowFocused()).toBe(true);
+  });
+});
+
+describe('interrupted turn lifecycle', () => {
+  beforeEach(() => {
+    resetFlowChatStore();
+    stateMachineManager.clear();
+    interruptedTurnRecoveryGate.resetForTests();
+  });
+
+  afterEach(() => {
+    resetFlowChatStore();
+    stateMachineManager.clear();
+    interruptedTurnRecoveryGate.resetForTests();
+  });
+
+  it('projects the authoritative recovered fence and releases the shared gate', async () => {
+    const turn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'continue this work', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-0',
+        index: 0,
+        items: [],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming',
+        startTime: 1,
+      }],
+      status: 'processing',
+      startTime: 1,
+    };
+    FlowChatStore.getInstance().setState(() => ({
+      sessions: new Map([['session-1', {
+        sessionId: 'session-1',
+        dialogTurns: [turn],
+        status: 'active',
+        config: { agentType: 'agentic' },
+        createdAt: 1,
+        lastActiveAt: 1,
+        error: null,
+        sessionKind: 'normal',
+      } as Session]]),
+      activeSessionId: 'session-1',
+    }));
+    await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+      taskId: 'session-1',
+      dialogTurnId: 'turn-1',
+    });
+    const context = createFlowChatContext();
+
+    __test_only__.handleDialogTurnInterrupted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 0,
+    });
+    await Promise.resolve();
+
+    let session = FlowChatStore.getInstance().getState().sessions.get('session-1')!;
+    expect(session.dialogTurns).toHaveLength(1);
+    expect(session.dialogTurns[0]).toMatchObject({
+      id: 'turn-1',
+      status: 'cancelled',
+      finishReason: 'interrupted',
+      recovery: { status: 'interrupted', executionGeneration: 0 },
+    });
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
+
+    expect(interruptedTurnRecoveryGate.tryBegin({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 0,
+    })).toBe(true);
+
+    __test_only__.handleDialogTurnRecovered(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 1,
+    });
+    await Promise.resolve();
+
+    session = FlowChatStore.getInstance().getState().sessions.get('session-1')!;
+    expect(session.dialogTurns).toHaveLength(1);
+    expect(session.dialogTurns[0]).toMatchObject({
+      id: 'turn-1',
+      status: 'processing',
+      recovery: { status: 'recovering', executionGeneration: 1 },
+    });
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(
+      SessionExecutionState.PROCESSING,
+    );
+    expect(interruptedTurnRecoveryGate.isSessionInFlight('session-1')).toBe(false);
+
+    __test_only__.handleDialogTurnInterrupted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 0,
+    });
+    await Promise.resolve();
+
+    session = FlowChatStore.getInstance().getState().sessions.get('session-1')!;
+    expect(session.dialogTurns[0]).toMatchObject({
+      status: 'processing',
+      recovery: { status: 'recovering', executionGeneration: 1 },
+    });
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(
+      SessionExecutionState.PROCESSING,
+    );
+  });
+
+  it('does not settle a newer turn when an older interrupted event arrives late', async () => {
+    const oldTurn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'old work', timestamp: 1 },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 1,
+    };
+    createSessionWithTurn(oldTurn);
+    await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+      taskId: 'session-1',
+      dialogTurnId: 'turn-1',
+    });
+    const context = createFlowChatContext();
+
+    await stateMachineManager.transition(
+      'session-1',
+      SessionExecutionEvent.BACKEND_STREAM_COMPLETED,
+    );
+    handleSessionStateChanged(context, {
+      sessionId: 'session-1',
+      newState: 'Idle',
+    });
+    await Promise.resolve();
+
+    const newTurn: DialogTurn = {
+      id: 'turn-2',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-2', content: 'new work', timestamp: 2 },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 2,
+    };
+    FlowChatStore.getInstance().setState(state => {
+      const sessions = new Map(state.sessions);
+      const session = sessions.get('session-1')!;
+      sessions.set('session-1', {
+        ...session,
+        dialogTurns: [...session.dialogTurns, newTurn],
+      });
+      return { ...state, sessions };
+    });
+    await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+      taskId: 'session-1',
+      dialogTurnId: 'turn-2',
+    });
+
+    __test_only__.handleDialogTurnInterrupted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 0,
+    });
+    await Promise.resolve();
+
+    const session = FlowChatStore.getInstance().getState().sessions.get('session-1')!;
+    expect(session.dialogTurns[0]).toMatchObject({
+      id: 'turn-1',
+      status: 'cancelled',
+      recovery: { status: 'interrupted', executionGeneration: 0 },
+    });
+    expect(session.dialogTurns[1]).toMatchObject({ id: 'turn-2', status: 'processing' });
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(
+      SessionExecutionState.PROCESSING,
+    );
+    expect(stateMachineManager.get('session-1')?.getContext().currentDialogTurnId).toBe('turn-2');
+  });
+
+  it('does not revive a recovered generation after it was interrupted again', async () => {
+    const turn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'resume safely', timestamp: 1 },
+      modelRounds: [],
+      status: 'cancelled',
+      finishReason: 'interrupted',
+      recovery: { status: 'interrupted', executionGeneration: 0, resumeCount: 0 },
+      startTime: 1,
+    };
+    createSessionWithTurn(turn);
+    const context = createFlowChatContext();
+
+    projectDialogTurnRecovered(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 1,
+    });
+    await Promise.resolve();
+    __test_only__.handleDialogTurnInterrupted(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 1,
+    });
+    await Promise.resolve();
+
+    __test_only__.handleDialogTurnRecovered(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 1,
+    });
+    await Promise.resolve();
+
+    const current = FlowChatStore.getInstance().getState().sessions
+      .get('session-1')!.dialogTurns[0];
+    expect(current).toMatchObject({
+      status: 'cancelled',
+      finishReason: 'interrupted',
+      recovery: { status: 'interrupted', executionGeneration: 1 },
+    });
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
+  });
+
+  it('accepts durable recovered completion when the recovered event was dropped', async () => {
+    vi.useFakeTimers();
+    const turn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'keep retryable', timestamp: 1 },
+      modelRounds: [],
+      status: 'cancelled',
+      finishReason: 'interrupted',
+      recovery: { status: 'interrupted', executionGeneration: 1, resumeCount: 1 },
+      startTime: 1,
+    };
+    createSessionWithTurn(turn);
+    const context = createFlowChatContext();
+
+    handleDialogTurnComplete(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      success: true,
+      finishReason: 'complete',
+    }, vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(FlowChatStore.getInstance().getState().sessions
+      .get('session-1')!.dialogTurns[0]).toMatchObject({
+      status: 'completed',
+      finishReason: 'complete',
+    });
+    expect(FlowChatStore.getInstance().getState().sessions
+      .get('session-1')!.dialogTurns[0].recovery).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it('does not settle a newer turn when an older cancelled event arrives late', async () => {
+    const oldTurn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'old', timestamp: 1 },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 1,
+    };
+    const newTurn: DialogTurn = {
+      id: 'turn-2',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-2', content: 'new', timestamp: 2 },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 2,
+    };
+    createSessionWithTurn(oldTurn);
+    FlowChatStore.getInstance().setState(state => {
+      const sessions = new Map(state.sessions);
+      sessions.set('session-1', { ...sessions.get('session-1')!, dialogTurns: [oldTurn, newTurn] });
+      return { ...state, sessions };
+    });
+    await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+      taskId: 'session-1',
+      dialogTurnId: 'turn-2',
+    });
+    const context = createFlowChatContext();
+
+    __test_only__.handleDialogTurnCancelled(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+    }, vi.fn());
+    await Promise.resolve();
+
+    expect(FlowChatStore.getInstance().getState().sessions
+      .get('session-1')!.dialogTurns[1]).toMatchObject({ id: 'turn-2', status: 'processing' });
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(
+      SessionExecutionState.PROCESSING,
+    );
+  });
+
+  it('holds finishing when backend idle arrives before the cancellation outcome', async () => {
+    const turn: DialogTurn = {
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'stop', timestamp: 1 },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 1,
+    };
+    createSessionWithTurn(turn);
+    await stateMachineManager.transition('session-1', SessionExecutionEvent.START, {
+      taskId: 'session-1',
+      dialogTurnId: 'turn-1',
+    });
+    await stateMachineManager.transition(
+      'session-1',
+      SessionExecutionEvent.BACKEND_STREAM_COMPLETED,
+    );
+    const context = createFlowChatContext();
+    context.userCancelledSessionIds.add('session-1');
+
+    handleSessionStateChanged(context, { sessionId: 'session-1', newState: 'Idle' });
+    await Promise.resolve();
+
+    expect(stateMachineManager.getCurrentState('session-1')).toBe(
+      SessionExecutionState.FINISHING,
+    );
   });
 });
 
@@ -673,6 +1008,7 @@ describe('handleDialogTurnFailed', () => {
       startTime: 900,
     });
     const context = createFlowChatContext();
+    context.userCancelledSessionIds.add('session-1');
 
     __test_only__.handleDialogTurnFailed(context, {
       sessionId: 'session-1',
@@ -700,6 +1036,7 @@ describe('handleDialogTurnFailed', () => {
     });
     expect(notificationService.error).not.toHaveBeenCalled();
     expect(notificationService.warning).not.toHaveBeenCalled();
+    expect(context.userCancelledSessionIds.has('session-1')).toBe(false);
   });
 });
 
@@ -1154,6 +1491,31 @@ describe('handleDialogTurnComplete', () => {
       ?.dialogTurns[0];
     expect(finalizedTurn?.status).toBe('completed');
     expect(finalizedTurn?.endTime).toBe(eventOwnedEndTime);
+  });
+
+  it('clears the cancellation gate when the same turn completes during cancel', async () => {
+    vi.useFakeTimers();
+    try {
+      putFinishingSessionInStore();
+      const context = createFlowChatContext();
+      context.userCancelledSessionIds.add('session-1');
+      await setFinishingMachine();
+
+      handleDialogTurnComplete(context, {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        success: true,
+        finishReason: 'complete',
+        hasFinalResponse: true,
+      }, vi.fn());
+
+      expect(context.userCancelledSessionIds.has('session-1')).toBe(true);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(context.userCancelledSessionIds.has('session-1')).toBe(false);
+      expect(stateMachineManager.getCurrentState('session-1')).toBe(SessionExecutionState.IDLE);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -38,12 +38,13 @@ import type {
   SessionModelAutoMigratedEvent,
   SessionReasoningPresetAutoClearedEvent,
   SubagentSessionLinkedEvent,
+  RecoverInterruptedDialogTurnResponse,
 } from '@/infrastructure/api/service-api/AgentAPI';
 import { MCPAPI } from '@/infrastructure/api/service-api/MCPAPI';
 import { ACPClientAPI, type AcpPermissionRequestEvent } from '@/infrastructure/api/service-api/ACPClientAPI';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import type { FlowChatContext, DialogTurn, ModelRound, FlowToolItem } from './types';
-import type { SteeringImage } from '../../types/flow-chat';
+import type { Session, SteeringImage } from '../../types/flow-chat';
 import {
   normalizeAiErrorDetail,
   type AiErrorDetail,
@@ -54,6 +55,7 @@ import { useBackgroundCommandActivityStore } from '../../store/backgroundCommand
 import { useBackgroundSubagentActivityStore } from '../../store/backgroundSubagentActivityStore';
 import { createTab } from '@/shared/utils/tabUtils';
 import { splitFilePathAndContent } from '@/shared/utils/partialJsonParser';
+import { interruptedTurnRecoveryGate } from '../interruptedTurnRecoveryGate';
 
 const pendingImageAnalysisTurns = new Map<string, string>();
 import { 
@@ -167,11 +169,25 @@ export const __test_only__ = {
   handleModelRoundStart,
   handleTokenUsageUpdate,
   handleCompressionCompleted,
+  handleDialogTurnInterrupted,
+  handleDialogTurnRecovered,
+  handleDialogTurnCancelled,
 };
 
 function shouldMarkUnreadCompletion(sessionId: string): boolean {
   const activeSessionId = FlowChatStore.getInstance().getState().activeSessionId;
   return sessionId !== activeSessionId || !isAppWindowFocused();
+}
+
+function eventOwnsLatestSessionTurn(
+  session: Session,
+  sessionId: string,
+  turnId: string,
+): boolean {
+  if (session.dialogTurns.at(-1)?.id !== turnId) return false;
+  const machine = stateMachineManager.get(sessionId);
+  const currentTurnId = machine?.getContext().currentDialogTurnId;
+  return !currentTurnId || currentTurnId === turnId;
 }
 
 function logDroppedDataEvent(
@@ -803,6 +819,12 @@ export async function initializeEventListeners(
     onDialogTurnCancelled: (event) => {
       handleDialogTurnCancelled(context, event, onTodoWriteResult);
     },
+    onDialogTurnInterrupted: (event) => {
+      handleDialogTurnInterrupted(context, event);
+    },
+    onDialogTurnRecovered: (event) => {
+      handleDialogTurnRecovered(context, event);
+    },
     onTokenUsageUpdated: (event) => {
       handleTokenUsageUpdate(context, event);
     },
@@ -1066,6 +1088,9 @@ function finalizeTurnCompletionState(
     clearPendingTurnCompletion(context, sessionId, turnId);
     return;
   }
+  const runtimeOwnsTurnPersistence = Boolean(
+    session.dialogTurns.find(turn => turn.id === turnId)?.recovery,
+  );
 
   completeActiveTextItems(context, sessionId, turnId);
   clearRuntimeStatus(context, sessionId, turnId);
@@ -1096,7 +1121,8 @@ function finalizeTurnCompletionState(
       ...turn,
       modelRounds: updatedModelRounds,
       status: 'completed' as const,
-      endTime: turn.endTime ?? completedAt
+      endTime: turn.endTime ?? completedAt,
+      recovery: undefined,
     };
   });
   reconcileBackgroundSubagentSession(sessionId);
@@ -1113,9 +1139,13 @@ function finalizeTurnCompletionState(
     appendPlanDisplayItemsIfNeeded(context, sessionId, turnId, dialogTurn);
   }
 
-  saveDialogTurnToDisk(context, sessionId, turnId).catch(error => {
-    log.warn('Failed to save dialog turn (non-critical)', { sessionId, turnId, error });
-  });
+  if (!runtimeOwnsTurnPersistence) {
+    saveDialogTurnToDisk(context, sessionId, turnId).catch(error => {
+      log.warn('Failed to save dialog turn (non-critical)', { sessionId, turnId, error });
+    });
+  }
+
+  context.userCancelledSessionIds.delete(sessionId);
 
   if (shouldMarkUnreadCompletion(sessionId)) {
     const pending = context.pendingTurnCompletions.get(sessionId);
@@ -1388,6 +1418,12 @@ export function handleSessionStateChanged(context: FlowChatContext, event: any):
   machineContext.backendSyncedAt = Date.now();
 
   if (isExpectedFinishingDrift) {
+    if (context.userCancelledSessionIds.has(sessionId)) {
+      log.debug('Holding FINISHING until the cancellation outcome is authoritative', {
+        sessionId,
+      });
+      return;
+    }
     finalizePendingTurnCompletionNow(context, sessionId);
     if (stateMachineManager.getCurrentState(sessionId) === SessionExecutionState.FINISHING) {
       const finishingTurnId = findFinishingTurnForBackendIdle(
@@ -1704,6 +1740,11 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
   if (projectedNewTurn) {
     reconcileBackgroundSubagentSession(sessionId);
 
+    // Backend admission of a distinct new Turn supersedes any stale local
+    // cancellation gate for the previous Turn. Late terminal events remain
+    // identity-guarded and cannot settle this new execution.
+    context.userCancelledSessionIds.delete(sessionId);
+
     context.contentBuffers.set(sessionId, new Map());
     context.activeTextItems.set(sessionId, new Map());
 
@@ -1732,7 +1773,10 @@ function handleDialogTurnStarted(context: FlowChatContext, event: any): void {
       kind: turn.kind || turnKind,
       userMessage: {
         ...turn.userMessage,
-        metadata: turn.userMessage.metadata || userMessageMetadata,
+        metadata: {
+          ...(turn.userMessage.metadata ?? {}),
+          ...(userMessageMetadata ?? {}),
+        },
       },
       storageTurnIndex: turnIndex,
       backendTurnIndex: turnIndex,
@@ -2417,6 +2461,11 @@ export function handleDialogTurnComplete(
     log.warn('DialogTurnCompleted missing sessionId or turnId', { event });
     return;
   }
+  interruptedTurnRecoveryGate.clearTerminal(sessionId, turnId);
+
+
+  const store = FlowChatStore.getInstance();
+  const session = store.getState().sessions.get(sessionId);
 
   if (success === false) {
     handleDialogTurnFailed(context, {
@@ -2438,23 +2487,36 @@ export function handleDialogTurnComplete(
   }
   context.handledTerminalTurnEvents.add(terminalKey);
 
-  const machine = stateMachineManager.get(sessionId);
-  if (machine) {
-    const ctx = machine.getContext();
-    if (ctx.currentDialogTurnId !== turnId) {
-      ctx.currentDialogTurnId = turnId;
-    }
-  }
-
-  const store = FlowChatStore.getInstance();
-  const session = store.getState().sessions.get(sessionId);
-  
   if (!session) {
     log.debug('Session not found (dialog turn complete)', { sessionId });
     return;
   }
+  const ownsSessionSettlement = eventOwnsLatestSessionTurn(session, sessionId, turnId);
 
   context.flowChatStore.updateDialogTurn(sessionId, turnId, turn => {
+    if (!ownsSessionSettlement) {
+      const completedAt = Date.now();
+      return {
+        ...turn,
+        modelRounds: turn.modelRounds.map(round => round.isStreaming
+          ? {
+              ...round,
+              isStreaming: false,
+              isComplete: true,
+              status: 'completed' as const,
+              endTime: round.endTime ?? completedAt,
+            }
+          : round),
+        status: 'completed' as const,
+        endTime: durationMs === undefined
+          ? turn.endTime ?? completedAt
+          : turn.startTime + Math.max(0, durationMs),
+        success: success ?? undefined,
+        finishReason: finishReason ?? undefined,
+        hasFinalResponse: typeof hasFinalResponse === 'boolean' ? hasFinalResponse : undefined,
+        recovery: undefined,
+      };
+    }
     return {
       ...turn,
       status: 'finishing' as const,
@@ -2469,7 +2531,7 @@ export function handleDialogTurnComplete(
   reconcileBackgroundSubagentSession(sessionId);
 
   const currentState = stateMachineManager.getCurrentState(sessionId);
-  if (currentState === SessionExecutionState.PROCESSING) {
+  if (ownsSessionSettlement && currentState === SessionExecutionState.PROCESSING) {
     void stateMachineManager
       .transition(sessionId, SessionExecutionEvent.BACKEND_STREAM_COMPLETED)
       .catch(error => {
@@ -2479,7 +2541,9 @@ export function handleDialogTurnComplete(
     log.debug('Skipping BACKEND_STREAM_COMPLETED transition', { currentState, sessionId, turnId });
   }
 
-  beginTurnCompletion(context, sessionId, turnId, partialRecoveryReason);
+  if (ownsSessionSettlement) {
+    beginTurnCompletion(context, sessionId, turnId, partialRecoveryReason);
+  }
 }
 
 function normalizeDialogErrorDetail(event: any): AiErrorDetail {
@@ -2494,6 +2558,10 @@ function normalizeDialogErrorDetail(event: any): AiErrorDetail {
 function handleDialogTurnFailed(context: FlowChatContext, event: any): void {
   const { sessionId, turnId, error } = event;
   const errorDetail = normalizeDialogErrorDetail(event);
+
+  if (sessionId && turnId) {
+    interruptedTurnRecoveryGate.clearTerminal(sessionId, turnId);
+  }
 
   // P1-11: Idempotent terminal-event handling.
   if (sessionId && turnId) {
@@ -2516,21 +2584,16 @@ function handleDialogTurnFailed(context: FlowChatContext, event: any): void {
     log.debug('Session not found (dialog turn failed)', { sessionId });
     return;
   }
+  const ownsSessionSettlement = eventOwnsLatestSessionTurn(session, sessionId, turnId);
   
-  const sessionActiveTextItems = context.activeTextItems.get(sessionId);
-  if (sessionActiveTextItems) {
-    sessionActiveTextItems.clear();
+  if (ownsSessionSettlement) {
+    cleanupSessionBuffers(context, sessionId);
+    context.flowChatStore.markSessionFinished(sessionId);
   }
-  
-  const sessionContentBuffer = context.contentBuffers.get(sessionId);
-  if (sessionContentBuffer) {
-    sessionContentBuffer.clear();
-  }
-
-  context.flowChatStore.markSessionFinished(sessionId);
   
   const dialogTurn = session.dialogTurns.find(turn => turn.id === turnId);
   if (dialogTurn) {
+    const runtimeOwnsTurnPersistence = Boolean(dialogTurn.recovery);
     const terminalError = typeof error === 'string' && error.trim()
       ? error
       : errorDetail.rawMessage || errorDetail.providerMessage || 'Execution failed';
@@ -2554,18 +2617,21 @@ function handleDialogTurnFailed(context: FlowChatContext, event: any): void {
         status: 'error' as const,
         error: terminalError,
         errorDetail,
-        endTime: Date.now()
+        endTime: Date.now(),
+        recovery: undefined,
       };
     });
     
-    saveDialogTurnToDisk(context, sessionId, turnId).catch(err => {
-      log.warn('Failed to save failed dialog turn', { sessionId, turnId, error: err });
-    });
+    if (!runtimeOwnsTurnPersistence) {
+      saveDialogTurnToDisk(context, sessionId, turnId).catch(err => {
+        log.warn('Failed to save failed dialog turn', { sessionId, turnId, error: err });
+      });
+    }
   }
   reconcileBackgroundSubagentSession(sessionId);
   
   const currentState = stateMachineManager.getCurrentState(sessionId);
-  if (isStreamingExecutionState(currentState)) {
+  if (ownsSessionSettlement && isStreamingExecutionState(currentState)) {
     stateMachineManager.transition(sessionId, SessionExecutionEvent.ERROR_OCCURRED, {
       error: error || 'Execution failed'
     }).catch(err => {
@@ -2576,8 +2642,11 @@ function handleDialogTurnFailed(context: FlowChatContext, event: any): void {
     });
   }
   
-  if (shouldMarkUnreadCompletion(sessionId)) {
+  if (ownsSessionSettlement && shouldMarkUnreadCompletion(sessionId)) {
     context.flowChatStore.markSessionUnreadCompletion(sessionId, 'error');
+  }
+  if (ownsSessionSettlement) {
+    context.userCancelledSessionIds.delete(sessionId);
   }
 }
 
@@ -2590,6 +2659,10 @@ function handleDialogTurnCancelled(
   _onTodoWriteResult: (sessionId: string, turnId: string, result: any) => void
 ): void {
   const { sessionId, turnId } = event;
+
+  if (sessionId && turnId) {
+    interruptedTurnRecoveryGate.clearTerminal(sessionId, turnId);
+  }
 
   // P1-11: Idempotent terminal-event handling. The execution engine may emit
   // DialogTurnCancelled when it detects cancellation between rounds, and the
@@ -2616,18 +2689,15 @@ function handleDialogTurnCancelled(
     log.debug('Session not found (dialog turn cancelled)', { sessionId });
     return;
   }
+  const ownsSessionSettlement = eventOwnsLatestSessionTurn(session, sessionId, turnId);
   
-  const sessionActiveTextItems = context.activeTextItems.get(sessionId);
-  if (sessionActiveTextItems) {
-    sessionActiveTextItems.clear();
+  if (ownsSessionSettlement) {
+    cleanupSessionBuffers(context, sessionId);
+    context.flowChatStore.markSessionFinished(sessionId);
   }
-  
-  const sessionContentBuffer = context.contentBuffers.get(sessionId);
-  if (sessionContentBuffer) {
-    sessionContentBuffer.clear();
-  }
-
-  context.flowChatStore.markSessionFinished(sessionId);
+  const runtimeOwnsTurnPersistence = Boolean(
+    session.dialogTurns.find(turn => turn.id === turnId)?.recovery,
+  );
   
   context.flowChatStore.updateDialogTurn(sessionId, turnId, turn => {
     const updatedModelRounds = turn.modelRounds.map((round) => {
@@ -2647,7 +2717,8 @@ function handleDialogTurnCancelled(
       ...turn,
       modelRounds: updatedModelRounds,
       status: 'cancelled' as const,
-      endTime: Date.now()
+      endTime: Date.now(),
+      recovery: undefined,
     };
   });
   reconcileBackgroundSubagentSession(sessionId);
@@ -2657,16 +2728,18 @@ function handleDialogTurnCancelled(
     appendPlanDisplayItemsIfNeeded(context, sessionId, turnId, dialogTurn);
   }
   
-  saveDialogTurnToDisk(context, sessionId, turnId).catch(err => {
-    log.warn('Failed to save cancelled dialog turn', { sessionId, turnId, error: err });
-  });
+  if (!runtimeOwnsTurnPersistence) {
+    saveDialogTurnToDisk(context, sessionId, turnId).catch(err => {
+      log.warn('Failed to save cancelled dialog turn', { sessionId, turnId, error: err });
+    });
+  }
 
   // Transition state machine to IDLE.  When the desktop's own stop button
   // is used, USER_CANCEL is dispatched before DialogTurnCancelled arrives,
   // so the machine is already IDLE.  When cancellation comes from an
   // external source (mobile remote), the machine is still PROCESSING.
   const currentState = stateMachineManager.getCurrentState(sessionId);
-  if (isStreamingExecutionState(currentState)) {
+  if (ownsSessionSettlement && isStreamingExecutionState(currentState)) {
     void stateMachineManager
       .transition(sessionId, SessionExecutionEvent.FINISHING_SETTLED)
       .catch(error => {
@@ -2674,10 +2747,197 @@ function handleDialogTurnCancelled(
       });
   }
 
-  if (shouldMarkUnreadCompletion(sessionId) && !context.userCancelledSessionIds.has(sessionId)) {
+  if (
+    ownsSessionSettlement
+    && shouldMarkUnreadCompletion(sessionId)
+    && !context.userCancelledSessionIds.has(sessionId)
+  ) {
     context.flowChatStore.markSessionUnreadCompletion(sessionId, 'completed');
   }
-  context.userCancelledSessionIds.delete(sessionId);
+  if (ownsSessionSettlement) {
+    context.userCancelledSessionIds.delete(sessionId);
+  }
+}
+
+function handleDialogTurnInterrupted(context: FlowChatContext, event: any): void {
+  const sessionId = event?.sessionId ?? event?.session_id;
+  const turnId = event?.turnId ?? event?.turn_id;
+  const executionGeneration = optionalNumber(
+    event?.executionGeneration ?? event?.execution_generation,
+  );
+  const rawModelId = event?.modelId ?? event?.model_id;
+  const modelId = typeof rawModelId === 'string' && rawModelId.trim()
+    ? rawModelId.trim()
+    : undefined;
+  if (!sessionId || !turnId || executionGeneration === undefined) {
+    log.warn('DialogTurnInterrupted missing identity or generation', { event });
+    return;
+  }
+  interruptedTurnRecoveryGate.clearInterrupted({ sessionId, turnId, executionGeneration });
+  if (context.handledTerminalTurnEvents.has(`${sessionId}:${turnId}`)) {
+    log.debug('Ignoring DialogTurnInterrupted after authoritative terminal settlement', {
+      sessionId,
+      turnId,
+      executionGeneration,
+    });
+    return;
+  }
+  const currentTurn = context.flowChatStore
+    .getState()
+    .sessions.get(sessionId)
+    ?.dialogTurns.find(turn => turn.id === turnId);
+  const currentGeneration = currentTurn?.recovery?.executionGeneration;
+  if (
+    currentGeneration !== undefined
+    && (currentGeneration > executionGeneration
+      || (currentGeneration === executionGeneration
+        && currentTurn?.recovery?.status === 'interrupted'))
+  ) {
+    log.debug('Ignoring stale or duplicate DialogTurnInterrupted', {
+      sessionId,
+      turnId,
+      executionGeneration,
+      currentGeneration,
+    });
+    return;
+  }
+
+  const machine = stateMachineManager.get(sessionId);
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  const latestTurnId = session?.dialogTurns.at(-1)?.id;
+  const currentState = stateMachineManager.getCurrentState(sessionId);
+  const ownsSessionSettlement = latestTurnId === turnId
+    && (machine?.getContext().currentDialogTurnId === turnId
+      || currentState === SessionExecutionState.IDLE);
+
+  clearPendingTurnCompletion(context, sessionId, turnId);
+  clearRuntimeStatus(context, sessionId, turnId);
+  if (ownsSessionSettlement) {
+    cleanupSessionBuffers(context, sessionId);
+    context.flowChatStore.markSessionFinished(sessionId);
+  }
+  context.flowChatStore.updateDialogTurn(sessionId, turnId, turn => ({
+    ...turn,
+    modelRounds: turn.modelRounds.map(round => ({
+      ...round,
+      isStreaming: false,
+      isComplete: true,
+      status: round.isStreaming ? 'cancelled' as const : round.status,
+      endTime: round.isStreaming ? Date.now() : round.endTime,
+    })),
+    status: 'cancelled' as const,
+    finishReason: 'interrupted',
+    endTime: Date.now(),
+    recovery: {
+      status: 'interrupted' as const,
+      executionGeneration,
+      resumeCount: executionGeneration,
+      interruptedAt: Date.now(),
+      modelId: modelId ?? turn.recovery?.modelId,
+    },
+  }));
+
+  if (ownsSessionSettlement && isStreamingExecutionState(currentState)) {
+    void stateMachineManager
+      .transition(sessionId, SessionExecutionEvent.FINISHING_SETTLED)
+      .catch(error => {
+        log.error('State machine transition failed on interrupted turn settlement', {
+          sessionId,
+          turnId,
+          error,
+        });
+      });
+  }
+  if (ownsSessionSettlement && shouldMarkUnreadCompletion(sessionId)) {
+    context.flowChatStore.markSessionUnreadCompletion(sessionId, 'interrupted');
+  }
+  if (ownsSessionSettlement) {
+    context.userCancelledSessionIds.delete(sessionId);
+  }
+}
+
+function handleDialogTurnRecovered(context: FlowChatContext, event: any): void {
+  const sessionId = event?.sessionId ?? event?.session_id;
+  const turnId = event?.turnId ?? event?.turn_id;
+  const executionGeneration = optionalNumber(
+    event?.executionGeneration ?? event?.execution_generation,
+  );
+  if (!sessionId || !turnId || executionGeneration === undefined) {
+    log.warn('DialogTurnRecovered missing identity or generation', { event });
+    return;
+  }
+  if (projectDialogTurnRecovered(context, { sessionId, turnId, executionGeneration })) {
+    interruptedTurnRecoveryGate.clearRecovered({ sessionId, turnId, executionGeneration });
+  }
+}
+
+/** Apply one authoritative recovery admission from either RPC or broadcast. */
+export function projectDialogTurnRecovered(
+  context: FlowChatContext,
+  outcome: RecoverInterruptedDialogTurnResponse,
+): boolean {
+  const { sessionId, turnId, executionGeneration } = outcome;
+  const currentTurn = context.flowChatStore
+    .getState()
+    .sessions.get(sessionId)
+    ?.dialogTurns.find(turn => turn.id === turnId);
+  const recovery = currentTurn?.recovery;
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  const isMonotonicRecovery = session?.dialogTurns.at(-1)?.id === turnId
+    && currentTurn?.status === 'cancelled'
+    && currentTurn.finishReason === 'interrupted'
+    && recovery?.status === 'interrupted'
+    && executionGeneration === recovery.executionGeneration + 1;
+  if (!isMonotonicRecovery) {
+    log.debug('Ignoring non-monotonic DialogTurnRecovered', {
+      sessionId,
+      turnId,
+      executionGeneration,
+      currentGeneration: recovery?.executionGeneration,
+      recoveryStatus: recovery?.status,
+    });
+    return false;
+  }
+
+  context.handledTerminalTurnEvents.delete(`${sessionId}:${turnId}`);
+  context.contentBuffers.set(sessionId, new Map());
+  context.activeTextItems.set(sessionId, new Map());
+  context.flowChatStore.updateDialogTurn(sessionId, turnId, turn => ({
+    ...turn,
+    status: 'processing' as const,
+    finishReason: undefined,
+    endTime: undefined,
+    success: undefined,
+    hasFinalResponse: undefined,
+    recovery: {
+      ...turn.recovery,
+      status: 'recovering' as const,
+      executionGeneration,
+      resumeCount: executionGeneration,
+    },
+  }));
+
+  const machine = stateMachineManager.get(sessionId);
+  if (machine) {
+    const machineContext = machine.getContext();
+    machineContext.taskId = sessionId;
+    machineContext.currentDialogTurnId = turnId;
+  }
+  if (stateMachineManager.getCurrentState(sessionId) === SessionExecutionState.IDLE) {
+    void stateMachineManager
+      .transition(sessionId, SessionExecutionEvent.START, {
+        taskId: sessionId,
+        dialogTurnId: turnId,
+      })
+      .catch(error => {
+        log.error('State machine transition failed on interrupted turn recovery', {
+          sessionId,
+          turnId,
+          error,
+        });
+      });
+  }
+  return true;
 }
 
 /**

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cancelSessionTask, sendMessage, syncSessionModelSelection } from './MessageModule';
+import {
+  cancelSessionTask,
+  drainPendingQueue,
+  sendMessage,
+  syncSessionModelSelection,
+} from './MessageModule';
 import { SessionExecutionEvent } from '../../state-machine/types';
 import {
   getRuntimeStatus,
@@ -9,6 +14,7 @@ import {
   tryBeginSessionMutation,
   useSessionMutationStore,
 } from '../../store/sessionMutationStore';
+import { interruptedTurnRecoveryGate } from '../interruptedTurnRecoveryGate';
 
 const mockTransition = vi.fn();
 const mockGetCurrentState = vi.fn(() => 'processing');
@@ -26,6 +32,8 @@ const mockNotificationError = vi.fn();
 const mockNotificationDismiss = vi.fn();
 const mockPendingList = vi.fn((): unknown[] => []);
 const mockPendingEnqueue = vi.fn();
+const mockPendingSetStatus = vi.fn();
+const mockPendingRemove = vi.fn();
 
 vi.mock('../../state-machine', () => ({
   SessionExecutionEvent: {
@@ -33,7 +41,9 @@ vi.mock('../../state-machine', () => ({
     USER_CANCEL: 'user_cancel',
   },
   SessionExecutionState: {
+    IDLE: 'idle',
     PROCESSING: 'processing',
+    FINISHING: 'finishing',
   },
   stateMachineManager: {
     getCurrentState: (...args: unknown[]) => mockGetCurrentState(...args),
@@ -101,6 +111,8 @@ vi.mock('./PendingQueueModule', () => ({
   pendingQueueManager: {
     list: (...args: unknown[]) => mockPendingList(...args),
     enqueue: (...args: unknown[]) => mockPendingEnqueue(...args),
+    setStatus: (...args: unknown[]) => mockPendingSetStatus(...args),
+    remove: (...args: unknown[]) => mockPendingRemove(...args),
   },
 }));
 
@@ -410,12 +422,16 @@ describe('MessageModule session writer conflict', () => {
 describe('MessageModule cancellation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    interruptedTurnRecoveryGate.resetForTests();
     resetRuntimeStatuses();
     mockGetCurrentState.mockReturnValue('processing');
     mockTransition.mockResolvedValue(true);
   });
 
   it('cancels persistent /btw sessions through the ordinary dialog-turn path', async () => {
+    mockGetCurrentState
+      .mockReturnValueOnce('processing')
+      .mockReturnValue('finishing');
     const session = {
       sessionId: 'btw-child',
       isTransient: false,
@@ -457,11 +473,223 @@ describe('MessageModule cancellation', () => {
     expect(contentBuffers.has('btw-child')).toBe(false);
     expect(activeTextItems.has('btw-child')).toBe(false);
   });
+
+  it('preserves the running UI when the interrupt transition rolls back to processing', async () => {
+    mockGetCurrentState.mockReturnValue('processing');
+    const session = {
+      sessionId: 'session-interrupt-rejected',
+      sessionKind: 'normal',
+      dialogTurns: [],
+      config: {},
+    };
+    const contentBuffers = new Map([[session.sessionId, new Map([['round-1', 'text']])]]);
+    const activeTextItems = new Map([[session.sessionId, new Map([['round-1', 'item-1']])]]);
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
+      },
+      userCancelledSessionIds: new Set<string>(),
+      eventBatcher: { getBufferSize: vi.fn(() => 0), clear: vi.fn() },
+      pendingTurnCompletions: new Map(),
+      runtimeStatusTimers: new Map(),
+      handledTerminalTurnEvents: new Set<string>(),
+      contentBuffers,
+      activeTextItems,
+    };
+
+    await expect(cancelSessionTask(context, session.sessionId)).resolves.toBe(false);
+
+    expect(context.userCancelledSessionIds.has(session.sessionId)).toBe(false);
+    expect(contentBuffers.has(session.sessionId)).toBe(true);
+    expect(activeTextItems.has(session.sessionId)).toBe(true);
+  });
+
+  it('queues a direct send while the cancellation outcome still owns the session', async () => {
+    mockGetCurrentState.mockReturnValue('idle');
+    mockPendingList.mockReturnValue([]);
+    mockPendingEnqueue.mockReturnValue({ id: 'queued-during-cancel' });
+    const session = {
+      sessionId: 'session-cancel-in-flight',
+      sessionKind: 'normal',
+      dialogTurns: [],
+      config: {},
+    };
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
+      },
+      userCancelledSessionIds: new Set([session.sessionId]),
+    };
+
+    await sendMessage(context, 'follow-up', session.sessionId);
+
+    expect(mockPendingEnqueue).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: session.sessionId,
+      content: 'follow-up',
+    }));
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+  });
+
+  it('holds pending input while an interrupt outcome is still in flight', async () => {
+    mockGetCurrentState.mockReturnValue('idle');
+    mockPendingList.mockReturnValue([{
+      id: 'pending-1',
+      sessionId: 'session-1',
+      content: 'do not auto-send',
+      status: 'queued',
+      retryCount: 0,
+    }]);
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({
+          sessions: new Map([['session-1', {
+            sessionId: 'session-1',
+            dialogTurns: [],
+            config: {},
+          }]]),
+        }),
+      },
+      userCancelledSessionIds: new Set(['session-1']),
+    };
+
+    await drainPendingQueue(context, 'session-1');
+
+    expect(mockPendingSetStatus).not.toHaveBeenCalled();
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+    expect(mockPendingRemove).not.toHaveBeenCalled();
+  });
+
+  it('rejects every direct submission while recovery admission is in flight', async () => {
+    const session: any = {
+      sessionId: 'session-interrupted',
+      dialogTurns: [],
+      config: {},
+    };
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
+      },
+    };
+    interruptedTurnRecoveryGate.tryBegin({
+      sessionId: session.sessionId,
+      turnId: 'interrupted-turn',
+      executionGeneration: 0,
+    });
+
+    await expect(sendMessage(context, 'must not race recovery', session.sessionId)).rejects.toThrow(
+      'recovery is in flight',
+    );
+    expect(mockPendingEnqueue).not.toHaveBeenCalled();
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+  });
+
+  it('lets an explicit send-now abandon interrupted recovery', async () => {
+    mockGetCurrentState.mockReturnValue('idle');
+    mockEnsureBackendSession.mockResolvedValue(undefined);
+    mockStartDialogTurn.mockResolvedValue({
+      sessionId: 'session-interrupted',
+      turnId: 'new-turn',
+      status: 'started',
+    });
+    const pendingItem = {
+      id: 'pending-explicit',
+      sessionId: 'session-interrupted',
+      content: 'start new work',
+      status: 'queued',
+      retryCount: 0,
+    };
+    mockPendingList.mockReturnValue([pendingItem]);
+    const session: any = {
+      sessionId: 'session-interrupted',
+      sessionKind: 'normal',
+      mode: 'agentic',
+      titleStatus: 'generated',
+      dialogTurns: [{
+        id: 'interrupted-turn',
+        status: 'cancelled',
+        finishReason: 'interrupted',
+        recovery: { status: 'interrupted', executionGeneration: 0 },
+      }],
+      config: { modelName: 'auto' },
+      maxContextTokens: 32_000,
+    };
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
+        addDialogTurn: vi.fn((_sessionId: string, turn: any) => session.dialogTurns.push(turn)),
+        deleteDialogTurn: vi.fn((_sessionId: string, turnId: string) => {
+          session.dialogTurns = session.dialogTurns.filter((turn: any) => turn.id !== turnId);
+        }),
+        updateSessionLastSubmittedMode: vi.fn(),
+        updateSessionMode: vi.fn(),
+        updateSessionModelName: vi.fn(),
+        updateSessionMaxContextTokens: vi.fn(),
+      },
+      processingManager: {
+        registerStatus: vi.fn(),
+        clearSessionStatus: vi.fn(),
+      },
+      userCancelledSessionIds: new Set<string>(),
+      pendingHistoryLoads: new Map(),
+      contentBuffers: new Map(),
+      activeTextItems: new Map(),
+    };
+
+    await drainPendingQueue(context, session.sessionId);
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+
+    await drainPendingQueue(context, session.sessionId, {
+      allowInterruptedRecoveryAbandon: true,
+    });
+
+    expect(mockStartDialogTurn).toHaveBeenCalledTimes(1);
+    expect(mockPendingRemove).toHaveBeenCalledWith(session.sessionId, pendingItem.id);
+  });
+
+  it('holds an explicit send-now while recovery admission is in flight', async () => {
+    mockGetCurrentState.mockReturnValue('idle');
+    mockPendingList.mockReturnValue([{
+      id: 'pending-race',
+      sessionId: 'session-interrupted',
+      content: 'must wait',
+      status: 'queued',
+      retryCount: 0,
+    }]);
+    const session: any = {
+      sessionId: 'session-interrupted',
+      dialogTurns: [{
+        id: 'interrupted-turn',
+        status: 'cancelled',
+        finishReason: 'interrupted',
+        recovery: { status: 'interrupted', executionGeneration: 0 },
+      }],
+      config: {},
+    };
+    const context: any = {
+      flowChatStore: {
+        getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
+      },
+      userCancelledSessionIds: new Set<string>(),
+    };
+    interruptedTurnRecoveryGate.tryBegin({
+      sessionId: session.sessionId,
+      turnId: 'interrupted-turn',
+      executionGeneration: 0,
+    });
+
+    await drainPendingQueue(context, session.sessionId, {
+      allowInterruptedRecoveryAbandon: true,
+    });
+
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+    expect(mockPendingSetStatus).not.toHaveBeenCalled();
+  });
 });
 
 describe('MessageModule detached dispatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPendingList.mockReturnValue([]);
     mockGetCurrentState.mockReturnValue('idle');
     mockDispatchSubmit.mockResolvedValue({
       accepted: true,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -19,6 +19,8 @@ import { i18nService } from '@/infrastructure/i18n';
 import { driverForSession } from '../../session-drivers/registry';
 import type { SendMessageOptions, SubmissionDraft, TurnTracker } from '../../session-drivers/types';
 import { assertSessionSubmissionAllowed } from '../../store/sessionMutationStore';
+import { hasInterruptedTurnHoldingQueue } from '../../utils/interruptedTurnRecovery';
+import { interruptedTurnRecoveryGate } from '../interruptedTurnRecoveryGate';
 
 export { syncSessionModelSelection } from '../../utils/modelSync';
 export { markCurrentTurnItemsAsCancelled } from '../../utils/turnCancellation';
@@ -88,6 +90,9 @@ export async function sendMessage(
   if (!session) {
     throw new Error(`Session does not exist: ${sessionId}`);
   }
+  if (interruptedTurnRecoveryGate.isSessionInFlight(sessionId)) {
+    throw new Error('Interrupted turn recovery is in flight');
+  }
   assertSessionSubmissionAllowed(sessionId, options?.sessionMutationLeaseId);
   const sendAttempt = beginSessionSend(sessionId);
   const draft: SubmissionDraft = {
@@ -100,7 +105,8 @@ export async function sendMessage(
     const machineState = stateMachineManager.getCurrentState(sessionId);
     const sessionBusy =
       machineState === SessionExecutionState.PROCESSING ||
-      machineState === SessionExecutionState.FINISHING;
+      machineState === SessionExecutionState.FINISHING ||
+      context.userCancelledSessionIds?.has(sessionId) === true;
     const hasPendingQueue = pendingQueueManager.list(sessionId).length > 0;
 
     if (sessionBusy || hasPendingQueue) {
@@ -348,9 +354,28 @@ export async function cancelCurrentTask(context: FlowChatContext): Promise<boole
 export async function drainPendingQueue(
   context: FlowChatContext,
   sessionId: string,
+  options?: { allowInterruptedRecoveryAbandon?: boolean },
 ): Promise<void> {
   const machineState = stateMachineManager.getCurrentState(sessionId);
   if (machineState !== SessionExecutionState.IDLE) {
+    return;
+  }
+  if (interruptedTurnRecoveryGate.isSessionInFlight(sessionId)) {
+    log.debug('Pending queue held while interrupted recovery admission is in flight', {
+      sessionId,
+    });
+    return;
+  }
+  if (context.userCancelledSessionIds.has(sessionId)) {
+    log.debug('Pending queue held until cancellation outcome is authoritative', { sessionId });
+    return;
+  }
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  if (
+    hasInterruptedTurnHoldingQueue(session)
+    && !options?.allowInterruptedRecoveryAbandon
+  ) {
+    log.debug('Pending queue held for interrupted turn recovery decision', { sessionId });
     return;
   }
   // Find the head item *that is still eligible for auto-drain*. Items with

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
@@ -343,6 +343,21 @@ describe('PersistenceModule', () => {
     expect(mockSaveSessionTurn).toHaveBeenCalledTimes(1);
   });
 
+  it('does not overwrite Runtime-owned interrupted or recovering turns', async () => {
+    const turn = createDialogTurn('processing');
+    turn.recovery = {
+      status: 'recovering',
+      executionGeneration: 1,
+      resumeCount: 1,
+    };
+    const context = createContext(turn);
+
+    await saveDialogTurnToDisk(context, SESSION_ID, TURN_ID);
+    await flushMicrotasks();
+
+    expect(mockSaveSessionTurn).not.toHaveBeenCalled();
+  });
+
   it('defers partial-history saves until a storage identity is available', async () => {
     const turn = createDialogTurn('completed');
     delete turn.storageTurnIndex;

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
@@ -309,6 +309,18 @@ async function performSaveDialogTurnToDisk(
       log.debug('Dialog turn not found, skipping save', { sessionId, turnId });
       return;
     }
+    if (dialogTurn.recovery) {
+      // The Runtime owns the durable snapshot and generation CAS for an
+      // interrupted/recovered turn. A frontend whole-turn save can otherwise
+      // overwrite newly appended rounds or restore stale recovery metadata.
+      log.debug('Runtime owns persistence for recoverable dialog turn', {
+        sessionId,
+        turnId,
+        recoveryStatus: dialogTurn.recovery.status,
+        executionGeneration: dialogTurn.recovery.executionGeneration,
+      });
+      return;
+    }
 
     const turnIndex = resolveStorageTurnIndex(session, dialogTurn);
     if (turnIndex === undefined) {
@@ -522,6 +534,7 @@ export function convertDialogTurnToBackendFormat(dialogTurn: DialogTurn, turnInd
         }
       : undefined,
     finishReason: dialogTurn.finishReason,
+    recovery: dialogTurn.recovery,
     hasFinalResponse: dialogTurn.hasFinalResponse,
     error: dialogTurn.error,
     errorDetail: dialogTurn.errorDetail,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
@@ -58,7 +58,8 @@ export {
   shouldProcessEvent,
   mapBackendStateToFrontend,
   initializeEventListeners,
-  processBatchedEvents
+  processBatchedEvents,
+  projectDialogTurnRecovered,
 } from './EventHandlerModule';
 
 export {

--- a/src/web-ui/src/flow_chat/services/interruptedTurnRecoveryGate.test.ts
+++ b/src/web-ui/src/flow_chat/services/interruptedTurnRecoveryGate.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { interruptedTurnRecoveryGate } from './interruptedTurnRecoveryGate';
+
+const first = {
+  sessionId: 'session-1',
+  turnId: 'turn-1',
+  executionGeneration: 0,
+};
+
+afterEach(() => {
+  interruptedTurnRecoveryGate.resetForTests();
+});
+
+describe('interruptedTurnRecoveryGate', () => {
+  it('keeps one session-scoped operation until an authoritative event clears it', () => {
+    const listener = vi.fn();
+    const unsubscribe = interruptedTurnRecoveryGate.subscribe(listener);
+
+    expect(interruptedTurnRecoveryGate.tryBegin(first)).toBe(true);
+    expect(interruptedTurnRecoveryGate.tryBegin(first)).toBe(false);
+    expect(interruptedTurnRecoveryGate.isSessionInFlight(first.sessionId)).toBe(true);
+    expect(interruptedTurnRecoveryGate.isSessionInFlight('session-2')).toBe(false);
+
+    interruptedTurnRecoveryGate.clearRecovered({
+      ...first,
+      executionGeneration: 1,
+    });
+    expect(interruptedTurnRecoveryGate.isSessionInFlight(first.sessionId)).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('does not clear for stale recovery or interruption events', () => {
+    expect(interruptedTurnRecoveryGate.tryBegin(first)).toBe(true);
+
+    interruptedTurnRecoveryGate.clearRecovered(first);
+    interruptedTurnRecoveryGate.clearInterrupted(first);
+    expect(interruptedTurnRecoveryGate.isSessionInFlight(first.sessionId)).toBe(true);
+
+    interruptedTurnRecoveryGate.clearInterrupted({
+      ...first,
+      executionGeneration: 1,
+    });
+    expect(interruptedTurnRecoveryGate.isSessionInFlight(first.sessionId)).toBe(false);
+  });
+
+  it('clears an RPC failure only for the exact request identity', () => {
+    expect(interruptedTurnRecoveryGate.tryBegin(first)).toBe(true);
+
+    interruptedTurnRecoveryGate.clearExact({
+      ...first,
+      turnId: 'another-turn',
+    });
+    expect(interruptedTurnRecoveryGate.isSessionInFlight(first.sessionId)).toBe(true);
+
+    interruptedTurnRecoveryGate.clearExact(first);
+    expect(interruptedTurnRecoveryGate.isSessionInFlight(first.sessionId)).toBe(false);
+  });
+});

--- a/src/web-ui/src/flow_chat/services/interruptedTurnRecoveryGate.ts
+++ b/src/web-ui/src/flow_chat/services/interruptedTurnRecoveryGate.ts
@@ -1,0 +1,88 @@
+export interface InterruptedTurnRecoveryOperation {
+  sessionId: string;
+  turnId: string;
+  executionGeneration: number;
+}
+
+type Listener = () => void;
+
+function sameOperation(
+  left: InterruptedTurnRecoveryOperation,
+  right: InterruptedTurnRecoveryOperation,
+): boolean {
+  return left.sessionId === right.sessionId
+    && left.turnId === right.turnId
+    && left.executionGeneration === right.executionGeneration;
+}
+
+class InterruptedTurnRecoveryGate {
+  private readonly operations = new Map<string, InterruptedTurnRecoveryOperation>();
+  private readonly listeners = new Set<Listener>();
+  private version = 0;
+
+  public readonly subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  public readonly getSnapshot = (): number => this.version;
+
+  public tryBegin(operation: InterruptedTurnRecoveryOperation): boolean {
+    if (this.operations.has(operation.sessionId)) return false;
+    this.operations.set(operation.sessionId, operation);
+    this.emit();
+    return true;
+  }
+
+  public isSessionInFlight(sessionId: string | null | undefined): boolean {
+    return Boolean(sessionId && this.operations.has(sessionId));
+  }
+
+  public clearExact(operation: InterruptedTurnRecoveryOperation): void {
+    const current = this.operations.get(operation.sessionId);
+    if (!current || !sameOperation(current, operation)) return;
+    this.operations.delete(operation.sessionId);
+    this.emit();
+  }
+
+  public clearRecovered(operation: InterruptedTurnRecoveryOperation): void {
+    this.clearNextGeneration(operation);
+  }
+
+  public clearInterrupted(operation: InterruptedTurnRecoveryOperation): void {
+    this.clearNextGeneration(operation);
+  }
+
+  public clearTerminal(sessionId: string, turnId: string): void {
+    const current = this.operations.get(sessionId);
+    if (!current || current.turnId !== turnId) return;
+    this.operations.delete(sessionId);
+    this.emit();
+  }
+
+  public resetForTests(): void {
+    if (this.operations.size === 0) return;
+    this.operations.clear();
+    this.emit();
+  }
+
+  private clearNextGeneration(operation: InterruptedTurnRecoveryOperation): void {
+    const current = this.operations.get(operation.sessionId);
+    if (
+      !current
+      || current.turnId !== operation.turnId
+      || operation.executionGeneration <= current.executionGeneration
+    ) {
+      return;
+    }
+    this.operations.delete(operation.sessionId);
+    this.emit();
+  }
+
+  private emit(): void {
+    this.version += 1;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const interruptedTurnRecoveryGate = new InterruptedTurnRecoveryGate();

--- a/src/web-ui/src/flow_chat/session-drivers/local/LocalSessionDriver.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/local/LocalSessionDriver.ts
@@ -206,17 +206,28 @@ export const localSessionDriver: SessionDriver = {
 
   async cancel(context: FlowChatContext, sessionId: string): Promise<boolean> {
     const currentState = stateMachineManager.getCurrentState(sessionId);
-    const success = currentState === SessionExecutionState.PROCESSING
-      ? await stateMachineManager.transition(sessionId, SessionExecutionEvent.USER_CANCEL)
-      : false;
+    if (currentState !== SessionExecutionState.PROCESSING) {
+      return false;
+    }
+    // Gate pending-queue auto-drain before the asynchronous interrupt RPC can
+    // race an Idle/terminal event back to the UI.
+    context.userCancelledSessionIds.add(sessionId);
+    const success = await stateMachineManager.transition(
+      sessionId,
+      SessionExecutionEvent.USER_CANCEL,
+    );
+    const settledInFinishing = success
+      && stateMachineManager.getCurrentState(sessionId) === SessionExecutionState.FINISHING;
+    if (!settledInFinishing) {
+      context.userCancelledSessionIds.delete(sessionId);
+    }
 
-    if (success) {
-      context.userCancelledSessionIds.add(sessionId);
+    if (settledInFinishing) {
       markCurrentTurnItemsAsCancelled(context, sessionId);
       cleanupSessionBuffers(context, sessionId);
     }
 
-    return success;
+    return settledInFinishing;
   },
 
   planSubmission(): SubmissionPlan {

--- a/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.test.ts
+++ b/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStateMachineImpl } from './SessionStateMachine';
+import { SessionExecutionEvent } from './types';
+
+const cancelSessionTask = vi.fn();
+const interruptDialogTurn = vi.fn();
+
+vi.mock('@/flow_chat/store/FlowChatStore', () => ({
+  flowChatStore: {
+    cancelSessionTask,
+    getState: () => ({
+      sessions: new Map([['session-1', {
+        sessionId: 'session-1',
+        sessionKind: 'normal',
+        mode: 'agentic',
+        config: { agentType: 'agentic' },
+      }]]),
+    }),
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: {
+    interruptDialogTurn,
+    cancelDialogTurn: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/peer-device/peerModeFlag', () => ({
+  isPeerDeviceModeActive: () => false,
+}));
+
+describe('SessionStateMachine recoverable interruption', () => {
+  beforeEach(() => {
+    cancelSessionTask.mockReset();
+    interruptDialogTurn.mockReset();
+    interruptDialogTurn.mockResolvedValue(undefined);
+  });
+
+  it('does not run the legacy optimistic turn persistence before Runtime interruption', async () => {
+    const machine = new SessionStateMachineImpl('session-1');
+    await machine.transition(SessionExecutionEvent.START, {
+      taskId: 'session-1',
+      dialogTurnId: 'turn-1',
+    });
+
+    await machine.transition(SessionExecutionEvent.USER_CANCEL);
+
+    expect(interruptDialogTurn).toHaveBeenCalledWith('session-1', 'turn-1');
+    expect(cancelSessionTask).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.ts
+++ b/src/web-ui/src/flow_chat/state-machine/SessionStateMachine.ts
@@ -261,8 +261,6 @@ export class SessionStateMachineImpl {
 
     if (event === SessionExecutionEvent.USER_CANCEL && this.context.taskId && this.context.currentDialogTurnId) {
       const { flowChatStore } = await import('@/flow_chat/store/FlowChatStore');
-      flowChatStore.cancelSessionTask(this.sessionId);
-
       const sessionId = this.context.taskId;
       const dialogTurnId = this.context.currentDialogTurnId;
       const { acpClientIdFromAgentType } = await import('@/flow_chat/utils/acpSession');
@@ -283,11 +281,37 @@ export class SessionStateMachineImpl {
           });
         } else {
           const { agentAPI } = await import('@/infrastructure/api/service-api/AgentAPI');
-          await agentAPI.cancelDialogTurn(sessionId, dialogTurnId);
+          const { isPeerDeviceModeActive } = await import(
+            '@/infrastructure/peer-device/peerModeFlag'
+          );
+          const goalStatus = session?.threadGoal?.status?.toLowerCase();
+          const supportsRecoverableInterruption =
+            session?.sessionKind === 'normal'
+            && !session.remoteConnectionId
+            && !session.remoteSshHost
+            && !session.config?.remoteConnectionId
+            && !session.config?.remoteSshHost
+            && !session.config?.dispatchTarget
+            && !session.config?.dispatchJobId
+            && goalStatus !== 'active'
+            && goalStatus !== 'paused'
+            && !isPeerDeviceModeActive();
+          if (supportsRecoverableInterruption) {
+            await agentAPI.interruptDialogTurn(sessionId, dialogTurnId);
+          } else {
+            await agentAPI.cancelDialogTurn(sessionId, dialogTurnId);
+          }
         }
-        log.debug('Backend cancellation completed', { sessionId, dialogTurnId, acpClientId });
+        log.debug('Backend interruption completed', { sessionId, dialogTurnId, acpClientId });
       } catch (error) {
         log.error('Backend cancellation failed', { sessionId, dialogTurnId, acpClientId, error });
+        await this.transition(SessionExecutionEvent.USER_CANCEL_FAILED).catch(transitionError => {
+          log.error('Failed to restore processing state after cancellation failure', {
+            sessionId,
+            dialogTurnId,
+            transitionError,
+          });
+        });
       }
     }
 

--- a/src/web-ui/src/flow_chat/state-machine/transitions.test.ts
+++ b/src/web-ui/src/flow_chat/state-machine/transitions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getNextState } from './transitions';
+import { SessionExecutionEvent, SessionExecutionState } from './types';
+
+describe('recoverable interruption transitions', () => {
+  it('keeps the session finishing until backend settlement is observed', () => {
+    expect(getNextState(
+      SessionExecutionState.PROCESSING,
+      SessionExecutionEvent.USER_CANCEL,
+    )).toBe(SessionExecutionState.FINISHING);
+    expect(getNextState(
+      SessionExecutionState.FINISHING,
+      SessionExecutionEvent.FINISHING_SETTLED,
+    )).toBe(SessionExecutionState.IDLE);
+  });
+
+  it('returns to processing if the backend rejects interruption admission', () => {
+    expect(getNextState(
+      SessionExecutionState.FINISHING,
+      SessionExecutionEvent.USER_CANCEL_FAILED,
+    )).toBe(SessionExecutionState.PROCESSING);
+  });
+});

--- a/src/web-ui/src/flow_chat/state-machine/transitions.ts
+++ b/src/web-ui/src/flow_chat/state-machine/transitions.ts
@@ -13,7 +13,8 @@ import { SessionExecutionState, SessionExecutionEvent, StateTransitionTable, Pro
  * - FINISHING: backend completed, frontend is draining late events before becoming idle
  * - ERROR: error state, can reset or retry
  * 
- * Cancellation logic: USER_CANCEL → immediately switch to IDLE (no backend wait)
+ * Cancellation logic: USER_CANCEL enters FINISHING until the backend confirms
+ * the old execution has settled, so queued input cannot race tail writes.
  */
 export const STATE_TRANSITIONS: StateTransitionTable = {
   [SessionExecutionState.IDLE]: {
@@ -21,7 +22,7 @@ export const STATE_TRANSITIONS: StateTransitionTable = {
   },
   
   [SessionExecutionState.PROCESSING]: {
-    [SessionExecutionEvent.USER_CANCEL]: SessionExecutionState.IDLE,
+    [SessionExecutionEvent.USER_CANCEL]: SessionExecutionState.FINISHING,
     [SessionExecutionEvent.FINISHING_SETTLED]: SessionExecutionState.IDLE,
     
     [SessionExecutionEvent.ERROR_OCCURRED]: SessionExecutionState.ERROR,
@@ -40,7 +41,8 @@ export const STATE_TRANSITIONS: StateTransitionTable = {
   },
 
   [SessionExecutionState.FINISHING]: {
-    [SessionExecutionEvent.USER_CANCEL]: SessionExecutionState.IDLE,
+    [SessionExecutionEvent.USER_CANCEL]: SessionExecutionState.FINISHING,
+    [SessionExecutionEvent.USER_CANCEL_FAILED]: SessionExecutionState.PROCESSING,
     [SessionExecutionEvent.ERROR_OCCURRED]: SessionExecutionState.ERROR,
     [SessionExecutionEvent.FINISHING_SETTLED]: SessionExecutionState.IDLE,
     [SessionExecutionEvent.COMPACTION_STARTED]: SessionExecutionState.FINISHING,
@@ -78,6 +80,7 @@ export const PHASE_TRANSITIONS: Record<SessionExecutionEvent, ProcessingPhase | 
   [SessionExecutionEvent.BACKEND_STREAM_COMPLETED]: ProcessingPhase.FINALIZING,
   [SessionExecutionEvent.FINISHING_SETTLED]: null,
   [SessionExecutionEvent.USER_CANCEL]: null,
+  [SessionExecutionEvent.USER_CANCEL_FAILED]: null,
   [SessionExecutionEvent.ERROR_OCCURRED]: null,
   [SessionExecutionEvent.RESET]: null,
 };

--- a/src/web-ui/src/flow_chat/state-machine/types.ts
+++ b/src/web-ui/src/flow_chat/state-machine/types.ts
@@ -58,6 +58,7 @@ export enum SessionExecutionEvent {
   BACKEND_STREAM_COMPLETED = 'backend_stream_completed',
   FINISHING_SETTLED = 'finishing_settled',
   USER_CANCEL = 'user_cancel',
+  USER_CANCEL_FAILED = 'user_cancel_failed',
   ERROR_OCCURRED = 'error_occurred',
   RESET = 'reset',
 }

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -7668,6 +7668,7 @@ export class FlowChatStore {
       finishReason: isLiveTurn
         ? persistedFinishReason
         : normalizeRecoveredTurnFinishReason(turn.status, persistedFinishReason),
+      recovery: turn.recovery,
       hasFinalResponse:
         typeof turn.hasFinalResponse === 'boolean'
           ? turn.hasFinalResponse

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -278,6 +278,14 @@ export interface DialogTurn {
   success?: boolean;
   /** Why the turn finished. */
   finishReason?: string;
+  /** Additive recovery metadata for an intentionally interrupted turn. */
+  recovery?: {
+    status: 'interrupted' | 'recovering';
+    executionGeneration: number;
+    resumeCount: number;
+    interruptedAt?: number;
+    modelId?: string;
+  };
   /** Whether the turn produced a final assistant response visible to the user. */
   hasFinalResponse?: boolean;
 }

--- a/src/web-ui/src/flow_chat/utils/interruptedTurnRecovery.test.ts
+++ b/src/web-ui/src/flow_chat/utils/interruptedTurnRecovery.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { Session } from '../types/flow-chat';
+import {
+  hasInterruptedTurnHoldingQueue,
+  selectInterruptedTurnRecovery,
+} from './interruptedTurnRecovery';
+
+function interruptedSession(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'session-1',
+    dialogTurns: [{
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'finish the task', timestamp: 1 },
+      modelRounds: [],
+      status: 'cancelled',
+      finishReason: 'interrupted',
+      recovery: {
+        status: 'interrupted',
+        executionGeneration: 2,
+        resumeCount: 2,
+        modelId: 'model-a',
+      },
+      startTime: 1,
+    }],
+    status: 'idle',
+    config: { agentType: 'agentic', modelName: 'model-a', workspacePath: 'D:/workspace' },
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    mode: 'agentic',
+    sessionKind: 'normal',
+    ...overrides,
+  };
+}
+
+const emptyComposer = {
+  draft: '',
+  hasComposerAttachments: false,
+  executionIdle: true,
+  desktopRuntime: true,
+  peerMode: false,
+  acpSession: false,
+  modeChangePending: false,
+  modelChangePending: false,
+};
+
+describe('selectInterruptedTurnRecovery', () => {
+  it('returns the latest interrupted turn and generation for an empty local composer', () => {
+    expect(selectInterruptedTurnRecovery(interruptedSession(), emptyComposer)).toEqual({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      executionGeneration: 2,
+    });
+  });
+
+  it.each([
+    ['draft text', { draft: 'new request' }],
+    ['attachments', { hasComposerAttachments: true }],
+    ['remote workspace', {}, { remoteConnectionId: 'remote-1' }],
+    ['peer mode', { peerMode: true }],
+    ['web runtime', { desktopRuntime: false }],
+    ['ACP session', { acpSession: true }],
+    ['active goal', {}, { threadGoal: { goalId: 'goal-1', objective: 'ship', status: 'active' } }],
+    ['mode change', {}, { mode: 'review' }],
+    ['model change', {}, { config: { agentType: 'agentic', modelName: 'model-b' } }],
+    ['pending mode update', { modeChangePending: true }],
+  ])('hides recovery for %s', (_label, optionOverrides, sessionOverrides = {}) => {
+    expect(selectInterruptedTurnRecovery(
+      interruptedSession(sessionOverrides as Partial<Session>),
+      { ...emptyComposer, ...optionOverrides },
+    )).toBeNull();
+  });
+
+  it('rejects stale, non-latest, recovering, and ordinary cancelled turns', () => {
+    const base = interruptedSession();
+    expect(selectInterruptedTurnRecovery({
+      ...base,
+      dialogTurns: [
+        base.dialogTurns[0],
+        { ...base.dialogTurns[0], id: 'turn-2', finishReason: 'cancelled', recovery: undefined },
+      ],
+    }, emptyComposer)).toBeNull();
+    expect(selectInterruptedTurnRecovery({
+      ...base,
+      dialogTurns: [{
+        ...base.dialogTurns[0],
+        status: 'processing',
+        recovery: { ...base.dialogTurns[0].recovery!, status: 'recovering' },
+      }],
+    }, emptyComposer)).toBeNull();
+  });
+
+  it('holds pending input only while the latest turn is awaiting a recovery decision', () => {
+    const session = interruptedSession();
+    expect(hasInterruptedTurnHoldingQueue(session)).toBe(true);
+    expect(hasInterruptedTurnHoldingQueue({
+      ...session,
+      dialogTurns: [{
+        ...session.dialogTurns[0],
+        recovery: { ...session.dialogTurns[0].recovery!, status: 'recovering' },
+      }],
+    })).toBe(false);
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/interruptedTurnRecovery.ts
+++ b/src/web-ui/src/flow_chat/utils/interruptedTurnRecovery.ts
@@ -1,0 +1,94 @@
+import type { Session } from '../types/flow-chat';
+
+export interface InterruptedTurnRecoveryCandidate {
+  sessionId: string;
+  turnId: string;
+  executionGeneration: number;
+}
+
+export interface InterruptedTurnRecoveryComposerState {
+  draft: string;
+  hasComposerAttachments: boolean;
+  executionIdle: boolean;
+  desktopRuntime: boolean;
+  peerMode: boolean;
+  acpSession: boolean;
+  modeChangePending: boolean;
+  modelChangePending: boolean;
+}
+
+/**
+ * Pure capability predicate for the input button. Runtime validation remains
+ * authoritative; this function prevents unsupported or ambiguous states from
+ * presenting a recovery action in the first place.
+ */
+export function selectInterruptedTurnRecovery(
+  session: Session | undefined,
+  composer: InterruptedTurnRecoveryComposerState,
+): InterruptedTurnRecoveryCandidate | null {
+  if (
+    !session
+    || session.sessionKind !== 'normal'
+    || !composer.executionIdle
+    || !composer.desktopRuntime
+    || composer.peerMode
+    || composer.acpSession
+    || composer.modeChangePending
+    || composer.modelChangePending
+    || composer.draft.trim().length > 0
+    || composer.hasComposerAttachments
+    || session.remoteConnectionId
+    || session.remoteSshHost
+    || session.config.remoteConnectionId
+    || session.config.remoteSshHost
+    || session.config.dispatchTarget
+    || session.config.dispatchJobId
+  ) {
+    return null;
+  }
+
+  const goalStatus = session.threadGoal?.status.toLowerCase();
+  if (goalStatus === 'active' || goalStatus === 'paused') {
+    return null;
+  }
+
+  const turn = session.dialogTurns.at(-1);
+  if (
+    !turn
+    || turn.status !== 'cancelled'
+    || turn.finishReason !== 'interrupted'
+    || turn.recovery?.status !== 'interrupted'
+    || !Number.isSafeInteger(turn.recovery.executionGeneration)
+    || turn.recovery.executionGeneration < 0
+  ) {
+    return null;
+  }
+
+  const selectedMode = session.mode || session.config.agentType;
+  if (turn.agentType && selectedMode && turn.agentType !== selectedMode) {
+    return null;
+  }
+  if (
+    turn.recovery.modelId
+    && session.config.modelName
+    && turn.recovery.modelId !== session.config.modelName
+  ) {
+    return null;
+  }
+
+  return {
+    sessionId: session.sessionId,
+    turnId: turn.id,
+    executionGeneration: turn.recovery.executionGeneration,
+  };
+}
+
+export function hasInterruptedTurnHoldingQueue(session: Session | undefined): boolean {
+  const latest = session?.dialogTurns.at(-1);
+  return Boolean(
+    latest
+    && latest.status === 'cancelled'
+    && latest.finishReason === 'interrupted'
+    && latest.recovery?.status === 'interrupted',
+  );
+}

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -515,6 +515,27 @@ export interface AgenticEvent {
   [key: string]: any;
 }
 
+export interface InterruptedDialogTurnEvent extends AgenticEvent {
+  turnId: string;
+  executionGeneration: number;
+  modelId?: string;
+}
+
+export interface RecoverInterruptedDialogTurnRequest {
+  sessionId: string;
+  dialogTurnId: string;
+  executionGeneration: number;
+  workspacePath?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
+}
+
+export interface RecoverInterruptedDialogTurnResponse {
+  sessionId: string;
+  turnId: string;
+  executionGeneration: number;
+}
+
 export type DialogTurnStartedEvent = AgenticEvent;
 
 export interface OpenBuiltInBrowserEvent {
@@ -853,6 +874,27 @@ export class AgentAPI {
       await api.invoke<void>('cancel_dialog_turn', { request: { sessionId, dialogTurnId } });
     } catch (error) {
       throw createTauriCommandError('cancel_dialog_turn', error, { sessionId, dialogTurnId });
+    }
+  }
+
+  async interruptDialogTurn(sessionId: string, dialogTurnId: string): Promise<void> {
+    try {
+      await api.invoke<void>('interrupt_dialog_turn', { request: { sessionId, dialogTurnId } });
+    } catch (error) {
+      throw createTauriCommandError('interrupt_dialog_turn', error, { sessionId, dialogTurnId });
+    }
+  }
+
+  async recoverInterruptedDialogTurn(
+    request: RecoverInterruptedDialogTurnRequest,
+  ): Promise<RecoverInterruptedDialogTurnResponse> {
+    try {
+      return await api.invoke<RecoverInterruptedDialogTurnResponse>(
+        'recover_interrupted_dialog_turn',
+        { request },
+      );
+    } catch (error) {
+      throw createTauriCommandError('recover_interrupted_dialog_turn', error, request);
     }
   }
 
@@ -1317,6 +1359,14 @@ export class AgentAPI {
    
   onDialogTurnCancelled(callback: (event: AgenticEvent) => void): () => void {
     return api.listen<AgenticEvent>('agentic://dialog-turn-cancelled', callback);
+  }
+
+  onDialogTurnInterrupted(callback: (event: InterruptedDialogTurnEvent) => void): () => void {
+    return api.listen<InterruptedDialogTurnEvent>('agentic://dialog-turn-interrupted', callback);
+  }
+
+  onDialogTurnRecovered(callback: (event: InterruptedDialogTurnEvent) => void): () => void {
+    return api.listen<InterruptedDialogTurnEvent>('agentic://dialog-turn-recovered', callback);
   }
 
    

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -533,6 +533,8 @@
     "sendShortcut": "Send (⏎)",
     "stop": "Stop",
     "stopGeneration": "Stop Generation (Esc)",
+    "continueInterrupted": "Continue interrupted work",
+    "continueInterruptedFailed": "Could not continue the interrupted work. Please try again.",
     "processingCapsule": "Processing",
     "cancelShortcut": "Cancel",
     "clear": "Clear",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -533,6 +533,8 @@
     "sendShortcut": "发送 (⏎)",
     "stop": "停止",
     "stopGeneration": "停止生成 (Esc)",
+    "continueInterrupted": "继续上次中断的工作",
+    "continueInterruptedFailed": "无法继续上次中断的工作，请重试。",
     "processingCapsule": "正在处理",
     "cancelShortcut": "取消",
     "clear": "清空",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -533,6 +533,8 @@
     "sendShortcut": "發送 (⏎)",
     "stop": "停止",
     "stopGeneration": "停止生成 (Esc)",
+    "continueInterrupted": "繼續上次中斷的工作",
+    "continueInterruptedFailed": "無法繼續上次中斷的工作，請重試。",
     "processingCapsule": "正在處理",
     "cancelShortcut": "取消",
     "clear": "清空",

--- a/src/web-ui/src/shared/context-system/drag-drop/ContextDropZone.tsx
+++ b/src/web-ui/src/shared/context-system/drag-drop/ContextDropZone.tsx
@@ -13,13 +13,15 @@ export interface ContextDropZoneProps {
   children?: React.ReactNode;
   className?: string;
   onContextAdded?: (context: ContextItem) => void;
+  disabled?: boolean;
 }
 
 export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
   acceptedTypes,
   children,
   className = '',
-  onContextAdded
+  onContextAdded,
+  disabled = false,
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [canAccept, setCanAccept] = useState(false);
@@ -40,10 +42,11 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
     acceptedTypes: acceptedTypesArray,
     
     canAccept: (payload: DragPayload<ContextItem>) => {
-      return acceptedTypesArray.includes(payload.dataType);
+      return !disabled && acceptedTypesArray.includes(payload.dataType);
     },
     
     onDrop: async (payload: DragPayload<ContextItem>) => {
+      if (disabled) return;
       const context = payload.data;
       
       
@@ -75,7 +78,7 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
     onDragOver: () => {
       
     }
-  }), [acceptedTypesArray, addContext, updateValidation, onContextAdded]);
+  }), [acceptedTypesArray, addContext, disabled, updateValidation, onContextAdded]);
   
   
   const dropTargetRef = useRef(dropTarget);

--- a/src/web-ui/src/shared/types/session-history.ts
+++ b/src/web-ui/src/shared/types/session-history.ts
@@ -204,6 +204,13 @@ export interface DialogTurnData {
   tokenUsage?: DialogTurnTokenUsageData;
   status: TurnStatus;
   finishReason?: string;
+  recovery?: {
+    status: 'interrupted' | 'recovering';
+    executionGeneration: number;
+    resumeCount: number;
+    interruptedAt?: number;
+    modelId?: string;
+  };
   hasFinalResponse?: boolean;
   error?: string;
   errorDetail?: AiErrorDetail;


### PR DESCRIPTION
## Summary

- add a recoverable interruption lifecycle for supported local Desktop dialog turns
- replace the empty composer Send button with a Play action after a recoverable Stop, then resume the same persisted turn without duplicating the user message
- make recovery generation-aware across scheduler ownership, persistence, lifecycle events, Tauri adapters, and frontend projection

This mirrors the observed Codex Desktop affordance while keeping the contract owned by BitFun's platform-neutral runtime. The detailed behavior below is BitFun's explicit product contract, not an assumption about unpublished Codex Desktop internals.

## User-visible contract

| Situation | Composer behavior | Runtime result |
| --- | --- | --- |
| A supported running turn is stopped | Empty composer changes from Send to Play | The latest turn is durably held as `Cancelled` with `recovery.status=Interrupted` |
| The user clicks Play | Recovery becomes single-flight and input is gated | The same `DialogTurn` reopens at the next execution generation; no user message or submit hooks are duplicated |
| Recovery completes | Normal idle composer returns | New rounds are merged into the existing turn and recovery metadata clears |
| Recovery is stopped again | Play returns | The new generation is journaled, persisted as Interrupted, and can be resumed again |
| The user explicitly sends new work | The queued or typed message is admitted normally | Recovery is abandoned only after the new work is successfully admitted |
| The app exits while Recovering | Play is restored after restart | Startup normalizes the abandoned generation back to Interrupted |

Automatic pending-queue drain is frozen while recovery is held. An explicit **Send now** remains an intentional recovery-abandon action.

## Eligibility and compatibility

V1 supports standard, persisted, local Desktop sessions using the native BitFun runtime. It fails closed for remote/SSH/peer sessions, ACP or externally owned reply routes, transient/subagent sessions, active Goal or Dispatch flows, BTW input, non-user turns, missing snapshots, changed execution contracts, non-empty composers, or attachments.

Unsupported paths retain their existing hard-cancel behavior and never expose a non-functional Play action.

## Runtime and safety design

- recovery admission uses exact turn identity and monotonic execution generations; duplicate clicks and stale lifecycle events cannot resurrect an older execution
- Interrupted is a durable scheduler hold, covering late background deliveries, queued work, active-turn cancellation, restart restoration, and explicit abandon
- the original permission mode remains a ceiling; later settings may tighten a resumed turn but cannot widen its permissions
- the concrete model binding and effective reasoning descriptor are fingerprinted; preflight or pre-request drift preserves Interrupted instead of silently switching execution contracts
- runtime-owned generation journals survive compression, repeated interruption, completion, failure, and cancellation, with stable round identity and frontend-prefix merging
- frontend whole-turn saves preserve runtime-owned recovery facts and cannot roll recovery state backward
- a shared session recovery gate covers the composer, model/mode controls, context drop, pending **Send now**, and cross-window lifecycle projection
- the legacy Desktop transport uses a dequeue-acknowledged Recovered fence before starting the new generation; authoritative Interrupted rollback controls use a bounded reserve and can replace stale same-session recovery controls without evicting unrelated lifecycle events
- completion/failure/cancellation is published only after the authoritative durable transition succeeds; uncertain persistence is reported explicitly instead of releasing the queue under a false terminal state

## Adversarial review

The final exact patch received independent runtime, frontend, and end-to-end adversarial review. The review drove fixes for persistence races, recovery admission cancellation, active-turn registration, queue freeze and explicit abandon, event priority reordering, stale saves/events, model/reasoning/permission drift, repeated interruption journals, AgentSession reply routes, restart normalization, bounded terminal delivery, and the latest main-branch runtime ownership boundary.

No production-reachable P0/P1 remained in the final review.

## Validation

- `cargo check --workspace`
- `cargo check -p bitfun-core --features product-full`
- `node --test scripts/check-core-boundaries.test.mjs` — 120 passed
- `cargo test -p bitfun-agent-runtime --features agent-runtime` — all unit and integration suites passed
- `cargo test -p bitfun-agent-runtime --features agent-runtime event_queue::tests -- --nocapture` — 11 passed
- `cargo test -p bitfun-agent-stream` — 67 passed
- exact-turn background and thread-goal Core regressions — 2 passed
- `cargo test -p bitfun-core --features product-full interrupted_ -- --nocapture` — 13 passed
- `cargo test -p bitfun-core --features product-full` — 2002 passed, 1 ignored; git facade contract 1 passed
- `pnpm run type-check:web`
- `pnpm run lint:web`
- focused interrupted-turn frontend suite — 8 files / 99 tests passed
- `pnpm --dir src/web-ui run test:run` — 468 files / 3356 tests passed
- `git diff --check gcwing/main...HEAD`

Full `cargo test --workspace -j1` was also exercised. The only failure was the existing `bitfun-server` bootstrap source assertion (`tests::agent_bootstrap_reuses_core_ownership_without_activating_the_http_shell`, 12/13 server tests passed); this PR does not modify that server file and the same contradictory production call/test is present on `main`.

## Known bounded degradation

- the first interruption still uses separate snapshot and Turn files; a process crash in the narrow gap before recovery metadata is written may require restart or manual retry rather than immediately exposing Play
- if the Desktop's 10,000-entry authoritative-control reserve itself is saturated while the consumer is unavailable, the oldest Interrupted projection may be evicted to preserve a hard memory bound; reloading reconciles from durable session state

## Integration

- rebased onto `main` at `48d43c33857a7f3f03bbcd77aacc701ec946143e`
- final head `d64571533021020d360721ec7d01e5200e41006f`
- delivered as one focused commit
