### PR TITLE
fix(desktop): disable update checks in development

### DIFF
--- a/src/web-ui/src/app/components/AboutDialog/AboutDialog.tsx
+++ b/src/web-ui/src/app/components/AboutDialog/AboutDialog.tsx
@@ -16,7 +16,7 @@ import {
 import { createLogger } from '@/shared/utils/logger';
 import { systemAPI } from '@/infrastructure/api';
 import type { CheckForUpdatesResponse } from '@/infrastructure/api/service-api/SystemAPI';
-import { isTauriRuntime } from '@/infrastructure/update/tauriEnv';
+import { canCheckForAppUpdates, isTauriRuntime } from '@/infrastructure/update/tauriEnv';
 import { UpdateAvailableDialog } from '@/infrastructure/update/UpdateAvailableDialog';
 import { useUpdateInstallStore } from '@/infrastructure/update/updateInstallStore';
 import { formatUpdateInstallError } from '@/infrastructure/update/updateErrorMessage';
@@ -51,6 +51,7 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
   const aboutInfo = getAboutInfo();
   const { version, license } = aboutInfo;
   const nativeRuntime = isTauriRuntime();
+  const updateChecksAvailable = canCheckForAppUpdates();
   const displayedVersion = formatDisplayedVersion(
     version,
     nativeVersion,
@@ -85,7 +86,7 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
   }, [isOpen, nativeRuntime]);
 
   const handleCheckForUpdates = useCallback(async () => {
-    if (!isTauriRuntime()) {
+    if (!canCheckForAppUpdates()) {
       return;
     }
     setManualCheckStatus('idle');
@@ -169,7 +170,7 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
 
         {/* Scrollable area */}
         <div className="bitfun-about-dialog__scrollable" data-bf-component="about-dialog" data-bf-part="content">
-          {nativeRuntime ? (
+          {updateChecksAvailable ? (
             <div
               className="bitfun-about-dialog__update-card"
               data-bf-component="about-dialog"
@@ -286,9 +287,9 @@ export const AboutDialog: React.FC<AboutDialogProps> = ({
                 />
               ) : null}
             </div>
-          ) : (
+          ) : !nativeRuntime ? (
             <p className="bitfun-about-dialog__update-hint">{t('update.desktopOnly')}</p>
-          )}
+          ) : null}
           <div className="bitfun-about-dialog__info-section">
             <div className="bitfun-about-dialog__info-card" data-bf-component="about-dialog" data-bf-part="infoCard">
               <div className="bitfun-about-dialog__info-row" data-bf-component="about-dialog" data-bf-part="infoRow">

--- a/src/web-ui/src/infrastructure/api/service-api/SystemAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SystemAPI.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SystemAPI } from './SystemAPI';
 
 const invokeMock = vi.hoisted(() => vi.fn());
@@ -9,12 +9,42 @@ vi.mock('./ApiClient', () => ({
   },
 }));
 
-describe('SystemAPI sleep prevention', () => {
+describe('SystemAPI', () => {
   let systemAPI: SystemAPI;
 
   beforeEach(() => {
     systemAPI = new SystemAPI();
     invokeMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does not invoke the updater in development mode', async () => {
+    vi.stubEnv('DEV', true);
+
+    await expect(systemAPI.checkForUpdates()).rejects.toThrow(
+      'Update checks are disabled in development mode',
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('invokes the updater outside development mode', async () => {
+    vi.stubEnv('DEV', false);
+    const response = {
+      updateAvailable: false,
+      currentVersion: '1.0.0',
+      latestVersion: null,
+      releaseNotes: null,
+      releaseDate: null,
+    };
+    invokeMock.mockResolvedValueOnce(response);
+
+    await expect(systemAPI.checkForUpdates()).resolves.toEqual(response);
+    expect(invokeMock).toHaveBeenCalledWith('check_for_updates', {
+      request: {},
+    });
   });
 
   it('reads the persisted desktop preference', async () => {

--- a/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
@@ -52,6 +52,9 @@ export class SystemAPI {
 
    
   async checkForUpdates(): Promise<CheckForUpdatesResponse> {
+    if (import.meta.env.DEV) {
+      throw new Error('Update checks are disabled in development mode');
+    }
     try {
       return await api.invoke('check_for_updates', { 
         request: {} 

--- a/src/web-ui/src/infrastructure/update/DailyAppUpdateGate.tsx
+++ b/src/web-ui/src/infrastructure/update/DailyAppUpdateGate.tsx
@@ -4,7 +4,7 @@ import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import { createLogger } from '@/shared/utils/logger';
 import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 import type { CheckForUpdatesResponse } from '@/infrastructure/api/service-api/SystemAPI';
-import { isTauriRuntime } from './tauriEnv';
+import { canCheckForAppUpdates, isTauriRuntime } from './tauriEnv';
 import {
   recordDailyPromptDismissed,
   recordSkipThisVersion,
@@ -32,7 +32,7 @@ export function DailyAppUpdateGate(): ReactElement | null {
   const clearUpdateInstalled = useUpdateInstallStore(state => state.clearInstalled);
 
   useEffect(() => {
-    if (!isTauriRuntime()) {
+    if (!canCheckForAppUpdates()) {
       return;
     }
     let cancelled = false;

--- a/src/web-ui/src/infrastructure/update/tauriEnv.test.ts
+++ b/src/web-ui/src/infrastructure/update/tauriEnv.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { canCheckForAppUpdates } from './tauriEnv';
+
+describe('app update runtime availability', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('disables update checks in a Tauri development runtime', () => {
+    vi.stubEnv('DEV', true);
+    vi.stubGlobal('window', { __TAURI__: {} });
+
+    expect(canCheckForAppUpdates()).toBe(false);
+  });
+
+  it('enables update checks in a packaged Tauri runtime', () => {
+    vi.stubEnv('DEV', false);
+    vi.stubGlobal('window', { __TAURI__: {} });
+
+    expect(canCheckForAppUpdates()).toBe(true);
+  });
+});

--- a/src/web-ui/src/infrastructure/update/tauriEnv.ts
+++ b/src/web-ui/src/infrastructure/update/tauriEnv.ts
@@ -2,3 +2,8 @@
 export function isTauriRuntime(): boolean {
   return typeof window !== 'undefined' && '__TAURI__' in window;
 }
+
+/** App update checks are available only in packaged desktop builds. */
+export function canCheckForAppUpdates(): boolean {
+  return isTauriRuntime() && !import.meta.env.DEV;
+}


### PR DESCRIPTION
## Summary

- Disable automatic application update checks in development mode.
- Hide the update section in the About dialog during development.
- Prevent `SystemAPI.checkForUpdates()` from invoking the Tauri updater in development.
- Add tests confirming update checks remain enabled in packaged builds.

Fixes #<issue-number>

## Type and Areas

Type:

Bug fix

Areas:

Desktop/Tauri, Web UI, tests

## Motivation / Impact

Running `pnpm run desktop:dev` could contact the production update endpoint and show update prompts. Developers could also trigger the check manually from the About dialog.

Update checks are now unavailable when `import.meta.env.DEV` is true. Production builds, including NSIS packages, retain automatic and manual update checking.

No direct end-user-facing change in production builds.

## Verification

- `pnpm --dir src/web-ui run test:run src/infrastructure/update/tauriEnv.test.ts src/infrastructure/api/service-api/SystemAPI.test.ts`
  - Passed: 2 test files, 6 tests.
- ESLint on the changed Web UI source files
  - Passed with no errors.
- `git diff --check`
  - Passed.
- `pnpm run type-check:web`
  - Blocked by unrelated existing missing generated exports: `SaveCloudSpeechConfigRequest` and `SaveCloudSpeechConfigResult`.

## Reviewer Notes

The restriction uses Vite's compile-time `import.meta.env.DEV` value. Production frontend builds set it to `false`, so release and NSIS packages continue to:

- Run automatic update checks.
- Show the manual update controls in the About dialog.
- Invoke the configured Tauri updater normally.

No updater endpoints, signing configuration, persisted settings, or user-facing strings were changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.