### PR TITLE
fix(input): simplify file mention path display

### DIFF
--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.appearance.ts
@@ -5,7 +5,8 @@ export const fileMentionPickerAppearanceDescriptor: AppearanceSurfaceDescriptor 
   parts: [
     { id: 'root' }, { id: 'header' }, { id: 'back' }, { id: 'content' },
     { id: 'loading' }, { id: 'empty' }, { id: 'list' }, { id: 'item' },
-    { id: 'itemName' }, { id: 'itemDetail' }, { id: 'footer' },
+    { id: 'itemName' }, { id: 'itemDetail' }, { id: 'currentDirectoryName' },
+    { id: 'parentDirectoryPath' }, { id: 'footer' },
   ],
   states: [
     { id: 'selected', selector: { kind: 'self', suffix: '[data-bf-state~="selected"]' } },

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.scss
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.scss
@@ -86,12 +86,32 @@
     }
   }
   
-  &__dir-name {
+  &__directory-label {
     flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: baseline;
+    gap: var(--bf-appearance-token-flowchat-inline-gap);
+  }
+
+  &__dir-name,
+  &__parent-path {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  &__dir-name {
+    flex: 0 1 auto;
+    max-width: 55%;
     color: var(--bf-appearance-token-color-text-secondary);
+  }
+
+  &__parent-path {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: var(--bf-appearance-token-color-text-muted);
+    font-weight: 400;
   }
   
   &__content {
@@ -190,11 +210,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     line-height: var(--bf-appearance-token-flowchat-support-line-height);
-
-    &--with-path {
-      flex: 0 1 auto;
-      max-width: 50%;
-    }
   }
 
   &__item-detail {
@@ -207,12 +222,6 @@
     white-space: nowrap;
   }
 
-  &__item-path {
-    flex: 1 1 0;
-    min-width: 0;
-    max-width: none;
-  }
-  
   &__expand-icon {
     flex-shrink: 0;
     opacity: 0.4;

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
@@ -398,9 +398,29 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
           ...(currentPath ? [] : referenceItems.map(item => ({ kind: 'file' as const, item }))),
         ]
   ), [currentFiles, currentPath, isSearchMode, referenceItems, results, sessionResults]);
-  const currentDirName = currentPath
-    ? currentPath.replace(/\\/g, '/').split('/').pop() || ''
-    : workspacePath?.replace(/\\/g, '/').split('/').pop() || t('fileMention.rootDirectory');
+  const currentDirectoryDisplay = useMemo(() => {
+    if (!workspacePath) {
+      const rootDirectory = t('fileMention.rootDirectory');
+      return { name: rootDirectory, parentPath: '', fullPath: rootDirectory };
+    }
+
+    const normalizedWorkspace = workspacePath.replace(/\\/g, '/').replace(/\/+$/, '');
+    const workspaceName = normalizedWorkspace.split('/').pop() || t('fileMention.rootDirectory');
+    const directorySegments = [workspaceName];
+
+    if (currentPath) {
+      const relativeCurrentPath = getRelativePath(currentPath)
+        .replace(/\\/g, '/')
+        .replace(/^\/+|\/+$/g, '');
+      if (relativeCurrentPath) directorySegments.push(...relativeCurrentPath.split('/').filter(Boolean));
+    }
+
+    return {
+      name: directorySegments[directorySegments.length - 1],
+      parentPath: directorySegments.slice(0, -1).join('/'),
+      fullPath: directorySegments.join('/'),
+    };
+  }, [currentPath, getRelativePath, t, workspacePath]);
   const isOverlay = Boolean(anchorRef) && !position;
   const overlayLayout = useAnchoredPopoverPosition({
     open: isOpen && isOverlay,
@@ -562,7 +582,24 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
           </Tooltip>
         )}
         {isSearchMode ? <><Search size={11} /><span>{t('fileMention.searchResults')}</span></> : (
-          <span className="file-mention-picker__dir-name">{currentDirName}</span>
+          <div className="file-mention-picker__directory-label" title={currentDirectoryDisplay.fullPath}>
+            <span
+              data-bf-component="file-mention-picker"
+              data-bf-part="currentDirectoryName"
+              className="file-mention-picker__dir-name"
+            >
+              {currentDirectoryDisplay.name}
+            </span>
+            {currentDirectoryDisplay.parentPath && (
+              <span
+                data-bf-component="file-mention-picker"
+                data-bf-part="parentDirectoryPath"
+                className="file-mention-picker__parent-path"
+              >
+                {currentDirectoryDisplay.parentPath}
+              </span>
+            )}
+          </div>
         )}
       </div>
       <div data-bf-component="file-mention-picker" data-bf-part="content" className="file-mention-picker__content">
@@ -602,21 +639,11 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
                   <span
                     data-bf-component="file-mention-picker"
                     data-bf-part="itemName"
-                    className={`file-mention-picker__item-name${file && !file.referenceStableKey ? ' file-mention-picker__item-name--with-path' : ''}`}
+                    className="file-mention-picker__item-name"
                   >
                     {session?.sessionName ?? file?.name}
                   </span>
                   {session && <span data-bf-component="file-mention-picker" data-bf-part="itemDetail" className="file-mention-picker__item-detail">{session.workspaceLabel}</span>}
-                  {file && !file.referenceStableKey && (
-                    <span
-                      data-bf-component="file-mention-picker"
-                      data-bf-part="itemDetail"
-                      className="file-mention-picker__item-detail file-mention-picker__item-path"
-                      title={file.relativePath}
-                    >
-                      {file.relativePath}
-                    </span>
-                  )}
                   {file?.referenceStableKey && (
                     <span data-bf-component="file-mention-picker" data-bf-part="itemDetail" className="file-mention-picker__item-detail">
                       {file.referenceDescription || file.path}

--- a/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
@@ -93,7 +93,26 @@ describe('FileMentionPicker overlay', () => {
     );
   });
 
-  it('shows the workspace-relative path after the file name', async () => {
+  it('shows the current directory name before its parent path', async () => {
+    vi.mocked(workspaceAPI.getDirectoryChildren).mockResolvedValueOnce([
+      {
+        path: '/workspace/src',
+        name: 'src',
+        isDirectory: true,
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    const item = document.querySelector<HTMLElement>('[data-bf-part="item"]');
+    expect(document.querySelector('[data-bf-part="currentDirectoryName"]')?.textContent).toBe('workspace');
+    expect(document.querySelector('[data-bf-part="parentDirectoryPath"]')).toBeNull();
+    expect(item?.querySelector('[data-bf-part="itemName"]')?.textContent).toBe('src');
+    expect(item?.querySelector('[data-bf-part="itemDetail"]')).toBeNull();
+
     vi.mocked(workspaceAPI.getDirectoryChildren).mockResolvedValueOnce([
       {
         path: '/workspace/src/App.tsx',
@@ -103,17 +122,15 @@ describe('FileMentionPicker overlay', () => {
     ]);
 
     await act(async () => {
-      root.render(<Harness />);
+      item?.click();
       await Promise.resolve();
     });
 
-    const item = document.querySelector('[data-bf-part="item"]');
-    const itemName = item?.querySelector('[data-bf-part="itemName"]');
-    const itemPath = item?.querySelector('[data-bf-part="itemDetail"]');
-    expect(itemName?.textContent).toBe('App.tsx');
-    expect(itemName?.classList.contains('file-mention-picker__item-name--with-path')).toBe(true);
-    expect(itemPath?.textContent).toBe('src/App.tsx');
-    expect(itemPath?.classList.contains('file-mention-picker__item-path')).toBe(true);
+    expect(document.querySelector('[data-bf-part="currentDirectoryName"]')?.textContent).toBe('src');
+    expect(document.querySelector('[data-bf-part="parentDirectoryPath"]')?.textContent).toBe('workspace');
+    const nestedItem = document.querySelector('[data-bf-part="item"]');
+    expect(nestedItem?.querySelector('[data-bf-part="itemName"]')?.textContent).toBe('App.tsx');
+    expect(nestedItem?.querySelector('[data-bf-part="itemDetail"]')).toBeNull();
   });
 
   it('does not present a remote browse failure as an empty directory', async () => {


### PR DESCRIPTION
## Summary

- Simplify the `@` file mention picker by removing repeated paths beside ordinary file and directory entries.
- Show the current directory name first, followed by its parent path in a secondary style.
- Preserve workspace reference descriptions and existing directory navigation behavior.
- Add coverage for root and nested directory header rendering.

Fixes #<!-- Add issue number -->

## Type and Areas

Type:

UI/UX / bug fix / test

Areas:

Web UI — Flow Chat file mention picker

## Motivation / Impact

The file mention picker previously repeated relative paths beside every file and displayed the active directory as a conventional combined path, such as `tmp/audios`.

This made the list visually noisy and did not clearly distinguish the active directory from its parent hierarchy.

After this change:

- Ordinary file and directory rows display names only.
- The active directory name is shown first and emphasized.
- Its parent path is displayed afterward in a secondary style.
- At the workspace root, only the root directory name is shown.

For example, inside `tmp/audios`, the header displays `audios` followed by `tmp`.

## Verification

- `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/FileMentionPickerOverlay.test.tsx --pool=threads --maxWorkers=1`
  - Passed: 1 test file, 4 tests.
- `pnpm --dir src/web-ui exec eslint src/flow_chat/components/FileMentionPicker.tsx --no-warn-ignored`
  - Passed with no errors.
- `git diff --check`
  - Passed.
- `pnpm run type-check:web`
  - Could not complete because of existing generated API inconsistencies unrelated to this change:
    - Missing `SaveCloudSpeechConfigRequest`
    - Missing `SaveCloudSpeechConfigResult`
- The local Web UI development server started successfully and returned HTTP 200.
- Remote workspace and Peer Device scenarios were not exercised.

## Reviewer Notes

- No user-facing strings or locale resources were changed.
- This is a presentation-only change; file selection, directory navigation, search, and reference payload behavior remain unchanged.
- Workspace reference descriptions remain visible because they identify special reference sources rather than duplicate ordinary file paths.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.