### PR TITLE
feat(editor): support Markdown frontmatter

### DIFF
--- a/src/web-ui/src/locales/en-US/tools.json
+++ b/src/web-ui/src/locales/en-US/tools.json
@@ -77,7 +77,7 @@
       "copiedMarkdown": "Copied Markdown",
       "viewModeLabel": "Markdown and preview mode",
       "notice": {
-        "sourcePreviewFallback": "This document contains HTML fragments that are not safely editable in visual mode. Edit in source mode or switch to preview."
+        "sourcePreviewFallback": "This document contains syntax that is not safely editable in visual mode. Edit in source mode or switch to preview."
       }
     },
     "planViewer": {
@@ -119,6 +119,9 @@
       "localImageFailed": "Image failed to load",
       "rawHtml": {
         "inlineLabel": "HTML"
+      },
+      "frontmatter": {
+        "label": "YAML Frontmatter"
       },
       "details": {
         "summaryPlaceholder": "Summary"

--- a/src/web-ui/src/locales/zh-CN/tools.json
+++ b/src/web-ui/src/locales/zh-CN/tools.json
@@ -77,7 +77,7 @@
       "copiedMarkdown": "已复制 Markdown",
       "viewModeLabel": "Markdown 与预览模式",
       "notice": {
-        "sourcePreviewFallback": "该文档包含无法在可视化模式中安全编辑的 HTML 片段。请在源码模式中编辑，或切换到预览查看效果。"
+        "sourcePreviewFallback": "该文档包含无法在可视化模式中安全编辑的语法。请在源码模式中编辑，或切换到预览模式查看。"
       }
     },
     "planViewer": {
@@ -119,6 +119,9 @@
       "localImageFailed": "图片加载失败",
       "rawHtml": {
         "inlineLabel": "HTML"
+      },
+      "frontmatter": {
+        "label": "YAML Frontmatter"
       },
       "details": {
         "summaryPlaceholder": "摘要"

--- a/src/web-ui/src/locales/zh-TW/tools.json
+++ b/src/web-ui/src/locales/zh-TW/tools.json
@@ -77,7 +77,7 @@
       "copiedMarkdown": "已複製 Markdown",
       "viewModeLabel": "Markdown 與預覽模式",
       "notice": {
-        "sourcePreviewFallback": "該文檔包含無法在可視化模式中安全編輯的 HTML 片段。請在源碼模式中編輯，或切換到預覽查看效果。"
+        "sourcePreviewFallback": "該文檔包含無法在可視化模式中安全編輯的語法。請在源碼模式中編輯，或切換到預覽模式查看。"
       }
     },
     "planViewer": {
@@ -119,6 +119,9 @@
       "localImageFailed": "圖片載入失敗",
       "rawHtml": {
         "inlineLabel": "HTML"
+      },
+      "frontmatter": {
+        "label": "YAML Frontmatter"
       },
       "details": {
         "summaryPlaceholder": "摘要"

--- a/src/web-ui/src/tools/editor/appearance.ts
+++ b/src/web-ui/src/tools/editor/appearance.ts
@@ -10,6 +10,7 @@ export const editorToolAppearanceDescriptor: AppearanceSurfaceDescriptor = {
     { id: 'saving' },
     { id: 'readOnlyCodeBlock' },
     { id: 'meditorPreview' },
+    { id: 'meditorFrontmatter' },
     { id: 'meditorEditArea' },
   ],
   states: [

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.appearance.ts
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.appearance.ts
@@ -3,7 +3,7 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
 export const markdownEditorAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'markdown-editor',
   parts: [
-    { id: 'root' }, { id: 'loading' }, { id: 'error' }, { id: 'notice' },
+    { id: 'root' }, { id: 'loading' }, { id: 'error' },
     { id: 'toolbar' }, { id: 'modeToggle' }, { id: 'actions' }, { id: 'body' },
   ],
   facets: [{ id: 'view', attribute: 'data-bf-view', values: ['preview', 'markdown', 'source'] }],

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.scss
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.scss
@@ -13,37 +13,6 @@
   overflow: hidden;
 }
 
-.bitfun-markdown-editor__notice-bar {
-  display: flex;
-  align-items: flex-start;
-  gap: $size-gap-3;
-  padding: $size-gap-3 $size-gap-4;
-  border-bottom: 1px solid color-mix(in srgb, var(--bf-appearance-token-color-warning) 22%, transparent);
-  background: color-mix(in srgb, var(--bf-appearance-token-color-warning) 8%, var(--bf-appearance-token-color-bg-scene));
-  color: var(--bf-appearance-token-color-text-secondary);
-  flex-shrink: 0;
-}
-
-.bitfun-markdown-editor__notice-icon {
-  width: 16px;
-  height: 16px;
-  margin-top: 2px;
-  color: var(--bf-appearance-token-color-warning);
-  flex-shrink: 0;
-}
-
-.bitfun-markdown-editor__notice-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-
-  p {
-    margin: 0;
-    font-size: var(--bf-appearance-token-font-size-xs);
-    line-height: $line-height-relaxed;
-  }
-}
-
 .bitfun-markdown-editor__mode-toolbar {
   display: flex;
   align-items: center;

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../meditor/utils/tiptapMarkdown', () => ({
 const messages: Record<string, string> = {
   'editor.markdownEditor.copiedMarkdown': 'Copied Markdown',
   'editor.markdownEditor.copyMarkdown': 'Copy Markdown',
+  'editor.markdownEditor.notice.sourcePreviewFallback': 'IR fallback warning',
 };
 
 vi.mock('@/infrastructure/i18n', () => ({
@@ -104,5 +105,13 @@ describe('MarkdownEditor', () => {
     );
 
     expect(html).toContain('data-mode="preview"');
+  });
+
+  it('does not show the IR fallback warning in the preview/source file UI', () => {
+    const html = renderToStaticMarkup(
+      <MarkdownEditor initialContent="# Ordinary Markdown" />,
+    );
+
+    expect(html).not.toContain('IR fallback warning');
   });
 });

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
@@ -5,7 +5,7 @@
  * @module components/MarkdownEditor
  */
 
-import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { MEditor } from '../meditor';
 import type { EditorInstance } from '../meditor';
 import { analyzeMarkdownEditability, type MarkdownEditabilityAnalysis } from '../meditor/utils/tiptapMarkdown';
@@ -617,20 +617,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     return () => clearTimeout(timer);
   }, [jumpToLine, jumpToColumn, filePath, loading, content]);
 
-  const notices = useMemo(() => {
-    const nextNotices: string[] = [];
-
-    if (filePath && (
-      editability.mode === 'unsafe' ||
-      editability.containsRenderOnlyBlocks ||
-      editability.containsRawHtmlInlines
-    )) {
-      nextNotices.push(t('editor.markdownEditor.notice.sourcePreviewFallback'));
-    }
-
-    return nextNotices;
-  }, [editability, filePath, t]);
-
   const shouldUseSourcePreviewFallback = !!filePath && (
     editability.mode === 'unsafe' ||
     editability.containsRenderOnlyBlocks ||
@@ -664,16 +650,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   if (shouldUseSourcePreviewFallback) {
     return (
       <div className={`bitfun-markdown-editor ${className}`} data-bf-component="markdown-editor" data-bf-part="root" data-bf-view={unsafeViewMode}>
-        {notices.length > 0 && (
-          <div className="bitfun-markdown-editor__notice-bar" data-bf-component="markdown-editor" data-bf-part="notice">
-            <AlertCircle className="bitfun-markdown-editor__notice-icon" />
-            <div className="bitfun-markdown-editor__notice-copy">
-              {notices.map(notice => (
-                <p key={notice}>{notice}</p>
-              ))}
-            </div>
-          </div>
-        )}
         <div className="bitfun-markdown-editor__mode-toolbar" data-bf-component="markdown-editor" data-bf-part="toolbar">
           <div className="bitfun-markdown-editor__mode-toggle" role="tablist" aria-label={t('editor.markdownEditor.viewModeLabel')} data-bf-component="markdown-editor" data-bf-part="modeToggle">
             <Button
@@ -771,16 +747,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 
   return (
     <div className={`bitfun-markdown-editor ${className}`} data-bf-component="markdown-editor" data-bf-part="root" data-bf-view={viewMode}>
-      {notices.length > 0 && (
-        <div className="bitfun-markdown-editor__notice-bar" data-bf-component="markdown-editor" data-bf-part="notice">
-          <AlertCircle className="bitfun-markdown-editor__notice-icon" />
-          <div className="bitfun-markdown-editor__notice-copy">
-            {notices.map(notice => (
-              <p key={notice}>{notice}</p>
-            ))}
-          </div>
-        </div>
-      )}
       <div className="bitfun-markdown-editor__mode-toolbar" data-bf-component="markdown-editor" data-bf-part="toolbar">
         <div className="bitfun-markdown-editor__mode-toggle" role="tablist" aria-label={t('editor.markdownEditor.viewModeLabel')} data-bf-component="markdown-editor" data-bf-part="modeToggle">
           <Button

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.appearance.ts
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.appearance.ts
@@ -4,6 +4,6 @@ export const mEditorAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'm-editor',
   parts: [
     { id: 'root' }, { id: 'toolbar' }, { id: 'content' },
-    { id: 'editPanel' }, { id: 'previewPanel' }, { id: 'irPanel' },
+    { id: 'notice' }, { id: 'editPanel' }, { id: 'previewPanel' }, { id: 'irPanel' },
   ],
 };

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.scss
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.scss
@@ -12,6 +12,26 @@
     background: var(--bf-appearance-token-element-bg-soft);
     backdrop-filter: blur(8px);
   }
+
+  &-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: $size-gap-2;
+    padding: $size-gap-2 $size-gap-3;
+    border-bottom: 1px solid color-mix(in srgb, var(--bf-appearance-token-color-warning) 30%, transparent);
+    background: color-mix(in srgb, var(--bf-appearance-token-color-warning) 8%, transparent);
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-size: var(--bf-appearance-token-font-size-sm);
+    line-height: 1.45;
+
+    &__icon {
+      flex: 0 0 auto;
+      width: 16px;
+      height: 16px;
+      margin-top: 2px;
+      color: var(--bf-appearance-token-color-warning);
+    }
+  }
   
   &-content {
     flex: 1;

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/shared/utils/logger', () => ({
   }),
 }))
 
-import { MEditorErrorBoundary } from './MEditor'
+import { MEditor, MEditorErrorBoundary } from './MEditor'
 
 function UnsupportedMarkdownRenderer(): never {
   throw new SyntaxError('Invalid regular expression: invalid group specifier name')
@@ -67,4 +67,31 @@ describe('MEditorErrorBoundary', () => {
       })
     )
   })
+
+  it('shows the compatibility warning only when IR mode requests a fallback', () => {
+    act(() => {
+      root.render(
+        <MEditor value={'Mix <span data-x="1">inline</span> HTML.'} mode="preview" />
+      )
+    })
+    expect(container.textContent).not.toContain('IR fallback warning')
+
+    act(() => {
+      root.render(
+        <MEditor value={'Mix <span data-x="1">inline</span> HTML.'} mode="ir" />
+      )
+    })
+    expect(container.textContent).toContain('IR fallback warning')
+  })
 })
+
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: {
+    t: (key: string) => key,
+  },
+  useI18n: () => ({
+    t: (key: string) => key === 'editor.markdownEditor.notice.sourcePreviewFallback'
+      ? 'IR fallback warning'
+      : key,
+  }),
+}))

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.tsx
@@ -20,6 +20,7 @@ import { Preview } from './Preview'
 import type { EditorOptions, EditorInstance } from '../types'
 import { useI18n } from '@/infrastructure/i18n'
 import { analyzeMarkdownEditability } from '../utils/tiptapMarkdown'
+import { AlertCircle } from 'lucide-react'
 import './MEditor.scss'
 
 const log = createLogger('MEditor')
@@ -260,7 +261,12 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
 
   const tiptapEditorRef = useRef<TiptapEditorHandle>(null)
   const editability = useMemo(() => analyzeMarkdownEditability(value), [value])
-  const effectiveMode = mode === 'ir' && editability.containsRenderOnlyBlocks
+  const irNeedsSourceFallback = mode === 'ir' && (
+    editability.mode === 'unsafe' ||
+    editability.containsRenderOnlyBlocks ||
+    editability.containsRawHtmlInlines
+  )
+  const effectiveMode = irNeedsSourceFallback
     ? (readonly ? 'preview' : 'split')
     : mode
 
@@ -437,6 +443,12 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
       tabIndex={-1}
     >
       {toolbar && <div data-bf-component="m-editor" data-bf-part="toolbar" className="m-editor-toolbar">{t('editor.meditor.toolbarPlaceholder')}</div>}
+      {irNeedsSourceFallback && (
+        <div className="m-editor-notice" data-bf-component="m-editor" data-bf-part="notice">
+          <AlertCircle className="m-editor-notice__icon" />
+          <span>{t('editor.markdownEditor.notice.sourcePreviewFallback')}</span>
+        </div>
+      )}
       
       <div data-bf-component="m-editor" data-bf-part="content" className="m-editor-content">
         {effectiveMode === 'preview' && (

--- a/src/web-ui/src/tools/editor/meditor/components/Preview.scss
+++ b/src/web-ui/src/tools/editor/meditor/components/Preview.scss
@@ -9,4 +9,36 @@
     padding: $size-gap-4;
     overflow-x: auto;
   }
+
+  &-frontmatter {
+    margin: 0 0 $size-gap-4;
+    overflow: hidden;
+    border: 1px solid var(--bf-appearance-token-border-base);
+    border-radius: $size-radius-base;
+    background: var(--bf-appearance-token-element-bg-soft);
+
+    &__header {
+      display: flex;
+      align-items: center;
+      padding: $size-gap-2 $size-gap-3;
+      border-bottom: 1px solid var(--bf-appearance-token-border-base);
+    }
+
+    &__label {
+      color: var(--bf-appearance-token-color-text-secondary);
+      font-size: var(--bf-appearance-token-font-size-xs);
+      font-weight: $font-weight-semibold;
+    }
+
+    &__source {
+      margin: 0;
+      padding: $size-gap-3;
+      overflow-x: auto;
+      color: var(--bf-appearance-token-color-text-secondary);
+      font-family: var(--bf-appearance-token-font-family-mono);
+      font-size: var(--bf-appearance-token-font-size-sm);
+      line-height: 1.55;
+      white-space: pre;
+    }
+  }
 }

--- a/src/web-ui/src/tools/editor/meditor/components/Preview.test.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/Preview.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { Preview } from './Preview';
+
+vi.mock('@/infrastructure/i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key === 'editor.meditor.frontmatter.label'
+      ? 'YAML Frontmatter'
+      : key,
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => (
+    <div data-testid="markdown-renderer">{content}</div>
+  ),
+}));
+
+describe('Preview', () => {
+  it('shows frontmatter separately and renders only the markdown body', () => {
+    const html = renderToStaticMarkup(
+      <Preview value={'---\nname: Demo\n---\n\n# Body'} />,
+    );
+
+    expect(html).toContain('m-editor-preview-frontmatter');
+    expect(html).toContain('YAML Frontmatter');
+    expect(html).toContain('name: Demo');
+    expect(html).not.toContain('---');
+    expect(html).toContain('data-testid="markdown-renderer"');
+    expect(html).toContain('# Body');
+  });
+});

--- a/src/web-ui/src/tools/editor/meditor/components/Preview.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/Preview.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { MarkdownRenderer } from '@/component-library';
+import { useI18n } from '@/infrastructure/i18n';
+import { splitMarkdownFrontmatter } from '../utils/markdownFrontmatter';
 import './Preview.scss';
 
 interface PreviewProps {
@@ -8,10 +10,25 @@ interface PreviewProps {
 }
 
 export const Preview: React.FC<PreviewProps> = ({ value, basePath }) => {
+  const { t } = useI18n('tools');
+  const frontmatter = splitMarkdownFrontmatter(value);
+
   return (
     <div className="m-editor-preview" data-bf-component="editor-tool" data-bf-part="meditorPreview">
       <div className="m-editor-preview-content">
-        <MarkdownRenderer content={value} basePath={basePath} />
+        {frontmatter && (
+          <section className="m-editor-preview-frontmatter" data-bf-component="editor-tool" data-bf-part="meditorFrontmatter">
+            <header className="m-editor-preview-frontmatter__header">
+              <span className="m-editor-preview-frontmatter__label">
+                {t('editor.meditor.frontmatter.label')}
+              </span>
+            </header>
+            <pre className="m-editor-preview-frontmatter__source">
+              <code>{frontmatter.yaml}</code>
+            </pre>
+          </section>
+        )}
+        <MarkdownRenderer content={frontmatter?.body ?? value} basePath={basePath} />
       </div>
     </div>
   );

--- a/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.scss
+++ b/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.scss
@@ -945,9 +945,28 @@
   }
 
   .m-editor-render-only-block,
-  .m-editor-raw-html-block {
+  .m-editor-raw-html-block,
+  .m-editor-frontmatter {
     margin: $size-gap-3 0;
+    overflow: hidden;
+    border: 1px solid var(--bf-appearance-token-border-base);
+    border-radius: $size-radius-base;
+    background: var(--bf-appearance-token-element-bg-soft);
     color: var(--bf-appearance-token-color-text-secondary);
+  }
+
+  .m-editor-frontmatter__header {
+    display: flex;
+    align-items: center;
+    padding: $size-gap-2 $size-gap-3;
+    border-bottom: 1px solid var(--bf-appearance-token-border-base);
+    user-select: none;
+  }
+
+  .m-editor-frontmatter__label {
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-size: var(--bf-appearance-token-font-size-xs);
+    font-weight: $font-weight-semibold;
   }
 
   .m-editor-raw-html-inline {
@@ -980,12 +999,14 @@
   }
 
   .m-editor-render-only-block__body,
-  .m-editor-raw-html-block__body {
+  .m-editor-raw-html-block__body,
+  .m-editor-frontmatter__body {
     min-width: 0;
   }
 
   .m-editor-render-only-block__pane,
-  .m-editor-raw-html-block__pane {
+  .m-editor-raw-html-block__pane,
+  .m-editor-frontmatter__pane {
     min-width: 0;
     min-height: 0;
   }
@@ -993,22 +1014,27 @@
   .m-editor-render-only-block__pane--editor,
   .m-editor-render-only-block__pane--preview,
   .m-editor-raw-html-block__pane--editor,
-  .m-editor-raw-html-block__pane--preview {
+  .m-editor-raw-html-block__pane--preview,
+  .m-editor-frontmatter__pane--editor,
+  .m-editor-frontmatter__pane--preview {
     padding: 0;
   }
 
   .m-editor-render-only-block[data-editing='true'] .m-editor-render-only-block__pane--preview,
-  .m-editor-raw-html-block[data-editing='true'] .m-editor-raw-html-block__pane--preview {
+  .m-editor-raw-html-block[data-editing='true'] .m-editor-raw-html-block__pane--preview,
+  .m-editor-frontmatter[data-editing='true'] .m-editor-frontmatter__pane--preview {
     display: none;
   }
 
   .m-editor-render-only-block[data-editing='false'] .m-editor-render-only-block__pane--editor,
-  .m-editor-raw-html-block[data-editing='false'] .m-editor-raw-html-block__pane--editor {
+  .m-editor-raw-html-block[data-editing='false'] .m-editor-raw-html-block__pane--editor,
+  .m-editor-frontmatter[data-editing='false'] .m-editor-frontmatter__pane--editor {
     display: none;
   }
 
   .m-editor-render-only-block__textarea,
-  .m-editor-raw-html-block__textarea {
+  .m-editor-raw-html-block__textarea,
+  .m-editor-frontmatter__textarea {
     margin: 0;
     font-family: var(--bf-appearance-token-font-family-mono);
     font-size: var(--bf-appearance-token-font-size-sm);
@@ -1035,12 +1061,53 @@
   }
 
   .m-editor-render-only-block__preview,
-  .m-editor-raw-html-block__preview {
+  .m-editor-raw-html-block__preview,
+  .m-editor-frontmatter__preview {
     min-height: 180px;
     cursor: text;
     user-select: text;
     -webkit-user-select: text;
     -webkit-user-drag: none;
+  }
+
+  .m-editor-frontmatter__textarea {
+    min-height: 0;
+    box-sizing: border-box;
+    resize: none;
+    overflow-y: hidden;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+
+    &:focus {
+      border-color: transparent;
+      box-shadow: inset 0 0 0 1px var(--bf-appearance-token-border-base);
+    }
+  }
+
+  .m-editor-frontmatter__preview {
+    min-height: 0;
+  }
+
+  .m-editor-frontmatter__preview > .m-editor-frontmatter__source {
+    margin: 0;
+    padding: $size-gap-3;
+    overflow-x: auto;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-family: var(--bf-appearance-token-font-family-mono);
+    font-size: var(--bf-appearance-token-font-size-sm);
+    line-height: 1.55;
+    white-space: pre;
+
+    &:hover {
+      border: 0;
+      background: transparent;
+      box-shadow: none;
+    }
   }
 
   .m-editor-render-only-block__preview .m-editor-render-only-block__markdown,
@@ -1069,7 +1136,8 @@
   }
 
   .m-editor-render-only-block__source-fallback,
-  .m-editor-raw-html-block__source-fallback {
+  .m-editor-raw-html-block__source-fallback,
+  .m-editor-frontmatter__source-fallback {
     display: none;
     margin: 0;
     font-family: var(--bf-appearance-token-font-family-mono);

--- a/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.tsx
@@ -37,7 +37,7 @@ import {
   InlineAiPreviewExtension,
 } from '../extensions/InlineAiPreviewExtension';
 import { inlineAiPreviewPluginKey } from '../extensions/InlineAiPreviewPluginKey';
-import { RawHtmlBlock, RawHtmlInline, RenderOnlyBlock } from '../extensions/RawHtmlExtensions';
+import { Frontmatter, RawHtmlBlock, RawHtmlInline, RenderOnlyBlock } from '../extensions/RawHtmlExtensions';
 import { getBlockIndexForLine } from '../utils/markdownBlocks';
 import {
   buildInlineContinuePrompt,
@@ -601,6 +601,9 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       }),
       DetailsSummary,
       DetailsContent,
+      Frontmatter.configure({
+        label: t('editor.meditor.frontmatter.label'),
+      }),
       // Keep raw/render-only fallbacks for HTML we still can't round-trip safely.
       RenderOnlyBlock.configure({
         basePath,

--- a/src/web-ui/src/tools/editor/meditor/extensions/BlockIdExtension.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/BlockIdExtension.ts
@@ -15,6 +15,7 @@ const TOP_LEVEL_TYPES = [
   'horizontalRule',
   'markdownTable',
   'details',
+  'frontmatter',
   'renderOnlyBlock',
   'rawHtmlBlock',
 ];

--- a/src/web-ui/src/tools/editor/meditor/extensions/RawHtmlExtensions.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/RawHtmlExtensions.ts
@@ -6,6 +6,7 @@ import { activeEditTargetService } from '@/tools/editor/services/ActiveEditTarge
 
 type SourceBackedBlockOptions = {
   basePath?: string;
+  label?: string;
 };
 
 type RawHtmlInlineOptions = {
@@ -205,8 +206,9 @@ function executeTextareaAction(
 
 function createSourceBackedBlock(
   name: string,
-  valueAttr: 'html' | 'markdown',
+  valueAttr: 'html' | 'markdown' | 'yaml',
   className: string,
+  metadataAttrs: readonly string[] = [],
 ) {
   return Node.create<SourceBackedBlockOptions>({
     name,
@@ -220,6 +222,7 @@ function createSourceBackedBlock(
     addOptions() {
       return {
         basePath: undefined,
+        label: undefined,
       };
     },
 
@@ -228,6 +231,7 @@ function createSourceBackedBlock(
         [valueAttr]: {
           default: '',
         },
+        ...Object.fromEntries(metadataAttrs.map(attr => [attr, { default: '' }])),
         kind: {
           default: null,
         },
@@ -239,6 +243,10 @@ function createSourceBackedBlock(
         tag: `div[data-type="${name}"]`,
         getAttrs: element => ({
           [valueAttr]: element.getAttribute(`data-${valueAttr}`) ?? '',
+          ...Object.fromEntries(metadataAttrs.map(attr => [
+            attr,
+            element.getAttribute(`data-${attr.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`)}`) ?? '',
+          ])),
           kind: element.getAttribute('data-kind'),
         }),
       }];
@@ -255,6 +263,10 @@ function createSourceBackedBlock(
         {
           'data-type': name,
           [`data-${valueAttr}`]: value,
+          ...Object.fromEntries(metadataAttrs.map(attr => [
+            `data-${attr.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`)}`,
+            String(node.attrs[attr] ?? ''),
+          ])),
           ...(kind ? { 'data-kind': kind } : {}),
         },
       ];
@@ -268,6 +280,7 @@ function createSourceBackedBlock(
         let lastEditableState = editor.isEditable;
         let previewRoot: Root | null = null;
         let previewCheckTimer: number | null = null;
+        let frontmatterEditingMinHeight = 0;
         const textareaTargetId = `${name}-textarea-${++sourceBackedBlockTextareaTargetCounter}`;
         let unbindEditTarget: (() => void) | null = null;
 
@@ -291,6 +304,15 @@ function createSourceBackedBlock(
         textarea.draggable = false;
         textarea.setAttribute('draggable', 'false');
 
+        const syncFrontmatterTextareaHeight = () => {
+          if (name !== 'frontmatter' || !isEditing) {
+            return;
+          }
+
+          textarea.style.height = '0px';
+          textarea.style.height = `${Math.max(textarea.scrollHeight, frontmatterEditingMinHeight)}px`;
+        };
+
         editorPane.append(textarea);
 
         const previewPane = document.createElement('div');
@@ -308,6 +330,19 @@ function createSourceBackedBlock(
 
         previewPane.append(preview, sourceFallback);
         body.append(editorPane, previewPane);
+
+        if (this.options.label) {
+          const header = document.createElement('div');
+          header.className = `${className}__header`;
+
+          const label = document.createElement('span');
+          label.className = `${className}__label`;
+          label.textContent = this.options.label;
+
+          header.append(label);
+          dom.append(header);
+        }
+
         dom.append(body);
 
         const applyAttrs = (attrs: Record<string, unknown>) => {
@@ -338,11 +373,24 @@ function createSourceBackedBlock(
             return;
           }
 
+          if (name === 'frontmatter' && resolvedEditing) {
+            frontmatterEditingMinHeight = previewPane.getBoundingClientRect().height;
+          }
+
           isEditing = resolvedEditing;
           syncEditingState();
 
+          // Measure only after the editor pane has become visible. Measuring
+          // while CSS still hides it returns an incomplete scroll height.
+          syncFrontmatterTextareaHeight();
+
           if (resolvedEditing && options?.focus) {
             focusElementWithoutScroll(textarea);
+          }
+
+          if (!resolvedEditing) {
+            frontmatterEditingMinHeight = 0;
+            textarea.style.height = '';
           }
         };
 
@@ -351,6 +399,19 @@ function createSourceBackedBlock(
         };
 
         const renderPreview = (markdown: string) => {
+          if (name === 'frontmatter') {
+            previewRoot?.render(
+              React.createElement(
+                'pre',
+                { className: `${className}__source` },
+                React.createElement('code', null, markdown),
+              ),
+            );
+            sourceFallback.textContent = markdown;
+            dom.setAttribute('data-preview-empty', 'false');
+            return;
+          }
+
           const kind = typeof currentNode.attrs.kind === 'string' ? currentNode.attrs.kind : null;
           const detailsSource = kind === 'details' ? parseDetailsSource(markdown) : null;
           const shouldCheckPreviewVisibility = name === 'rawHtmlBlock' || kind === 'details';
@@ -455,6 +516,8 @@ function createSourceBackedBlock(
           if (valueChanged && textarea.value !== value) {
             textarea.value = value;
           }
+
+          syncFrontmatterTextareaHeight();
 
           textarea.readOnly = !editable;
           if (!editable && isEditing) {
@@ -574,6 +637,7 @@ function createSourceBackedBlock(
         textarea.addEventListener('input', () => {
           const nextValue = textarea.value;
           lastSyncedValue = nextValue;
+          syncFrontmatterTextareaHeight();
           applyAttrs({ [valueAttr]: nextValue });
           void renderPreview(nextValue);
         });
@@ -652,6 +716,19 @@ export const RawHtmlBlock = createSourceBackedBlock(
   'rawHtmlBlock',
   'html',
   'm-editor-raw-html-block',
+);
+
+export const Frontmatter = createSourceBackedBlock(
+  'frontmatter',
+  'yaml',
+  'm-editor-frontmatter',
+  [
+    'delimiter',
+    'openingLineEnding',
+    'contentLineEnding',
+    'closingLineEnding',
+    'bodyPrefix',
+  ],
 );
 
 export const RawHtmlInline = Node.create<RawHtmlInlineOptions>({

--- a/src/web-ui/src/tools/editor/meditor/utils/markdownFrontmatter.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/markdownFrontmatter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { splitMarkdownFrontmatter } from './markdownFrontmatter';
+
+describe('splitMarkdownFrontmatter', () => {
+  it('keeps the complete frontmatter envelope and body boundary', () => {
+    const markdown = '---\nname: Demo\n---\n\n# Body';
+
+    expect(splitMarkdownFrontmatter(markdown)).toEqual({
+      raw: '---\nname: Demo\n---\n',
+      body: '\n# Body',
+      delimiter: '---',
+      yaml: 'name: Demo',
+      openingLineEnding: '\n',
+      contentLineEnding: '\n',
+      closingLineEnding: '\n',
+    });
+  });
+
+  it('does not treat a thematic break in the body as frontmatter', () => {
+    expect(splitMarkdownFrontmatter('---\n\n# Body')).toBeNull();
+  });
+
+  it('supports an empty frontmatter envelope', () => {
+    expect(splitMarkdownFrontmatter('---\n---\n# Body')).toEqual({
+      raw: '---\n---\n',
+      body: '# Body',
+      delimiter: '---',
+      yaml: '',
+      openingLineEnding: '\n',
+      contentLineEnding: '',
+      closingLineEnding: '\n',
+    });
+  });
+
+  it('keeps every line ending after the closing delimiter in the body', () => {
+    expect(splitMarkdownFrontmatter('---\r\nname: Demo\r\n---\r\n\r\n\r\n# Body')).toMatchObject({
+      raw: '---\r\nname: Demo\r\n---\r\n',
+      body: '\r\n\r\n# Body',
+      yaml: 'name: Demo',
+      openingLineEnding: '\r\n',
+      contentLineEnding: '\r\n',
+      closingLineEnding: '\r\n',
+    });
+  });
+});

--- a/src/web-ui/src/tools/editor/meditor/utils/markdownFrontmatter.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/markdownFrontmatter.ts
@@ -1,0 +1,72 @@
+export interface MarkdownFrontmatterSplit {
+  raw: string;
+  body: string;
+  delimiter: '---' | '+++';
+  yaml: string;
+  openingLineEnding: '\n' | '\r\n';
+  contentLineEnding: '' | '\n' | '\r\n';
+  closingLineEnding: '' | '\n' | '\r\n';
+}
+
+/**
+ * Split leading YAML/TOML-style frontmatter without parsing or normalizing it.
+ * `raw` ends after the first line ending following the closing delimiter. Any
+ * additional blank lines belong to `body`, so joining `raw + body` preserves
+ * the source document byte-for-byte.
+ */
+export function splitMarkdownFrontmatter(markdown: string): MarkdownFrontmatterSplit | null {
+  const openingMatch = markdown.match(/^(---|\+\+\+)(\r?\n)/);
+  if (!openingMatch) {
+    return null;
+  }
+
+  const delimiter = openingMatch[1] as MarkdownFrontmatterSplit['delimiter'];
+  const openingLineEnding = openingMatch[2] as MarkdownFrontmatterSplit['openingLineEnding'];
+  const afterOpening = markdown.slice(openingMatch[0].length);
+  const escapedDelimiter = delimiter.replace(/\+/g, '\\+');
+  const closingPattern = new RegExp(`^${escapedDelimiter}(?:((?:\\r?\\n))|$)`, 'm');
+  const closingMatch = closingPattern.exec(afterOpening);
+  if (!closingMatch) {
+    return null;
+  }
+
+  const yamlWithStructuralEnding = afterOpening.slice(0, closingMatch.index);
+  const contentLineEndingMatch = yamlWithStructuralEnding.match(/(\r?\n)$/);
+  const contentLineEnding = (contentLineEndingMatch?.[1] ?? '') as MarkdownFrontmatterSplit['contentLineEnding'];
+  const yaml = contentLineEnding
+    ? yamlWithStructuralEnding.slice(0, -contentLineEnding.length)
+    : yamlWithStructuralEnding;
+  const closingLineEnding = (closingMatch[1] ?? '') as MarkdownFrontmatterSplit['closingLineEnding'];
+  const rawLength = openingMatch[0].length + closingMatch.index + closingMatch[0].length;
+  const raw = markdown.slice(0, rawLength);
+
+  return {
+    raw,
+    body: markdown.slice(raw.length),
+    delimiter,
+    yaml,
+    openingLineEnding,
+    contentLineEnding,
+    closingLineEnding,
+  };
+}
+
+export function serializeMarkdownFrontmatter(
+  frontmatter: Pick<
+    MarkdownFrontmatterSplit,
+    'delimiter' | 'yaml' | 'openingLineEnding' | 'contentLineEnding' | 'closingLineEnding'
+  >,
+): string {
+  const contentLineEnding = frontmatter.contentLineEnding || (
+    frontmatter.yaml ? frontmatter.openingLineEnding : ''
+  );
+
+  return [
+    frontmatter.delimiter,
+    frontmatter.openingLineEnding,
+    frontmatter.yaml,
+    contentLineEnding,
+    frontmatter.delimiter,
+    frontmatter.closingLineEnding,
+  ].join('');
+}

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
@@ -5,6 +5,7 @@ import {
   getUnsupportedTiptapMarkdownFeatures,
   markdownToTiptapDoc,
   tiptapDocToMarkdown,
+  tiptapDocToTopLevelMarkdownBlocks,
 } from './tiptapMarkdown';
 
 describe('tiptap markdown compatibility', () => {
@@ -146,7 +147,7 @@ describe('tiptap markdown compatibility', () => {
     expect(getUnsupportedTiptapMarkdownFeatures(markdown)).toContain('roundTripMismatch');
   });
 
-  it('treats frontmatter as unsafe for the IR editor', () => {
+  it('preserves frontmatter as an editable IR block', () => {
     const markdown = [
       '---',
       'name: Demo',
@@ -160,11 +161,52 @@ describe('tiptap markdown compatibility', () => {
 
     const analysis = analyzeMarkdownEditability(markdown);
 
-    expect(analysis.mode).toBe('unsafe');
-    expect(analysis.hardIssues).toContain('frontmatter');
-    expect(analysis.hardIssues).toContain('semanticMismatch');
-    expect(analysis.softIssues).toContain('roundTripMismatch');
-    expect(analysis.canonicalMarkdown).toContain('## name: Demo');
+    const doc = markdownToTiptapDoc(markdown);
+
+    expect(analysis.mode).toBe('lossless');
+    expect(analysis.hardIssues).toEqual([]);
+    expect(analysis.softIssues).toEqual([]);
+    expect(analysis.canonicalMarkdown).toBe(markdown);
+    expect(doc.content?.[0]).toMatchObject({
+      type: 'frontmatter',
+      attrs: {
+        yaml: expect.stringContaining('name: Demo'),
+        delimiter: '---',
+        bodyPrefix: '\n',
+      },
+    });
+    expect(tiptapDocToMarkdown(doc)).toBe(markdown);
+    expect(tiptapDocToTopLevelMarkdownBlocks(doc)).toEqual([
+      expect.objectContaining({ markdown: '# Body' }),
+    ]);
+  });
+
+  it('preserves TOML-style frontmatter delimiters and CRLF inside the envelope', () => {
+    const markdown = '+++\r\ntitle = "Demo"\r\n+++\r\n\r\n# Body\r\n';
+    const doc = markdownToTiptapDoc(markdown);
+
+    expect(doc.content?.[0]?.type).toBe('frontmatter');
+    expect(doc.content?.[0]?.attrs).toMatchObject({
+      yaml: 'title = "Demo"',
+      delimiter: '+++',
+      openingLineEnding: '\r\n',
+      contentLineEnding: '\r\n',
+      closingLineEnding: '\r\n',
+      bodyPrefix: '\r\n',
+    });
+    expect(tiptapDocToMarkdown(doc, { preserveTrailingNewline: true })).toBe(
+      '+++\r\ntitle = "Demo"\r\n+++\r\n\r\n# Body\n',
+    );
+  });
+
+  it('rebuilds structural delimiters around edited frontmatter content', () => {
+    const doc = markdownToTiptapDoc('---\nname: Demo\n---\n\n# Body');
+    const frontmatter = doc.content?.[0];
+
+    expect(frontmatter?.attrs).toBeDefined();
+    frontmatter!.attrs!.yaml = 'name: Updated';
+
+    expect(tiptapDocToMarkdown(doc)).toBe('---\nname: Updated\n---\n\n# Body');
   });
 
   it('upgrades simple details regions into structured details nodes', () => {

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.ts
@@ -5,6 +5,7 @@ import remarkRehype from 'remark-rehype';
 import rehypeRaw from 'rehype-raw';
 import type { JSONContent } from '@tiptap/core';
 import { createBlockId } from './blockId';
+import { serializeMarkdownFrontmatter, splitMarkdownFrontmatter } from './markdownFrontmatter';
 
 type MdastNode = {
   type?: string;
@@ -108,6 +109,7 @@ const TOP_LEVEL_BLOCK_TYPES = new Set([
   'horizontalRule',
   'markdownTable',
   'details',
+  'frontmatter',
   'renderOnlyBlock',
   'rawHtmlBlock',
 ]);
@@ -194,6 +196,45 @@ function createRenderOnlyBlock(markdown: string, kind: string): JSONContent {
       kind,
     },
   };
+}
+
+function createFrontmatterBlock(
+  frontmatter: NonNullable<ReturnType<typeof splitMarkdownFrontmatter>>,
+  bodyPrefix: string,
+): JSONContent {
+  return {
+    type: 'frontmatter',
+    attrs: {
+      yaml: frontmatter.yaml,
+      delimiter: frontmatter.delimiter,
+      openingLineEnding: frontmatter.openingLineEnding,
+      contentLineEnding: frontmatter.contentLineEnding,
+      closingLineEnding: frontmatter.closingLineEnding,
+      bodyPrefix,
+    },
+  };
+}
+
+function getLeadingBlankLines(markdown: string): string {
+  return markdown.match(/^(?:[\t ]*\r?\n)+/)?.[0] ?? '';
+}
+
+function serializeFrontmatterNode(node: JSONContent): string {
+  return serializeMarkdownFrontmatter({
+    delimiter: node.attrs?.delimiter === '+++' ? '+++' : '---',
+    yaml: String(node.attrs?.yaml ?? ''),
+    openingLineEnding: node.attrs?.openingLineEnding === '\r\n' ? '\r\n' : '\n',
+    contentLineEnding: node.attrs?.contentLineEnding === '\r\n'
+      ? '\r\n'
+      : node.attrs?.contentLineEnding === '\n'
+        ? '\n'
+        : '',
+    closingLineEnding: node.attrs?.closingLineEnding === '\r\n'
+      ? '\r\n'
+      : node.attrs?.closingLineEnding === '\n'
+        ? '\n'
+        : '',
+  });
 }
 
 function withBlockAttrs(node: JSONContent, align: string | null, alignGroup: number | null): JSONContent {
@@ -708,10 +749,6 @@ function parseMarkdownTree(markdown: string): MdastNode {
     .parse(markdown) as MdastNode;
 }
 
-function hasMarkdownFrontmatter(markdown: string): boolean {
-  return /^(---|\+\+\+)\r?\n[\s\S]*?\r?\n\1(?:\r?\n|$)/.test(markdown);
-}
-
 function normalizeComparableJson(
   value: ComparableJsonValue,
   keysToStrip: Set<string>,
@@ -1224,11 +1261,8 @@ export function analyzeMarkdownEditability(markdown: string): MarkdownEditabilit
     softIssues.add('multipleTrailingBlankLines');
   }
 
-  if (hasMarkdownFrontmatter(markdown)) {
-    hardIssues.add('frontmatter');
-  }
-
-  const tree = parseMarkdownTree(markdown);
+  const frontmatter = splitMarkdownFrontmatter(markdown);
+  const tree = parseMarkdownTree(frontmatter?.body ?? markdown);
 
   walkMdast(tree, (node) => {
     if (node.type === 'footnoteDefinition' || node.type === 'footnoteReference') {
@@ -1614,6 +1648,8 @@ function renderBlock(node: JSONContent, depth = 0): string {
     }
     case 'horizontalRule':
       return '---';
+    case 'frontmatter':
+      return serializeFrontmatterNode(node);
     case 'details': {
       const summaryNode = getDetailsChild(node, 'detailsSummary');
       const detailsContentNode = getDetailsChild(node, 'detailsContent');
@@ -1673,9 +1709,16 @@ function wrapAlignedMarkdownBlocks(markdownBlocks: string[], align: string | nul
 }
 
 export function markdownToTiptapDoc(markdown: string): JSONContent {
-  const tree = parseMarkdownTree(markdown);
+  const frontmatter = splitMarkdownFrontmatter(markdown);
+  const bodyPrefix = frontmatter ? getLeadingBlankLines(frontmatter.body) : '';
+  const markdownBody = frontmatter ? frontmatter.body.slice(bodyPrefix.length) : markdown;
+  const tree = parseMarkdownTree(markdownBody);
 
-  const content = withTopLevelBlockIds(convertRootMarkdownChildren(tree.children ?? [], markdown));
+  const bodyContent = convertRootMarkdownChildren(tree.children ?? [], markdownBody);
+  const content = withTopLevelBlockIds([
+    ...(frontmatter ? [createFrontmatterBlock(frontmatter, bodyPrefix)] : []),
+    ...bodyContent,
+  ]);
 
   return {
     type: 'doc',
@@ -1688,6 +1731,8 @@ export function tiptapDocToMarkdown(
   options: TiptapMarkdownOptions = {},
 ): string {
   const content = doc?.content ?? [];
+  const frontmatterNode = content[0]?.type === 'frontmatter' ? content[0] : null;
+  const renderableContent = frontmatterNode ? content.slice(1) : content;
   const chunks: string[] = [];
   let group: string[] = [];
   let groupAlign: string | null = null;
@@ -1704,7 +1749,7 @@ export function tiptapDocToMarkdown(
     groupAlignId = null;
   };
 
-  content.forEach((node: JSONContent) => {
+  renderableContent.forEach((node: JSONContent) => {
     const rendered = renderBlock(node);
     if (!rendered) {
       return;
@@ -1742,18 +1787,31 @@ export function tiptapDocToMarkdown(
     .join('\n\n')
     .replace(/<\/div>\n\n<div\b/g, '</div>\n<div');
 
+  const frontmatterRaw = frontmatterNode ? serializeFrontmatterNode(frontmatterNode) : '';
+  const frontmatterBodyPrefix = frontmatterNode ? String(frontmatterNode.attrs?.bodyPrefix ?? '') : '';
+  const frontmatterEnvelope = `${frontmatterRaw}${frontmatterBodyPrefix}`;
   if (!markdown) {
-    return '';
+    if (!frontmatterEnvelope) {
+      return '';
+    }
+    return options.preserveTrailingNewline && !frontmatterEnvelope.endsWith('\n')
+      ? `${frontmatterEnvelope}\n`
+      : frontmatterEnvelope;
   }
 
-  return options.preserveTrailingNewline ? `${markdown}\n` : markdown;
+  const combinedMarkdown = `${frontmatterEnvelope}${markdown}`;
+  return options.preserveTrailingNewline && !combinedMarkdown.endsWith('\n')
+    ? `${combinedMarkdown}\n`
+    : combinedMarkdown;
 }
 
 export function tiptapDocToTopLevelMarkdownBlocks(
   doc: JSONContent | null | undefined,
 ): TiptapTopLevelMarkdownBlock[] {
-  return (doc?.content ?? []).map((node: JSONContent) => ({
-    blockId: typeof node.attrs?.blockId === 'string' ? node.attrs.blockId : undefined,
-    markdown: renderBlock(node).trim(),
-  }));
+  return (doc?.content ?? [])
+    .filter((node: JSONContent) => node.type !== 'frontmatter')
+    .map((node: JSONContent) => ({
+      blockId: typeof node.attrs?.blockId === 'string' ? node.attrs.blockId : undefined,
+      markdown: renderBlock(node).trim(),
+    }));
 }


### PR DESCRIPTION
Preserve YAML and TOML frontmatter through Markdown and TipTap
round trips without exposing structural delimiters for editing.

- Render labeled frontmatter metadata in preview mode
- Support protected frontmatter editing in IR mode
- Preserve delimiters, line endings, comments, and body spacing
- Show unsafe syntax warnings only when IR requires fallback
- Add focused parser, preview, and editor regression tests
