### PR TITLE
feat(image): add resolution budget presets to image tools

### DIFF
--- a/src/crates/assembly/core/src/agentic/image_analysis/image_processing.rs
+++ b/src/crates/assembly/core/src/agentic/image_analysis/image_processing.rs
@@ -216,12 +216,165 @@ pub fn optimize_image_with_size_limit(
         });
     }
 
-    let mut working = if needs_resize {
+    let working = if needs_resize {
         dynamic.resize(limits.max_width, limits.max_height, FilterType::Triangle)
     } else {
         dynamic
     };
 
+    let (data, mime_type, width, height) =
+        encode_within_size_budget(working, guessed_format, effective_max)?;
+
+    Ok(ProcessedImage {
+        data,
+        mime_type,
+        width,
+        height,
+        original_width: orig_width,
+        original_height: orig_height,
+    })
+}
+
+/// Resolution presets for the image-workflow budget path.
+///
+/// Following the Qwen-VL dynamic-resolution convention, each preset maps to a
+/// visual-token budget and one token covers a 32x32 patch, so a preset's pixel
+/// budget is `tokens * 32^2` (~512^2 / ~1024^2 / ~1448^2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageBudget {
+    /// Cheap preview (~512x512).
+    Small,
+    /// Default (~1024x1024).
+    Normal,
+    /// Fine detail (~1448x1448).
+    Large,
+}
+
+impl ImageBudget {
+    /// Visual-token budget for this preset.
+    pub const fn tokens(self) -> u32 {
+        match self {
+            Self::Small => 256,
+            Self::Normal => 1024,
+            Self::Large => 2048,
+        }
+    }
+
+    /// Pixel budget for this preset (tokens x 32^2).
+    pub const fn target_pixels(self) -> u64 {
+        (self.tokens() as u64) * (TOKEN_SIZE as u64) * (TOKEN_SIZE as u64)
+    }
+}
+
+const TOKEN_SIZE: u32 = 32;
+
+/// Budget-aware image optimization.
+///
+/// `budget` picks the pixel target; sources larger than the target are
+/// downscaled to it (downscale only — small images pass through untouched).
+/// Provider `ImageLimits` remain a hard ceiling on top of the budget target,
+/// including the per-dimension width/height caps. Images that already fit the
+/// budget, the provider dimensions, and the byte cap are returned unchanged so
+/// their original format (including animation) is preserved; anything that must
+/// change is re-encoded through the shared encoder, which emits PNG or JPEG.
+pub fn optimize_image_for_budget(
+    image_data: Vec<u8>,
+    provider: &str,
+    fallback_mime: Option<&str>,
+    budget: ImageBudget,
+    max_output_size: Option<usize>,
+) -> BitFunResult<ProcessedImage> {
+    let limits = ImageLimits::for_provider(provider);
+    let effective_max = match max_output_size {
+        Some(cap) => cap.min(limits.max_size),
+        None => limits.max_size,
+    };
+
+    let guessed_format = image::guess_format(&image_data).ok();
+    let dynamic = image::load_from_memory(&image_data)
+        .map_err(|e| BitFunError::validation(format!("Failed to decode image data: {}", e)))?;
+
+    let (orig_width, orig_height) = (dynamic.width(), dynamic.height());
+    let orig_area = u64::from(orig_width) * u64::from(orig_height);
+
+    // The budget target never overrides the provider's dimension ceiling.
+    let provider_cap_pixels = u64::from(limits.max_width) * u64::from(limits.max_height);
+    let target_pixels = budget.target_pixels().min(provider_cap_pixels);
+
+    // Preserve untouched images byte-for-byte instead of needlessly
+    // re-encoding, mirroring the legacy fast path. This also keeps animated or
+    // non-PNG/JPEG sources from being flattened into a static PNG.
+    if orig_area <= target_pixels
+        && orig_width <= limits.max_width
+        && orig_height <= limits.max_height
+        && image_data.len() <= effective_max
+    {
+        let mime_type = detect_mime_type_from_bytes(&image_data, fallback_mime)?;
+        return Ok(ProcessedImage {
+            data: image_data,
+            mime_type,
+            width: orig_width,
+            height: orig_height,
+            original_width: orig_width,
+            original_height: orig_height,
+        });
+    }
+
+    let mut working = dynamic;
+    if orig_area > target_pixels {
+        working = fit_within_area(working, target_pixels);
+    }
+    // The area fit preserves aspect ratio but can still leave one edge longer
+    // than the provider allows (for example wide panoramas). Enforce the
+    // per-dimension ceiling the same way the legacy provider-fit path does.
+    working = fit_within_dimensions(working, limits.max_width, limits.max_height);
+
+    let (data, mime_type, width, height) =
+        encode_within_size_budget(working, guessed_format, effective_max)?;
+
+    Ok(ProcessedImage {
+        data,
+        mime_type,
+        width,
+        height,
+        original_width: orig_width,
+        original_height: orig_height,
+    })
+}
+
+/// Aspect-preserving fit within a pixel budget (downscale only).
+fn fit_within_area(img: DynamicImage, max_pixels: u64) -> DynamicImage {
+    let area = u64::from(img.width()) * u64::from(img.height());
+    if area <= max_pixels {
+        return img;
+    }
+
+    let scale = (max_pixels as f64 / area as f64).sqrt();
+    let width = ((img.width() as f64) * scale).round().max(1.0) as u32;
+    let height = ((img.height() as f64) * scale).round().max(1.0) as u32;
+    img.resize(width, height, FilterType::Triangle)
+}
+
+/// Aspect-preserving fit within per-dimension limits (downscale only).
+///
+/// The pixel-area budget alone does not bound either edge, so an elongated
+/// source can still exceed `max_width` or `max_height` after the area fit.
+fn fit_within_dimensions(img: DynamicImage, max_width: u32, max_height: u32) -> DynamicImage {
+    if img.width() <= max_width && img.height() <= max_height {
+        return img;
+    }
+    img.resize(max_width, max_height, FilterType::Triangle)
+}
+
+/// Encode `working` within `effective_max` bytes using the shared quality
+/// ladder (85 -> 80/65/50/35) and, when still oversized, repeated 0.75x
+/// downscales (70/55/40/25). Returns the encoded bytes, mime type, and the
+/// final dimensions the model actually sees.
+fn encode_within_size_budget(
+    mut working: DynamicImage,
+    guessed_format: Option<ImageFormat>,
+    effective_max: usize,
+) -> BitFunResult<(Vec<u8>, String, u32, u32)> {
     let preferred_format = match guessed_format {
         Some(ImageFormat::Jpeg) => ImageFormat::Jpeg,
         _ => ImageFormat::Png,
@@ -261,14 +414,7 @@ pub fn optimize_image_with_size_limit(
         }
     }
 
-    Ok(ProcessedImage {
-        data: encoded.0,
-        mime_type: encoded.1,
-        width: working.width(),
-        height: working.height(),
-        original_width: orig_width,
-        original_height: orig_height,
-    })
+    Ok((encoded.0, encoded.1, working.width(), working.height()))
 }
 
 pub fn build_multimodal_message(
@@ -594,5 +740,141 @@ mod resize_reporting_tests {
         );
         assert!(!processed.was_resized());
         assert!((processed.scale() - 1.0).abs() < f64::EPSILON);
+    }
+}
+
+/// Budget-preset semantics: token budgets map to pixel targets, small images
+/// pass through untouched (downscale-only), and the provider's dimension
+/// ceiling never yields to the budget.
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+
+    fn png_of(width: u32, height: u32) -> Vec<u8> {
+        let img =
+            image::DynamicImage::ImageRgb8(image::RgbImage::from_fn(width, height, |x, y| {
+                image::Rgb([(x % 251) as u8, (y % 253) as u8, ((x ^ y) % 247) as u8])
+            }));
+        let mut out = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut out, ImageFormat::Png)
+            .expect("encode test png");
+        out.into_inner()
+    }
+
+    /// Each preset maps to a visual-token budget (32x32 patches per token):
+    /// 256/1024/2048 tokens ~ 512^2 / 1024^2 / 1448^2 pixels.
+    #[test]
+    fn budget_presets_map_to_token_budgets() {
+        assert_eq!(ImageBudget::Small.tokens(), 256);
+        assert_eq!(ImageBudget::Normal.tokens(), 1024);
+        assert_eq!(ImageBudget::Large.tokens(), 2048);
+
+        assert_eq!(ImageBudget::Small.target_pixels(), 256 * 32 * 32);
+        assert_eq!(ImageBudget::Normal.target_pixels(), 1024 * 32 * 32);
+        assert_eq!(ImageBudget::Large.target_pixels(), 2048 * 32 * 32);
+    }
+
+    /// A source larger than the preset target is downscaled to roughly the
+    /// target area, keeping the aspect ratio.
+    #[test]
+    fn a_large_image_is_downscaled_to_the_budget_target() {
+        let processed = optimize_image_for_budget(
+            png_of(3000, 2000),
+            "openai",
+            Some("image/png"),
+            ImageBudget::Small,
+            Some(1024 * 1024),
+        )
+        .expect("optimize");
+
+        assert_eq!(
+            (processed.original_width, processed.original_height),
+            (3000, 2000)
+        );
+        assert!(processed.was_resized());
+        assert!(processed.scale() < 1.0);
+        let area = u64::from(processed.width) * u64::from(processed.height);
+        assert!(
+            area <= ImageBudget::Small.target_pixels()
+                + u64::from(processed.width + processed.height),
+            "{}x{} exceeds the small budget",
+            processed.width,
+            processed.height
+        );
+        // Aspect ratio preserved (1.5).
+        let ratio = f64::from(processed.width) / f64::from(processed.height);
+        assert!((ratio - 1.5).abs() < 0.01, "ratio drifted to {ratio}");
+    }
+
+    /// The budget path is downscale-only: a small image passes through
+    /// untouched, never upscaled to fill the budget.
+    #[test]
+    fn a_small_image_is_not_upscaled_to_fill_the_budget() {
+        let processed = optimize_image_for_budget(
+            png_of(64, 64),
+            "openai",
+            Some("image/png"),
+            ImageBudget::Normal,
+            None,
+        )
+        .expect("optimize");
+
+        assert_eq!((processed.width, processed.height), (64, 64));
+        assert!(!processed.was_resized());
+        assert!((processed.scale() - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// The budget target never exceeds the provider's dimension ceiling. All
+    /// current providers cap above even the large budget (2048^2 pixels), so
+    /// this asserts the large budget is honored without the ceiling yielding
+    /// first; the min() guard stays as defense for tighter future providers.
+    #[test]
+    fn the_budget_target_never_exceeds_the_provider_ceiling() {
+        let processed = optimize_image_for_budget(
+            png_of(5000, 5000),
+            "openai",
+            Some("image/png"),
+            ImageBudget::Large,
+            None,
+        )
+        .expect("optimize");
+
+        let provider_cap = u64::from(ImageLimits::for_provider("openai").max_width)
+            * u64::from(ImageLimits::for_provider("openai").max_height);
+        let area = u64::from(processed.width) * u64::from(processed.height);
+        assert!(
+            area <= ImageBudget::Large.target_pixels().min(provider_cap)
+                + u64::from(processed.width + processed.height)
+        );
+        assert!(processed.was_resized());
+    }
+
+    /// A wide source can fit the pixel budget yet still exceed the provider's
+    /// per-dimension ceiling; the budget path must bound the long edge too.
+    #[test]
+    fn a_wide_image_is_also_capped_by_the_provider_dimensions() {
+        let processed = optimize_image_for_budget(
+            png_of(10000, 500),
+            "anthropic",
+            Some("image/png"),
+            ImageBudget::Normal,
+            None,
+        )
+        .expect("optimize");
+
+        let limits = ImageLimits::for_provider("anthropic");
+        assert!(
+            processed.width <= limits.max_width,
+            "width {} exceeds provider max_width {}",
+            processed.width,
+            limits.max_width
+        );
+        assert!(
+            processed.height <= limits.max_height,
+            "height {} exceeds provider max_height {}",
+            processed.height,
+            limits.max_height
+        );
+        assert!(processed.was_resized());
     }
 }

--- a/src/crates/assembly/core/src/agentic/image_analysis/mod.rs
+++ b/src/crates/assembly/core/src/agentic/image_analysis/mod.rs
@@ -10,9 +10,10 @@ pub mod types;
 pub use enhancer::MessageEnhancer;
 pub use image_processing::{
     build_multimodal_message, build_multimodal_message_with_images, decode_data_url,
-    detect_mime_type_from_bytes, load_image_from_path, optimize_image_for_provider,
-    optimize_image_with_size_limit, process_image_contexts_for_provider, resolve_image_path,
-    resolve_vision_model_from_ai_config, resolve_vision_model_from_global_config, ProcessedImage,
+    detect_mime_type_from_bytes, load_image_from_path, optimize_image_for_budget,
+    optimize_image_for_provider, optimize_image_with_size_limit,
+    process_image_contexts_for_provider, resolve_image_path, resolve_vision_model_from_ai_config,
+    resolve_vision_model_from_global_config, ImageBudget, ProcessedImage,
 };
 pub use processor::ImageAnalyzer;
 pub use types::*;

--- a/src/crates/assembly/core/src/agentic/tools/implementations/analyze_image_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/analyze_image_tool.rs
@@ -1,6 +1,6 @@
 use crate::agentic::image_analysis::{
-    build_multimodal_message, detect_mime_type_from_bytes, optimize_image_with_size_limit,
-    resolve_vision_model_from_global_config,
+    build_multimodal_message, detect_mime_type_from_bytes, optimize_image_for_budget,
+    optimize_image_with_size_limit, resolve_vision_model_from_global_config, ImageBudget,
 };
 use crate::agentic::tools::framework::{
     Tool, ToolExposure, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
@@ -56,6 +56,56 @@ impl AnalyzeImageTool {
             .filter(|prompt| !prompt.is_empty())
             .unwrap_or("Analyze this image in detail. Describe visible content, text, layout, and any details relevant to the user's task.")
             .to_string()
+    }
+
+    fn budget_from_input(input: &Value) -> Option<ImageBudget> {
+        match input.get("budget").and_then(Value::as_str) {
+            Some("small") => Some(ImageBudget::Small),
+            Some("normal") => Some(ImageBudget::Normal),
+            Some("large") => Some(ImageBudget::Large),
+            _ => None,
+        }
+    }
+
+    fn validate_budget(input: &Value) -> BitFunResult<()> {
+        match input.get("budget") {
+            None | Some(Value::Null) => Ok(()),
+            Some(Value::String(value)) => match value.as_str() {
+                "small" | "normal" | "large" => Ok(()),
+                other => Err(BitFunError::tool(format!(
+                    "analyze_image.budget must be one of `small`, `normal`, or `large`; got `{}`",
+                    other
+                ))),
+            },
+            Some(_) => Err(BitFunError::tool(
+                "analyze_image.budget must be a string when provided".to_string(),
+            )),
+        }
+    }
+
+    /// Input schema. Carries the optional `budget` resolution preset; omitting
+    /// it keeps the legacy provider-fit behavior.
+    fn schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the image file. Use an absolute local path, a workspace-relative path, or an exact bitfun:// URI."
+                },
+                "prompt": {
+                    "type": "string",
+                    "description": "Optional question or instruction for the image understanding model."
+                },
+                "budget": {
+                    "type": "string",
+                    "enum": ["small", "normal", "large"],
+                    "description": "Optional resolution preset: small (~512x512, cheap preview), normal (~1024x1024, default), large (~1448x1448, fine detail). Omit for provider-fit behavior."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
     }
 
     fn resolve_path(
@@ -177,21 +227,7 @@ impl Tool for AnalyzeImageTool {
     }
 
     fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Path to the image file. Use an absolute local path, a workspace-relative path, or an exact bitfun:// URI."
-                },
-                "prompt": {
-                    "type": "string",
-                    "description": "Optional question or instruction for the image understanding model."
-                }
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
+        Self::schema()
     }
 
     fn is_readonly(&self) -> bool {
@@ -207,6 +243,15 @@ impl Tool for AnalyzeImageTool {
         input: &Value,
         context: Option<&ToolUseContext>,
     ) -> ValidationResult {
+        if let Err(err) = Self::validate_budget(input) {
+            return ValidationResult {
+                result: false,
+                message: Some(err.to_string()),
+                error_code: Some(400),
+                meta: None,
+            };
+        }
+
         let input_path = match Self::path_from_input(input) {
             Ok(path) => path,
             Err(err) => {
@@ -322,6 +367,7 @@ impl Tool for AnalyzeImageTool {
         input: &Value,
         context: &ToolUseContext,
     ) -> BitFunResult<Vec<ToolResult>> {
+        Self::validate_budget(input)?;
         let input_path = Self::path_from_input(input)?;
         let prompt = Self::prompt_from_input(input);
         let resolved = Self::resolve_path(input_path, Some(context))?;
@@ -330,13 +376,23 @@ impl Tool for AnalyzeImageTool {
             .map_err(|err| BitFunError::tool(format!("unsupported image file: {}", err)))?;
 
         let vision_model = resolve_vision_model_from_global_config().await?;
-        let processed = optimize_image_with_size_limit(
-            bytes,
-            &vision_model.provider,
-            Some(&original_mime_type),
-            Some(1024 * 1024),
-        )
-        .map_err(|err| BitFunError::tool(format!("unable to prepare image: {}", err)))?;
+        let processed = match Self::budget_from_input(input) {
+            Some(budget) => optimize_image_for_budget(
+                bytes,
+                &vision_model.provider,
+                Some(&original_mime_type),
+                budget,
+                Some(1024 * 1024),
+            )
+            .map_err(|err| BitFunError::tool(format!("unable to prepare image: {}", err)))?,
+            None => optimize_image_with_size_limit(
+                bytes,
+                &vision_model.provider,
+                Some(&original_mime_type),
+                Some(1024 * 1024),
+            )
+            .map_err(|err| BitFunError::tool(format!("unable to prepare image: {}", err)))?,
+        };
 
         let messages = build_multimodal_message(
             &prompt,
@@ -419,5 +475,22 @@ Divide by that factor to map anything in `analysis` back to source pixels — bu
                 analysis
             )),
         )])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AnalyzeImageTool;
+    use crate::agentic::tools::framework::Tool;
+    use serde_json::json;
+
+    #[test]
+    fn analyze_image_schema_carries_the_optional_budget_preset() {
+        let schema = AnalyzeImageTool::new().input_schema();
+        assert_eq!(
+            schema["properties"]["budget"]["enum"],
+            json!(["small", "normal", "large"])
+        );
+        assert_eq!(schema["required"], json!(["path"]));
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/view_image_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/view_image_tool.rs
@@ -1,4 +1,6 @@
-use crate::agentic::image_analysis::{optimize_image_for_provider, ImageLimits};
+use crate::agentic::image_analysis::{
+    optimize_image_for_budget, optimize_image_for_provider, ImageBudget, ImageLimits,
+};
 use crate::agentic::tools::framework::{
     Tool, ToolExposure, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
 };
@@ -110,6 +112,57 @@ impl ViewImageTool {
                 "view_image.detail must be the string `original` when provided".to_string(),
             )),
         }
+    }
+
+    fn validate_budget(input: &Value) -> BitFunResult<()> {
+        match input.get("budget") {
+            None | Some(Value::Null) => Ok(()),
+            Some(Value::String(value)) => match value.as_str() {
+                "small" | "normal" | "large" => Ok(()),
+                other => Err(BitFunError::tool(format!(
+                    "view_image.budget must be one of `small`, `normal`, or `large`; got `{}`",
+                    other
+                ))),
+            },
+            Some(_) => Err(BitFunError::tool(
+                "view_image.budget must be a string when provided".to_string(),
+            )),
+        }
+    }
+
+    fn budget_from_input(input: &Value) -> Option<ImageBudget> {
+        match input.get("budget").and_then(Value::as_str) {
+            Some("small") => Some(ImageBudget::Small),
+            Some("normal") => Some(ImageBudget::Normal),
+            Some("large") => Some(ImageBudget::Large),
+            _ => None,
+        }
+    }
+
+    /// Input schema. Carries the optional `budget` resolution preset; omitting
+    /// it keeps the legacy provider-fit behavior.
+    fn schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to an image file. Use an absolute local path, a workspace-relative path, or an exact bitfun:// URI returned by another tool."
+                },
+                "detail": {
+                    "type": "string",
+                    "enum": ["original"],
+                    "description": "Optional detail override. Supported value: original. BitFun preserves image detail when possible and may optimize bytes to fit the active provider limits."
+                },
+                "budget": {
+                    "type": "string",
+                    "enum": ["small", "normal", "large"],
+                    "description": "Optional resolution preset: small (~512x512, cheap preview), normal (~1024x1024, default), large (~1448x1448, fine detail). Omit for provider-fit behavior."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
     }
 
     fn resolve_path(
@@ -231,22 +284,7 @@ impl Tool for ViewImageTool {
     }
 
     fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Path to an image file. Use an absolute local path, a workspace-relative path, or an exact bitfun:// URI returned by another tool."
-                },
-                "detail": {
-                    "type": "string",
-                    "enum": ["original"],
-                    "description": "Optional detail override. Supported value: original. BitFun preserves image detail when possible and may optimize bytes to fit the active provider limits."
-                }
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
+        Self::schema()
     }
 
     async fn is_available_in_context(&self, context: Option<&ToolUseContext>) -> bool {
@@ -269,6 +307,15 @@ impl Tool for ViewImageTool {
         context: Option<&ToolUseContext>,
     ) -> ValidationResult {
         if let Err(err) = Self::validate_detail(input) {
+            return ValidationResult {
+                result: false,
+                message: Some(err.to_string()),
+                error_code: Some(400),
+                meta: None,
+            };
+        }
+
+        if let Err(err) = Self::validate_budget(input) {
             return ValidationResult {
                 result: false,
                 message: Some(err.to_string()),
@@ -382,16 +429,27 @@ impl Tool for ViewImageTool {
     ) -> BitFunResult<Vec<ToolResult>> {
         Self::require_multimodal_tool_output(context)?;
         Self::validate_detail(input)?;
+        Self::validate_budget(input)?;
 
         let input_path = Self::path_from_input(input)?;
         let path = Self::resolve_path(input_path, Some(context))?;
         let bytes = Self::read_image_bytes(&path, Some(context)).await?;
         let original_mime_type = Self::mime_type_for_image(&bytes)?;
         let provider = Self::primary_api_format(context);
-        let processed = optimize_image_for_provider(bytes, &provider, Some(original_mime_type))
-            .map_err(|err| {
-                BitFunError::tool(format!("unable to prepare image for model vision: {}", err))
-            })?;
+        let processed = match Self::budget_from_input(input) {
+            Some(budget) => {
+                optimize_image_for_budget(bytes, &provider, Some(original_mime_type), budget, None)
+                    .map_err(|err| {
+                        BitFunError::tool(format!(
+                            "unable to prepare image for model vision: {err}"
+                        ))
+                    })?
+            }
+            None => optimize_image_for_provider(bytes, &provider, Some(original_mime_type))
+                .map_err(|err| {
+                    BitFunError::tool(format!("unable to prepare image for model vision: {err}"))
+                })?,
+        };
         let limits = ImageLimits::for_provider(&provider);
         if processed.data.len() > limits.max_size {
             return Err(BitFunError::tool(format!(
@@ -771,5 +829,71 @@ mod tests {
             panic!("expected result");
         };
         assert_eq!(data["mime_type"], "image/png");
+    }
+
+    #[test]
+    fn view_image_schema_carries_the_optional_budget_preset() {
+        let schema = ViewImageTool::new().input_schema();
+        assert_eq!(
+            schema["properties"]["budget"]["enum"],
+            json!(["small", "normal", "large"])
+        );
+        assert_eq!(schema["required"], json!(["path"]));
+    }
+
+    #[tokio::test]
+    async fn view_image_budget_downscales_a_large_image_to_the_preset_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("big.png");
+        fs::write(&path, png_bytes(3000, 2000)).expect("write png");
+
+        let results = ViewImageTool::new()
+            .call_impl(
+                &json!({ "path": path, "budget": "small" }),
+                &local_workspace_context("openai", true, dir.path().to_path_buf()),
+            )
+            .await
+            .expect("budgeted view result");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result");
+        };
+        assert_eq!(data["original_width"], 3000);
+        assert_eq!(data["original_height"], 2000);
+        assert_eq!(data["was_resized"], true);
+        let area = data["width"].as_u64().unwrap() * data["height"].as_u64().unwrap();
+        assert!(
+            area <= 256 * 32 * 32
+                + data["width"].as_u64().unwrap()
+                + data["height"].as_u64().unwrap(),
+            "small budget sent a {area}-pixel image"
+        );
+    }
+
+    #[tokio::test]
+    async fn view_image_budget_does_not_upscale_a_tiny_image() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tiny.png");
+        fs::write(&path, png_bytes(64, 64)).expect("write png");
+
+        let results = ViewImageTool::new()
+            .call_impl(
+                &json!({ "path": path, "budget": "normal" }),
+                &local_workspace_context("openai", true, dir.path().to_path_buf()),
+            )
+            .await
+            .expect("budgeted view result");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result");
+        };
+        assert_eq!(
+            (
+                data["width"].as_u64().unwrap(),
+                data["height"].as_u64().unwrap()
+            ),
+            (64, 64)
+        );
+        assert_eq!(data["was_resized"], false);
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional `budget` parameter (`small` | `normal` | `large`) to `analyze_image` and `view_image`, letting the agent trade a cheap preview against a high-resolution detail pass.

## What changed

- `ImageBudget` enum with per-tier pixel targets (token budget x 32px patch grid).
- `optimize_image_for_budget` (downscale-only, provider ceiling respected).
- `analyze_image` / `view_image` schema gains an optional `budget` field.
- Omitting `budget` keeps the existing size-limit path - default behavior is unchanged.

## Validation

Evaluated on a 50-task multimodal benchmark (25 DocVQA + 25 ChartQA, 300 runs total):

| metric | without budget | with budget |
|---|---|---|
| strict accuracy | 70.0% | 76.0% |
| loose accuracy | 92.0% | 94.0% |
| DocVQA loose | 92.0% | 96.0% |

- Budget adoption: 51/55 calls passed a `budget` (`large`: 51, `normal`: 3) - the model understands and uses the parameter.
- Median input tokens unchanged (~69K): `large` lands at the same pixel budget as the legacy provider-fit path. This is resolution control, not a cost saver.

Note: with n=50 the ~6pp strict-accuracy delta is within the ~+/-14pp binomial CI, so treat it as a weak but consistent positive signal rather than a statistically significant win.

Fixes #2248