### PR TITLE
fix(flow-chat): keep user position in tail blank

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/AGENTS.md
+++ b/src/web-ui/src/flow_chat/components/modern/AGENTS.md
@@ -11,7 +11,7 @@ Also follow the repository and Web UI instructions in the parent guides.
 
 | Changing | Read |
 |---|---|
-| the tail spacer, the follow target, pinning, holding, the snap back, resizing, the footer, the reveal | `FLOWCHAT_SCROLL_STABILITY.md` |
+| the tail spacer, the follow target, pinning, holding, resizing, the footer, the reveal | `FLOWCHAT_SCROLL_STABILITY.md` |
 | history paging, the prepend, the viewport anchor, history presentation | `FLOWCHAT_HISTORY_PAGING.md` |
 | anything that writes `scrollTop`, one-shot navigation, the diagnostic trail | `FLOWCHAT_VIEWPORT_REGISTER.md` |
 | the virtualizer, item measurement, item keys, anything a row renders | `FLOWCHAT_VIRTUALIZATION.md` |
@@ -34,7 +34,7 @@ before reporting a defect as new.
   what keeps a collapse from moving the viewport.
 - `useFlowChatFollowOutput` is the only continuous outer viewport writer.
 - The follow's **write** may be eased; its **target** may not. Everything that
-  reads the follow — the settle budget, the at-tail band, the snap back — reads
+  reads the follow — the settle budget and the at-tail band — reads
   the offset the rule owns, never how far behind the ease is riding. The ease
   stands down while the transcript is opening, where the target is
   authoritative.

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
@@ -92,10 +92,8 @@ range inside the reserved blank:
 
 - at the bottom of that range no row intersects the viewport at all, so
   `getVisibleItemRange` returns nothing and there is no position to judge;
-- the snap back returns the reader to offset 0 and hands the viewport to
-  follow-output, so the one evaluation that does land at the head is refused as
-  our own placement — four times in the log, each three milliseconds after a
-  `followOutput.enter`;
+- at offset 0, an evaluation may still be refused while follow-output owns the
+  opening placement;
 - and at offset 0 the reader's own gestures produced twenty `user-gesture`
   claims over seven seconds with no scroll event, no anchor capture, and not
   one evaluation.
@@ -169,8 +167,8 @@ compensation, and the viewport anchor. Both are `viewportOwner.shift`, which
 asks a different question — content moving under the reader changes what their
 offset *means*, and restoring that meaning is not competing with anyone over
 where the viewport should be. So they are refused only by an owner that holds a
-target and will re-assert it: follow-output, a navigation still reaching its
-Turn, a snap back mid-animation.
+target and will re-assert it: follow-output or a navigation still reaching its
+Turn.
 
 The two are not redundant. The compensation is a pixel delta applied in the
 commit that prepends, and it is the only thing that can act when the reader's
@@ -215,11 +213,8 @@ over-states and they do so for different reasons:
 | `contentEndPx - scrollTop` — what the range can absorb | never; content arriving above the reader cannot push them past the end |
 
 Overshooting is the expensive direction. It puts the reader below the content
-end, where the snap back correctly reads them as parked in the reserved blank
-and returns them to the tail — and since paging happens only while scrolling up,
-it then does that on every attempt, which is what "scrolling up loops back to
-the end" was. Undershooting leaves them looking at slightly earlier content,
-which the anchor removes.
+end inside the reserved blank. Undershooting leaves them looking at slightly
+earlier content, which the anchor removes.
 
 **The cache is measured before it is read.** Left alone it is not close:
 measured twice in one session, 2174px reserved against 670px of real growth,
@@ -574,8 +569,8 @@ itself through `FLOWCHAT_TURNS_ROLLED_BACK_EVENT`, exactly as a submission does,
 and the transcript settles on the new tail — the Turn it was pinning is one of
 the ones that stopped existing.
 
-It takes the viewport whether or not follow owned it, on the same asymmetry that
-licenses the snap back. A rollback at Turn N removes N *and everything after
+It takes the viewport whether or not follow owned it. A rollback at Turn N
+removes N *and everything after
 it*, and the reader had N on screen — they clicked its own button. So the new
 tail is always within a Turn of where they already are, and there is no history
 below them to be pulled out of. Gating it on ownership instead — the first
@@ -586,11 +581,6 @@ answered a different question: it holds the reader's Turn at its offset from the
 viewport top, so an 8-Turn session rolled back at Turn 7 came to rest showing
 Turns 2..6, with the new last Turn's answer below the fold. Nothing was wrong
 with the anchor. It was the only thing still running.
-
-The snap back cannot cover this either, and for two reasons worth keeping: it
-runs only from a gesture coming to rest, and a truncation is not a gesture; and
-`tailSnapBackScrollTop` returns nothing unless the viewport is *below* the
-follow target, where a rollback leaves it above.
 
 The event fires a frame after the truncation, because the answer is a scroll to
 the end of *real content* and that has to be read from a DOM the truncation has

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -11,7 +11,7 @@ That is this document. Four siblings carry the rest.
 
 | Changing | Read |
 |---|---|
-| the tail spacer, the follow target, pinning, holding, the snap back, resizing, the footer | this file |
+| the tail spacer, the follow target, pinning, holding, resizing, the footer | this file |
 | history paging, the prepend, the viewport anchor, history presentation | `FLOWCHAT_HISTORY_PAGING.md` |
 | anything that writes `scrollTop`, one-shot navigation, the diagnostic trail | `FLOWCHAT_VIEWPORT_REGISTER.md` |
 | the virtualizer, item measurement, item keys, anything a row renders | `FLOWCHAT_VIRTUALIZATION.md` |
@@ -131,34 +131,25 @@ stop changing. Before the virtualizer renders anything, `scrollHeight` and the
 end sit unchanged at their unmeasured values, which is indistinguishable from
 having finished; a stability test reveals on frame 3 and shows the whole settle.
 
-## Snapping Back Out of the Reserved Blank
+## User-Controlled Reserved Blank
 
-The spacer is a full viewport the user can scroll into, and under slow streaming
-it can take a long time for output to push it away. So a gesture that comes to
-rest **below the follow target** returns to that target and hands the viewport
-to follow, whether or not follow owned it before.
+The spacer is a full viewport the user can scroll into. Once a reader exits
+follow-output, their own scroll position is preserved even when it lands in the
+blank. There is no `scrollend` correction or quiet-period fallback that takes
+the viewport back. Explicit actions such as opening a session, submitting a new
+Turn, navigating a Turn, rolling back, or choosing jump-to-latest remain the
+ways to re-enter follow-output.
 
-Three properties carry the whole design:
+The remaining follow rules carry the live-tail design:
 
 **The target is the follow target, never the content end.** A short new Turn is
-pinned above the content end, so snapping to the content end would scroll *up*
+pinned above the content end, so aiming at the content end would scroll *up*
 and shove the message the user just sent into the middle of the viewport. A
 held collapse gap is likewise a legitimate offset up to `tailHoldMaxGapPx` past
 the content end; judged against the content end it would read as an overshoot
 and fight the hold rule on every collapse. `memorylessFollowState` computes the
 target from live geometry with no remembered offset, because the offset the hold
 rule was protecting stopped being meaningful the moment the user took over.
-
-**It acts on rest, never during the gesture.** `scrollend` where available, a
-quiet period after the last scroll event where it is not. Correcting inside a
-`scroll` handler fights momentum and the virtualizer's own writes; correcting
-after the gesture ends fights nothing.
-
-**Re-entering follow here does not violate "no intent from geometry".** The
-region below the follow target is reserved blank — it carries no content, so a
-gesture ending there can only mean "take me to the end". Scrolling up to read
-history can never satisfy the condition. That asymmetry is the licence; do not
-extend it to any position that has content in it.
 
 The pin's *identity* therefore outlives a user takeover; only its *activity*
 stops. Three things retire a pin: the crossover to `hold-tail`, a newer Turn,
@@ -167,34 +158,18 @@ content back under one viewport, and re-pinning there would jump the viewport
 backwards. Since nothing re-pins a Turn whose identity was dropped, that is
 automatic.
 
-The snap completes on a second settle, and only when the viewport actually
-arrived: a gesture that overrode the animation mid-flight belongs to the user
-and keeps the viewport.
-
-**The snap asks whether follow is *correcting* the viewport, not whether it owns
-it.** Ownership outlives the frame loop deliberately — streaming has to be able
-to resume follow after the settle budget runs out — so the two questions differ.
-A live loop gets the viewport to itself, since it reaches its target in one
-frame and a snap back would only race it. An asleep one does not: a viewport
-left in the reserved blank under a sleeping loop is stranded, and nothing else
-was watching for it. This is the half of the scrollbar problem that is fixed
-everywhere, including where the drag itself cannot be recognised.
-
 **Where a jump to latest lands.** Every entry into follow-output resumes at the
 end of real content, with one exception: a jump to latest while the **newest**
 Turn is still pinned returns to the pin. That mode only holds while the Turn's
 answer is shorter than one viewport, so everything it has produced is already on
 screen, and aiming at the content end would scroll *up* and shove the message
-the user just sent into the middle. It is also the landing place the snap back
-picks for the same viewport state — having the two disagree would be worse than
-either choice. The exemption therefore outlives the Turn: a short Turn stays
-pinned until a newer one replaces it.
+the user just sent into the middle. The exemption therefore outlives the Turn:
+a short Turn stays pinned until a newer one replaces it.
 
 ## Output Catching Up With a Reader in the Blank
 
-The snap back covers the reader who came to rest *below* the follow target.
-This covers the other edge of the same region: the reader who scrolled up out of
-the tail but is still looking at reserved blank, and whom output then overtakes.
+This watch covers the reader who scrolled up out of the tail but is still
+looking at reserved blank, and whom output then overtakes.
 
 Scrolling up gives the follow away permanently, and that is right only for a
 reader who left the live region. A small scroll up may not have. The blank is up
@@ -205,9 +180,7 @@ seeing it with no affordance saying so.
 
 So a watch runs for as long as the reader holds the viewport — from the scroll
 that took it to whatever hands it back. `scrollTop > contentEnd` is the
-predicate for "the blank is on screen", deliberately *not* the snap back's,
-which is relative to the follow target and therefore reports a reader above a
-pin as having nothing to snap back from. The watch keeps one bit between
+predicate for "the blank is on screen". The watch keeps one bit between
 samples: whether the blank was on screen at the previous one. A crossing is that
 bit going from set to clear, and which side moved decides who keeps the viewport
 (`resolveTailDepartureCrossing`):
@@ -242,10 +215,6 @@ crossing rather than settling it — the latch stays set, so the next sample
 judges the same transition again: a reader who carries on climbing out-moves the
 content and is let go by a verdict that never needed the veto, and one who has
 stopped is followed as soon as the claim lapses.
-
-**A travelling snap back is not the reader.** It crosses the same line from the
-wrong side — downwards through the blank — so samples taken while one is in
-flight update the offsets and take no verdict.
 
 **Geometry read from two moments is not geometry.** `scrollTop` is clamped to
 `scrollHeight - clientHeight`, so no settled viewport is more than the spacer
@@ -289,7 +258,7 @@ sets is how far behind the tail the offset rides, and that lag is what has to be
 given back when the stream stops.
 
 **Only the write is eased.** `followStateRef` still holds the offset the rule
-owns, so the settle budget, the at-tail band and the snap back all keep reading
+owns, so the settle budget and the at-tail band both keep reading
 a target rather than a position in transit. An ease that leaked into the target
 would make every one of them chase the lag.
 
@@ -337,8 +306,8 @@ not the end of content.
 
 The band is recomputed on scroll, on resize, **and when follow ownership
 changes** — its lower edge is the follow target, which can move while the
-viewport is perfectly still. A snap back completes at rest by construction,
-and a jump to latest that lands on a pin the viewport already sits on writes
+viewport is perfectly still. A jump to latest that lands on a pin the viewport
+already sits on writes
 nothing at all. Driving the band from scroll events alone left the affordance
 visible over a viewport that was at the tail, and clicking it then had nothing
 to do — an inert button is worse than a missing one.
@@ -348,9 +317,9 @@ definition.** The eased write rides behind the offset it owns, so a burst of
 two or three lines would otherwise drop the viewport out of the band for a few
 frames and flash the affordance over a transcript that is following the newest
 output. Ownership cannot express this: it outlives the loop deliberately, and a
-viewport stranded in the reserved blank under a sleeping loop is the case the
-snap back exists for. A gesture stops the loop before it can hide anything —
-that is what makes reading the loop safe here and reading ownership not.
+viewport resting in the reserved blank is an intentional reader-controlled
+state. A gesture stops the loop before it can hide anything, and no later settle
+step reclaims the viewport.
 
 ## Resizing Anchors the Viewport Bottom
 
@@ -531,25 +500,14 @@ content such as history state and `RuntimeStatusSlot`.
 - A scrollbar drag is recognised from the gutter the bar occupies, so it is
   invisible where the platform draws overlay scrollbars that take no layout
   width — WebKit-backed builds, where `scrollbar-gutter: stable` reserves
-  nothing either. There the drag still fights the frame loop while output
-  streams; it no longer strands the viewport, because the snap back now asks
-  whether follow is correcting rather than whether it owns. Closing the rest
-  means either a signal that does not depend on the bar having a box, or a
-  scrollbar of our own — which would also stop the thumb from reaching the
-  reserved blank at all, and take the empty-range gap below with it.
+  nothing either. There the drag can still fight the frame loop while output
+  streams. Closing it means either a signal that does not depend on the bar
+  having a box, or a scrollbar of our own.
 - A collapse larger than `tailHoldMaxGapPx` still moves the viewport, by the
   excess only.
 - **A reader who scrolls out of the blank and stops at the content end keeps no
-  follow.** Measured, and more common than the case above covers: four of nine
-  watched departures moved almost exactly the blank's height and stopped —
-  `readerMovedPx` −665.3 against a 664px blank, −294.7 against 294.7, −296
-  against 296 — then sat there for up to 2.9s. That is not reading history, it
-  is getting rid of the blank. But it ends the departure as `reader-left-blank`,
-  and the snap back cannot help either, because under a pin the reader is
-  *above* the follow target. Output then accumulates below the bottom edge
-  unseen. Deliberately not covered yet: acting on it means reading intent from a
-  resting position that has content in it, which is the thing the snap back's
-  licence explicitly does not extend to.
+  follow.** Output then accumulates below the bottom edge unseen until an
+  explicit follow entry takes the viewport again.
 - **Paging a long history while still scrolling throws the reading position a
   long way.** Reproduced four times: a session opened on its three-Turn tail
   pages the rest on the first scroll up, the prepend is compensated, and the
@@ -592,8 +550,7 @@ content such as history state and `RuntimeStatusSlot`.
   captured before the reflow. Closing this means sampling an element anchor on
   the scroll path.
 - On a very short transcript the scrollbar exposes a viewport of empty range.
-  The snap back makes this more visible, not less: the range is draggable and
-  bounces back.
+  The range is intentionally draggable and no longer bounces back.
 - The opening reveal has a hard frame cap. A session that pages for longer than
   the cap is revealed mid-settle; raising the cap trades that against a longer
   blank on open.

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
@@ -18,7 +18,7 @@ each missing what the other had.
 |---|---|
 | `flowChatTailFollow.test.ts` | the follow target, `pin-turn-top`, `hold-tail` |
 | `flowChatCollapseMotion.test.ts` | collapse does not move earlier content |
-| `useFlowChatFollowOutput.test.tsx` | the frame loop, snap back, resize realign |
+| `useFlowChatFollowOutput.test.tsx` | the frame loop, user-controlled blank, resize realign |
 | `../../tool-cards/useToolCardHeightContract.test.tsx` | tool cards reflow rather than compensate |
 | `flowChatHistoryBoundary.test.ts` | the screenful lead, and the latch's own predicate |
 | `flowChatLiveTailWindow.test.ts` | "does the transcript still reach the newest Turn" |
@@ -110,21 +110,19 @@ group does not renumber the others.
 2. Expand and collapse a tall tool card near the top of the viewport, and one
    below it, and confirm earlier content stays put in both cases.
 
-### The reserved blank and the snap back
+### The user-controlled reserved blank
 
-1. Scrolling down into the reserved blank and letting go returns to the end of
-   real content, and streaming resumes following from there.
-2. Pressing End scrolls to the bottom of the scroll range and then comes back —
-   that key is the cheapest way to land deep in the spacer.
+1. Scrolling down into the reserved blank and letting go leaves the viewport at
+   the user's chosen offset; it must not return automatically.
+2. Pressing End scrolls to the bottom of the scroll range and stays there until
+   an explicit follow action occurs.
 3. Scroll to the very bottom and confirm the transcript ends where content
    ends, with the reserved blank below it reachable but not where the session
    opens.
-4. Wheel down into the reserved blank and stop. The transcript must return to
-   the content end in one smooth movement, not shudder in place.
-5. With a short Turn pinned, scroll up, jump to latest, then scroll down into
-   the blank and let go. After the snap back the jump-to-latest affordance must
-   be gone — this is the one path where the viewport arrives at the tail
-   without a scroll event to notice it.
+4. Wheel down into the reserved blank and stop. The transcript must remain
+   still and the jump-to-latest affordance must stay available.
+5. With a short Turn pinned, scroll up and jump to latest. The explicit jump
+   must still return to the pin rather than the physical bottom of the spacer.
 
 ### Output catching up with a reader in the blank
 
@@ -152,7 +150,7 @@ group does not renumber the others.
    reservation. Repeat with the composer expanded, which is where the reserve
    falls back to the hold-gap floor.
 2. Drag the scrollbar, without touching the wheel first, down into the reserved
-   blank and let go: it must snap back. Then drag it while output streams: the
+   blank and let go: it must stay there. Then drag it while output streams: the
    transcript must follow the thumb without the frame loop fighting it. A press
    on the thumb that moves nothing must leave the viewport alone.
 
@@ -195,7 +193,7 @@ group does not renumber the others.
    history must load. This is the case where the reader is at the top, so the
    wheel emits no scroll event and the gesture is the only thing to go on.
 6. In an `isPartial` session that paged on open and is now streaming, scroll
-   down into the reserved blank and let the snap back return you. No history
+   down into the reserved blank and use jump-to-latest to return. No history
    status may appear at either end of the transcript — the transcript already
    reaches the newest Turn, so there is nothing past its bottom to load. This
    is the case that showed "preparing the conversation history" under a

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIEWPORT_REGISTER.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIEWPORT_REGISTER.md
@@ -23,15 +23,13 @@ design:
 |---|---|---|
 | 1 | `user-gesture` | 200ms from the last wheel, touch, key, or scrollbar press |
 | 2 | `one-shot-navigation` | a Turn, search hit, or focus request is being reached |
-| 3 | `snap-back` | the return from the reserved blank is animating |
-| 4 | `follow-output` | the continuous writer owns the viewport |
-| 5 | `layout-correction` | the scroller's box changed and a resting viewport is re-aligned |
+| 3 | `follow-output` | the continuous writer owns the viewport |
+| 4 | `layout-correction` | the scroller's box changed and a resting viewport is re-aligned |
 
 The register decides **whether**, never **where** — targets stay with the writer
 that owns them, and the anchor's correction stays idempotent. Ordering answers
 what idempotency cannot: whether a movement was ours on purpose or something to
-be undone. The anchor is idempotent and still destroyed the snap back, because
-it restored a relationship we had deliberately changed.
+be undone.
 
 **Repairing a displacement is not on this list**, and putting it there was a
 mistake worth keeping recorded. The prepend compensation and the viewport anchor
@@ -39,14 +37,9 @@ both use `viewportOwner.shift` — see *A Displacement Is Not a Movement* in
 `FLOWCHAT_HISTORY_PAGING.md`.
 
 **Taking ownership and writing are one call.** Adding a writer without declaring
-it means not using the helper, which is visible in review — where the previous
-scheme needed the new writer added by hand to every other writer's private
-predicate, and a single missed pair was a bug. The failure that made this
-explicit: a snap back was missing from the hand-written predicate that preceded
-the register, so it belonged to nobody while it animated. The snap travelled
-0.7px, the anchor wrote it back, the write cancelled the animation, the
-cancellation read as a gesture coming to rest, and the snap was issued again —
-**958 times over 20 seconds, arriving nowhere**.
+it means not using the helper, which is visible in review — the register keeps
+the deliberate movement owners explicit and leaves user-controlled positions
+alone until another explicit action takes the viewport.
 
 **Only an owner that releases may hold the viewport indefinitely**, and
 follow-output is the only one — a claim with no expiry and no release is a
@@ -71,17 +64,15 @@ at once, so the reveal remains an explicit condition beside the register.
 
 Not everything collapsed into it, and the difference is worth keeping straight.
 `smoothScrollFramesRef` is follow-output yielding to *its own* animation, which
-is intra-owner; `settleFramesRef` is a frame budget; `pendingSnapBackTargetRef`
-still answers "did our snap land here"; `boundaryArmedRef` is paging policy.
+is intra-owner; `settleFramesRef` is a frame budget; `boundaryArmedRef` is paging policy.
 Only the parts that were really answering "is someone else moving the viewport"
 are gone.
 
 ## What Counts as a Gesture
 
 Ordinary `scroll` events do not transfer viewport ownership; only explicit
-wheel, touch, or keyboard navigation exits follow-output. A gesture that comes
-to rest inside the reserved blank hands it back — see *Snapping Back Out of the
-Reserved Blank* in `FLOWCHAT_SCROLL_STABILITY.md`.
+wheel, touch, or keyboard navigation exits follow-output. Once a reader takes
+the viewport, resting inside the reserved blank does not hand it back.
 
 A scrollbar drag is the one exception, and the press is what makes it one: a
 pointer held past the content box's trailing edge is on the bar, so the
@@ -89,9 +80,8 @@ scrolling it causes *is* intent. The press only arms it — `scrollbar-gutter:
 stable` keeps the gutter reserved whether or not a bar is drawn there, so a
 press that scrolls nothing changes nothing. Unqualified, a drag never released
 the viewport: measured on WebView2, follow-output rewrote its target against the
-thumb every frame for a 100px oscillation, and a drag that came to rest in the
-reserved blank was skipped by the snap back because follow still nominally owned
-it — with the frame loop long since asleep, so nothing corrected it.
+thumb every frame for a 100px oscillation. Recognising the drag transfers
+ownership to the reader, and their resting position is preserved.
 
 ## Reaching a Turn Is One Shot
 
@@ -216,8 +206,8 @@ the same switch history paging uses — and tagged `viewport`.
 The second half is the one that pays. A write that never happened leaves nothing
 at the register to find, and "nothing happened" has been the report more often
 than a wrong move has: a deferred new Turn, an anchor whose Turn left the
-rendered window, a snap back declined because the settle belonged to the opening
-reveal, a boundary that never re-armed. Each of those is now one line saying
+rendered window, a boundary declined because the transcript was opening, or a
+boundary that never re-armed. Each of those is now one line saying
 which.
 
 **A placement is recorded with what became of it.** `traceViewportPlacement`
@@ -297,9 +287,8 @@ pnpm run flowchat:log:analyze -- <path-to-flowchat.log> [--around <sequence>]
 `scripts/diagnostics/analyze-flowchat-log.mjs` reports, in this order:
 
 1. **Episodes** of viewport activity, worst *churn* first — travel per pixel of
-   progress. A clean move is 1. The snap back that never arrived would be
-   hundreds, and that number is the difference between "it moved wrongly" and
-   "it fought".
+   progress. A clean move is 1; a much larger number distinguishes "it moved
+   wrongly" from "two writers fought".
 2. **Placements that did not stick**, ranked by drift. A placement with no
    outcome sampled is listed separately rather than counted as clean.
 3. **Refusals**, as owner × who outranked them.

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -184,7 +184,6 @@ vi.mock('./useFlowChatFollowOutput', () => ({
       },
       handleTurnsRolledBack: vi.fn(),
       handleScroll: vi.fn(),
-      handleScrollSettled: vi.fn(),
       handleViewportResize: vi.fn(),
       // Follow owns nothing here, which is what the real hook returns when
       // `isFollowingOutput` is false.
@@ -610,7 +609,7 @@ describe('VirtualMessageList natural scroll contract', () => {
        * Content arriving above the reader cannot push them past the end of the
        * transcript, so needing more than the range can absorb is proof the
        * amount is wrong. Overshooting leaves them inside the reserved blank,
-       * where the snap back correctly returns them to the tail — which, since
+       * where the reserved blank begins — which, since
        * paging happens only while scrolling up, it then does every time.
        */
       const contentEndPx = 1000 - tailSpacerPxForViewport(600, BOTTOM_INSET) - 600;
@@ -779,7 +778,7 @@ describe('VirtualMessageList natural scroll contract', () => {
        * event and the evaluation that hangs off it never runs. The log shows
        * twenty `user-gesture` claims across seven seconds with no scroll event,
        * no anchor capture and not one boundary evaluation; the only evaluations
-       * in that session landed in the three milliseconds after a snap back
+       * in that session landed in the three milliseconds after follow-output
        * handed the viewport to follow-output, and were refused for exactly that
        * reason. Scrolling up did nothing, permanently.
        */
@@ -839,8 +838,8 @@ describe('VirtualMessageList natural scroll contract', () => {
       mocks.items = Array.from({ length: 20 }, (_unused, index) => (
         userMessage(`turn-${index}`, `message-${index}`, 'Body')
       ));
-      // Follow owns the viewport as of the last render — a snap back has just
-      // landed — and the gesture below releases it without a render in between.
+      // Follow owns the viewport as of the last render, and the gesture below
+      // releases it without a render in between.
       mocks.isFollowingOutput = true;
       mocks.followsNow = true;
       const restoreLayout = fakeLayout({

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -92,14 +92,6 @@ const OPEN_REVEAL_QUIET_FRAMES = 2;
 /** Hard cap so the transcript is always revealed, settled or not. */
 const OPEN_REVEAL_MAX_FRAMES = 40;
 /**
- * Quiet period after the last scroll event that stands in for `scrollend`.
- *
- * Only used where the event is missing. It has to outlast the gap between
- * frames of a momentum scroll without making the snap back feel detached from
- * the gesture that caused it.
- */
-const SCROLL_SETTLE_FALLBACK_MS = 140;
-/**
  * Resize callbacks over which a viewport resting at the end is re-aligned after
  * the scroller's own box changes.
  *
@@ -642,7 +634,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     handleUserScrollIntent,
     handleTurnsRolledBack,
     handleScroll,
-    handleScrollSettled,
     handleViewportResize,
     getFollowTargetScrollTop,
   } = useFlowChatFollowOutput({
@@ -815,9 +806,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      *   transcript, so needing more than this is proof the amount is wrong.
      *
      * Overshooting is the expensive direction: it puts the reader below the
-     * content end, where the snap back correctly reads them as parked in the
-     * blank and returns them to the tail — which, since paging happens only
-     * while scrolling up, it then did on every attempt. Undershooting leaves
+     * content end, inside the reserved blank. Undershooting leaves
      * them looking at slightly earlier content, which the anchor removes.
      */
     const contentEndPx = readContentEndScrollTop(scroller);
@@ -842,8 +831,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      * Follow-output is the only holder that can be asleep. Its ownership
      * deliberately outlives its frame loop, so that streaming can resume
      * without re-entering, and the loop stops on its own once the transcript
-     * settles; a navigation's aim and a snap back's animation are both still
-     * running by construction. So a page landing after the settle budget ran
+     * settles; a navigation's aim is still running by construction. So a page
+     * landing after the settle budget ran
      * out is refused by a writer that will never act, and the reader is left
      * holding an offset that now means something else.
      *
@@ -950,9 +939,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
      * Measured on a tail window of three Turns that fitted inside the viewport,
      * so the whole scroll range was reserved blank: twenty gestures over seven
      * seconds produced twenty `user-gesture` claims, no scroll events, and not
-     * one boundary evaluation. The only evaluations in that session landed in
-     * the three milliseconds after each snap back handed the viewport to
-     * follow-output, and were refused for that reason. Nothing could ever page.
+     * one boundary evaluation. Nothing could ever page.
      *
      * After `handleUserScrollIntent`, which clears follow-output's ownership
      * synchronously — so this asks as the reader rather than as our placement.
@@ -1157,49 +1144,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   /*
    * The band's lower edge is whatever the follow rule owns, so it moves when
    * ownership changes — and that can happen with the viewport perfectly still.
-   * A snap back completes at rest by construction, and a jump to latest that
-   * lands on a pin the viewport is already on writes nothing. Neither produces
-   * a scroll event, so without this the affordance stays as the last scroll
+   * A jump to latest that lands on a pin the viewport is already on writes
+   * nothing. That produces no scroll event, so without this the affordance
+   * stays as the last scroll
    * left it: visible, over a viewport that is already at the tail, and inert
    * because clicking it has nothing left to do.
    */
   useEffect(() => {
     updateIsAtBottom();
   }, [isFollowingOutput, updateIsAtBottom]);
-
-  /*
-   * Snap out of the reserved blank once a gesture is over.
-   *
-   * `scrollend` is the accurate signal — it knows when momentum has actually
-   * died, which a quiet timer can only approximate — but it is recent enough
-   * that the WebKit-backed builds may not have it. Where it is missing, a quiet
-   * period after the last scroll event stands in.
-   */
-  useEffect(() => {
-    if (!scrollerElement) return;
-
-    if ('onscrollend' in window) {
-      const handleScrollEnd = () => {
-        handleScrollSettled();
-      };
-      scrollerElement.addEventListener('scrollend', handleScrollEnd, { passive: true });
-      return () => scrollerElement.removeEventListener('scrollend', handleScrollEnd);
-    }
-
-    let settleTimer: number | null = null;
-    const handleScrollTick = () => {
-      if (settleTimer !== null) window.clearTimeout(settleTimer);
-      settleTimer = window.setTimeout(() => {
-        settleTimer = null;
-        handleScrollSettled();
-      }, SCROLL_SETTLE_FALLBACK_MS);
-    };
-    scrollerElement.addEventListener('scroll', handleScrollTick, { passive: true });
-    return () => {
-      if (settleTimer !== null) window.clearTimeout(settleTimer);
-      scrollerElement.removeEventListener('scroll', handleScrollTick);
-    };
-  }, [handleScrollSettled, scrollerElement]);
 
   /*
    * A rollback removed Turns from the session, so the transcript ends somewhere
@@ -1228,9 +1181,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
        * event does carry intent — the press is what qualifies it. Left
        * unqualified, a drag never released the viewport: follow-output kept
        * writing its target every frame against the thumb (measured: a 100px
-       * oscillation, every frame, for as long as the drag lasted), and a drag
-       * that came to rest in the reserved blank was skipped by the snap back
-       * because follow still nominally owned it.
+       * oscillation, every frame, for as long as the drag lasted). Recognising
+       * the drag transfers ownership to the reader and preserves where it ends.
        */
       if (isScrollbarPressRef.current) notifyUserScrollIntent();
       updateIsAtBottom();

--- a/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.test.ts
@@ -11,7 +11,6 @@ import {
   resolveTailDepartureCrossing,
   shouldResumeFollowAfterDeparture,
   tailHoldMaxGapPx,
-  tailSnapBackScrollTop,
   tailSpacerPxForViewport,
   turnTopAlignmentEntersReservedBlank,
   type TailFollowState,
@@ -248,44 +247,6 @@ describe('memorylessFollowState', () => {
       pinScrollTop: 5000,
       maxGapPx: MAX_GAP,
     })).toEqual({ mode: 'hold-tail', target: 5200 });
-  });
-});
-
-describe('tailSnapBackScrollTop', () => {
-  it('returns the follow target when the viewport rests below it', () => {
-    expect(tailSnapBackScrollTop({
-      scrollTop: 4000 + SPACER,
-      followTargetScrollTop: 4000,
-      thresholdPx: THRESHOLD,
-    })).toBe(4000);
-  });
-
-  it('ignores an overshoot inside the tolerance', () => {
-    expect(tailSnapBackScrollTop({
-      scrollTop: 4000 + THRESHOLD,
-      followTargetScrollTop: 4000,
-      thresholdPx: THRESHOLD,
-    })).toBeNull();
-  });
-
-  it('never fires while the user reads history above the target', () => {
-    // Reading upwards is the case the whole rule must stay away from: the
-    // region below the target carries no content, the region above is the
-    // transcript.
-    expect(tailSnapBackScrollTop({
-      scrollTop: 100,
-      followTargetScrollTop: 4000,
-      thresholdPx: THRESHOLD,
-    })).toBeNull();
-  });
-
-  it('leaves a pinned Turn alone even though it sits past the content end', () => {
-    // The pin *is* the target here, so the blank below it is not an overshoot.
-    expect(tailSnapBackScrollTop({
-      scrollTop: 5000,
-      followTargetScrollTop: 5000,
-      thresholdPx: THRESHOLD,
-    })).toBeNull();
   });
 });
 

--- a/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.ts
@@ -204,30 +204,6 @@ export function memorylessFollowState(
   return nextTailFollowState({ mode, target: input.desiredScrollTop }, input);
 }
 
-export interface TailSnapBackInput {
-  scrollTop: number;
-  /** Offset the follow rule owns, from `memorylessFollowTarget`. */
-  followTargetScrollTop: number;
-  thresholdPx: number;
-}
-
-/**
- * Offset to snap back to once a gesture has come to rest below the follow
- * target, or `null` when it has not.
- *
- * Only the region *below* the target qualifies, and that region is the reserved
- * tail spacer. It carries no content, so a gesture ending there can only mean
- * "take me to the end" — the one direction in which reading intent from
- * geometry is unambiguous. Scrolling up to read history can never satisfy this,
- * and neither can a pinned Turn or a held collapse gap, because both are the
- * target rather than a departure from it.
- */
-export function tailSnapBackScrollTop(input: TailSnapBackInput): number | null {
-  return input.scrollTop - input.followTargetScrollTop > input.thresholdPx
-    ? input.followTargetScrollTop
-    : null;
-}
-
 export type TailDepartureCrossing =
   /** The blank is still on screen; nothing has been crossed. */
   | 'watching'
@@ -247,10 +223,9 @@ export type TailDepartureCrossing =
  * below the newest output — nothing hidden from them yet — until output grows
  * past the bottom edge and they silently stop seeing it.
  *
- * Note this is deliberately *not* the predicate `tailSnapBackScrollTop` uses.
- * That one is relative to the follow target, and under a pin the target sits
- * inside the blank, so a reader above it is reported as having nothing to snap
- * back from. These are the two edges of the same region.
+ * The follow target may sit inside the blank while a new Turn is pinned, but
+ * this watch deliberately uses the real content end: it only observes output
+ * catching up with a reader, never a user's resting position.
  *
  * `watching` is a *position*, not a pending outcome: the blank is on screen
  * right now. It says nothing about whether the reader has ever left it, and the

--- a/src/web-ui/src/flow_chat/components/modern/flowChatViewportOwnership.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatViewportOwnership.test.ts
@@ -36,7 +36,6 @@ describe('the order of viewport owners', () => {
     expect(FLOWCHAT_VIEWPORT_OWNERS).toEqual([
       'user-gesture',
       'one-shot-navigation',
-      'snap-back',
       'follow-output',
       'layout-correction',
     ]);
@@ -70,18 +69,6 @@ describe('claimViewport', () => {
     });
     expect(outcome.granted).toBe(true);
     expect(outcome.claim?.owner).toBe('user-gesture');
-  });
-
-  it('refuses a correction while a snap back is animating', () => {
-    // The failure this register exists for: the anchor read the snap's own
-    // travel as a displacement, and the write cancelled the animation. It is
-    // `canShiftViewport` that refuses the anchor now, on the same grounds.
-    const outcome = claimViewport(heldBy('snap-back', { holdForMs: 1_200 }), {
-      owner: 'layout-correction',
-      nowMs: NOW,
-    });
-    expect(outcome.granted).toBe(false);
-    expect(outcome.claim?.owner).toBe('snap-back');
   });
 
   it('leaves the register untouched when it refuses', () => {
@@ -147,11 +134,11 @@ describe('claimViewport', () => {
   it('still resolves a correction against whoever holds the viewport', () => {
     // A zero-length hold is not the absence of a claim: the question it answers
     // is whether the write happens at all.
-    const outcome = claimViewport(heldBy('snap-back', { holdForMs: 1_200 }), {
+    const outcome = claimViewport(null, {
       owner: 'layout-correction',
       nowMs: NOW + 16,
     });
-    expect(outcome.granted).toBe(false);
+    expect(outcome.granted).toBe(true);
   });
 });
 
@@ -172,7 +159,7 @@ describe('canShiftViewport', () => {
     // displacement must cancel the stale animation and be reconsidered.
     expect(canShiftViewport(heldBy('follow-output'), NOW)).toBe(false);
     expect(canShiftViewport(heldBy('one-shot-navigation', { holdForMs: 600 }), NOW)).toBe(false);
-    expect(canShiftViewport(heldBy('snap-back', { holdForMs: 1_200 }), NOW)).toBe(true);
+    expect(canShiftViewport(null, NOW)).toBe(true);
   });
 
   it('shifts an unheld viewport, and one held only by a correction', () => {
@@ -194,7 +181,7 @@ describe('activeViewportClaim', () => {
 
   it('reports nothing once the hold has elapsed', () => {
     // A missed release costs a bounded wait, never a viewport nobody may write.
-    expect(activeViewportClaim(heldBy('snap-back', { holdForMs: 200 }), NOW + 200)).toBeNull();
+    expect(activeViewportClaim(heldBy('user-gesture', { holdForMs: 200 }), NOW + 200)).toBeNull();
   });
 });
 

--- a/src/web-ui/src/flow_chat/components/modern/flowChatViewportOwnership.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatViewportOwnership.ts
@@ -3,10 +3,8 @@
  *
  * Several things move it, and each of them has to know not to fight the
  * others. That was a hand-written predicate per writer, which is O(n²) pairs
- * and fails the moment one is forgotten: a snap back was missing from the
- * anchor's copy, so the anchor undid the snap's own 0.7px of travel, the write
- * cancelled the animation, the cancellation read as a gesture coming to rest,
- * and the snap was re-issued 958 times over 20 seconds without arriving.
+ * and fails the moment one is forgotten: two otherwise valid movements can
+ * fight because one writer was missing from another writer's predicate.
  *
  * The pairs collapse into one register. A writer claims the viewport for as
  * long as it is moving it, and everything else asks the register rather than
@@ -25,7 +23,6 @@
  *
  * - `user-gesture` — the reader's own hands, which nothing overrides.
  * - `one-shot-navigation` — a Turn, search hit, or focus request being reached.
- * - `snap-back` — returning from the reserved blank to the follow target.
  * - `follow-output` — the continuous writer that follows streaming output.
  * - `layout-correction` — the scroller's own box changed and a viewport nobody
  *   was following has to be re-aligned to the end it was resting against.
@@ -49,7 +46,6 @@
 export const FLOWCHAT_VIEWPORT_OWNERS = [
   'user-gesture',
   'one-shot-navigation',
-  'snap-back',
   'follow-output',
   'layout-correction',
 ] as const;
@@ -71,15 +67,6 @@ function priorityOf(owner: FlowChatViewportOwner): number {
  * ends it immediately regardless, which is the rule that matters.
  */
 export const ONE_SHOT_NAVIGATION_HOLD_MS = 600;
-
-/**
- * How long a snap back holds the viewport while it animates.
- *
- * Released on the settle that follows; this is only the backstop for a
- * `scrollend` that never comes, because a snap that is never released would
- * leave the viewport unwritable by everything below it.
- */
-export const SNAP_BACK_HOLD_MS = 1_200;
 
 /**
  * The owners that give the viewport back.
@@ -191,16 +178,10 @@ export function claimViewport(
 /**
  * The owners that hold a target and re-assert it.
  *
- * `follow-output` recomputes its target every frame, a navigation's aim is
- * re-taken by the virtualizer while the measurements under it settle, and a
- * snap back is animating towards a resolved offset. All three already say where
- * the reader belongs, so a displacement applied underneath them is either
- * redundant or a fight.
- *
- * `snap-back` is deliberately not one of them either: a late measurement of
- * history above the reader invalidates the snap target's coordinate. Letting
- * that displacement through cancels the stale animation by changing the real
- * scroll position; the next settle re-evaluates the target from fresh geometry.
+ * `follow-output` recomputes its target every frame, and a navigation's aim is
+ * re-taken by the virtualizer while the measurements under it settle. Both
+ * already say where the reader belongs, so a displacement applied underneath
+ * them is either redundant or a fight.
  * `user-gesture` is deliberately not one of them, and that is the whole point
  * of this being a separate question.
  */

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
@@ -233,7 +233,7 @@ describe('useFlowChatFollowOutput', () => {
      * viewport top, and an 8-Turn session rolled back at Turn 7 came to rest on
      * Turns 2..6 with the new last Turn's answer below the fold.
      *
-     * Taking it is safe for the reason the snap back's is: a rollback at Turn N
+     * Taking it is safe because a rollback at Turn N
      * removes N and everything after it, and N was on screen. The new tail is
      * within a Turn of where the reader already is.
      */
@@ -991,120 +991,8 @@ describe('useFlowChatFollowOutput', () => {
     });
   });
 
-  describe('snapping back out of the reserved blank', () => {
-    /** Places the viewport where a gesture into the tail spacer would leave it. */
-    function restInBlank(scrollTop: number) {
-      scroller.scrollTop = scrollTop;
-      act(() => controller?.handleScrollSettled());
-    }
-
-    it('returns an idle transcript to the end of real content', () => {
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      act(() => {
-        root.render(
-          <Harness
-            latestTurnId="turn-1"
-            isStreaming={false}
-            scroller={scroller}
-            onController={next => { controller = next; }}
-          />,
-        );
-      });
-      act(() => controller?.handleUserScrollIntent());
-
-      restInBlank(1000 + TAIL_SPACER);
-
-      expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
-    });
-
-    it('returns a viewport follow owns but is no longer correcting', () => {
-      /*
-       * Ownership outlives the frame loop by design, so "follow owns this" does
-       * not mean "something is bringing it back". A scrollbar drag reaches this
-       * state on every platform whose scrollbar leaves no gutter to recognise
-       * the press by; before this, the viewport simply stayed in the blank.
-       */
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      act(() => {
-        root.render(
-          <Harness
-            latestTurnId="turn-1"
-            isStreaming={false}
-            scroller={scroller}
-            onController={next => { controller = next; }}
-          />,
-        );
-      });
-      // Run the settle budget out: the loop stops, ownership does not.
-      while (frames.length > 0) runNextFrame();
-      expect(controller?.isFollowingOutput).toBe(true);
-
-      restInBlank(1000 + TAIL_SPACER);
-
-      expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
-    });
-
-    it('leaves a viewport the frame loop is still correcting to the loop', () => {
-      // A live loop reaches its target in one frame; snapping back would only
-      // race it, and with an animation that the next frame would cancel.
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      act(() => {
-        root.render(
-          <Harness
-            latestTurnId="turn-1"
-            scroller={scroller}
-            onController={next => { controller = next; }}
-          />,
-        );
-      });
-      scrollTo.mockClear();
-
-      restInBlank(1000 + TAIL_SPACER);
-
-      expect(scrollTo).not.toHaveBeenCalled();
-    });
-
-    it('returns a short new Turn to the viewport top, not to the content end', () => {
-      // The pin outlives the user takeover on purpose. Snapping to the content
-      // end here would scroll *up* and shove the message the user just sent
-      // into the middle of the viewport.
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1200 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 900,
-      });
-      const props = {
-        scroller,
-        scrollTurnToTop: () => true,
-        resolveTurnTopScrollTop: () => 900,
-        onController: (next: Controller) => { controller = next; },
-      };
-      act(() => {
-        root.render(<Harness {...props} latestTurnId="turn-1" />);
-      });
-      act(() => {
-        root.render(<Harness {...props} latestTurnId="turn-2" />);
-      });
-      act(() => controller?.handleUserScrollIntent());
-
-      restInBlank(1400);
-
-      expect(scrollTo).toHaveBeenCalledWith({ top: 900, behavior: 'smooth' });
-    });
-
-    it('leaves a viewport resting above the target alone', () => {
+  describe('user-controlled reserved blank', () => {
+    it('keeps a reader in the blank after their scroll ends', () => {
       setScrollerMetrics(scroller, {
         scrollHeight: 1500 + TAIL_SPACER,
         clientHeight: VIEWPORT,
@@ -1123,207 +1011,11 @@ describe('useFlowChatFollowOutput', () => {
       act(() => controller?.handleUserScrollIntent());
       scrollTo.mockClear();
 
-      restInBlank(200);
+      scroller.scrollTop = 1000 + TAIL_SPACER;
+      act(() => controller?.handleScroll());
 
+      expect(scroller.scrollTop).toBe(1000 + TAIL_SPACER);
       expect(scrollTo).not.toHaveBeenCalled();
-      expect(controller?.isFollowingOutput).toBe(false);
-    });
-
-    it('hands the viewport back to follow once the snap arrives', () => {
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      act(() => {
-        root.render(
-          <Harness
-            latestTurnId="turn-1"
-            isStreaming={false}
-            scroller={scroller}
-            onController={next => { controller = next; }}
-          />,
-        );
-      });
-      act(() => controller?.handleUserScrollIntent());
-      restInBlank(1000 + TAIL_SPACER);
-
-      restInBlank(1000);
-
-      expect(controller?.isFollowingOutput).toBe(true);
-    });
-
-    it('asks again once the gesture that refused it has lapsed', () => {
-      /*
-       * The gesture's claim is a lapse timer, because a wheel has no end of its
-       * own, and this correction is the one writer that asks from inside that
-       * window — coming to rest is what triggers it. So the first ask is
-       * refused by construction, and the answer is to ask again rather than to
-       * release the hold: a settle also lands *between* two notches of a
-       * gesture still in progress, and forcing the snap through there drags the
-       * reader out of the blank they are scrolling into, every 800ms.
-       *
-       * Measured, the case the retry is for: a wheel at the head of a
-       * three-Turn tail paged in 13 Turns, the compensation moved the reader
-       * 2727px on the virtualizer's estimates, the real heights landed ~1670px
-       * shorter and the browser clamped the offset to the end of the shrunken
-       * range — 841px past the content end, the whole reserved spacer, blank.
-       * The snap back was refused `heldBy: user-gesture` 57ms into a 200ms
-       * hold, and nothing moved for the four minutes that followed.
-       */
-      let owner: FlowChatViewportOwnerApi | null = null;
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      vi.useFakeTimers();
-      try {
-        act(() => {
-          root.render(
-            <Harness
-              latestTurnId="turn-1"
-              isStreaming={false}
-              scroller={scroller}
-              onController={next => { controller = next; }}
-              onViewportOwner={next => { owner = next; }}
-            />,
-          );
-        });
-        act(() => controller?.handleUserScrollIntent());
-        // The wheel, as the list takes it: the reader holds the viewport for
-        // the window the anchor uses, and the settle below lands inside it.
-        act(() => {
-          owner?.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
-        });
-        scrollTo.mockClear();
-
-        restInBlank(1000 + TAIL_SPACER);
-        // Refused, and rightly: as far as the register knows the reader still
-        // has the viewport.
-        expect(scrollTo).not.toHaveBeenCalled();
-
-        act(() => { vi.advanceTimersByTime(USER_DRIVEN_SCROLL_WINDOW_MS + 20); });
-
-        expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it('stops asking rather than chase a reader who keeps scrolling', () => {
-      // Every retry is refused while the reader keeps re-taking the viewport,
-      // and none of them move it. Their own next settle is what asks again.
-      let owner: FlowChatViewportOwnerApi | null = null;
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      vi.useFakeTimers();
-      try {
-        act(() => {
-          root.render(
-            <Harness
-              latestTurnId="turn-1"
-              isStreaming={false}
-              scroller={scroller}
-              onController={next => { controller = next; }}
-              onViewportOwner={next => { owner = next; }}
-            />,
-          );
-        });
-        act(() => controller?.handleUserScrollIntent());
-        act(() => {
-          owner?.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
-        });
-        scrollTo.mockClear();
-        restInBlank(1000 + TAIL_SPACER);
-
-        // Notches inside the window they renew, for longer than the retry
-        // budget covers. This is what a wheel actually looks like: the register
-        // never stops answering with the reader.
-        for (let notch = 0; notch < 16; notch += 1) {
-          act(() => {
-            owner?.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
-            vi.advanceTimersByTime(USER_DRIVEN_SCROLL_WINDOW_MS / 2);
-          });
-        }
-
-        expect(scrollTo).not.toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it('resumes on the end the content has now, not the one the snap aimed at', () => {
-      /*
-       * The snap is animated, and what it was aiming at can move while it
-       * travels — a history page whose items are still measuring is exactly
-       * that, and is also the reason the snap was needed. Resuming on
-       * `scrollTop` adopts the stale offset as the hold rule's memory, and the
-       * hold rule defends a gap rather than closing it.
-       *
-       * Measured on a 43-Turn session paged from a three-Turn tail: issued for
-       * 12336, landed 608ms later against a content end of 11972, and the first
-       * frame after it read `desired 11972, target 12336, onTarget true`. The
-       * reader kept 364px of reserved blank and a Turn cut off at the top.
-       */
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      act(() => {
-        root.render(
-          <Harness
-            latestTurnId="turn-1"
-            isStreaming={false}
-            scroller={scroller}
-            onController={next => { controller = next; }}
-          />,
-        );
-      });
-      act(() => controller?.handleUserScrollIntent());
-      restInBlank(1000 + TAIL_SPACER);
-      expect(scrollTo).toHaveBeenCalledWith({ top: 1000, behavior: 'smooth' });
-
-      // The items measured shorter while the snap travelled, so the end of
-      // content is 300px above where it was aimed.
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1200 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 1000,
-      });
-      restInBlank(1000);
-
-      expect(controller?.isFollowingOutput).toBe(true);
-      // Not 1000, which is inside the gap the hold rule tolerates and would
-      // therefore have been kept for good.
-      expect(controller?.getFollowTargetScrollTop()).toBe(700);
-    });
-
-    it('does not take the viewport back when a gesture overrode the snap', () => {
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1500 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 0,
-      });
-      act(() => {
-        root.render(
-          <Harness
-            latestTurnId="turn-1"
-            isStreaming={false}
-            scroller={scroller}
-            onController={next => { controller = next; }}
-          />,
-        );
-      });
-      act(() => controller?.handleUserScrollIntent());
-      restInBlank(1000 + TAIL_SPACER);
-
-      restInBlank(200);
-
       expect(controller?.isFollowingOutput).toBe(false);
     });
   });
@@ -1490,6 +1182,23 @@ describe('useFlowChatFollowOutput', () => {
       }));
 
       expect(scroller.scrollTop).toBe(200);
+    });
+
+    it('does not pull a user-controlled blank position back to the tail', () => {
+      restAtContentEnd();
+      setScrollerMetrics(scroller, {
+        scrollHeight: 1800 + spacerFor(VIEWPORT),
+        clientHeight: VIEWPORT,
+        scrollTop: 1600,
+      });
+
+      act(() => controller?.handleViewportResize({
+        viewportHeightDeltaPx: 0,
+        wasAtTail: false,
+      }));
+
+      expect(scroller.scrollTop).toBe(1600);
+      expect(controller?.isFollowingOutput).toBe(false);
     });
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -15,8 +15,6 @@ import {
 } from '../../utils/flowChatTailEase';
 import { getMotionAwareScrollBehavior } from '../../utils/motionPreference';
 import type { FlowChatViewportOwnerApi } from './useFlowChatViewportOwner';
-import { USER_DRIVEN_SCROLL_WINDOW_MS } from './flowChatViewportAnchor';
-import { SNAP_BACK_HOLD_MS } from './flowChatViewportOwnership';
 import {
   contentEndScrollTop,
   FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
@@ -27,7 +25,6 @@ import {
   resolveTailDepartureCrossing,
   shouldResumeFollowAfterDeparture,
   tailHoldMaxGapPx,
-  tailSnapBackScrollTop,
   type TailFollowState,
 } from './flowChatTailFollow';
 
@@ -37,7 +34,6 @@ export type FollowOutputEnterReason =
   | 'session-open'
   | 'streaming-resumed'
   | 'tail-caught-up'
-  | 'tail-snap-back'
   | 'turns-rolled-back';
 export type FollowOutputExitReason =
   | 'session-changed'
@@ -130,8 +126,6 @@ interface UseFlowChatFollowOutputResult {
   /** Turns were rolled back out of the session; end on the new tail. */
   handleTurnsRolledBack: () => void;
   handleScroll: () => void;
-  /** A scroll gesture has come to rest; snap out of the reserved blank if in it. */
-  handleScrollSettled: () => void;
   /**
    * The viewport was resized; keep whatever was on the bottom edge there.
    */
@@ -204,27 +198,6 @@ export const SMOOTH_SCROLL_STALL_MS = 120;
  */
 const SETTLE_FRAMES = 90;
 
-/**
- * How long after a refused snap back it is asked for again.
- *
- * One gesture window plus a frame, because the gesture is what refuses it: the
- * claim `notifyUserScrollIntent` takes lapses after `USER_DRIVEN_SCROLL_WINDOW_MS`,
- * and asking before then can only be refused a second time.
- */
-const SNAP_BACK_RETRY_DELAY_MS = USER_DRIVEN_SCROLL_WINDOW_MS + 20;
-
-/**
- * Times a refused snap back is re-asked before it is left to the next settle.
- *
- * A reader who is still scrolling refuses every one of these and does not need
- * them — their own next settle asks again with a fresh budget. This is for the
- * reader who has *stopped* while something else was still moving the transcript
- * under them, where no further scroll event is coming and this is the only
- * thing left that will ask. A second of cover is enough for that; more would
- * just be a timer chasing a viewport nobody is touching.
- */
-const SNAP_BACK_RETRY_ATTEMPTS = 5;
-
 export function useFlowChatFollowOutput({
   activeSessionId,
   latestTurnId,
@@ -276,12 +249,6 @@ export function useFlowChatFollowOutput({
   const smoothScrollLastMoveAtMsRef = useRef(0);
   /** Where the animation started, so the trace can say how far it got. */
   const smoothScrollFromPxRef = useRef(0);
-  const pendingSnapBackTargetRef = useRef<number | null>(null);
-  /** A refused snap back waiting for the hold that refused it to lapse. */
-  const snapBackRetryTimerRef = useRef<number | null>(null);
-  const snapBackRetryAttemptsRef = useRef(0);
-  /** Assigned below, so a retry can re-enter the evaluation that scheduled it. */
-  const evaluateSnapBackRef = useRef<() => void>(() => {});
 
   /*
    * Deliberately *not* mirrored from `isFollowingOutput` here.
@@ -309,13 +276,6 @@ export function useFlowChatFollowOutput({
   isStreamingRef.current = isStreaming;
   isViewportActiveRef.current = isViewportActive;
   latestTurnIdRef.current = latestTurnId;
-
-  const clearSnapBackRetry = useCallback(() => {
-    if (snapBackRetryTimerRef.current !== null) {
-      window.clearTimeout(snapBackRetryTimerRef.current);
-      snapBackRetryTimerRef.current = null;
-    }
-  }, []);
 
   const stopFollowFrame = useCallback(() => {
     if (followFrameRef.current !== null) {
@@ -349,14 +309,13 @@ export function useFlowChatFollowOutput({
   /**
    * Forget which Turn is pinned.
    *
-   * This is the pin's *identity*, not its activity. A user takeover only
-   * suspends the pin — it must survive so that a snap back out of the reserved
-   * blank returns a short new Turn to the viewport top instead of yanking it
-   * into the middle. Only three things retire a pin: the crossover to
-   * `hold-tail`, a newer Turn replacing it, and the session changing. The
-   * crossover is one-way by construction, since nothing re-pins a Turn whose
-   * identity has been dropped; a card collapse that pulls content back under one
-   * viewport must not resurrect the pin.
+   * This is the pin's *identity*, not its activity. A user takeover suspends
+   * the pin, while an explicit jump to latest may still return to it. Only
+   * three things retire a pin: the crossover to `hold-tail`, a newer Turn
+   * replacing it, and the session changing. The crossover is one-way by
+   * construction, since nothing re-pins a Turn whose identity has been
+   * dropped; a card collapse that pulls content back under one viewport must
+   * not resurrect the pin.
    */
   const retirePin = useCallback(() => {
     pinTurnIdRef.current = null;
@@ -393,9 +352,8 @@ export function useFlowChatFollowOutput({
 
   /**
    * The state the follow rule would hold for the current geometry, ignoring any
-   * offset it was holding. Used to decide and to aim a snap back — both of
-   * which happen while the viewport belongs to nobody — and to resume on one
-   * that has landed.
+   * offset it was holding. Used to resolve explicit follow targets and to
+   * resume on the live content end.
    *
    * Retires a pin that has crossed over on the way past: with no frame loop
    * running, this is the only place that crossover can be noticed.
@@ -433,13 +391,9 @@ export function useFlowChatFollowOutput({
    *
    * "Still looking at the blank" is `scrollTop > contentEnd`, because
    * `contentEnd` is by definition the offset that puts the end of real content
-   * on the viewport's bottom edge. Note this is *not* the predicate the snap
-   * back uses: that one is relative to the follow target, and under a pin the
-   * target sits inside the blank, so a reader above it is reported as having
-   * nothing to snap back from. These are the two edges of the same region, and
-   * between them they cover it: the snap back returns a reader who came to rest
-   * *below* the follow target, and this returns one whom output caught up with
-   * from above.
+   * on the viewport's bottom edge. This watch only handles output catching up
+   * with a stationary reader; it never turns a user's resting position into a
+   * follow target.
    *
    * The watch therefore runs for as long as the reader holds the viewport, not
    * for one crossing. `blankWasVisible` is the whole state it keeps between
@@ -786,7 +740,7 @@ export function useFlowChatFollowOutput({
        * converges on the content's growth per frame whatever the fraction is.
        *
        * Only the *write* is eased. `followStateRef` still holds the true
-       * target, so the settle budget, the at-tail band and the snap back all
+       * target, so the settle budget and the at-tail band both
        * keep reading the offset the follow rule owns rather than how far
        * behind its own ease is riding.
        *
@@ -981,33 +935,6 @@ export function useFlowChatFollowOutput({
     const contentEnd = scroller ? readContentEndScrollTop(scroller) : 0;
 
     /*
-     * A snap back has already placed the viewport, so resume ownership without
-     * a second move — but on the offset the follow rule owns *now*, not on the
-     * one the animation stopped at.
-     *
-     * The two are the same only if nothing moved while it travelled, and the
-     * one thing that reliably does is the reason the snap was needed: a history
-     * page whose items are still measuring. Taking `scrollTop` instead adopts
-     * the stale offset as the hold rule's memory, and the hold rule then
-     * defends it — it tolerates a gap below the content end of up to 60% of the
-     * viewport, so the difference is not corrected, it is *kept*.
-     *
-     * Measured on a 43-Turn session paged from a three-Turn tail: the snap was
-     * issued for 12336 while the content end was there, landed 608ms later
-     * against a content end of 11972, and the first follow frame afterwards
-     * read `desired 11972, target 12336, onTarget true` and never moved again.
-     * The reader was left with 364px of reserved blank under the transcript and
-     * the fourth-from-last Turn cut off at the top of the viewport.
-     */
-    if (reason === 'tail-snap-back') {
-      followStateRef.current = scroller
-        ? resolveFollowState(scroller)
-        : { mode: pinTurnIdRef.current ? 'pin-turn-top' : 'hold-tail', target: contentEnd };
-      startFollowFrame();
-      return;
-    }
-
-    /*
      * A pin on the newest Turn already satisfies "show me the latest output".
      * The mode only holds while that Turn's answer is shorter than one
      * viewport, so everything it has produced is on screen; re-aiming at the
@@ -1093,7 +1020,6 @@ export function useFlowChatFollowOutput({
     endSmoothScrollYield,
     readContentEndScrollTop,
     readPinScrollTop,
-    resolveFollowState,
     resolveJumpBehavior,
     retirePin,
     runContentEndScroll,
@@ -1105,8 +1031,8 @@ export function useFlowChatFollowOutput({
 
   /**
    * Release the viewport without forgetting the pin. The user owns it from
-   * here; the pin stays on record so a snap back can restore the mode rather
-   * than fall through to the tail.
+   * here; the pin stays on record so an explicit jump to latest can restore
+   * the mode rather than fall through to the tail.
    */
   const exitFollowOutput = useCallback((reason: FollowOutputExitReason) => {
     /*
@@ -1131,9 +1057,7 @@ export function useFlowChatFollowOutput({
     isFollowingOutputRef.current = false;
     setIsFollowingOutput(false);
     endSmoothScrollYield('superseded');
-    pendingSnapBackTargetRef.current = null;
     viewportOwner.release('follow-output');
-    viewportOwner.release('snap-back');
     stopFollowFrame();
 
     /*
@@ -1213,18 +1137,6 @@ export function useFlowChatFollowOutput({
       contentDeltaPx,
       scrollDeltaPx,
     });
-    /*
-     * A snap back of ours is travelling, so the viewport is moving under a rule
-     * rather than under the reader — and it is travelling *down* through the
-     * blank, which crosses this line from the wrong side. The latch and the
-     * offsets are kept current so the next real sample compares against
-     * something recent; no verdict is taken, because the snap hands the viewport
-     * to follow by its own route the moment it lands.
-     */
-    if (pendingSnapBackTargetRef.current !== null) {
-      watch.blankWasVisible = crossing === 'watching';
-      return;
-    }
     if (crossing === 'watching') {
       watch.blankWasVisible = true;
       return;
@@ -1307,7 +1219,6 @@ export function useFlowChatFollowOutput({
   }, [applyFollowTarget, sampleTailWatch, startFollowFrame]);
 
   const handleUserScrollIntent = useCallback(() => {
-    pendingSnapBackTargetRef.current = null;
     exitFollowOutput('user-scroll');
   }, [exitFollowOutput]);
 
@@ -1320,8 +1231,7 @@ export function useFlowChatFollowOutput({
    * *absence* of the pin: the Turn that was pinned is one of the ones that just
    * stopped existing, and the transcript now ends somewhere else.
    *
-   * This takes the viewport whether or not follow owned it, which is the same
-   * licence the snap back has and rests on the same asymmetry. A rollback at
+   * This takes the viewport whether or not follow owned it. A rollback at
    * Turn N removes N and everything after it, and the reader had N on screen —
    * they clicked its own button. So the new tail is always within a Turn of
    * where they already are, and there is no history below them to be pulled out
@@ -1350,176 +1260,6 @@ export function useFlowChatFollowOutput({
     // handing the viewport back to a reader who is still climbing out of it.
     sampleTailWatch();
   }, [sampleTailWatch]);
-
-  /**
-   * A scroll gesture has come to rest.
-   *
-   * The reserved tail spacer is a full viewport of blank that the user can park
-   * in, and during slow streaming it can take a long time for output to push it
-   * away — with nothing on screen and, until the viewport is back in the tail
-   * band, no jump-to-latest affordance either. So resting below the follow
-   * target snaps back to it and hands the viewport to follow, whether or not
-   * follow owned it before.
-   *
-   * Acting on rest rather than on every scroll event is what keeps this from
-   * fighting momentum: the correction runs after the gesture is over, never
-   * during it.
-   */
-  const evaluateSnapBack = useCallback(() => {
-    const scroller = scrollerRef.current;
-    if (!scroller || !isViewportActiveRef.current) {
-      return;
-    }
-
-    const pendingTarget = pendingSnapBackTargetRef.current;
-    if (pendingTarget !== null) {
-      pendingSnapBackTargetRef.current = null;
-      // The animation is over either way, so the hold ends here rather than
-      // waiting out its backstop.
-      viewportOwner.release('snap-back');
-      // Take the viewport back only if our own snap is what landed it here. A
-      // gesture that overrode the animation mid-flight belongs to the user.
-      const arrived = Math.abs(scroller.scrollTop - pendingTarget)
-        <= FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX;
-      traceViewportRepeating(`snapBack|settled|${arrived}`, {
-        location: 'snapBack.settled',
-        message: arrived
-          ? 'snap back arrived and handed the viewport to follow'
-          : 'snap back was overridden before it arrived',
-        data: () => ({
-          targetPx: roundViewportPx(pendingTarget),
-          scrollTopPx: roundViewportPx(scroller.scrollTop),
-        }),
-      });
-      if (arrived) {
-        enterFollowOutput('tail-snap-back');
-        return;
-      }
-    }
-
-    /*
-     * Ownership is not correction, and the difference is deliberate — see
-     * `isFollowCorrectingViewport`.
-     *
-     * A live loop still gets the viewport to itself. It converges on its target
-     * within a few frames, so a snap back would only be racing it.
-     */
-    const isCorrecting = isFollowCorrectingViewport();
-    if (isCorrecting || isOpeningViewport()) {
-      // "The wheel went down and nothing brought me back" is this line or the
-      // one below it, and they are not the same fault.
-      traceViewportRepeating(
-        `snapBack|declined|${isCorrecting ? 'follow-correcting' : 'opening'}`,
-        {
-          location: 'snapBack.declined',
-          message: 'gesture came to rest, but the snap back is not this settle\'s business',
-          data: () => ({
-            reason: isCorrecting ? 'follow-correcting' : 'opening-reveal',
-            scrollTopPx: roundViewportPx(scroller.scrollTop),
-          }),
-        },
-      );
-      return;
-    }
-
-    const followTarget = resolveFollowTargetScrollTop(scroller);
-    const snapTo = tailSnapBackScrollTop({
-      scrollTop: scroller.scrollTop,
-      followTargetScrollTop: followTarget,
-      thresholdPx: FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
-    });
-    if (snapTo === null) {
-      traceViewportRepeating('snapBack|not-in-blank', {
-        location: 'snapBack.notNeeded',
-        message: 'gesture came to rest above the follow target, so nothing to snap back from',
-        data: () => ({
-          scrollTopPx: roundViewportPx(scroller.scrollTop),
-          followTargetPx: roundViewportPx(followTarget),
-        }),
-      });
-      return;
-    }
-
-    /*
-     * Held for the animation, not just the write. Ownership passing to
-     * follow-output only on landing is what left the snap belonging to nobody
-     * while it travelled, and the anchor undid its first 0.7px 958 times.
-     */
-    const issued = viewportOwner.write({
-      owner: 'snap-back',
-      topPx: snapTo,
-      behavior: getMotionAwareScrollBehavior('smooth'),
-      holdForMs: SNAP_BACK_HOLD_MS,
-    });
-    traceViewportRepeating(`snapBack|issued|${issued}`, {
-      location: 'snapBack.issued',
-      message: issued ? 'snap back is on its way' : 'snap back was refused the viewport',
-      data: () => ({
-        fromPx: roundViewportPx(scroller.scrollTop),
-        targetPx: roundViewportPx(snapTo),
-        followTargetPx: roundViewportPx(followTarget),
-        // Who refused it. The gesture is the one that lapses on a timer, and
-        // the retry below is aimed at exactly that.
-        heldBy: viewportOwner.currentOwner(),
-        attempt: snapBackRetryAttemptsRef.current,
-      }),
-    });
-    if (issued) {
-      pendingSnapBackTargetRef.current = snapTo;
-      return;
-    }
-
-    /*
-     * A refused snap back is still owed, so ask again rather than give up.
-     *
-     * What refuses it is almost always the reader's own gesture, and that claim
-     * is a lapse timer — a wheel has no end of its own, so the register goes on
-     * answering with them for a window after each notch. This correction is the
-     * one writer that asks from inside that window, because coming to rest is
-     * what triggers it.
-     *
-     * Which is also why the hold must not simply be released here. Tried, and
-     * measured: a settle lands between two wheel notches, so releasing put the
-     * snap back in the middle of a gesture that was still going — the reader
-     * scrolled down into the reserved blank and was dragged back out of it
-     * every 800ms, a dozen times, which is the transcript stuttering under
-     * their hands. The hold was doing its job; what was missing was a second
-     * ask once it had done it.
-     *
-     * So the ask repeats while the refusal is the kind that expires. A reader
-     * still scrolling keeps re-taking the viewport and keeps being answered
-     * with a refusal that moves nothing, and their next settle re-arms the
-     * whole thing anyway; a reader who has stopped is snapped back one window
-     * after their last notch.
-     */
-    if (snapBackRetryAttemptsRef.current >= SNAP_BACK_RETRY_ATTEMPTS) {
-      return;
-    }
-    snapBackRetryAttemptsRef.current += 1;
-    clearSnapBackRetry();
-    snapBackRetryTimerRef.current = window.setTimeout(() => {
-      snapBackRetryTimerRef.current = null;
-      evaluateSnapBackRef.current();
-    }, SNAP_BACK_RETRY_DELAY_MS);
-  }, [
-    clearSnapBackRetry,
-    viewportOwner,
-    enterFollowOutput,
-    isFollowCorrectingViewport,
-    isOpeningViewport,
-    resolveFollowTargetScrollTop,
-    scrollerRef,
-  ]);
-  evaluateSnapBackRef.current = evaluateSnapBack;
-
-  const handleScrollSettled = useCallback(() => {
-    // A settle of the reader's own is a fresh ask, not a continuation of the
-    // last one: it gets the full retry budget, and supersedes what is left of
-    // the previous one.
-    snapBackRetryAttemptsRef.current = 0;
-    clearSnapBackRetry();
-    evaluateSnapBack();
-  }, [clearSnapBackRetry, evaluateSnapBack]);
 
   const getFollowTargetScrollTop = useCallback(() => (
     isFollowingOutputRef.current ? followStateRef.current.target : null
@@ -1604,16 +1344,6 @@ export function useFlowChatFollowOutput({
       return;
     }
 
-    // Whatever left the viewport below the target — a reflow, or a gesture that
-    // never settled — it must not stay there.
-    const snapTo = tailSnapBackScrollTop({
-      scrollTop: scroller.scrollTop,
-      followTargetScrollTop: followTarget,
-      thresholdPx: FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
-    });
-    if (snapTo !== null) {
-      viewportOwner.write({ owner: 'layout-correction', topPx: snapTo });
-    }
   }, [resolveFollowTargetScrollTop, scrollerRef, viewportOwner]);
 
   useEffect(() => {
@@ -1730,7 +1460,6 @@ export function useFlowChatFollowOutput({
   }, [scheduleFollowToLatest]);
 
   useEffect(() => stopFollowFrame, [stopFollowFrame]);
-  useEffect(() => clearSnapBackRetry, [clearSnapBackRetry]);
   // A watch the transcript outlived is not an outcome, and leaving it open
   // would drop it from the trail entirely.
   useEffect(() => () => closeTailWatchRef.current('unmounted'), []);
@@ -1745,7 +1474,6 @@ export function useFlowChatFollowOutput({
     handleUserScrollIntent,
     handleTurnsRolledBack,
     handleScroll,
-    handleScrollSettled,
     handleViewportResize,
     getFollowTargetScrollTop,
   };

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.ts
@@ -143,7 +143,7 @@ export interface FlowChatViewportAnchorApi {
    *   delivered after the intent window closed.
    * - **Left alone**, when a registered writer owns the viewport. That
    *   movement is theirs and crediting it to the reader would drag the anchor
-   *   along with every follow, snap back and aim.
+   *   along with every follow and aim.
    */
   captureAnchorForScroll: () => void;
   /** The user did something that scrolls, by their own hand. */
@@ -454,7 +454,7 @@ export function useFlowChatViewportAnchor({
      * Owned elsewhere is the case this must not touch. A registered writer
      * moving the viewport is the one other thing that changes `scrollTop`
      * without the reader, and crediting *that* to them would carry the anchor
-     * along with every follow, snap back and aim.
+     * along with every follow and aim.
      */
     if (!isViewportOwnedElsewhereRef.current()) {
       carryAnchorThroughScroll(scroller, 'unclaimed-scroll');

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportOwner.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportOwner.ts
@@ -37,7 +37,7 @@ export interface ViewportWriteRequest {
    * Omitted holds it for the frame the write happens in, which is what a
    * correction wants. An animated write has to outlast its own animation, or
    * the first frame of travel is read as a displacement by whatever corrects
-   * next — see the snap back in `FLOWCHAT_SCROLL_STABILITY.md`.
+ * next — see the follow and viewport rules in `FLOWCHAT_SCROLL_STABILITY.md`.
    */
   holdForMs?: number;
 }


### PR DESCRIPTION
Remove automatic snap-back when the user scrolls into the reserved
blank below the conversation tail.

- Preserve explicit session, rollback, navigation, and tail alignment
- Keep tail-follow recovery when output catches up with the reader
- Update viewport ownership tests and FlowChat behavior documentation
