### PR TITLE
feat(harmonyos): keep tri-fold conversation on remaining screens

### DIFF
--- a/src/apps/mobile/harmonyos/docs/wide-conversation-navigation-design.md
+++ b/src/apps/mobile/harmonyos/docs/wide-conversation-navigation-design.md
@@ -10,7 +10,7 @@ Scope: `src/apps/mobile/harmonyos`，主要涉及双屏/三屏布局、会话来
 
 ### 已实现
 
-- 布局判定对齐官方 GridRow 横向断点：md `600vp` 起双栏，lg `840vp` 起 extra-wide；合盖与悬停（`HALF_FOLDED`）强制不走 master-detail。不再用 `deviceType === tablet` 决定宽屏。
+- 布局判定对齐官方 GridRow 横向断点：md `600vp` 起双栏，lg `840vp` 起 extra-wide；合盖与帐篷悬停（`HALF_FOLDED` / 双轴都半折，且不是仍横屏宽窗）强制不走 master-detail。三折单轴半折、另一轴展开时窗口仍是横屏宽窗，继续走 master-detail。不再用 `deviceType === tablet` 决定宽屏。
 - 展开折叠屏若 `getCurrentFoldCreaseRegion()` 为空，合成中线铰链（16vp）作为 master/detail 分界，避免内容压在铰链上。
 - 悬停态会话使用官方 `FolderStack`：上半为显示区（时间线），下半为操作区（Composer）。
 - 展开态只要存在可用纵向折痕（双折叠一道、三折叠两道），且当前视口放得下 master + detail，就进入 master-detail。
@@ -21,10 +21,9 @@ Scope: `src/apps/mobile/harmonyos`，主要涉及双屏/三屏布局、会话来
 - 本地与远程来源切换使用路由合同计算目标，不累积跨来源返回路径。
 - 切回本地时停止手机侧远程轮询，但不清空远程活动会话或断开桌面。
 - 通过 `display.getCurrentFoldCreaseRegion()` 读取折痕；第一道有效纵向折痕用于 master/detail 分界。
-- 双折叠展开打开文件预览时，会话/预览分界对齐那一道折痕，而不是按视口对半切。
+- 双折叠展开打开文件预览时，会话/预览分界对齐那一道折痕，而不是按视口对半切。三折一道或两道折痕对不齐三栏最小宽度时，仍对齐折痕做 focus split，不把整窗对半切。
 - 两道折痕或 lg 宽度被识别为 extra-wide，但会话仍使用同一个 master-detail，不创建第三会话栏。官方聊天分栏在 md/lg/xl 均为列表|会话；第三窗格只用于文件预览。
-- 第二道折痕会把 detail 划分为无折痕候选内容带；会话视图选择最宽的候选带，同宽时优先右侧，避免 Composer、菜单和消息内操作热区跨越折痕。
-- extra-wide detail 外层仍覆盖中间和右侧两屏；上述内容带只是 presentation 几何约束，不增加第三个业务 pane。
+- 第二道折痕不再把会话详情收成中间或右侧的单屏带。detail 从第一道折痕之后一直铺到窗口右缘，中间和右侧两屏共同承载同一会话；正文用最大宽度约束，避免无限制拉宽。不增加第三个业务 pane。
 - 监听 `foldStatusChange` 与 `foldDisplayModeChange`，折叠形态变化时重算几何。
 
 ### 已验证
@@ -96,7 +95,8 @@ HarmonyOS 手机在展开双屏、完整展开三屏或其他宽屏形态下，�
 
 ```text
 设备处于折叠状态                                      -> 单屏
-设备处于悬停（HALF_FOLDED）                          -> 单屏 + FolderStack（上显示 / 下操作）
+设备处于帐篷悬停（HALF_FOLDED / 双轴都半折，且不是仍横屏宽窗） -> 单屏 + FolderStack（上显示 / 下操作）
+设备单轴半折、另一轴展开，窗口仍是横屏宽窗            -> 宽屏 master-detail（左第一屏 master，右展开带 detail）
 设备非折叠，宽视口（≥600vp 或 media query），有纵向折痕，且放得下两栏 -> 宽屏
 设备非折叠，宽视口，折叠屏展开且折痕缺失              -> 宽屏，合成中线铰链
 设备非折叠，宽视口，无折痕                            -> 宽屏（断点驱动，含平板）
@@ -104,6 +104,8 @@ HarmonyOS 手机在展开双屏、完整展开三屏或其他宽屏形态下，�
 ```
 
 折叠与悬停优先于宽度和折痕。双折叠展开的一道折痕与三折叠的两道折痕使用同一套 master-detail，不新增第三会话栏。
+
+本应用自己用折痕几何做 master-detail，不能把会话交给系统 `Navigation` 分栏或平行视界。`module.json5` 的 `easyGo` 必须把 `wideWindowMode` 与 `squareWindowMode`（三折 M 态 / 双折展开）设为 `original`。根 `Navigation` 保持 `NavigationMode.Stack`，只承担单屏路由。宽屏可见内容必须画在 `Navigation` 外面，按 `activeRoute` 渲染 `WideConversationHost`；否则即使用 Stack，HarmonyOS 6.1 仍可能把 `Navigation` 切成 1:1，会话锁在左半屏，右侧露出 `startWindow`。
 
 ### 路由分流
 
@@ -273,9 +275,10 @@ MasterDetail -> 双屏和三屏共同使用的 master-detail
 
 - 页面头部和背景可以占满整个 detail pane。
 - 消息阅读区、状态内容和 Composer 应设置合理最大宽度，并在 detail pane 内稳定对齐。
-- 存在第二道折痕时，将 detail 划分为互不跨越折痕的候选内容带；会话视图选择最宽内容带，同宽时选择右侧内容带。
+- 存在第二道折痕时，会话详情仍占据第一道折痕之后的整段剩余宽度（中间+右侧），不得只留在最宽的那一屏。
+- 收起 master 后：双折一道折痕且两侧接近对半时，内容可以铺满整窗；三折时内容必须留在第一道折痕之后的整段剩余宽度，不能整屏重新居中，也不能被系统分栏裁到左半屏。恢复按钮钉在空出来的第一屏左上角。
 - 最大宽度不能按视口宽度缩放字体，只限制内容容器。
-- 第二道折痕位于 detail 内部时，发送、停止、菜单、附件和语音等关键点击控件不能落在折痕安全区。
+- 第二道折痕位于 detail 内部时，不因此再切出第三会话栏；关键点击控件随内容带一起落在剩余两屏内。
 - 第一阶段不利用第二道折痕拆出文件、任务或其他辅助面板。
 
 ### 几何更新

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppRootPresentation.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppRootPresentation.ets
@@ -12,7 +12,8 @@ import {
 import { AppShellState } from '../state/AppShellState';
 import {
   ConversationLayoutCrease,
-  ConversationLayoutPolicy
+  ConversationLayoutPolicy,
+  ConversationLayoutRect
 } from '../policy/ConversationLayoutPolicy';
 import { GeneralChatPageState } from '../state/GeneralChatPageState';
 import { RemotePageState } from '../state/RemotePageState';
@@ -55,6 +56,7 @@ export struct AppRootPresentation {
   @Param filePreviewState: FilePreviewState = new FilePreviewState();
   @Param deviceId: string = '';
   @Local viewportWidth: number = 0;
+  @Local viewportHeight: number = 0;
   @Local wideLayoutMatched: boolean = false;
   @Local foldStatus: display.FoldStatus = safeFoldStatus();
   @Local largeScreenLayout: boolean = false;
@@ -119,16 +121,48 @@ export struct AppRootPresentation {
     }.width('100%').height('100%')
     .bindSheet($$this.showRemoteViewSettings, this.RemoteViewSettingsSheet(), this.remoteViewSettingsSheetOptions())
     .onAreaChange((_oldArea: Area, newArea: Area) => {
-      this.viewportWidth = this.areaWidth(newArea.width);
+      const areaWidth = this.areaWidth(newArea.width);
+      const areaHeight = this.areaWidth(newArea.height);
+      const displaySize = this.currentDisplaySize();
+      this.viewportWidth = ConversationLayoutPolicy.resolveLayoutViewportWidth(
+        areaWidth,
+        areaHeight,
+        displaySize[0],
+        displaySize[1],
+        displaySize[2]
+      );
+      this.viewportHeight = areaHeight > 0 ? areaHeight : displaySize[1];
+      if (this.viewportWidth === Math.max(displaySize[0], displaySize[1]) &&
+        areaWidth !== this.viewportWidth) {
+        this.viewportHeight = Math.min(displaySize[0], displaySize[1]);
+      }
       this.refreshWideGeometry();
     })
   }
 
   @Builder
   NavigationContent() {
-    Navigation(this.navigationStack) { this.RouteContent(AppRoute.ChatHome) }
-      .width('100%').height('100%').hideTitleBar(true).mode(NavigationMode.Stack)
-      .navDestination(this.NavigationDestination)
+    Stack() {
+      Navigation(this.navigationStack) { this.RouteContent(AppRoute.ChatHome) }
+        .id('bitfunHomeNavigation')
+        .width('100%').height('100%').hideTitleBar(true)
+        .mode(NavigationMode.Stack)
+        .navBarWidth('100%')
+        .minContentWidth(0)
+        .navDestination(this.NavigationDestination)
+        .visibility(this.isWideLayout() ? Visibility.Hidden : Visibility.Visible)
+
+      if (this.isWideLayout()) {
+        Column() {
+          this.RouteContent(this.shellState.activeRoute)
+        }
+        .width('100%')
+        .height('100%')
+        .backgroundColor(PAGE_BG)
+      }
+    }
+    .width('100%')
+    .height('100%')
   }
 
   @Builder
@@ -315,7 +349,7 @@ export struct AppRootPresentation {
     this.largeScreenLayout = ConversationLayoutPolicy.useMasterDetail(
       this.viewportWidth,
       this.wideLayoutMatched,
-      this.foldStatus === display.FoldStatus.FOLD_STATUS_FOLDED,
+      ConversationLayoutPolicy.isFoldedStatus(this.foldStatus),
       verticalCreases,
       this.isExpandedFoldable(),
       this.isHoverLayout()
@@ -337,25 +371,41 @@ export struct AppRootPresentation {
   }
 
   private isHoverLayout(): boolean {
-    return this.foldStatus === display.FoldStatus.FOLD_STATUS_HALF_FOLDED;
+    return ConversationLayoutPolicy.useHoverOperate(
+      this.foldStatus,
+      this.viewportWidth,
+      this.viewportHeight
+    );
   }
 
   private isExpandedFoldable(): boolean {
-    return this.foldStatus === display.FoldStatus.FOLD_STATUS_EXPANDED && this.isFoldableDevice();
+    return ConversationLayoutPolicy.isExpandedFoldableStatus(this.foldStatus) && this.isFoldableDevice();
+  }
+
+  private currentDisplaySize(): [number, number, number] {
+    try {
+      const metrics = display.getDefaultDisplaySync();
+      return [
+        this.getUIContext().px2vp(metrics.width),
+        this.getUIContext().px2vp(metrics.height),
+        metrics.rotation
+      ];
+    } catch (_err) {
+      return [0, 0, 0];
+    }
   }
 
   private isFoldableDevice(): boolean {
     try {
       return display.isFoldable();
     } catch (_err) {
-      return this.foldStatus === display.FoldStatus.FOLD_STATUS_EXPANDED ||
-        this.foldStatus === display.FoldStatus.FOLD_STATUS_HALF_FOLDED ||
-        this.foldStatus === display.FoldStatus.FOLD_STATUS_FOLDED;
+      return ConversationLayoutPolicy.isExpandedFoldableStatus(this.foldStatus) ||
+        ConversationLayoutPolicy.isFoldedStatus(this.foldStatus);
     }
   }
 
   private currentVerticalCreases(): ConversationLayoutCrease[] {
-    if (this.foldStatus === display.FoldStatus.FOLD_STATUS_FOLDED || this.isHoverLayout()) {
+    if (ConversationLayoutPolicy.isFoldedStatus(this.foldStatus) || this.isHoverLayout()) {
       return [];
     }
     return ConversationLayoutPolicy.effectiveVerticalCreases(
@@ -372,14 +422,19 @@ export struct AppRootPresentation {
       if (!creaseRects) {
         return [];
       }
-      return creaseRects
-        .filter((rect: display.Rect): boolean => rect.height > rect.width)
-        .map((rect: display.Rect): ConversationLayoutCrease => {
-          return new ConversationLayoutCrease(
-            this.getUIContext().px2vp(rect.left),
-            this.getUIContext().px2vp(rect.width)
-          );
-        });
+      const rects = creaseRects.map((rect: display.Rect): ConversationLayoutRect => {
+        return new ConversationLayoutRect(
+          this.getUIContext().px2vp(rect.left),
+          this.getUIContext().px2vp(rect.top),
+          this.getUIContext().px2vp(rect.width),
+          this.getUIContext().px2vp(rect.height)
+        );
+      });
+      return ConversationLayoutPolicy.verticalCreasesFromRects(
+        this.viewportWidth,
+        this.viewportHeight,
+        rects
+      );
     } catch (_err) {
       return [];
     }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/WideConversationHost.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/WideConversationHost.ets
@@ -81,19 +81,43 @@ export struct WideConversationHost {
         this.MasterPane(ConversationSource.Remote, false)
         this.MasterDetailGap()
       }
-      Column() {
-        RemoteSurfaceHost({
-          mode: RemoteSurfaceMode.Placeholder,
-          remotePageState: this.remotePageState,
-          presentationState: this.remoteSurfaceState,
-          actions: this.actions,
-          wideMasterPaneCollapsed: this.wideMasterPaneCollapsed,
-          onRestoreSidebar: this.onRestoreMasterPane
-        })
-      }
-      .layoutWeight(1).height('100%').backgroundColor(PAGE_BG)
+      this.RemoteHomeDetail()
     }
     .width('100%').height('100%').backgroundColor(PAGE_BG)
+  }
+
+  @Builder
+  private RemoteHomeDetail() {
+    Stack({ alignContent: Alignment.TopStart }) {
+      Row() {
+        if (this.currentDetailOffset() > 0) {
+          Row() {}.width(this.currentDetailOffset()).height('100%')
+        }
+        Column() {
+          RemoteSurfaceHost({
+            mode: RemoteSurfaceMode.Placeholder,
+            remotePageState: this.remotePageState,
+            presentationState: this.remoteSurfaceState,
+            actions: this.actions,
+            wideMasterPaneCollapsed: false,
+            onRestoreSidebar: this.onRestoreMasterPane
+          })
+        }
+        .width(this.currentDetailWidth() > 0 ? this.currentDetailWidth() : '100%')
+        .height('100%').backgroundColor(PAGE_BG)
+        if (this.currentDetailOffset() > 0) {
+          Row() {}.layoutWeight(1).height('100%')
+        }
+      }
+      .width('100%').height('100%').justifyContent(FlexAlign.Start).backgroundColor(PAGE_BG)
+
+      if (this.wideMasterPaneCollapsed) {
+        SidebarToggleButton({ restore: true, controlSize: 44, onToggle: this.onRestoreMasterPane })
+          .position({ x: 12, y: 12 }).zIndex(2)
+          .hitTestBehavior(HitTestMode.Default)
+      }
+    }
+    .layoutWeight(1).height('100%').backgroundColor(PAGE_BG)
   }
 
   @Builder
@@ -232,7 +256,9 @@ export struct WideConversationHost {
     } else {
       Stack({ alignContent: Alignment.TopStart }) {
         Row() {
-          if (this.currentDetailOffset() > 0) Blank().width(this.currentDetailOffset())
+          if (this.currentDetailOffset() > 0) {
+            Row() {}.width(this.currentDetailOffset()).height('100%')
+          }
           Row() {
             Column() { this.RouteSurface(showBackButton) }
               .width('100%').height('100%').constraintSize({ maxWidth: WIDE_DETAIL_CONTENT_MAX_WIDTH })
@@ -240,9 +266,11 @@ export struct WideConversationHost {
           }
           .width(this.currentDetailWidth() > 0 ? this.currentDetailWidth() : '100%')
           .height('100%').justifyContent(FlexAlign.Center)
-          if (this.currentDetailOffset() > 0) Blank().layoutWeight(1)
+          if (this.currentDetailOffset() > 0) {
+            Row() {}.layoutWeight(1).height('100%')
+          }
         }
-        .width('100%').height('100%').justifyContent(FlexAlign.Center).backgroundColor(PAGE_BG)
+        .width('100%').height('100%').justifyContent(FlexAlign.Start).backgroundColor(PAGE_BG)
 
         if (this.wideMasterPaneCollapsed) {
           SidebarToggleButton({ restore: true, controlSize: 44, onToggle: this.onRestoreMasterPane })

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/policy/ConversationLayoutPolicy.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/policy/ConversationLayoutPolicy.ets
@@ -8,6 +8,20 @@ export class ConversationLayoutCrease {
   }
 }
 
+export class ConversationLayoutRect {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+
+  constructor(left: number, top: number, width: number, height: number) {
+    this.left = left;
+    this.top = top;
+    this.width = width;
+    this.height = height;
+  }
+}
+
 export class ConversationLayoutGeometry {
   readonly masterPaneWidth: number;
   readonly masterDetailGap: number;
@@ -57,6 +71,91 @@ export class ConversationLayoutPolicy {
   static readonly MIN_MASTER_PANE_WIDTH: number = 280;
   static readonly MIN_DETAIL_PANE_WIDTH: number = 360;
   static readonly SYNTHETIC_HINGE_WIDTH: number = 16;
+  static readonly FOLD_STATUS_UNKNOWN: number = 0;
+  static readonly FOLD_STATUS_EXPANDED: number = 1;
+  static readonly FOLD_STATUS_FOLDED: number = 2;
+  static readonly FOLD_STATUS_HALF_FOLDED: number = 3;
+  static readonly FOLD_STATUS_EXPANDED_WITH_SECOND_EXPANDED: number = 11;
+  static readonly FOLD_STATUS_FOLDED_WITH_SECOND_EXPANDED: number = 12;
+  static readonly FOLD_STATUS_HALF_FOLDED_WITH_SECOND_EXPANDED: number = 13;
+  static readonly FOLD_STATUS_EXPANDED_WITH_SECOND_HALF_FOLDED: number = 21;
+  static readonly FOLD_STATUS_FOLDED_WITH_SECOND_HALF_FOLDED: number = 22;
+  static readonly FOLD_STATUS_HALF_FOLDED_WITH_SECOND_HALF_FOLDED: number = 23;
+
+  static isFoldedStatus(status: number): boolean {
+    return status === ConversationLayoutPolicy.FOLD_STATUS_FOLDED;
+  }
+
+  static isExpandedFoldableStatus(status: number): boolean {
+    return status !== ConversationLayoutPolicy.FOLD_STATUS_UNKNOWN &&
+      status !== ConversationLayoutPolicy.FOLD_STATUS_FOLDED;
+  }
+
+  static isHoverStatus(status: number): boolean {
+    return status === ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED ||
+      status === ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED_WITH_SECOND_HALF_FOLDED;
+  }
+
+  static useHoverOperate(
+    status: number,
+    viewportWidth: number,
+    viewportHeight: number
+  ): boolean {
+    if (!ConversationLayoutPolicy.isHoverStatus(status)) {
+      return false;
+    }
+    if (viewportWidth >= ConversationLayoutPolicy.MD_MIN_WIDTH &&
+      viewportWidth >= viewportHeight) {
+      return false;
+    }
+    return true;
+  }
+
+  static isLandscapeRotation(rotation: number): boolean {
+    return rotation === 1 || rotation === 3 || rotation === 90 || rotation === 270;
+  }
+
+  static resolveLayoutViewportWidth(
+    areaWidth: number,
+    areaHeight: number,
+    displayWidth: number,
+    displayHeight: number,
+    rotation: number = 0
+  ): number {
+    const landscape = ConversationLayoutPolicy.isLandscapeRotation(rotation) ||
+      (displayWidth > 0 && displayWidth >= displayHeight);
+    const layoutWidth = landscape ? Math.max(displayWidth, displayHeight) : displayWidth;
+    if (layoutWidth > 0 && areaWidth > 0 && areaWidth < layoutWidth * 0.8) {
+      return layoutWidth;
+    }
+    return areaWidth > 0 ? areaWidth : layoutWidth;
+  }
+
+  static verticalCreasesFromRects(
+    viewportWidth: number,
+    viewportHeight: number,
+    rects: ConversationLayoutRect[]
+  ): ConversationLayoutCrease[] {
+    const mapped: ConversationLayoutCrease[] = [];
+    rects.forEach((rect: ConversationLayoutRect): void => {
+      if (rect.width < 0 || rect.height < 0) {
+        return;
+      }
+      if (rect.height > rect.width) {
+        mapped.push(new ConversationLayoutCrease(rect.left, rect.width));
+        return;
+      }
+      if (viewportWidth <= 0 || viewportHeight <= 0) {
+        return;
+      }
+      const spansViewportWidth = rect.width >= viewportWidth * 0.8;
+      const spansViewportHeight = rect.width >= viewportHeight * 0.8;
+      if (!spansViewportWidth && spansViewportHeight) {
+        mapped.push(new ConversationLayoutCrease(rect.top, rect.height));
+      }
+    });
+    return ConversationLayoutPolicy.visibleCreases(viewportWidth, mapped);
+  }
 
   static useMasterDetail(
     viewportWidth: number,
@@ -93,18 +192,19 @@ export class ConversationLayoutPolicy {
       ConversationLayoutPolicy.fallbackMasterPaneWidth(viewportWidth);
     const masterDetailGap = firstCrease ? Math.max(0, firstCrease.width) : 0;
     const detailStart = masterPaneWidth + masterDetailGap;
-    const detailSegments = ConversationLayoutPolicy.detailSegments(viewportWidth, detailStart, visibleCreases);
-    const contentSegment = ConversationLayoutPolicy.widestSegment(detailSegments);
+    const detailWidth = Math.max(0, viewportWidth - detailStart);
     const collapsedContentSegment = ConversationLayoutPolicy.collapsedContentSegment(
       viewportWidth,
-      visibleCreases
+      visibleCreases,
+      detailStart,
+      detailWidth
     );
     return new ConversationLayoutGeometry(
       masterPaneWidth,
       masterDetailGap,
       visibleCreases.length > 1 || viewportWidth >= ConversationLayoutPolicy.LG_MIN_WIDTH,
-      contentSegment ? contentSegment.left - detailStart : 0,
-      contentSegment ? contentSegment.width : 0,
+      0,
+      detailWidth,
       collapsedContentSegment.left,
       collapsedContentSegment.width
     );
@@ -112,15 +212,22 @@ export class ConversationLayoutPolicy {
 
   private static collapsedContentSegment(
     viewportWidth: number,
-    visibleCreases: ConversationLayoutCrease[]
+    visibleCreases: ConversationLayoutCrease[],
+    detailStart: number,
+    detailWidth: number
   ): ConversationLayoutSegment {
-    if (visibleCreases.length <= 1) {
+    if (visibleCreases.length === 0) {
       return new ConversationLayoutSegment(0, Math.max(0, viewportWidth));
     }
-    const widest = ConversationLayoutPolicy.widestSegment(
-      ConversationLayoutPolicy.detailSegments(viewportWidth, 0, visibleCreases)
-    );
-    return widest ? widest : new ConversationLayoutSegment(0, Math.max(0, viewportWidth));
+    if (visibleCreases.length === 1) {
+      const widest = ConversationLayoutPolicy.widestSegment(
+        ConversationLayoutPolicy.detailSegments(viewportWidth, 0, visibleCreases)
+      );
+      if (widest && widest.width <= viewportWidth * 0.55) {
+        return new ConversationLayoutSegment(0, Math.max(0, viewportWidth));
+      }
+    }
+    return new ConversationLayoutSegment(detailStart, detailWidth);
   }
 
   static effectiveVerticalCreases(

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/policy/FilePreviewPlacementPolicy.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/policy/FilePreviewPlacementPolicy.ets
@@ -80,6 +80,10 @@ export class FilePreviewPlacementPolicy {
     if (creaseFocusLayout) {
       return creaseFocusLayout;
     }
+    const lastCreaseFocusLayout = FilePreviewPlacementPolicy.lastCreaseFocusSplit(viewportWidth, creases);
+    if (lastCreaseFocusLayout) {
+      return lastCreaseFocusLayout;
+    }
     const flatLayout = FilePreviewPlacementPolicy.flatTriplePane(
       viewportWidth,
       creases,
@@ -159,8 +163,33 @@ export class FilePreviewPlacementPolicy {
     const crease = visible[0];
     const conversationWidth = crease.left;
     const previewWidth = viewportWidth - crease.left - crease.width;
-    if (conversationWidth < FilePreviewPlacementPolicy.MIN_CONVERSATION_WIDTH ||
+    if (conversationWidth < FilePreviewPlacementPolicy.MIN_MASTER_WIDTH ||
       previewWidth < FilePreviewPlacementPolicy.MIN_PREVIEW_WIDTH) {
+      return undefined;
+    }
+    return new FilePreviewLayout(
+      FilePreviewPlacement.WideFocusSplit,
+      0,
+      0,
+      conversationWidth,
+      crease.width,
+      previewWidth
+    );
+  }
+
+  private static lastCreaseFocusSplit(
+    viewportWidth: number,
+    creases: ConversationLayoutCrease[]
+  ): FilePreviewLayout | undefined {
+    const visible = FilePreviewPlacementPolicy.visibleCreases(viewportWidth, creases);
+    if (visible.length < 2) {
+      return undefined;
+    }
+    const crease = visible[visible.length - 1];
+    const conversationWidth = crease.left;
+    const previewWidth = viewportWidth - crease.left - crease.width;
+    if (conversationWidth < FilePreviewPlacementPolicy.MIN_CONVERSATION_WIDTH ||
+      previewWidth < FilePreviewPlacementPolicy.MIN_MASTER_WIDTH) {
       return undefined;
     }
     return new FilePreviewLayout(

--- a/src/apps/mobile/harmonyos/entry/src/main/module.json5
+++ b/src/apps/mobile/harmonyos/entry/src/main/module.json5
@@ -59,6 +59,7 @@
       }
     ],
     "pages": "$profile:main_pages",
+    "easyGo": "$profile:easy_go",
     "abilities": [
       {
         "name": "EntryAbility",

--- a/src/apps/mobile/harmonyos/entry/src/main/resources/base/profile/easy_go.json
+++ b/src/apps/mobile/harmonyos/entry/src/main/resources/base/profile/easy_go.json
@@ -1,0 +1,8 @@
+{
+  "common": {
+    "displayModeOptions": {
+      "wideWindowMode": "original",
+      "squareWindowMode": "original"
+    }
+  }
+}

--- a/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
@@ -115,7 +115,8 @@ import {
 } from '../main/ets/pages/policy/FilePreviewPlacementPolicy';
 import {
   ConversationLayoutCrease,
-  ConversationLayoutPolicy
+  ConversationLayoutPolicy,
+  ConversationLayoutRect
 } from '../main/ets/pages/policy/ConversationLayoutPolicy';
 import { SessionActionPolicy, SessionActionScope } from '../main/ets/pages/policy/SessionActionPolicy';
 import { ConversationSessionFilterPolicy } from '../main/ets/pages/policy/ConversationSessionFilterPolicy';
@@ -787,6 +788,25 @@ export default function remoteControllersUnitTest() {
       expect(layout.conversationPaneWidth).assertEqual(1100);
       expect(layout.conversationPreviewGap).assertEqual(16);
       expect(layout.previewPaneWidth).assertEqual(1094);
+    });
+
+    it('keeps tri-fold preview on a crease instead of splitting the full window in half', 0, () => {
+      const single = FilePreviewPlacementPolicy.resolveLayout(true, true, 1107, [
+        new ConversationLayoutCrease(351, 44)
+      ]);
+      expect(single.placement).assertEqual(FilePreviewPlacement.WideFocusSplit);
+      expect(single.conversationPaneWidth).assertEqual(351);
+      expect(single.conversationPreviewGap).assertEqual(44);
+      expect(single.previewPaneWidth).assertEqual(712);
+
+      const dual = FilePreviewPlacementPolicy.resolveLayout(true, true, 1107, [
+        new ConversationLayoutCrease(351, 44),
+        new ConversationLayoutCrease(773, 44)
+      ]);
+      expect(dual.placement).assertEqual(FilePreviewPlacement.WideFocusSplit);
+      expect(dual.conversationPaneWidth).assertEqual(773);
+      expect(dual.conversationPreviewGap).assertEqual(44);
+      expect(dual.previewPaneWidth).assertEqual(290);
     });
 
     it('falls back from crease-aligned focus when one side is too narrow', 0, () => {
@@ -2477,6 +2497,62 @@ export default function remoteControllersUnitTest() {
   });
 
   describe('ConversationLayoutPolicy', () => {
+    it('treats only tent statuses as hover candidates', 0, () => {
+      expect(ConversationLayoutPolicy.isHoverStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED
+      )).assertTrue();
+      expect(ConversationLayoutPolicy.isHoverStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED_WITH_SECOND_HALF_FOLDED
+      )).assertTrue();
+      expect(ConversationLayoutPolicy.isHoverStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED_WITH_SECOND_EXPANDED
+      )).assertFalse();
+      expect(ConversationLayoutPolicy.isHoverStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_EXPANDED_WITH_SECOND_HALF_FOLDED
+      )).assertFalse();
+      expect(ConversationLayoutPolicy.isHoverStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_EXPANDED_WITH_SECOND_EXPANDED
+      )).assertFalse();
+    });
+
+    it('keeps one-axis half-fold landscape windows on master-detail', 0, () => {
+      expect(ConversationLayoutPolicy.useHoverOperate(
+        ConversationLayoutPolicy.FOLD_STATUS_EXPANDED_WITH_SECOND_HALF_FOLDED,
+        1107,
+        776
+      )).assertFalse();
+      expect(ConversationLayoutPolicy.useHoverOperate(
+        ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED_WITH_SECOND_EXPANDED,
+        1107,
+        776
+      )).assertFalse();
+      expect(ConversationLayoutPolicy.useMasterDetail(
+        1107,
+        true,
+        false,
+        [new ConversationLayoutCrease(351, 44)],
+        true,
+        ConversationLayoutPolicy.useHoverOperate(
+          ConversationLayoutPolicy.FOLD_STATUS_EXPANDED_WITH_SECOND_HALF_FOLDED,
+          1107,
+          776
+        )
+      )).assertTrue();
+    });
+
+    it('uses FolderStack only for tent hover that is not still landscape-wide', 0, () => {
+      expect(ConversationLayoutPolicy.useHoverOperate(
+        ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED,
+        480,
+        800
+      )).assertTrue();
+      expect(ConversationLayoutPolicy.useHoverOperate(
+        ConversationLayoutPolicy.FOLD_STATUS_HALF_FOLDED,
+        1107,
+        776
+      )).assertFalse();
+    });
+
     it('keeps folded, hover and narrow surfaces compact', 0, () => {
       expect(ConversationLayoutPolicy.useMasterDetail(480, false, false, [])).assertFalse();
       expect(ConversationLayoutPolicy.useMasterDetail(900, true, true, [])).assertFalse();
@@ -2626,6 +2702,50 @@ export default function remoteControllersUnitTest() {
       expect(geometry.collapsedDetailContentWidth).assertEqual(2210);
     });
 
+    it('keeps collapsed tri-fold content on the dominant hinge-free band', 0, () => {
+      const geometry = ConversationLayoutPolicy.resolveWideGeometry(
+        1107,
+        [new ConversationLayoutCrease(351, 44)]
+      );
+      expect(geometry.collapsedDetailContentOffset).assertEqual(395);
+      expect(geometry.collapsedDetailContentWidth).assertEqual(712);
+    });
+
+    it('treats dual-axis expanded fold status as an unfolded foldable', 0, () => {
+      expect(ConversationLayoutPolicy.isFoldedStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_FOLDED
+      )).assertTrue();
+      expect(ConversationLayoutPolicy.isFoldedStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_EXPANDED_WITH_SECOND_EXPANDED
+      )).assertFalse();
+      expect(ConversationLayoutPolicy.isExpandedFoldableStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_EXPANDED_WITH_SECOND_EXPANDED
+      )).assertTrue();
+      expect(ConversationLayoutPolicy.isExpandedFoldableStatus(
+        ConversationLayoutPolicy.FOLD_STATUS_FOLDED
+      )).assertFalse();
+    });
+
+    it('uses the landscape display width when area reports the short side', 0, () => {
+      expect(ConversationLayoutPolicy.resolveLayoutViewportWidth(776, 1107, 1107, 776))
+        .assertEqual(1107);
+      expect(ConversationLayoutPolicy.resolveLayoutViewportWidth(776, 1107, 776, 1107, 270))
+        .assertEqual(1107);
+      expect(ConversationLayoutPolicy.resolveLayoutViewportWidth(360, 780, 360, 780, 0))
+        .assertEqual(360);
+    });
+
+    it('rotates a physical horizontal crease into a vertical layout crease', 0, () => {
+      const creases = ConversationLayoutPolicy.verticalCreasesFromRects(
+        1107,
+        776,
+        [new ConversationLayoutRect(0, 351, 776, 44)]
+      );
+      expect(creases.length).assertEqual(1);
+      expect(creases[0].left).assertEqual(351);
+      expect(creases[0].width).assertEqual(44);
+    });
+
     it('accepts a zero-width crease without creating an empty detail segment', 0, () => {
       const geometry = ConversationLayoutPolicy.resolveWideGeometry(
         900,
@@ -2637,7 +2757,7 @@ export default function remoteControllersUnitTest() {
       expect(geometry.detailContentWidth).assertEqual(548);
     });
 
-    it('treats two creases as an extra-wide master-detail surface', 0, () => {
+    it('keeps tri-fold detail across both remaining screens instead of one hinge-free band', 0, () => {
       const geometry = ConversationLayoutPolicy.resolveWideGeometry(
         1080,
         [new ConversationLayoutCrease(352, 8), new ConversationLayoutCrease(712, 8)]
@@ -2645,21 +2765,34 @@ export default function remoteControllersUnitTest() {
       expect(geometry.masterPaneWidth).assertEqual(352);
       expect(geometry.masterDetailGap).assertEqual(8);
       expect(geometry.isExtraWide).assertTrue();
-      expect(geometry.detailContentOffset).assertEqual(360);
-      expect(geometry.detailContentWidth).assertEqual(360);
-      expect(geometry.collapsedDetailContentOffset).assertEqual(720);
-      expect(geometry.collapsedDetailContentWidth).assertEqual(360);
+      expect(geometry.detailContentOffset).assertEqual(0);
+      expect(geometry.detailContentWidth).assertEqual(720);
+      expect(geometry.collapsedDetailContentOffset).assertEqual(360);
+      expect(geometry.collapsedDetailContentWidth).assertEqual(720);
     });
 
-    it('selects the widest hinge-free detail band on asymmetric three-screen geometry', 0, () => {
+    it('keeps asymmetric tri-fold detail on the full remaining span after the first crease', 0, () => {
       const geometry = ConversationLayoutPolicy.resolveWideGeometry(
         1080,
         [new ConversationLayoutCrease(352, 8), new ConversationLayoutCrease(800, 8)]
       );
       expect(geometry.detailContentOffset).assertEqual(0);
-      expect(geometry.detailContentWidth).assertEqual(440);
+      expect(geometry.detailContentWidth).assertEqual(720);
       expect(geometry.collapsedDetailContentOffset).assertEqual(360);
-      expect(geometry.collapsedDetailContentWidth).assertEqual(440);
+      expect(geometry.collapsedDetailContentWidth).assertEqual(720);
+    });
+
+    it('spans remaining screens when a second crease sits inside the detail pane', 0, () => {
+      const geometry = ConversationLayoutPolicy.resolveWideGeometry(
+        1107,
+        [new ConversationLayoutCrease(351, 44), new ConversationLayoutCrease(773, 44)]
+      );
+      expect(geometry.masterPaneWidth).assertEqual(351);
+      expect(geometry.masterDetailGap).assertEqual(44);
+      expect(geometry.detailContentOffset).assertEqual(0);
+      expect(geometry.detailContentWidth).assertEqual(712);
+      expect(geometry.collapsedDetailContentOffset).assertEqual(395);
+      expect(geometry.collapsedDetailContentWidth).assertEqual(712);
     });
 
     it('uses width as the extra-wide fallback when crease data is missing', 0, () => {
@@ -2692,8 +2825,8 @@ export default function remoteControllersUnitTest() {
         [new ConversationLayoutCrease(600, 8)]
       );
       expect(geometry.masterPaneWidth).assertEqual(ConversationLayoutPolicy.FALLBACK_MASTER_PANE_WIDTH);
-      expect(geometry.detailContentOffset).assertEqual(264);
-      expect(geometry.detailContentWidth).assertEqual(292);
+      expect(geometry.detailContentOffset).assertEqual(0);
+      expect(geometry.detailContentWidth).assertEqual(556);
     });
   });
 


### PR DESCRIPTION
## Summary
- Keep tri-fold conversation detail across both remaining screens after the first crease, instead of shrinking it to a single hinge-free band.
- Treat tent hover (`HALF_FOLDED` / both axes half-folded) separately from one-axis half-fold landscape windows, which stay on master-detail.
- Keep wide content outside system `Navigation` and set `easyGo` wide/square modes to `original`, so HarmonyOS 6.1 cannot split the session 1:1.
- Align file preview to a crease on tri-fold instead of splitting the full window in half.

## Test plan
- [x] `pnpm run harmony:architecture`
- [x] HarmonyOS `assembleHap` (`entry@default`)
- [x] HarmonyOS LocalTest (`entry@default` LocalTest)
- [ ] Dual-fold expanded: master-detail still splits on the single crease
- [ ] Tri-fold expanded: conversation detail spans the middle and right screens
- [ ] Tent hover: FolderStack (top display / bottom operate)
- [ ] One-axis half-fold landscape: stays master-detail, not FolderStack
- [ ] Wide file preview stays crease-aligned and does not bisect the window

Remote scenario exercised: **none**. Verification is local HarmonyOS compile plus LocalTest for fold/layout policy. This change does not alter remote workspace, remote control, peer-device, or detached-dispatch paths.

Made with [Cursor](https://cursor.com)